### PR TITLE
feat/reference-semantics - Consolidar semântica de referências

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Typed public native contracts and runtime reference-mode validation.
+- Safe references to captured upvalues.
+
+### Fixed
+
+- Reference documentation now distinguishes contextual passing, update, and rebind.
+- Dynamic calls reject incompatible reference modes before entering the callee.
+
 ## [1.4.0] - 2026-08-08
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ For a complete guide, consult the [NOXY_LANGUAGE_SPEC.md](docs/NOXY_LANGUAGE_SPE
 
 Noxy VM is a bytecode compiler and virtual machine for the Noxy language created by Estêvão Fonseca. This implementation compiles source code into bytecode and executes it on a stack-based VM, offering high performance.
 
+Noxy is statically typed, with explicit dynamic boundaries through `any`, bare
+`func`, untyped native primitives, and plugins without signatures. Its
+variables are type-stable: the declared type does not change, while values may
+be mutable.
+
 ### Features
 
 - ✅ Bytecode compiler

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -242,7 +242,7 @@ func runWithConfig(filename string, input string, rootPath string, showDisasm bo
 		os.Exit(1)
 	}
 
-	c := compiler.NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filename)
+	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filename, rootPath)
 	chunk, _, err := c.Compile(program)
 	if err != nil {
 		fmt.Printf("Compiler error: %s\n", err)

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-Noxy is a statically typed programming language. Designed for educational purposes and practical applications, it supports structs, references, arrays, f-strings, and a module system.
+Noxy is statically typed, with explicit dynamic boundaries through `any`, bare
+`func`, untyped native primitives, and plugins without signatures. Designed for
+educational purposes and practical applications, it supports structs,
+references, arrays, f-strings, and a module system.
 The current implementation is a **Stack-based VM** written in **Go**.
 
 ---
@@ -55,11 +58,12 @@ The current implementation is a **Stack-based VM** written in **Go**.
 
 ### 2.0 Fundamental Typing Rules
 
-#### Static and Immutable Typing
+#### Static Typing and Type-Stable Variables
 
-Noxy is a **statically typed** language with **immutable types**:
+Noxy uses **type-stable variables**: a variable's declared type remains stable,
+while the value stored in it may be mutable.
 
-1. **The type of a variable is defined at declaration and can NEVER be changed.**
+1. **The type of a variable is defined at declaration and cannot be changed.**
 2. Attempts to assign a value of a different type result in a compilation error.
 3. There is no implicit conversion between types (except where explicitly documented).
 
@@ -72,8 +76,10 @@ x = "text"       // ✗ ERROR - cannot assign string to int variable
 
 #### Compile-Time Type Checking
 
-- All type errors are detected **before** execution.
-- The compiler checks compatibility in assignments, function calls, and operations.
+- Outside the explicit dynamic boundaries listed above, type errors are detected
+  **before** execution.
+- The compiler checks compatibility in assignments, exact function calls, and
+  operations. Dynamic boundaries validate the contracts available at runtime.
 
 ### 2.1 Primitive Types
 
@@ -154,6 +160,12 @@ The `ref` operator creates a reference (pointer) to an existing variable.
 You can **ONLY** take a reference of an **addressable value** (L-Value). This means the operand must be a variable, a struct field, or an array/map index.
 **You CANNOT take a reference of a temporary value (R-Value), such as a function call result or a literal.**
 
+Captured variables are addressable through their upvalue storage. Non-null
+literals and plain function-result temporaries are not addressable. A function
+result whose declared type is already `ref T` is a reference value and may be
+passed directly. `null` remains the explicit nullable `ref T` value: it is
+accepted without pretending that it owns a storage slot.
+
 **Correct Usage:**
 ```noxy
 let err: Error = Error("msg")
@@ -217,7 +229,7 @@ Functions can modify external variables through references:
 
 ```noxy
 func double_it(val: ref int)
-    val = val * 2  // UPDATE: writes to original variable
+    *val = val * 2  // UPDATE: writes to original variable
 end
 
 func swap(a: ref int, b: ref int)
@@ -228,7 +240,8 @@ func swap(a: ref int, b: ref int)
 end
 
 let x: int = 10
-double_it(ref x)  // x is now 20
+double_it(x)      // exact signature borrows addressable x; x is now 20
+double_it(ref x)  // explicit reference is also valid; x is now 40
 
 let a: int = 100
 let b: int = 200
@@ -355,6 +368,20 @@ end
 
 Calls through exact types are checked during compilation: arity, argument types, `ref` addressability, and return types must match. Exact signatures are invariant; parameter count, parameter types, `ref` modifiers, and return types must be identical. `null` satisfies `ref`, struct, and `any` contracts, but not primitive value or callable contracts. An omitted return annotation on a function declaration or literal means `void`.
 
+When an exact parameter is `ref T`, an addressable expression of type `T` is
+converted contextually at the call site. Both the concise and explicit forms
+are valid:
+
+```noxy
+let value: int = 10
+double_it(value)       // exact signature borrows addressable value
+double_it(ref value)   // explicit reference is also valid
+```
+
+This contextual conversion is limited to exact script signatures and public
+native contracts known by the compiler. It never applies at a dynamic
+boundary.
+
 Bare `func` is the **dynamic callable type**. It guarantees only that the value is callable:
 
 ```noxy
@@ -367,6 +394,11 @@ Calls through bare `func` are checked by the runtime because their arity and res
 ```noxy
 let callbacks: func[] = [no_arguments, two_arguments]
 ```
+
+Because bare `func` has no exact signature, a reference argument must be
+written explicitly as `ref value`; `dynamic(value)` passes a plain value and
+never infers or manufactures a reference. The same rule applies to untyped
+native primitives, plugins without signatures, and dynamic module members.
 
 Use parentheses for an array whose elements are exact functions. Without parentheses, the array belongs to the return type:
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -154,11 +154,24 @@ Structs are passed by **VALUE** using a shallow copy by default. Direct fields b
 ---
 ### 2.3 The `ref` Operator
 
-The `ref` operator creates a reference (pointer) to an existing variable.
+The `ref` operator produces an explicit first-class reference value according
+to the operand's type:
+
+1. For an addressable operand of type `T`, `ref value` creates a `ref T` that
+   points to that operand's storage.
+2. For an operand whose type is already `ref T`, `ref reference` forwards the
+   existing reference value. Its result remains `ref T`; it does not take the
+   address of the reference variable or create `ref ref T`.
+
+The forwarding form is useful when an existing reference crosses a dynamic
+boundary whose signature is not available for contextual conversion.
 
 #### L-Value Requirement
-You can **ONLY** take a reference of an **addressable value** (L-Value). This means the operand must be a variable, a struct field, or an array/map index.
-**You CANNOT take a reference of a temporary value (R-Value), such as a function call result or a literal.**
+Creating a new reference requires an **addressable value** (L-Value). The
+operand must be a variable, a struct field, or an array/map index. A non-reference
+temporary, such as an ordinary function result or a literal, is not
+addressable. Forwarding an expression that already has type `ref T` does not
+create a new reference and therefore does not require a second storage slot.
 
 Captured variables are addressable through their upvalue storage. Non-null
 literals and plain function-result temporaries are not addressable. A function
@@ -170,6 +183,7 @@ accepted without pretending that it owns a storage slot.
 ```noxy
 let err: Error = Error("msg")
 let r: ref Error = ref err      // OK: 'err' is a variable
+let forwarded: ref Error = ref r // OK: forwards the existing ref Error
 ```
 
 **Incorrect Usage:**
@@ -178,7 +192,9 @@ let r: ref Error = ref Error("msg") // ERROR: Cannot take reference of temporary
 ```
 
 ### 2.3 Reference Semantics (`ref`)
-The `ref` keyword allows creating pointers to existing values. Noxy unifies reference usage through **"Automatic Dereference"** and **"Type-Based Assignment"**.
+The `ref` keyword creates references to addressable values or explicitly
+forwards existing reference values. Noxy unifies reference usage through
+**"Automatic Dereference"** and **"Type-Based Assignment"**.
 
 #### 1. Automatic Dereference (Expressions)
 You can use a reference (`ref T`) in expressions just like a normal value. The compiler automatically assumes you want the **value**.

--- a/docs/REF_SEMANTICS.md
+++ b/docs/REF_SEMANTICS.md
@@ -1,221 +1,145 @@
-# Referências em Noxy: Guia Completo
+# Referências em Noxy
 
-## O que é `ref`?
-
-Em Noxy, `ref` tem dois usos distintos:
-
-1. **Como tipo**: `ref Node` significa "ponteiro para Node"
-2. **Como operador**: `ref x` cria uma referência que permite modificação
-
----
-
-## 1. `ref` como Tipo de Variável
-
-Quando você declara uma variável com tipo `ref Node`, ela armazena um **ponteiro** para um Node:
-
-```noxy
-let current: ref Node = algumNode
-```
-
-Isso significa que `current` contém um **endereço de memória** que aponta para um Node.
-
-### Exemplo Visual
-
-```
-Variável 'current'          Memória
-┌─────────────┐             ┌─────────────────┐
-│ ponteiro ───────────────▶ │ Node            │
-└─────────────┘             │  valor: 20      │
-                            │  proximo: ────────▶ ...
-                            └─────────────────┘
-```
-
----
-
-## 2. `ref` como Parâmetro de Função
-
-Quando um parâmetro é declarado como `ref`, você está permitindo que a função **modifique o valor original** do chamador:
-
-```noxy
-func modificar(n: ref Node)
-    n.valor = 999    // Modifica o Node original ✓
-    n = outroNode    // CUIDADO: Modifica a variável do chamador!
-end
-```
-
-### Diferença Crítica
-
-| Código | Parâmetro `ref` | Variável local `ref Node` |
-|--------|-----------------|---------------------------|
-| `x.campo = val` | Modifica o objeto ✓ | Modifica o objeto ✓ |
-| `x = outro` | **Modifica a variável do chamador!** | Só muda o ponteiro local |
-
----
-
-## 3. Exemplo Prático: O Mito da Destruição
-
-Muitos pensam que como `ref` permite alterar o objeto, reatribuir a variável também altera o chamador. **Isso não é verdade para ponteiros!**
-
-### O que realmente acontece
-
-```noxy
-let global_node: Node = Node(10, null)
-
-func traverse(node: ref Node)
-    // Isso é seguro! 'node' é uma variável local que contém um endereço.
-    // Mudar o endereço que 'node' aponta NÃO muda 'global_node'.
-    while node != null do
-        print(to_str(node.valor))
-        node = node.proximo  // ← Só muda a variável local 'node'
-    end
-end
-
-traverse(ref global_node)
-// global_node continua apontando para o início da lista!
-```
-
-### Então, qual é o risco?
-
-O risco é **confundir o leitor**. Reusar o parâmetro para iterar é má prática, mas não corrompe a memória do chamador.
-
-O **verdadeiro poder (e perigo)** do `ref` é alterar o CONTEÚDO:
-
-```noxy
-func destruir(node: ref Node)
-    // Isso é PERIGOSO. Atribuir um VALOR sobrescreve a memória original!
-    *node = Node(666, null) 
-end
-// global_node agora teria ID 666!
-```
-
----
-
-## 4. Modificando Campos vs Modificando o Ponteiro
-
-A Noxy introduziu uma distinção sintática explícita para evitar ambiguidades:
-
-1.  **Rebind** (`ptr = ref outro`): Muda para ONDE o ponteiro aponta.
-2.  **Update** (`*ptr = valor`): Muda o VALOR no endereço apontado.
-
-### Modificar um campo (Sempre Update se não for ref)
-
-Para campos primitivos, a atribuição é direta e modifica o objeto original (graças ao auto-deref na leitura do ponteiro struct):
-
-```noxy
-func mudar_valor(node: ref Node)
-    node.valor = 999  // OK: Acessa o objeto original e muda o campo
-end
-```
-
-### Modificar o ponteiro (Rebind) vs Sobrescrever (Update)
-
-```noxy
-// 1. REBIND (Mudar a seta)
-func rebind_exemplo(node: ref Node)
-    // Muda a variável LOCAL 'node' para apontar para outro lugar
-    node = Node(999, null)  // ERRO! Não pode atribuir valor a ref.
-    
-    let novo: Node = Node(999, null)
-    node = ref novo // OK: Agora 'node' aponta para 'novo'
-    // O Node original do chamador NÃO foi afetado.
-end
-
-// 2. UPDATE DESTRUTIVO (Mudar o alvo)
-func update_exemplo(node: ref Node)
-    // Usa o asterisco (*) para dizer: "Vá no endereço e escreva lá"
-    *node = Node(999, null)
-    // AGORA o objeto original do chamador FOI DESTRUÍDO/SUBSTITUÍDO!
-end
-```
-
-### Tabela Verdade da Sintaxe
-
-| Sintaxe | Ação | Efeito no Chamador |
-| :--- | :--- | :--- |
-| `r = ref x` | **Rebind** | Nenhum (só muda variável local `r`) |
-| `*r = x` | **Update** | **Destrutivo** (altera memória original) |
-| `r = x` | **Erro** | Proteção contra bugs |
-
----
-
-## 6. Analogia com C
-
-Para quem conhece C, a semântica é similar a:
-
-```c
-// Parâmetro ref em Noxy = ponteiro para ponteiro em C
-void func_ref(Node** node) {
-    *node = (*node)->next;  // Modifica o ponteiro original!
-}
-
-// Variável local ref Node = ponteiro simples em C
-void func_local(Node** node) {
-    Node* current = *node;    // Cópia local do ponteiro
-    current = current->next;  // Só muda o local
-}
-```
-
-## 7. `ref Node` vs `Node` em Variáveis Locais
-
-Uma pergunta comum: posso usar `Node` em vez de `ref Node` para a variável local?
-
-```noxy
-// Opção A: com ref
-let current: ref Node = node
-
-// Opção B: sem ref
-let current: Node = node
-```
-
-### Para reassignação simples: ambos funcionam igual
-
-```noxy
-func teste_com_ref(node: ref Node)
-    let local: ref Node = node
-    local = Node(999, null)  // Não afeta o original
-end
-
-func teste_sem_ref(node: ref Node)
-    let local: Node = node
-    local = Node(888, null)  // Também não afeta o original
-end
-```
-
-### Para traversar linked lists: use `ref Node`
-
-O campo `proximo` é do tipo `ref Node`. Para manter compatibilidade de tipos:
-
-```noxy
-struct Node
-    valor: int,
-    proximo: ref Node  // ← É ref Node!
-end
-
-func traverse(head: ref Node)
-    // CORRETO: tipos compatíveis
-    let current: ref Node = head.proximo
-    while current != null do
-        current = current.proximo  // ref Node = ref Node ✓
-    end
-end
-```
-
-### Regra prática
-
-| Situação | Use |
-|----------|-----|
-| Apenas isolar reassignação | `Node` ou `ref Node` (ambos funcionam) |
-| Traversar estruturas com campos `ref` | `ref Node` (para compatibilidade de tipos) |
-| Modificar campos do objeto | Ambos funcionam (o objeto é o mesmo) |
-
----
+Noxy usa `ref T` para representar uma referência de primeira classe a um valor
+do tipo `T`. Leituras fazem dereference automático, mas escrita e rebind usam
+sintaxes distintas. Assim, o tipo declarado de uma variável permanece estável
+mesmo quando seu valor ou o armazenamento referenciado são mutáveis.
 
 ## Resumo
 
-| Situação | Código | Efeito |
-|----------|--------|--------|
-| Parâmetro `ref`, atribuir campo | `n.valor = x` | Modifica objeto ✓ |
-| Parâmetro `ref`, rebind | `n = ref outro` | Só muda variável local `n` |
-| Parâmetro `ref`, update | `*n = valor` | **Modifica original do chamador!** |
-| Variável local `ref T`, update | `*v = valor` | Modifica objeto apontado ✓ |
-| Variável local `ref T`, rebind | `v = ref outro` | Só muda ponteiro local |
+| Form | Meaning |
+|---|---|
+| `f(value)` where exact parameter is `ref T` | Contextual reference conversion |
+| `ref value` | Create a first-class reference |
+| `*reference = value` | Update referenced storage |
+| `reference = ref other` | Rebind the reference value |
+
+## 1. Conversão contextual em chamadas exatas
+
+Quando a assinatura exata de uma função espera `ref T`, uma expressão
+endereçável do tipo `T` é convertida contextualmente em referência:
+
+```noxy
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+
+let answer: int = 41
+increment(answer)       // empréstimo contextual; answer passa a ser 42
+increment(ref answer)   // a referência explícita também é válida
+```
+
+São endereçáveis variáveis locais e globais, campos de structs, slots de arrays
+e maps e variáveis capturadas. Literais não nulos e temporários comuns
+produzidos por funções não são endereçáveis:
+
+```noxy
+increment(41)          // erro de compilação: not addressable
+increment(make_int())  // erro se make_int() retorna int
+```
+
+Um resultado que já tenha o tipo declarado `ref T` é um valor de referência e
+pode ser passado diretamente. O literal `null` também é aceito como o valor
+nullable explícito de `ref T`; ele não possui nem simula um slot de
+armazenamento.
+
+A conversão contextual só existe quando o compilador conhece a assinatura
+exata, incluindo contratos públicos nativos conhecidos pelo compilador.
+
+## 2. Referências explícitas em fronteiras dinâmicas
+
+`ref value` cria uma referência de primeira classe. Ela pode ser guardada,
+retornada ou passada através de uma fronteira dinâmica.
+
+O tipo bare `func` não contém a assinatura dos parâmetros. Por isso, ele exige
+`ref value` para transportar uma referência; a chamada não infere referências:
+
+```noxy
+let dynamic: func = increment
+let answer: int = 41
+
+dynamic(ref answer) // envia ref int
+dynamic(answer)     // envia int; o runtime rejeita antes de entrar na função
+```
+
+Primitivas nativas sem tipo, plugins sem assinatura e membros de módulo cujo
+tipo exato não é conhecido são fronteiras dinâmicas equivalentes. Também nelas
+a referência deve ser explícita.
+
+Se uma variável já possui tipo `ref T`, a forma explícita encaminha o valor de
+referência existente, sem criar `ref ref T`:
+
+```noxy
+let pointer: ref int = ref answer
+dynamic(ref pointer) // encaminha o mesmo ref int
+```
+
+## 3. Leitura automática
+
+Uma referência usada onde `T` é necessário é lida automaticamente:
+
+```noxy
+let answer: int = 41
+let pointer: ref int = ref answer
+let next: int = pointer + 1
+print(pointer) // 41
+```
+
+O dereference automático vale para expressões e acesso a campos. Ele não muda
+as regras explícitas de escrita.
+
+## 4. Update do armazenamento
+
+`*reference = value` escreve no armazenamento apontado:
+
+```noxy
+func double_it(value: ref int) -> void
+    *value = value * 2
+end
+```
+
+Uma atribuição bare a uma variável `ref T` não atualiza o alvo. Portanto,
+`value = value * 2` é inválido: o lado direito é `T`, mas um rebind requer
+`ref T`.
+
+Campos e índices do valor referenciado continuam usando a sintaxe normal:
+
+```noxy
+func rename(person: ref Person) -> void
+    person.name = "Noxy"
+end
+```
+
+## 5. Rebind da referência
+
+`reference = ref other` troca o alvo armazenado na variável de referência:
+
+```noxy
+let first: int = 10
+let second: int = 20
+let pointer: ref int = ref first
+
+pointer = ref second
+*pointer = 21
+```
+
+O rebind de um parâmetro muda apenas o valor de referência local do parâmetro;
+ele não faz rebind da variável de referência mantida pelo chamador.
+
+## 6. `null` e tempo de vida
+
+`null` é um valor válido de `ref T`. Pode ser armazenado, comparado, retornado
+ou substituído por rebind. Leituras por dereference automático propagam
+`null`; tentar atualizar através de `null` é erro de runtime.
+
+Referências podem escapar por retorno, closure, campo ou global. Quando o alvo
+é uma variável local capturada, a VM usa o armazenamento de upvalue para que a
+referência permaneça válida depois que a função criadora retorna.
+
+## 7. Parâmetros comuns e cópia rasa
+
+Parâmetros sem `ref` mantêm a semântica comum de Noxy. Primitivos são copiados,
+e arrays, maps e structs recebem uma cópia rasa do container superior. Valores
+compostos aninhados continuam compartilhando identidade. Use um parâmetro
+`ref T` quando a função precisar alcançar o armazenamento superior do
+chamador.

--- a/docs/superpowers/plans/2026-08-08-consistent-reference-semantics.md
+++ b/docs/superpowers/plans/2026-08-08-consistent-reference-semantics.md
@@ -1,0 +1,1309 @@
+# Consistent Reference Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Noxy's observed reference-semantics gaps while preserving shallow parameter copies, contextual borrowing for exact calls, and existing valid source syntax.
+
+**Architecture:** Keep the compiler's current exact-call contextual conversion and extend it to captured upvalues and compiler-known public natives. Pair those compiler contracts with runtime native descriptors, while retaining the current Go native ABI and shallow `copyValue` behavior. Add runtime parameter-mode validation shared by script and native calls. Treat untyped native/plugin calls and VM-only descriptors as dynamic boundaries that never infer references.
+
+**Tech Stack:** Go 1.24, Noxy lexer/parser/AST/compiler, bytecode chunk opcodes, stack VM, Go `testing`, Noxy conformance fixtures.
+
+## Global Constraints
+
+- Preserve ordinary composite parameter shallow-copy behavior exactly.
+- Preserve assignment behavior for arrays, maps, and structs.
+- Preserve `increment(value)`, `append(values, item)`, `pop(values)`, `delete(mapping, key)`, and `json_loads(json, target)` for exact/typed calls.
+- Preserve automatic dereference for reads.
+- `*reference = value` updates the target; `reference = ref other` rebinds the reference.
+- Exact user calls and compiler-known public native calls use the same contextual reference conversion.
+- Bare `func`, untyped native primitives, VM-only descriptors, and plugins without signatures never infer references.
+- Do not add `mut`, `readonly`, ownership, borrow checking, deep copy, or copy-on-write.
+- Do not change the Go `NativeFunc func([]Value) Value` ABI.
+- Every behavior change starts with a failing test and ends with focused plus full verification.
+
+## File Map
+
+- `internal/compiler/compiler.go`: exact call lowering, reference-argument diagnostics, `OP_REF_UPVALUE` emission.
+- `internal/compiler/builtin_calls.go`: new focused compiler logic for typed generic mutating builtins.
+- `internal/compiler/function_types_test.go`: compiler conformance and diagnostics.
+- `internal/chunk/chunk.go`: `OP_REF_UPVALUE` declaration, string name, and disassembly.
+- `internal/value/value.go`: runtime parameter type names and optional native signatures.
+- `internal/vm/call_validation.go`: new shared script/native arity and reference-mode validation.
+- `internal/vm/references.go`: new focused reference resolution used by native mutators.
+- `internal/vm/vm.go`: opcode execution, typed native registration, mutating native handlers, call integration.
+- `internal/vm/function_types_test.go`: runtime reference-mode and upvalue conformance.
+- `internal/vm/native_signatures_test.go`: new typed-native contract tests.
+- `docs/NOXY_LANGUAGE_SPEC.md`: normative shallow copy, contextual conversion, dynamic boundaries, update/rebind correction.
+- `docs/REF_SEMANTICS.md`: focused reference guide aligned with compiler behavior.
+- `README.md`: accurate static/dynamic typing wording.
+- `noxy_examples/typed_function_conformance.nx`: positive reference examples.
+- `noxy_examples/type_errors/typed_function_invalid_ref_argument.nx`: non-addressable argument fixture.
+- `CHANGELOG.md`: user-visible fixes and additions.
+
+---
+
+### Task 1: Make reference update diagnostics match the existing semantics
+
+**Files:**
+- Modify: `internal/compiler/function_types_test.go`
+- Modify: `internal/compiler/compiler.go`
+
+**Interfaces:**
+- Consumes: existing local, upvalue, global, field, array-element, and map-value `ref T` assignment handling.
+- Produces: `referenceAssignmentTypeError(name string, expected, actual ast.NoxyType, line int) error`, used whenever plain `T` is assigned to a reference-bearing storage slot.
+
+- [ ] **Step 1: Write the failing compiler diagnostic test**
+
+Add to `internal/compiler/function_types_test.go`:
+
+```go
+func TestReferenceValueAssignmentSuggestsDereference(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func increment(value: ref int) -> void
+    value = value + 1
+end`)
+	if err == nil {
+		t.Fatal("expected reference assignment error")
+	}
+	want := "cannot assign int to ref int"
+	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "use '*value = ...'") {
+		t.Fatalf("error=%q, want %q and dereference hint", err, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test and verify the current generic diagnostic fails it**
+
+Run:
+
+```powershell
+go test ./internal/compiler -run TestReferenceValueAssignmentSuggestsDereference -v
+```
+
+Expected: FAIL because the local parameter path currently reports only `type mismatch in assignment` and lacks the `*value` hint.
+
+- [ ] **Step 3: Add one diagnostic helper and use it for every reference-bearing assignment target**
+
+Add near the compiler type helpers in `internal/compiler/compiler.go`:
+
+```go
+func referenceAssignmentTypeError(line int, name string, expected, actual ast.NoxyType) error {
+	return fmt.Errorf(
+		"[line %d] cannot assign %s to %s\n  hint: use '*%s = ...' to update the referenced value",
+		line, noxyTypeName(actual), noxyTypeName(expected), name,
+	)
+}
+```
+
+In every assignment branch, first preserve compatible `ref T`/`null` rebinds. If the destination type is `ref T` and the RHS is compatible plain `T`, call this helper with the exact source target (`value`, `holder.field`, or `items[index]`). Apply that ordering to locals, captured upvalues, globals, struct fields, array elements, and map values. Preserve the existing strict mismatch diagnostic when the RHS is neither compatible `T`, compatible `ref T`, nor `null`.
+
+Add table-driven cases for a local reference parameter, a global reference variable, and a captured reference parameter. Retain the existing field/index behavior while routing their compatible-value diagnostics through the same helper.
+
+- [ ] **Step 4: Run focused and compiler tests**
+
+Run:
+
+```powershell
+go test ./internal/compiler -run 'TestReferenceValueAssignmentSuggestsDereference|TestExactReferenceCallsCompile' -v
+go test ./internal/compiler
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the diagnostic improvement**
+
+```powershell
+git add internal/compiler/compiler.go internal/compiler/function_types_test.go
+git commit -m "fix: clarify reference update diagnostics"
+```
+
+---
+
+### Task 2: Support contextual references to captured upvalues
+
+**Files:**
+- Modify: `internal/chunk/chunk.go`
+- Modify: `internal/compiler/compiler.go`
+- Modify: `internal/compiler/function_types_test.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/function_types_test.go`
+
+**Interfaces:**
+- Consumes: `Compiler.resolveUpvalue`, `ObjClosure.Upvalues`, `ObjRef{RefType: REF_UPVALUE}`, and existing open/closed `ObjUpvalue` lifetime.
+- Produces: bytecode `OP_REF_UPVALUE <slot>` and runtime construction of an upvalue-backed `VAL_REF`.
+
+- [ ] **Step 1: Write the failing compiler test for captured contextual conversion**
+
+Add to `internal/compiler/function_types_test.go`:
+
+```go
+func TestExactReferenceCallAcceptsCapturedVariable(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+func make_incrementer() -> func() -> int
+    let value: int = 0
+    return func() -> int
+        increment(value)
+        return value
+    end
+end`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+- [ ] **Step 2: Run it and verify the captured-variable restriction fails**
+
+Run:
+
+```powershell
+go test ./internal/compiler -run TestExactReferenceCallAcceptsCapturedVariable -v
+```
+
+Expected: FAIL with `captured variables cannot be passed by reference`.
+
+- [ ] **Step 3: Add `OP_REF_UPVALUE` to the chunk contract**
+
+In `internal/chunk/chunk.go`, insert the opcode beside `OP_REF_LOCAL`:
+
+```go
+OP_REF_LOCAL
+OP_REF_UPVALUE
+OP_REF_GLOBAL
+```
+
+Add its string and disassembly cases:
+
+```go
+case OP_REF_UPVALUE:
+	return "OP_REF_UPVALUE"
+```
+
+```go
+case OP_REF_UPVALUE:
+	return c.byteInstruction("OP_REF_UPVALUE", offset)
+```
+
+- [ ] **Step 4: Emit `OP_REF_UPVALUE` from `compileReferenceArgument`**
+
+Replace the current captured-variable error in `internal/compiler/compiler.go`:
+
+```go
+if upvalue, declared := c.resolveUpvalue(target.Value); upvalue != -1 {
+	if ref, ok := declared.(*ast.RefType); ok {
+		c.emitBytes(byte(chunk.OP_GET_UPVALUE), byte(upvalue))
+		return ref.ElementType, nil
+	}
+	c.emitBytes(byte(chunk.OP_REF_UPVALUE), byte(upvalue))
+	return declared, nil
+}
+```
+
+Apply the same lowering when a prefix expression `ref captured` reaches `compileReferenceArgument`.
+
+- [ ] **Step 5: Execute `OP_REF_UPVALUE` in the VM**
+
+Add beside `OP_REF_LOCAL` in `internal/vm/vm.go`:
+
+```go
+case chunk.OP_REF_UPVALUE:
+	slot := int(c.Code[ip])
+	ip++
+	if slot < 0 || slot >= len(frame.Closure.Upvalues) {
+		return vm.runtimeError(c, ip, "upvalue reference index out of bounds: %d", slot)
+	}
+	vm.push(value.Value{
+		Type: value.VAL_REF,
+		Obj: &value.ObjRef{
+			RefType: value.REF_UPVALUE,
+			Upvalue: frame.Closure.Upvalues[slot],
+		},
+	})
+```
+
+- [ ] **Step 6: Write the failing-then-passing closed-upvalue VM test**
+
+Add to `internal/vm/function_types_test.go`:
+
+```go
+func TestContextualReferenceUpdatesClosedUpvalue(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+func make_incrementer() -> func() -> int
+    let value: int = 40
+    return func() -> int
+        increment(value)
+        return value
+    end
+end
+let incrementer: func() -> int = make_incrementer()
+incrementer()
+test_report(incrementer())`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestExplicitReferenceToClosedUpvalueCanEscape(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func make_reference_factory() -> func() -> ref int
+    let value: int = 41
+    return func() -> ref int
+        return ref value
+    end
+end
+let get_reference: func() -> ref int = make_reference_factory()
+let pointer: ref int = get_reference()
+*pointer = 42
+test_report(pointer)`)
+	testExpectedObject(t, 42, got)
+}
+```
+
+Run before and after the VM opcode implementation:
+
+```powershell
+go test ./internal/vm -run 'TestContextualReferenceUpdatesClosedUpvalue|TestExplicitReferenceToClosedUpvalueCanEscape' -v
+```
+
+Expected before: FAIL with unknown/missing opcode behavior. Expected after: PASS with `42`.
+
+- [ ] **Step 7: Run focused packages and commit**
+
+```powershell
+gofmt -w internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/function_types_test.go internal/vm/vm.go internal/vm/function_types_test.go
+go test ./internal/compiler ./internal/vm
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/function_types_test.go internal/vm/vm.go internal/vm/function_types_test.go
+git commit -m "feat: support references to captured upvalues"
+```
+
+Expected: compiler and VM packages PASS.
+
+---
+
+### Task 3: Validate runtime reference modes and null updates
+
+**Files:**
+- Create: `internal/vm/call_validation.go`
+- Modify: `internal/value/value.go`
+- Modify: `internal/compiler/compiler.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/function_types_test.go`
+
+**Interfaces:**
+- Consumes: `value.ParamInfo`, `ObjFunction.Params`, runtime argument slice.
+- Produces: `validateParameterModes(name string, params []value.ParamInfo, args []value.Value) error`, reused by Task 4 for native descriptors.
+
+- [ ] **Step 1: Store human-readable parameter type names**
+
+Change `ParamInfo` in `internal/value/value.go`:
+
+```go
+type ParamInfo struct {
+	IsRef    bool
+	TypeName string
+}
+```
+
+Update `compileFunction` in `internal/compiler/compiler.go`:
+
+```go
+paramsInfo = append(paramsInfo, value.ParamInfo{
+	IsRef:    isRef,
+	TypeName: param.Type.String(),
+})
+```
+
+- [ ] **Step 2: Write dynamic-mode tests**
+
+Add a helper to `internal/vm/function_types_test.go` that compiles and returns the VM error instead of failing immediately:
+
+```go
+func runTypedFunctionProgramError(t *testing.T, input string) error {
+	t.Helper()
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	bytecode, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+	return New().Interpret(bytecode)
+}
+```
+
+Add:
+
+```go
+func TestDynamicCallRejectsPlainValueForReferenceParameter(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func increment(value: ref int) -> void
+    return
+end
+let dynamic: func = increment
+let answer: int = 41
+dynamic(answer)`)
+	if err == nil || !strings.Contains(err.Error(), "argument 1: expected ref int, got int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDynamicCallRejectsReferenceForValueParameter(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func consume(value: int) -> void
+    return
+end
+let dynamic: func = consume
+let answer: int = 41
+dynamic(ref answer)`)
+	if err == nil || !strings.Contains(err.Error(), "argument 1: expected int, got ref") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDynamicReferenceParameterAcceptsNull(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func consume(value: ref int) -> void
+    return
+end
+let dynamic: func = consume
+dynamic(null)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdatingNullReferenceFailsClearly(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+let pointer: ref int = null
+*pointer = 1`)
+	if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
+		t.Fatalf("error=%v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify at least one current behavior lacks the pre-frame contract**
+
+```powershell
+go test ./internal/vm -run 'TestDynamicCallRejectsPlainValueForReferenceParameter|TestDynamicCallRejectsReferenceForValueParameter|TestDynamicReferenceParameterAcceptsNull|TestUpdatingNullReferenceFailsClearly' -v
+```
+
+Expected: FAIL because `call` currently copies/skips copying without validating actual reference mode or producing these diagnostics.
+
+- [ ] **Step 4: Implement shared mode validation**
+
+Create `internal/vm/call_validation.go`:
+
+```go
+package vm
+
+import (
+	"fmt"
+	"noxy-vm/internal/value"
+)
+
+func runtimeValueMode(v value.Value) string {
+	switch v.Type {
+	case value.VAL_BOOL:
+		return "bool"
+	case value.VAL_NULL:
+		return "null"
+	case value.VAL_INT:
+		return "int"
+	case value.VAL_FLOAT:
+		return "float"
+	case value.VAL_OBJ:
+		return "object"
+	case value.VAL_FUNCTION:
+		return "func"
+	case value.VAL_NATIVE:
+		return "native"
+	case value.VAL_BYTES:
+		return "bytes"
+	case value.VAL_CHANNEL:
+		return "chan"
+	case value.VAL_WAITGROUP:
+		return "waitgroup"
+	case value.VAL_REF:
+		return "ref"
+	default:
+		return "unknown"
+	}
+}
+
+func validateParameterModes(name string, params []value.ParamInfo, args []value.Value) error {
+	for i, param := range params {
+		if i >= len(args) {
+			break
+		}
+		actual := args[i]
+		if param.IsRef && actual.Type != value.VAL_REF && actual.Type != value.VAL_NULL {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got %s", name, i+1, param.TypeName, runtimeValueMode(actual))
+		}
+		if !param.IsRef && actual.Type == value.VAL_REF {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got ref", name, i+1, param.TypeName)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Call validation before shallow-copy preparation**
+
+In `VM.call`, build the argument slice before the copy loop:
+
+```go
+baseArgs := vm.stackTop - argCount
+args := vm.stack[baseArgs:vm.stackTop]
+if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
+	return false, vm.runtimeError(c, ip, "%s", err)
+}
+```
+
+Keep the existing non-reference `copyValue` loop unchanged after validation.
+
+In the `OP_STORE_REF` handler, distinguish the nullable reference value before the generic non-reference error:
+
+```go
+if refVal.Type == value.VAL_NULL {
+	return vm.runtimeError(c, ip, "cannot update null reference")
+}
+if refVal.Type != value.VAL_REF {
+	return vm.runtimeError(c, ip, "cannot store via non-reference value")
+}
+```
+
+Do not change `OP_DEREF` null propagation; nullable reference reads and comparisons continue to produce `null`.
+
+- [ ] **Step 6: Run tests and commit**
+
+```powershell
+gofmt -w internal/value/value.go internal/compiler/compiler.go internal/vm/call_validation.go internal/vm/vm.go internal/vm/function_types_test.go
+go test ./internal/compiler ./internal/vm
+git add internal/value/value.go internal/compiler/compiler.go internal/vm/call_validation.go internal/vm/vm.go internal/vm/function_types_test.go
+git commit -m "feat: validate runtime reference boundaries"
+```
+
+Expected: PASS, including the existing explicit dynamic reference test.
+
+---
+
+### Task 4: Add typed native descriptors and pre-invocation validation
+
+**Files:**
+- Modify: `internal/value/value.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/call_validation.go`
+- Create: `internal/vm/native_signatures_test.go`
+
+**Interfaces:**
+- Consumes: Task 3 `value.ParamInfo` and `validateParameterModes`.
+- Produces: `value.NativeSignature`, `value.NewNativeWithSignature`, and `VM.DefineNativeWithSignature` for Task 5.
+
+- [ ] **Step 1: Write failing typed-native validation tests**
+
+Create `internal/vm/native_signatures_test.go` with a helper that compiles dynamic native calls and registers a descriptor:
+
+```go
+package vm
+
+import (
+	"strings"
+	"testing"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+	"noxy-vm/internal/value"
+)
+
+func runWithTypedTestNative(t *testing.T, input string, sig value.NativeSignature, called *bool) error {
+	t.Helper()
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+	machine := New()
+	machine.DefineNativeWithSignature("typed_test", sig, func(args []value.Value) value.Value {
+		*called = true
+		return value.NewNull()
+	})
+	return machine.Interpret(code)
+}
+
+func TestTypedNativeRejectsModeBeforeInvocation(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{
+		Arity: 1,
+		Params: []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "void",
+	}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(n)", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "expected ref int") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after contract failure")
+	}
+}
+```
+
+- [ ] **Step 2: Run and verify missing descriptor APIs fail compilation**
+
+```powershell
+go test ./internal/vm -run TestTypedNativeRejectsModeBeforeInvocation -v
+```
+
+Expected: build FAIL because `NativeSignature` and `DefineNativeWithSignature` do not exist.
+
+- [ ] **Step 3: Add optional signatures to native values**
+
+In `internal/value/value.go`:
+
+```go
+type NativeSignature struct {
+	Arity      int
+	Variadic   bool
+	Params     []ParamInfo
+	ReturnType string
+}
+
+type ObjNative struct {
+	Name      string
+	Fn        NativeFunc
+	Signature *NativeSignature
+}
+
+func NewNativeWithSignature(name string, signature NativeSignature, fn NativeFunc) Value {
+	return Value{
+		Type: VAL_NATIVE,
+		Obj: &ObjNative{Name: name, Fn: fn, Signature: &signature},
+	}
+}
+```
+
+Keep `NewNative` creating `Signature: nil` for dynamic internal natives.
+
+- [ ] **Step 4: Register and validate typed natives**
+
+Add to `internal/vm/vm.go`:
+
+```go
+func (vm *VM) DefineNativeWithSignature(name string, signature value.NativeSignature, fn value.NativeFunc) {
+	if _, ok := vm.GetGlobal(name); ok {
+		return
+	}
+	vm.SetGlobal(name, value.NewNativeWithSignature(name, signature, fn))
+}
+```
+
+In the native branch of `callValue`, validate arity and modes before `native.Fn(args)`. For a typed native, copy ordinary arguments with the same shallow-copy operation used by script functions; pass reference arguments unchanged. Untyped internal natives retain their current raw boundary:
+
+```go
+if native.Signature != nil {
+	sig := native.Signature
+	if !sig.Variadic && argCount != sig.Arity {
+		return false, vm.runtimeError(c, ip, "native '%s' expects %d arguments, got %d", native.Name, sig.Arity, argCount)
+	}
+	if sig.Variadic && argCount < sig.Arity {
+		return false, vm.runtimeError(c, ip, "native '%s' expects at least %d arguments, got %d", native.Name, sig.Arity, argCount)
+	}
+	params := sig.Params
+	if sig.Variadic && len(params) > 0 && argCount > len(params) {
+		expanded := make([]value.ParamInfo, argCount)
+		copy(expanded, params)
+		for i := len(params); i < argCount; i++ {
+			expanded[i] = params[len(params)-1]
+		}
+		params = expanded
+	}
+	if err := validateParameterModes(native.Name, params, args); err != nil {
+		return false, vm.runtimeError(c, ip, "%s", err)
+	}
+	callArgs := make([]value.Value, len(args))
+	copy(callArgs, args)
+	for i, param := range params {
+		if i >= len(callArgs) {
+			break
+		}
+		if !param.IsRef {
+			callArgs[i] = vm.copyValue(callArgs[i])
+		}
+	}
+	args = callArgs
+}
+```
+
+- [ ] **Step 5: Add success, arity, ordinary-ref rejection, and shallow-copy cases**
+
+Extend `internal/vm/native_signatures_test.go`:
+
+```go
+func TestTypedNativeAcceptsExplicitReference(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{IsRef: true, TypeName: "ref int"}}, ReturnType: "void"}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(ref n)", sig, &called)
+	if err != nil || !called {
+		t.Fatalf("called=%v error=%v", called, err)
+	}
+}
+```
+
+Add equivalent assertions for incorrect exact arity, fewer-than-minimum variadic arity, and passing `ref n` to `ParamInfo{IsRef:false, TypeName:"int"}`. Add this test to prove that a typed native receives an ordinary composite with the same shallow pass-by-value behavior as a script function:
+
+```go
+func TestTypedNativeShallowCopiesOrdinaryComposite(t *testing.T) {
+	source := "let values: int[] = [1]\ntyped_test(values)"
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := New()
+	machine.DefineNativeWithSignature("typed_test", value.NativeSignature{
+		Arity: 1,
+		Params: []value.ParamInfo{{IsRef: false, TypeName: "int[]"}},
+		ReturnType: "void",
+	}, func(args []value.Value) value.Value {
+		args[0].Obj.(*value.ObjArray).Elements[0] = value.NewInt(9)
+		return value.NewNull()
+	})
+	if err := machine.Interpret(code); err != nil {
+		t.Fatal(err)
+	}
+	global, ok := machine.GetGlobal("values")
+	if !ok {
+		t.Fatal("missing values global")
+	}
+	if got := global.Obj.(*value.ObjArray).Elements[0].AsInt; got != 1 {
+		t.Fatalf("caller value=%d, want 1", got)
+	}
+}
+```
+
+- [ ] **Step 6: Run tests and commit**
+
+```powershell
+gofmt -w internal/value/value.go internal/vm/vm.go internal/vm/call_validation.go internal/vm/native_signatures_test.go
+go test ./internal/vm
+git add internal/value/value.go internal/vm/vm.go internal/vm/call_validation.go internal/vm/native_signatures_test.go
+git commit -m "feat: validate typed native contracts"
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Give mutating builtins exact contextual-reference behavior
+
+**Files:**
+- Create: `internal/compiler/builtin_calls.go`
+- Create: `internal/compiler/builtin_calls_test.go`
+- Modify: `internal/compiler/compiler.go`
+- Create: `internal/vm/references.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/native_signatures_test.go`
+
+**Interfaces:**
+- Consumes: `Compiler.compileReferenceArgument`, Task 4 typed native descriptors, and existing `ObjRef` variants.
+- Produces: `compileBuiltinCall(*ast.CallExpression) (handled bool, result ast.NoxyType, err error)` and `VM.resolveReferenceValue(value.Value) (value.Value, error)`.
+
+- [ ] **Step 1: Write compiler tests that preserve existing builtin syntax**
+
+Create `internal/compiler/builtin_calls_test.go`:
+
+```go
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMutatingBuiltinsBorrowAddressableArguments(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let values: int[] = [1]
+let mapping: map[string, int] = {"a": 1}
+append(values, 2)
+let removed: int = pop(values)
+delete(mapping, "a")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMutatingBuiltinsRejectNonAddressableArguments(t *testing.T) {
+	_, err := compileFunctionSource(t, `append([1], 2)`)
+	if err == nil || !strings.Contains(err.Error(), "not addressable") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAppendChecksElementType(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let values: int[] = [1]
+append(values, "wrong")`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run and verify generic native calls lack these static contracts**
+
+```powershell
+go test ./internal/compiler -run 'TestMutatingBuiltins' -v
+```
+
+Expected: FAIL for non-addressable/type-check cases because these identifiers currently cross an untyped native boundary.
+
+- [ ] **Step 3: Add focused builtin call compilation**
+
+First, change the default branch of `compileReferenceArgument` to use a stable addressability diagnostic:
+
+```go
+return nil, fmt.Errorf(
+	"[line %d] reference argument '%s' is not addressable\n  hint: use a variable, property, index, or null",
+	c.currentLine, expression.String(),
+)
+```
+
+Then create `internal/compiler/builtin_calls.go` with this complete lowering for `append`, `pop`, `delete`, and `json_loads`:
+
+```go
+package compiler
+
+import (
+	"fmt"
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+)
+
+func builtinType(name string) ast.NoxyType {
+	return &ast.PrimitiveType{Name: name}
+}
+
+func (c *Compiler) compileBuiltinValueArgument(expression ast.Expression) (ast.NoxyType, error) {
+	_, actual, err := c.Compile(expression)
+	if err != nil {
+		return nil, err
+	}
+	if ref, ok := actual.(*ast.RefType); ok {
+		c.emitByte(byte(chunk.OP_DEREF))
+		return ref.ElementType, nil
+	}
+	return actual, nil
+}
+
+func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyType, error) {
+	ident, ok := call.Function.(*ast.Identifier)
+	if !ok {
+		return false, nil, nil
+	}
+	name := ident.Value
+	if name != "append" && name != "pop" && name != "delete" && name != "json_loads" {
+		return false, nil, nil
+	}
+	if slot, _ := c.resolveLocal(name); slot != -1 {
+		return false, nil, nil
+	}
+	if _, declared := c.resolveGlobalType(name); declared {
+		return false, nil, nil
+	}
+
+	wantArity := map[string]int{"append": 2, "pop": 1, "delete": 2, "json_loads": 2}[name]
+	if len(call.Arguments) != wantArity {
+		return true, nil, fmt.Errorf(
+			"[line %d] %s expects %d arguments, got %d",
+			c.currentLine, name, wantArity, len(call.Arguments),
+		)
+	}
+	if _, _, err := c.Compile(call.Function); err != nil {
+		return true, nil, err
+	}
+
+	switch ident.Value {
+	case "append":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		array, ok := container.(*ast.ArrayType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] append expects an array, got %s", c.currentLine, noxyTypeName(container))
+		}
+		item, err := c.compileBuiltinValueArgument(call.Arguments[1])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(array.ElementType, item) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 2 to 'append': expected %s, got %s",
+				c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
+			)
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("void"), nil
+	case "pop":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		array, ok := container.(*ast.ArrayType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] pop expects an array, got %s", c.currentLine, noxyTypeName(container))
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 1)
+		return true, array.ElementType, nil
+	case "delete":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		mapping, ok := container.(*ast.MapType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] delete expects a map, got %s", c.currentLine, noxyTypeName(container))
+		}
+		key, err := c.compileBuiltinValueArgument(call.Arguments[1])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(mapping.KeyType, key) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 2 to 'delete': expected %s, got %s",
+				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
+			)
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("void"), nil
+	case "json_loads":
+		jsonText, err := c.compileBuiltinValueArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(builtinType("string"), jsonText) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 1 to 'json_loads': expected string, got %s",
+				c.currentLine, noxyTypeName(jsonText),
+			)
+		}
+		if _, err := c.compileReferenceArgument(call.Arguments[1]); err != nil {
+			return true, nil, err
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("bool"), nil
+	default:
+		return false, nil, nil
+	}
+}
+```
+
+Call the helper at the start of the `ast.CallExpression` branch, before generic native/dynamic handling:
+
+```go
+if handled, resultType, err := c.compileBuiltinCall(n); handled {
+	return c.currentChunk, resultType, err
+}
+```
+
+Add `TestMutatingBuiltinNamesCanBeShadowed` to define a user function named `append` and verify its declared signature takes precedence over builtin lowering.
+
+- [ ] **Step 4: Write VM tests showing builtin mutation still reaches the caller**
+
+Add to `internal/vm/native_signatures_test.go`:
+
+```go
+func TestTypedMutatingBuiltinsPreserveSourceSyntax(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let values: int[] = [1]
+append(values, 2)
+let removed: int = pop(values)
+test_report(length(values) * 10 + removed)`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedDeleteMutatesCallerMap(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let mapping: map[string, int] = {"a": 1}
+delete(mapping, "a")
+test_report(length(keys(mapping)))`)
+	testExpectedObject(t, 0, got)
+}
+
+func TestTypedJSONLoadsPopulatesCallerTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: map[string, int] = {"old": 0}
+let ok: bool = json_loads("{\"answer\":42}", target)
+test_report(target["answer"])`)
+	testExpectedObject(t, 42, got)
+}
+```
+
+Run now:
+
+```powershell
+go test ./internal/vm -run 'TestTypedMutatingBuiltinsPreserveSourceSyntax|TestTypedDeleteMutatesCallerMap|TestTypedJSONLoadsPopulatesCallerTarget' -v
+```
+
+Expected after compiler lowering but before native changes: FAIL because the native receives `VAL_REF` instead of `VAL_OBJ`.
+
+- [ ] **Step 5: Add centralized native reference resolution**
+
+Create `internal/vm/references.go`:
+
+```go
+package vm
+
+import (
+	"fmt"
+	"noxy-vm/internal/value"
+)
+
+func referenceMapKey(index value.Value) (interface{}, bool) {
+	switch index.Type {
+	case value.VAL_INT:
+		return index.AsInt, true
+	case value.VAL_OBJ:
+		key, ok := index.Obj.(string)
+		return key, ok
+	default:
+		return nil, false
+	}
+}
+
+func (vm *VM) resolveReferenceValue(input value.Value) (value.Value, error) {
+	if input.Type == value.VAL_NULL {
+		return value.Value{}, fmt.Errorf("cannot dereference null reference")
+	}
+	if input.Type != value.VAL_REF {
+		return value.Value{}, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
+	}
+	ref := input.Obj.(*value.ObjRef)
+	switch ref.RefType {
+	case value.REF_GLOBAL:
+		if vm.currentFrame != nil && vm.currentFrame.Globals != nil {
+			if result, ok := vm.currentFrame.Globals[ref.Name]; ok {
+				return result, nil
+			}
+		}
+		if result, ok := vm.GetGlobal(ref.Name); ok {
+			return result, nil
+		}
+	case value.REF_UPVALUE:
+		return *ref.Upvalue.Location, nil
+	case value.REF_PTR:
+		return *ref.Ptr, nil
+	case value.REF_PROPERTY:
+		if instance, ok := ref.Container.Obj.(*value.ObjInstance); ok {
+			return instance.Fields[ref.Name], nil
+		}
+	case value.REF_INDEX:
+		if array, ok := ref.Container.Obj.(*value.ObjArray); ok {
+			if ref.Index.Type != value.VAL_INT {
+				return value.Value{}, fmt.Errorf("array reference index must be int")
+			}
+			index := int(ref.Index.AsInt)
+			if index >= 0 && index < len(array.Elements) {
+				return array.Elements[index], nil
+			}
+			return value.Value{}, fmt.Errorf("array reference index out of bounds")
+		}
+		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ok {
+			key, ok := referenceMapKey(ref.Index)
+			if !ok {
+				return value.Value{}, fmt.Errorf("map reference key must be int or string")
+			}
+			result, ok := mapping.Data[key]
+			if !ok {
+				return value.Value{}, fmt.Errorf("map reference key not found")
+			}
+			return result, nil
+		}
+	}
+	return value.Value{}, fmt.Errorf("invalid reference target")
+}
+```
+
+- [ ] **Step 6: Register and update the four mutating natives**
+
+Change their registrations in `internal/vm/vm.go` to `DefineNativeWithSignature` with these exact descriptors:
+
+```go
+appendSignature := value.NativeSignature{
+	Arity: 2,
+	Params: []value.ParamInfo{
+		{IsRef: true, TypeName: "ref array"},
+		{IsRef: false, TypeName: "any"},
+	},
+	ReturnType: "void",
+}
+
+popSignature := value.NativeSignature{
+	Arity: 1,
+	Params: []value.ParamInfo{
+		{IsRef: true, TypeName: "ref array"},
+	},
+	ReturnType: "any",
+}
+
+deleteSignature := value.NativeSignature{
+	Arity: 2,
+	Params: []value.ParamInfo{
+		{IsRef: true, TypeName: "ref map"},
+		{IsRef: false, TypeName: "any"},
+	},
+	ReturnType: "void",
+}
+
+jsonLoadsSignature := value.NativeSignature{
+	Arity: 2,
+	Params: []value.ParamInfo{
+		{IsRef: false, TypeName: "string"},
+		{IsRef: true, TypeName: "ref any"},
+	},
+	ReturnType: "bool",
+}
+```
+
+Pass the corresponding descriptor to each registration. At the start of `append`, `pop`, and `delete`, resolve `args[0]`:
+
+```go
+arrVal, err := vm.resolveReferenceValue(args[0])
+if err != nil {
+	return value.NewNull()
+}
+```
+
+Keep passing `json_loads` argument 2 directly to the existing `populateTarget` function because that path already consumes `VAL_REF` and writes through every supported reference target. Descriptor validation guarantees reference mode; the focused compiler lowering guarantees exact static types. Preserve existing domain return conventions (`null` for failed collection operations and `false` for failed JSON population).
+
+- [ ] **Step 7: Run focused/full tests and commit**
+
+```powershell
+gofmt -w internal/compiler/builtin_calls.go internal/compiler/builtin_calls_test.go internal/compiler/compiler.go internal/vm/references.go internal/vm/vm.go internal/vm/native_signatures_test.go
+go test ./internal/compiler ./internal/vm
+go test ./...
+git add internal/compiler/builtin_calls.go internal/compiler/builtin_calls_test.go internal/compiler/compiler.go internal/vm/references.go internal/vm/vm.go internal/vm/native_signatures_test.go
+git commit -m "feat: type mutating native builtins"
+```
+
+Expected: all tests PASS and existing builtin call syntax remains unchanged.
+
+---
+
+### Task 6: Align language documentation and conformance fixtures
+
+**Files:**
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `docs/REF_SEMANTICS.md`
+- Modify: `README.md`
+- Modify: `noxy_examples/typed_function_conformance.nx`
+- Modify: `noxy_examples/type_errors/typed_function_invalid_ref_argument.nx`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: final compiler/VM behavior from Tasks 1-5.
+- Produces: normative user documentation and runnable positive/negative examples.
+
+- [ ] **Step 1: Correct update/rebind examples in the language spec**
+
+Replace the invalid example:
+
+```diff
+ func double_it(val: ref int)
+-    val = val * 2
++    *val = val * 2
+ end
+```
+
+Add the normative contextual-call rule:
+
+```noxy
+let value: int = 10
+double_it(value)       // exact signature borrows addressable value
+double_it(ref value)   // explicit reference is also valid
+```
+
+State that non-null literals and plain function-result temporaries are not addressable. `null` remains the explicit nullable `ref T` value and is accepted without pretending that it has a storage slot.
+
+- [ ] **Step 2: Rewrite the focused reference guide around three operations**
+
+Ensure `docs/REF_SEMANTICS.md` contains this exact summary table:
+
+```markdown
+| Form | Meaning |
+|---|---|
+| `f(value)` where exact parameter is `ref T` | Contextual reference conversion |
+| `ref value` | Create a first-class reference |
+| `*reference = value` | Update referenced storage |
+| `reference = ref other` | Rebind the reference value |
+```
+
+Document that bare `func` requires `ref value` because its signature is dynamic.
+
+- [ ] **Step 3: Correct the static typing claim**
+
+In `docs/NOXY_LANGUAGE_SPEC.md` and `README.md`, use:
+
+```markdown
+Noxy is statically typed, with explicit dynamic boundaries through `any`, bare
+`func`, untyped native primitives, and plugins without signatures.
+```
+
+Replace “immutable types” with “type-stable variables” and explain that the declared type is stable while values may be mutable.
+
+- [ ] **Step 4: Expand positive and negative fixtures**
+
+In `noxy_examples/typed_function_conformance.nx`, retain `increment(answer)` and add:
+
+```noxy
+func make_counter() -> func() -> int
+    let count: int = 40
+    return func() -> int
+        increment(count)
+        return count
+    end
+end
+
+let counter: func() -> int = make_counter()
+assert(counter() == 41, "first captured ref update must produce 41")
+assert(counter() == 42, "second captured ref update must produce 42")
+```
+
+Keep `noxy_examples/type_errors/typed_function_invalid_ref_argument.nx` as:
+
+```noxy
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+
+increment(41)
+```
+
+Expected diagnostic must include `not addressable`.
+
+- [ ] **Step 5: Update changelog**
+
+Add under a new unreleased section:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- Typed public native contracts and runtime reference-mode validation.
+- Safe references to captured upvalues.
+
+### Fixed
+
+- Reference documentation now distinguishes contextual passing, update, and rebind.
+- Dynamic calls reject incompatible reference modes before entering the callee.
+```
+
+- [ ] **Step 6: Run documentation-backed conformance tests and commit**
+
+```powershell
+go test ./internal/compiler ./internal/vm
+go run cmd/noxy/main.go noxy_examples/typed_function_conformance.nx
+go run cmd/noxy/main.go noxy_examples/type_errors/typed_function_invalid_ref_argument.nx
+```
+
+Expected: positive fixture prints `typed function conformance: PASS`; negative fixture exits non-zero with `not addressable`.
+
+```powershell
+git add docs/NOXY_LANGUAGE_SPEC.md docs/REF_SEMANTICS.md README.md noxy_examples/typed_function_conformance.nx noxy_examples/type_errors/typed_function_invalid_ref_argument.nx CHANGELOG.md
+git commit -m "docs: specify contextual reference semantics"
+```
+
+---
+
+### Task 7: Run full verification and close migration gaps
+
+**Files:**
+- Modify only files revealed by verification failures, within the approved reference/native scope.
+
+**Interfaces:**
+- Consumes: all earlier tasks.
+- Produces: a clean branch whose unit, integration, build, formatting, and vet checks pass.
+
+- [ ] **Step 1: Format all changed Go files**
+
+```powershell
+gofmt -w internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/builtin_calls.go internal/compiler/builtin_calls_test.go internal/compiler/function_types_test.go internal/value/value.go internal/vm/call_validation.go internal/vm/references.go internal/vm/vm.go internal/vm/function_types_test.go internal/vm/native_signatures_test.go
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run all Go tests**
+
+```powershell
+go test ./...
+```
+
+Expected: PASS for every package.
+
+- [ ] **Step 3: Run race-enabled reference tests**
+
+```powershell
+go test -race ./internal/compiler ./internal/vm
+```
+
+Expected: PASS with no race report. If the installed Windows Go toolchain cannot build `runtime/race`, record that environment limitation and do not claim race verification.
+
+- [ ] **Step 4: Build the CLI used by the integration runner**
+
+```powershell
+go build -o noxy.exe ./cmd/noxy
+```
+
+Expected: `noxy.exe` is produced and exits successfully for a simple example.
+
+- [ ] **Step 5: Run the required concurrent Noxy suite**
+
+```powershell
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Expected: final report contains `Falhou: 0` and `TODOS TESTES PASSARAM.`
+
+- [ ] **Step 6: Run build and vet gates**
+
+```powershell
+go build ./...
+go vet ./...
+```
+
+Expected: both commands exit 0 with no diagnostics.
+
+- [ ] **Step 7: Inspect the final diff and route failures back to their owning task**
+
+```powershell
+git diff --check
+git status --short
+git diff --stat develop...HEAD
+```
+
+Expected: no whitespace errors; only approved source, test, fixture, and documentation files differ.
+
+If verification exposes a defect, return to the task that owns the affected file, add a focused regression test, implement the smallest in-scope correction, rerun that task's focused commands, and then repeat Steps 1-7. Do not create a generic verification-only commit.
+
+- [ ] **Step 8: Record final evidence**
+
+Capture the exact successful outputs for `go test ./...`, the concurrent Noxy suite, `go build ./...`, and `go vet ./...` in the handoff. Do not claim race validation if Step 3 was unavailable.

--- a/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
@@ -1,6 +1,6 @@
 # Consistent Reference Semantics Design
 
-**Status:** Revised draft for user review
+**Status:** Approved for implementation
 **Branch:** `feat/consistent-reference-semantics`
 
 ## Summary
@@ -91,7 +91,7 @@ Returning a composite adds no new implicit copy. A non-reference parameter has a
 
 ### 2.1 Exact reference parameters
 
-When an exact signature expects `ref T`, an addressable expression of type `T` is borrowed for the duration of the call.
+When an exact signature expects `ref T`, an addressable expression of type `T` is converted contextually to a reference argument at the call site. The reference is not lifetime-limited to the call and may escape under the rules in Section 2.3.
 
 ```noxy
 func increment(value: ref int) -> void
@@ -184,7 +184,7 @@ Rebinding a reference parameter changes only the parameter's local reference val
 
 ### 3.4 Null
 
-`null` remains a valid `ref T` value. It has no target and may be stored, compared, returned, or rebound. Dereferencing it is a runtime error.
+`null` remains a valid `ref T` value. It has no target and may be stored, compared, returned, or rebound. Reading through automatic dereference propagates `null`, which keeps nullable-reference comparisons usable. Updating through `null` is a runtime error.
 
 A field or index slot whose stored reference is currently `null` remains addressable; a contextual borrow can pass that slot so the callee may fill it. The literal `null` itself has no addressable slot.
 
@@ -244,15 +244,15 @@ Public native APIs receive descriptors containing:
 
 - name;
 - arity and variadic behavior;
-- parameter types or compiler-recognized generic constraints;
+- parameter type names for diagnostics;
 - parameter reference modes;
 - return type.
 
-The Go `NativeFunc` ABI remains unchanged. The descriptor validates the public contract before invoking the Go closure.
+The Go `NativeFunc` ABI remains unchanged. The VM descriptor validates arity and reference modes before invoking the Go closure. Exact static type validation belongs to a compiler-visible signature or typed `.nx` wrapper; the native implementation retains its domain validation at a dynamic boundary.
 
 ### 6.2 Same contextual rule
 
-An exact public native signature uses the same contextual borrowing rule as an exact Noxy function.
+A compiler-visible public native signature uses the same contextual borrowing rule as an exact Noxy function. The runtime descriptor and the compiler signature are paired parts of one public contract; a descriptor registered only inside the VM cannot retroactively give the compiler exact call-site information.
 
 Conceptual builtin signatures:
 
@@ -272,7 +272,7 @@ delete(mapping, key)
 json_loads(json, target)
 ```
 
-Because the signatures are exact, the compiler borrows the addressable arguments contextually. These builtins no longer depend on an undocumented native exception.
+Because these signatures are known by the compiler, it borrows the addressable arguments contextually. Their matching VM descriptors verify the reference modes again before native execution. These builtins no longer depend on an undocumented native exception.
 
 Generic collection builtins remain compiler-recognized because Noxy does not yet expose user-defined generics.
 
@@ -284,13 +284,13 @@ Identity-bearing channels, wait groups, files, sockets, statements, and database
 
 ### 6.4 Stdlib and internal primitives
 
-Public stdlib APIs must be typed `.nx` wrappers or typed native descriptors. Raw implementation primitives remain dynamic internals and are not documented public APIs.
+Public stdlib APIs must be typed `.nx` wrappers or paired compiler/VM native contracts. Raw implementation primitives and VM-only descriptors remain dynamic internals and are not documented public APIs.
 
-Enforcing module-private native visibility is desirable but is a separate module-system change. Until then, direct calls to raw primitives are documented dynamic boundaries and receive runtime validation only.
+Enforcing module-private native visibility is desirable but is a separate module-system change. Until then, direct calls to raw primitives are documented dynamic boundaries and receive only the runtime checks implemented by those primitives; they never gain contextual borrowing.
 
 ### 6.5 Contract errors
 
-Descriptor-level arity, reference-mode, and type failures become VM runtime errors and never invoke the native closure. Domain errors may continue using existing Noxy `Result` contracts. Replacing every legacy `null` error convention is outside this feature.
+Descriptor-level arity and reference-mode failures become VM runtime errors and never invoke the native closure. Compiler-visible contracts reject exact type mismatches at compile time. Native domain errors may continue using existing Noxy `Result` contracts. Replacing every legacy `null` error convention is outside this feature.
 
 ## 7. Static and Dynamic Boundaries
 
@@ -306,7 +306,7 @@ Normative rules:
 - concrete values widen to `any`;
 - `any` does not narrow implicitly to concrete or exact callable types;
 - dynamic boundaries validate what is known at runtime and never manufacture references;
-- plugin exports with signature metadata follow exact-call rules; other plugin exports remain dynamic.
+- current plugin exports remain dynamic and never receive contextual borrowing; adding compiler-visible plugin signatures is separate work.
 
 The misleading phrase "immutable types" will be replaced by "type-stable variables": a variable's declared type does not change, although values may be mutable.
 
@@ -315,8 +315,8 @@ The misleading phrase "immutable types" will be replaced by "type-stable variabl
 Required compile-time diagnostics include:
 
 ```text
-argument 1 to 'increment' expects ref int, but 41 is not addressable
-hint: store the value in a variable before passing it
+reference argument '41' is not addressable
+hint: use a variable, property, index, or null
 ```
 
 ```text
@@ -327,11 +327,11 @@ hint: use '*value = ...' to update the referenced value
 Required runtime diagnostics include:
 
 ```text
-function 'increment' argument 1: expected a reference value, got int
+function 'increment' argument 1: expected ref int, got int
 ```
 
 ```text
-cannot dereference null reference
+cannot update null reference
 ```
 
 ## 9. Compatibility
@@ -361,7 +361,7 @@ No compatibility flag or mass source migration is required.
 
 - Preserve contextual borrowing for exact `ref T` parameters.
 - Preserve direct passing of existing reference values.
-- Add contextual borrowing for typed public natives.
+- Add contextual borrowing for compiler-known public natives.
 - Add `OP_REF_UPVALUE` generation.
 - Improve diagnostics for non-addressable reference arguments and invalid ref assignment.
 
@@ -386,14 +386,14 @@ No compatibility flag or mass source migration is required.
 - explicit and existing references still work;
 - literals and non-reference temporaries are rejected;
 - update and rebind diagnostics are distinct;
-- native signatures apply the same contextual rules;
+- compiler-known native signatures apply the same contextual rules;
 - exact-call return propagation remains unchanged.
 
 ### VM tests
 
 - updates through local, global, property, index, and upvalue references reach the intended slot;
 - dynamic calls accept explicit references and reject plain values for ref parameters;
-- null dereference is a runtime error;
+- nullable reference reads propagate `null`, while updates through `null` fail at runtime;
 - reference rebind remains local to the reference variable;
 - ordinary parameters retain top-level isolation and nested sharing;
 - public native parameter modes match user-function behavior.
@@ -407,7 +407,7 @@ No compatibility flag or mass source migration is required.
 
 ## 12. Acceptance Criteria
 
-1. Exact user and typed-native calls use the same contextual borrowing rule.
+1. Exact user calls and compiler-known public native calls use the same contextual borrowing rule.
 2. Existing valid call syntax remains valid.
 3. Dynamic calls never infer or manufacture references.
 4. Reference read, update, and rebind semantics match compiler behavior and documentation.

--- a/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
@@ -1,51 +1,52 @@
 # Consistent Reference Semantics Design
 
-**Status:** Draft for user review  
-**Target:** Noxy 2.0  
+**Status:** Revised draft for user review
 **Branch:** `feat/consistent-reference-semantics`
 
 ## Summary
 
-Noxy keeps its existing shallow pass-by-value behavior for ordinary user-defined function parameters. This design removes the inconsistencies around that model instead of replacing it:
+This feature closes observed gaps in Noxy's reference model without redesigning its established semantics.
 
-- creating a reference at a call site becomes explicit;
-- reading, updating, and rebinding a reference each have one documented meaning;
-- dynamic calls validate reference parameters at runtime instead of manufacturing references implicitly;
-- public native APIs declare whether a parameter is passed by value or by reference;
-- native collection mutators use explicit reference arguments;
-- `any`, bare `func`, plugins, and untyped native exports are documented as dynamic boundaries;
-- normative tests become the executable definition of these rules.
+Noxy already has a coherent core:
 
-This is a breaking change because existing calls that rely on contextual address-taking must add `ref`. Mutating builtins that currently receive composites directly must also add `ref`.
+- ordinary composite parameters receive shallow copies;
+- `ref T` parameters access addressable caller storage;
+- exact calls may borrow an addressable value contextually;
+- reference reads auto-dereference;
+- `*reference = value` updates the target;
+- `reference = ref other` rebinds the reference.
+
+The work will preserve those rules, correct contradictory documentation, make native functions obey the same public contracts, validate reference modes across dynamic calls, and add missing reference support for captured variables.
 
 ## Goals
 
-1. Make reference creation visible in source code.
-2. Apply the same public parameter contract to Noxy functions and native functions.
-3. Preserve Noxy's established shallow-copy behavior for ordinary parameters.
-4. Preserve automatic dereference for reads and explicit syntax for writes and rebinds.
-5. Make dynamic boundaries honest and runtime-safe.
-6. Produce precise diagnostics and conformance tests.
+1. Specify contextual borrowing as a deliberate language rule.
+2. Preserve current call syntax for exact functions and mutating builtins.
+3. Make user-defined and public native functions follow the same parameter modes.
+4. Validate reference modes at dynamic boundaries.
+5. Support references to captured variables through upvalues.
+6. Correct documentation and add executable conformance tests.
 
 ## Non-goals
 
-- Deep-copy or copy-on-write semantics.
-- An ownership, borrow-checking, `mut`, or `readonly` system.
+- Requiring `ref` at every exact call site.
+- Adding `mut`, `readonly`, ownership, or borrow checking.
+- Changing shallow-copy behavior.
 - Changing assignment semantics for arrays, maps, or structs.
+- Adding deep-copy or copy-on-write semantics.
+- Removing automatic dereference for reads.
 - Removing `any` or bare `func`.
-- Redesigning resource identity for channels, files, sockets, wait groups, databases, or plugins.
-- Splitting the VM monolith as part of this feature.
+- Rewriting every native's domain-level error convention.
 
-## 1. Copy and Sharing Semantics
+## 1. Copy and Sharing
 
 ### 1.1 Assignment
 
 Assignment behavior remains unchanged:
 
-- `int`, `float`, `bool`, `string`, `bytes`, and `null` are copied as scalar values;
-- assigning an array, map, or struct shares the same heap-backed object;
-- assigning a function, channel, wait group, native resource, or plugin value shares its identity;
-- assigning a `ref T` copies the reference value and therefore preserves its target.
+- scalar values are copied;
+- arrays, maps, structs, functions, channels, resources, and plugins preserve their heap-backed identity;
+- assigning a `ref T` copies the reference value and preserves its target.
 
 ```noxy
 let first: int[] = [1, 2]
@@ -54,22 +55,20 @@ alias[0] = 99
 print(first[0]) // 99
 ```
 
-### 1.2 Ordinary function parameters
+### 1.2 Ordinary parameters
 
-A user-defined parameter whose declared type is not `ref T` receives a shallow copy of arrays, maps, and structs. Immediate top-level mutation stays local to the callee. Nested composite identities remain shared.
+A user-defined parameter whose type is not `ref T` receives the existing shallow copy of arrays, maps, and structs. Top-level mutation remains local to the callee; nested composite identities remain shared.
 
 ```noxy
 func change(values: int[]) -> void
     values[0] = 99
-    append(ref values, 3)
+    append(values, 3)
 end
 
 let original: int[] = [1, 2]
 change(original)
 print(original) // [1, 2]
 ```
-
-Nested behavior remains intentionally shallow:
 
 ```noxy
 func change_nested(matrix: int[][]) -> void
@@ -82,42 +81,17 @@ change_nested(matrix)
 print(matrix[0][0]) // 99
 ```
 
-This is a call-boundary rule, not a claim of deep value semantics.
+No new copy rule is introduced.
 
-### 1.3 Reference parameters
+### 1.3 Returns
 
-A `ref T` parameter receives a reference to an addressable storage location and does not perform a shallow copy.
+Returning a composite adds no new implicit copy. A non-reference parameter has already been shallow-copied on entry.
 
-```noxy
-func replace(values: ref int[]) -> void
-    *values = [10, 20]
-end
+## 2. Contextual Borrowing
 
-let original: int[] = [1, 2]
-replace(ref original)
-print(original) // [10, 20]
-```
+### 2.1 Exact reference parameters
 
-### 1.4 Returns
-
-Returning a composite does not add a second implicit copy. The returned value is the container produced or held by the callee. A non-reference parameter has already been shallow-copied on entry.
-
-## 2. Reference Semantics
-
-### 2.1 Reference creation is explicit
-
-`ref expression` is the only operation that creates a new reference. The expression must be an addressable identifier, struct field, array index, or map index.
-
-```noxy
-let value: int = 41
-let pointer: ref int = ref value
-```
-
-References to literals, function results, and other temporaries are compile-time errors.
-
-### 2.2 Exact calls never take an address contextually
-
-When an exact function signature expects `ref T`, a value of type `T` is insufficient. The caller must construct the reference explicitly:
+When an exact signature expects `ref T`, an addressable expression of type `T` is borrowed for the duration of the call.
 
 ```noxy
 func increment(value: ref int) -> void
@@ -125,97 +99,162 @@ func increment(value: ref int) -> void
 end
 
 let answer: int = 41
-increment(ref answer) // valid
-increment(answer)     // compile-time error
-increment(41)         // compile-time error
+increment(answer)
+print(answer) // 42
 ```
 
-An expression whose type is already `ref T` is passed directly:
+The compiler verifies that `answer` is addressable and emits the existing reference bytecode. This is a temporary call argument, not a new source-level variable.
+
+The following expressions are addressable:
+
+- local and global variables;
+- struct fields;
+- array and map index slots;
+- captured variables once upvalue reference support is implemented.
+
+Literals and non-reference temporaries are not addressable:
+
+```noxy
+increment(41)          // compile-time error
+increment(make_int())  // compile-time error when make_int returns int
+```
+
+A function result whose declared type is already `ref T` is a reference value and may be passed.
+
+### 2.2 Existing and explicit references
+
+An existing `ref T` value passes directly:
 
 ```noxy
 let pointer: ref int = ref answer
 increment(pointer)
 ```
 
-A `ref T` struct field or indexed slot is also already a reference and is passed directly. The compiler must not create `ref ref T` implicitly.
+The explicit spelling also remains valid for an exact call:
 
-### 2.3 Reading, updating, and rebinding
+```noxy
+increment(ref answer)
+```
 
-The existing three operations are retained and made normative:
+The canonical concise spelling for an exact call is `increment(answer)`. `ref answer` creates an explicit first-class reference value and is useful when storing the reference or crossing a dynamic boundary.
 
-- using `r: ref T` in a value expression reads the referenced `T` through automatic dereference;
-- `*r = value` updates the referenced storage location;
-- `r = ref other` rebinds the reference variable itself.
+### 2.3 Lifetime
+
+The contextual conversion occurs at the call site, but the resulting reference may escape through a return, closure, field, or global. When a referenced local can escape, the compiler captures it through the existing upvalue model. Escaping references must target an upvalue-backed location, never an expired raw stack slot. This feature does not add borrow-checker restrictions or prohibit reference escape.
+
+## 3. Reference Operations
+
+The existing operations become normative.
+
+### 3.1 Read
+
+Using `r: ref T` where a value `T` is required automatically dereferences it:
+
+```noxy
+let result: int = r + 1
+print(r)
+```
+
+### 3.2 Update
+
+`*r = value` updates the referenced storage:
+
+```noxy
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+```
+
+The documentation example `value = value + 1` is invalid and will be corrected. The compiler already rejects it because a bare assignment to `value: ref int` is a rebind and therefore requires `ref int` on the right-hand side.
+
+### 3.3 Rebind
+
+`r = ref other` changes the target stored in the reference variable:
 
 ```noxy
 let first: int = 10
 let second: int = 20
 let pointer: ref int = ref first
 
-print(pointer)      // 10: automatic dereference for reading
-*pointer = 11      // first becomes 11
 pointer = ref second
-*pointer = 21      // second becomes 21
+*pointer = 21
 ```
 
-`pointer = 21` is always an error. The diagnostic suggests `*pointer = 21`.
+Rebinding a reference parameter changes only the parameter's local reference value. It does not rebind a reference variable held by the caller. The existing compiler warning remains.
 
-### 2.4 Null references
+### 3.4 Null
 
-`null` remains compatible with `ref T`. It represents the absence of a target and may be compared or rebound. Dereferencing a null reference is a runtime error.
+`null` remains a valid `ref T` value. It has no target and may be stored, compared, returned, or rebound. Dereferencing it is a runtime error.
 
-Passing a reference field whose current value is `null` still passes the field's addressable slot, allowing a callee to fill it. Passing the literal `null` passes no slot and therefore cannot be written through.
+A field or index slot whose stored reference is currently `null` remains addressable; a contextual borrow can pass that slot so the callee may fill it. The literal `null` itself has no addressable slot.
 
-## 3. Dynamic Calls
+## 4. Dynamic Calls
 
-Bare `func` remains a dynamic callable type. The compiler cannot infer its runtime parameter modes, so it never takes an address contextually.
+Bare `func` intentionally erases exact parameter information. Therefore contextual borrowing is unavailable when the compiler only knows `func`.
 
 ```noxy
 let dynamic: func = increment
-dynamic(ref answer) // reference survives the dynamic boundary
-dynamic(answer)     // runtime arity/type-mode error when target expects ref int
+
+dynamic(ref answer) // passes an explicit reference
+dynamic(answer)     // passes a plain int
 ```
 
-At runtime, every script function call validates its declared parameter modes before the frame starts:
+At runtime, the second call fails before starting the target frame because the actual function expects a reference parameter.
 
-- a `ref` parameter accepts `VAL_REF` or `null`;
-- a non-reference parameter receives the existing shallow-copy treatment;
-- a plain value passed to a `ref` parameter is rejected;
-- a reference passed to an ordinary parameter is dereferenced by compiled exact calls; dynamic calls retain the explicit reference and must reject an incompatible runtime mode rather than guess.
+Runtime call preparation will enforce:
 
-Runtime errors identify the function, argument position, expected mode, and actual value.
+- a declared reference parameter accepts a reference value or `null`;
+- a plain value is never converted into a reference dynamically;
+- an ordinary parameter retains shallow-copy behavior;
+- an explicit reference passed to an incompatible ordinary parameter is rejected rather than guessed or silently dereferenced.
 
-## 4. Public Native APIs
+Reference-mode errors include the function name and argument position. Full runtime reconstruction of every static Noxy type is outside this feature; dynamic mode validation distinguishes reference from non-reference values.
 
-### 4.1 Raw native ABI versus public signature
+## 5. Captured Variables
 
-The Go `NativeFunc` ABI remains an internal mechanism. Publicly callable natives receive signature metadata describing arity, value types, return type, variadic behavior, and reference parameters.
+The specification already promises safe references to captured variables, but the compiler currently rejects passing a captured variable by reference.
 
-Stdlib modules must expose typed `.nx` wrappers over internal native primitives. Internal primitives are dynamic implementation details and are not part of the documented public API; the wrapper is the public language contract.
-
-Plugins without signature metadata remain explicit dynamic boundaries.
-
-### 4.2 Native parameter behavior
-
-For public native calls:
-
-- an ordinary composite parameter behaves as if it received the same shallow copy as a Noxy function;
-- a `ref T` parameter requires an explicit reference and receives the original storage slot;
-- identity-bearing runtime values such as channels, wait groups, open files, sockets, statements, and database handles may change external resource state without becoming `ref` parameters; this does not rebind or mutate the caller's Noxy container;
-- an implementation may elide an unobservable shallow copy for a proven read-only native, but this optimization must not change program behavior.
-
-### 4.3 Mutating collection builtins
-
-The builtins that mutate Noxy containers receive reference parameters:
+This feature closes that implementation gap:
 
 ```noxy
-append(ref values, item)
-let last: int = pop(ref values)
-delete(ref mapping, key)
-json_loads(json, ref target)
+func make_incrementer() -> func() -> void
+    let value: int = 0
+
+    return func() -> void
+        increment(value)
+    end
+end
 ```
 
-Their public contracts are:
+The compiler will emit a new `OP_REF_UPVALUE` when contextual borrowing or `ref value` targets a captured variable. The VM creates an `ObjRef` with `REF_UPVALUE`, using the existing `ObjUpvalue` location and closed-value lifetime.
+
+Acceptance requirements:
+
+- open captured locals refer to the live stack slot;
+- closed captured locals refer to the heap-backed closed value;
+- references remain valid after the defining function returns;
+- multiple closures observe updates to the same captured slot;
+- no escaping reference stores a raw pointer to an expired stack slot.
+
+## 6. Public Native Contracts
+
+### 6.1 Signature metadata
+
+Public native APIs receive descriptors containing:
+
+- name;
+- arity and variadic behavior;
+- parameter types or compiler-recognized generic constraints;
+- parameter reference modes;
+- return type.
+
+The Go `NativeFunc` ABI remains unchanged. The descriptor validates the public contract before invoking the Go closure.
+
+### 6.2 Same contextual rule
+
+An exact public native signature uses the same contextual borrowing rule as an exact Noxy function.
+
+Conceptual builtin signatures:
 
 ```text
 append(ref T[], T) -> void
@@ -224,156 +263,155 @@ delete(ref map[K, V], K) -> void
 json_loads(string, ref T) -> bool
 ```
 
-The compiler continues to type-check these generic builtins specially because Noxy does not yet have user-facing generics. The first argument must be an explicit reference or an existing `ref` value.
-
-Read-only builtins keep ordinary arguments:
+Source syntax remains unchanged:
 
 ```noxy
-length(values)
-contains(values, item)
-keys(mapping)
-has_key(mapping, key)
-json_dumps(value)
+append(values, item)
+let removed: int = pop(values)
+delete(mapping, key)
+json_loads(json, target)
 ```
 
-### 4.4 Native errors
+Because the signatures are exact, the compiler borrows the addressable arguments contextually. These builtins no longer depend on an undocumented native exception.
 
-The Go `NativeFunc` ABI remains unchanged in this feature. A public native descriptor validates arity, parameter modes, and declared value types before invoking the Go closure. Validation failures become structured VM runtime errors and never invoke the closure.
+Generic collection builtins remain compiler-recognized because Noxy does not yet expose user-defined generics.
 
-Domain APIs may continue returning Noxy `Result` values when failure is part of their normal contract. Replacing every legacy native's internal `null` error convention is outside this feature; only descriptor-level contract failures are standardized here.
+### 6.3 Ordinary native parameters
 
-## 5. Static and Dynamic Boundaries
+An ordinary composite parameter has the same observable shallow-copy semantics as an ordinary Noxy parameter. A proven read-only native may operate directly on the value as an optimization because no mutation is observable.
 
-The specification will describe Noxy as a statically typed language with explicit dynamic boundaries, rather than claiming that every type error is detected before execution.
+Identity-bearing channels, wait groups, files, sockets, statements, and database handles may change external resource state through ordinary parameters. This does not rebind the caller's Noxy variable or change the language's composite-copy contract.
+
+### 6.4 Stdlib and internal primitives
+
+Public stdlib APIs must be typed `.nx` wrappers or typed native descriptors. Raw implementation primitives remain dynamic internals and are not documented public APIs.
+
+Enforcing module-private native visibility is desirable but is a separate module-system change. Until then, direct calls to raw primitives are documented dynamic boundaries and receive runtime validation only.
+
+### 6.5 Contract errors
+
+Descriptor-level arity, reference-mode, and type failures become VM runtime errors and never invoke the native closure. Domain errors may continue using existing Noxy `Result` contracts. Replacing every legacy `null` error convention is outside this feature.
+
+## 7. Static and Dynamic Boundaries
+
+The language specification will say:
+
+> Noxy is statically typed, with explicit dynamic boundaries through `any`, bare `func`, untyped native primitives, and plugins without signatures.
 
 Normative rules:
 
-- exact `func(T...) -> R` calls check arity, argument types, reference modes, and result types at compile time;
-- widening an exact function to bare `func` is allowed;
-- narrowing bare `func` to an exact signature remains forbidden;
-- assigning any concrete value to `any` is allowed;
-- narrowing `any` to a concrete or exact callable type remains forbidden by this feature;
-- calls through bare `func`, untyped plugin exports, and untyped internal native exports validate at runtime;
-- neither static nor dynamic boundaries manufacture references from plain values.
+- exact calls validate arity, types, and reference modes at compile time;
+- exact-to-bare-function widening remains valid;
+- bare-to-exact narrowing remains invalid;
+- concrete values widen to `any`;
+- `any` does not narrow implicitly to concrete or exact callable types;
+- dynamic boundaries validate what is known at runtime and never manufacture references;
+- plugin exports with signature metadata follow exact-call rules; other plugin exports remain dynamic.
 
-The phrase "immutable types" will be replaced with "type-stable variables": a variable's declared type does not change, although its value may be mutable.
+The misleading phrase "immutable types" will be replaced by "type-stable variables": a variable's declared type does not change, although values may be mutable.
 
-## 6. Diagnostics
+## 8. Diagnostics
 
 Required compile-time diagnostics include:
 
 ```text
-argument 1 to 'increment': expected ref int, got int
-hint: use 'ref answer'
-```
-
-```text
-cannot take a reference to temporary value of type int
-hint: store the value in a variable before using 'ref'
+argument 1 to 'increment' expects ref int, but 41 is not addressable
+hint: store the value in a variable before passing it
 ```
 
 ```text
 cannot assign int to ref int
-hint: use '*pointer = ...' to update the referenced value
+hint: use '*value = ...' to update the referenced value
 ```
 
-Required runtime diagnostics for dynamic boundaries include:
+Required runtime diagnostics include:
 
 ```text
-function 'dynamic' argument 1: expected ref int, got int
+function 'increment' argument 1: expected a reference value, got int
 ```
 
-## 7. Migration
-
-This feature requires a semver-major release.
-
-Mechanical migrations:
-
-```diff
-- increment(answer)
-+ increment(ref answer)
-
-- append(values, item)
-+ append(ref values, item)
-
-- pop(values)
-+ pop(ref values)
-
-- delete(mapping, key)
-+ delete(ref mapping, key)
-
-- json_loads(json, target)
-+ json_loads(json, ref target)
+```text
+cannot dereference null reference
 ```
 
-Calls that already pass a `ref T` value remain unchanged:
+## 9. Compatibility
+
+Valid exact-call source syntax remains compatible:
 
 ```noxy
-let pointer: ref int = ref answer
-increment(pointer)
+increment(answer)
+append(values, item)
+pop(values)
+delete(mapping, key)
+json_loads(json, target)
 ```
 
-The stdlib, examples, feature fixtures, error fixtures, concurrent runner, and documentation must migrate in the same branch. No compatibility flag or implicit fallback will remain in Noxy 2.0.
+Behavioral tightening is limited to invalid or dynamic cases:
 
-## 8. Implementation Boundaries
+- dynamic calls no longer pass plain values into reference parameters;
+- raw native calls with descriptor violations fail before invocation;
+- captured-variable references that previously failed now compile and execute safely;
+- incorrect documentation examples are fixed.
+
+No compatibility flag or mass source migration is required.
+
+## 10. Implementation Boundaries
 
 ### Compiler
 
-- Exact-call compilation accepts a plain l-value for `ref T` only when wrapped in an explicit `ref` prefix.
-- Existing `ref T` expressions and reference-valued fields pass directly.
-- Generic mutating builtins receive dedicated compile-time validation.
-- Diagnostics distinguish missing `ref`, non-addressable values, and type mismatch.
+- Preserve contextual borrowing for exact `ref T` parameters.
+- Preserve direct passing of existing reference values.
+- Add contextual borrowing for typed public natives.
+- Add `OP_REF_UPVALUE` generation.
+- Improve diagnostics for non-addressable reference arguments and invalid ref assignment.
 
 ### Runtime value model
 
-- Function parameter metadata continues to record `IsRef`.
-- Dynamic script calls validate `IsRef` against the actual `Value` mode.
-- Public native descriptors add parameter-mode and signature metadata without importing AST types into the value package.
-- Native reference arguments are resolved through the existing `ObjRef` mechanisms.
+- Continue recording reference mode in function parameter metadata.
+- Add native signature descriptors without importing AST types into the value package.
+- Reuse `ObjRef` and `REF_UPVALUE` for captured storage.
 
 ### VM
 
-- User-defined non-reference parameters keep `copyValue` shallow copying.
-- Native public-call preparation applies the declared parameter modes.
-- Runtime mode mismatches return VM errors before invoking script or native code.
-- No new ownership model, collector, or copy opcode is introduced.
+- Validate parameter reference modes before starting dynamic script frames.
+- Validate native descriptors before invoking native closures.
+- Preserve shallow `copyValue` behavior for ordinary script parameters.
+- Execute `OP_REF_UPVALUE` using the existing open/closed upvalue representation.
 
-## 9. Verification
+## 11. Verification
 
 ### Compiler tests
 
-- explicit local/global/property/index references compile;
-- an existing `ref T` value compiles without another `ref`;
-- implicit local/global/property/index address-taking fails with the expected hint;
-- temporaries and literals fail;
-- mutating builtin calls require references and validate element/key/value types;
-- exact calls preserve return types and existing null rules.
+- exact contextual borrowing works for locals, globals, fields, indexes, and captured variables;
+- explicit and existing references still work;
+- literals and non-reference temporaries are rejected;
+- update and rebind diagnostics are distinct;
+- native signatures apply the same contextual rules;
+- exact-call return propagation remains unchanged.
 
 ### VM tests
 
-- explicit reference calls update the intended local, global, property, and index;
-- dynamic calls accept explicit references and reject plain values for reference parameters;
-- update and rebind remain distinct;
-- null reference dereference returns an error;
-- ordinary parameters retain shallow-copy behavior, including nested sharing;
-- public native value and reference parameters match user-function behavior;
-- mutating collection builtins modify the intended caller container.
+- updates through local, global, property, index, and upvalue references reach the intended slot;
+- dynamic calls accept explicit references and reject plain values for ref parameters;
+- null dereference is a runtime error;
+- reference rebind remains local to the reference variable;
+- ordinary parameters retain top-level isolation and nested sharing;
+- public native parameter modes match user-function behavior.
 
 ### Integration tests
 
-- migrate and run all Noxy examples;
-- add positive and negative reference-conformance fixtures;
+- add positive and negative conformance fixtures;
 - run `go test ./...`;
 - run `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx`;
-- run `go build ./...` and `go vet ./...` before completion.
+- run `go build ./...` and `go vet ./...`.
 
-## 10. Acceptance Criteria
+## 12. Acceptance Criteria
 
-1. No exact or dynamic call implicitly turns a plain value into a reference.
-2. All newly created references are visible as `ref` in source.
-3. Reading, updating, and rebinding references follow one rule everywhere.
-4. Ordinary user-function shallow-copy behavior is unchanged.
-5. Public native APIs declare and enforce the same parameter modes.
-6. Mutating collection builtins require explicit reference arguments.
-7. Static and dynamic boundaries are accurately documented.
-8. The full Go and Noxy integration suites pass after migration.
+1. Exact user and typed-native calls use the same contextual borrowing rule.
+2. Existing valid call syntax remains valid.
+3. Dynamic calls never infer or manufacture references.
+4. Reference read, update, and rebind semantics match compiler behavior and documentation.
+5. Captured variables can be referenced safely after closure.
+6. Ordinary shallow-copy semantics remain unchanged.
+7. Static and dynamic boundaries are described accurately.
+8. Conformance and integration suites pass.

--- a/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-08-consistent-reference-semantics-design.md
@@ -1,0 +1,379 @@
+# Consistent Reference Semantics Design
+
+**Status:** Draft for user review  
+**Target:** Noxy 2.0  
+**Branch:** `feat/consistent-reference-semantics`
+
+## Summary
+
+Noxy keeps its existing shallow pass-by-value behavior for ordinary user-defined function parameters. This design removes the inconsistencies around that model instead of replacing it:
+
+- creating a reference at a call site becomes explicit;
+- reading, updating, and rebinding a reference each have one documented meaning;
+- dynamic calls validate reference parameters at runtime instead of manufacturing references implicitly;
+- public native APIs declare whether a parameter is passed by value or by reference;
+- native collection mutators use explicit reference arguments;
+- `any`, bare `func`, plugins, and untyped native exports are documented as dynamic boundaries;
+- normative tests become the executable definition of these rules.
+
+This is a breaking change because existing calls that rely on contextual address-taking must add `ref`. Mutating builtins that currently receive composites directly must also add `ref`.
+
+## Goals
+
+1. Make reference creation visible in source code.
+2. Apply the same public parameter contract to Noxy functions and native functions.
+3. Preserve Noxy's established shallow-copy behavior for ordinary parameters.
+4. Preserve automatic dereference for reads and explicit syntax for writes and rebinds.
+5. Make dynamic boundaries honest and runtime-safe.
+6. Produce precise diagnostics and conformance tests.
+
+## Non-goals
+
+- Deep-copy or copy-on-write semantics.
+- An ownership, borrow-checking, `mut`, or `readonly` system.
+- Changing assignment semantics for arrays, maps, or structs.
+- Removing `any` or bare `func`.
+- Redesigning resource identity for channels, files, sockets, wait groups, databases, or plugins.
+- Splitting the VM monolith as part of this feature.
+
+## 1. Copy and Sharing Semantics
+
+### 1.1 Assignment
+
+Assignment behavior remains unchanged:
+
+- `int`, `float`, `bool`, `string`, `bytes`, and `null` are copied as scalar values;
+- assigning an array, map, or struct shares the same heap-backed object;
+- assigning a function, channel, wait group, native resource, or plugin value shares its identity;
+- assigning a `ref T` copies the reference value and therefore preserves its target.
+
+```noxy
+let first: int[] = [1, 2]
+let alias: int[] = first
+alias[0] = 99
+print(first[0]) // 99
+```
+
+### 1.2 Ordinary function parameters
+
+A user-defined parameter whose declared type is not `ref T` receives a shallow copy of arrays, maps, and structs. Immediate top-level mutation stays local to the callee. Nested composite identities remain shared.
+
+```noxy
+func change(values: int[]) -> void
+    values[0] = 99
+    append(ref values, 3)
+end
+
+let original: int[] = [1, 2]
+change(original)
+print(original) // [1, 2]
+```
+
+Nested behavior remains intentionally shallow:
+
+```noxy
+func change_nested(matrix: int[][]) -> void
+    matrix[0][0] = 99
+end
+
+let row: int[] = [1, 2]
+let matrix: int[][] = [row]
+change_nested(matrix)
+print(matrix[0][0]) // 99
+```
+
+This is a call-boundary rule, not a claim of deep value semantics.
+
+### 1.3 Reference parameters
+
+A `ref T` parameter receives a reference to an addressable storage location and does not perform a shallow copy.
+
+```noxy
+func replace(values: ref int[]) -> void
+    *values = [10, 20]
+end
+
+let original: int[] = [1, 2]
+replace(ref original)
+print(original) // [10, 20]
+```
+
+### 1.4 Returns
+
+Returning a composite does not add a second implicit copy. The returned value is the container produced or held by the callee. A non-reference parameter has already been shallow-copied on entry.
+
+## 2. Reference Semantics
+
+### 2.1 Reference creation is explicit
+
+`ref expression` is the only operation that creates a new reference. The expression must be an addressable identifier, struct field, array index, or map index.
+
+```noxy
+let value: int = 41
+let pointer: ref int = ref value
+```
+
+References to literals, function results, and other temporaries are compile-time errors.
+
+### 2.2 Exact calls never take an address contextually
+
+When an exact function signature expects `ref T`, a value of type `T` is insufficient. The caller must construct the reference explicitly:
+
+```noxy
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+
+let answer: int = 41
+increment(ref answer) // valid
+increment(answer)     // compile-time error
+increment(41)         // compile-time error
+```
+
+An expression whose type is already `ref T` is passed directly:
+
+```noxy
+let pointer: ref int = ref answer
+increment(pointer)
+```
+
+A `ref T` struct field or indexed slot is also already a reference and is passed directly. The compiler must not create `ref ref T` implicitly.
+
+### 2.3 Reading, updating, and rebinding
+
+The existing three operations are retained and made normative:
+
+- using `r: ref T` in a value expression reads the referenced `T` through automatic dereference;
+- `*r = value` updates the referenced storage location;
+- `r = ref other` rebinds the reference variable itself.
+
+```noxy
+let first: int = 10
+let second: int = 20
+let pointer: ref int = ref first
+
+print(pointer)      // 10: automatic dereference for reading
+*pointer = 11      // first becomes 11
+pointer = ref second
+*pointer = 21      // second becomes 21
+```
+
+`pointer = 21` is always an error. The diagnostic suggests `*pointer = 21`.
+
+### 2.4 Null references
+
+`null` remains compatible with `ref T`. It represents the absence of a target and may be compared or rebound. Dereferencing a null reference is a runtime error.
+
+Passing a reference field whose current value is `null` still passes the field's addressable slot, allowing a callee to fill it. Passing the literal `null` passes no slot and therefore cannot be written through.
+
+## 3. Dynamic Calls
+
+Bare `func` remains a dynamic callable type. The compiler cannot infer its runtime parameter modes, so it never takes an address contextually.
+
+```noxy
+let dynamic: func = increment
+dynamic(ref answer) // reference survives the dynamic boundary
+dynamic(answer)     // runtime arity/type-mode error when target expects ref int
+```
+
+At runtime, every script function call validates its declared parameter modes before the frame starts:
+
+- a `ref` parameter accepts `VAL_REF` or `null`;
+- a non-reference parameter receives the existing shallow-copy treatment;
+- a plain value passed to a `ref` parameter is rejected;
+- a reference passed to an ordinary parameter is dereferenced by compiled exact calls; dynamic calls retain the explicit reference and must reject an incompatible runtime mode rather than guess.
+
+Runtime errors identify the function, argument position, expected mode, and actual value.
+
+## 4. Public Native APIs
+
+### 4.1 Raw native ABI versus public signature
+
+The Go `NativeFunc` ABI remains an internal mechanism. Publicly callable natives receive signature metadata describing arity, value types, return type, variadic behavior, and reference parameters.
+
+Stdlib modules must expose typed `.nx` wrappers over internal native primitives. Internal primitives are dynamic implementation details and are not part of the documented public API; the wrapper is the public language contract.
+
+Plugins without signature metadata remain explicit dynamic boundaries.
+
+### 4.2 Native parameter behavior
+
+For public native calls:
+
+- an ordinary composite parameter behaves as if it received the same shallow copy as a Noxy function;
+- a `ref T` parameter requires an explicit reference and receives the original storage slot;
+- identity-bearing runtime values such as channels, wait groups, open files, sockets, statements, and database handles may change external resource state without becoming `ref` parameters; this does not rebind or mutate the caller's Noxy container;
+- an implementation may elide an unobservable shallow copy for a proven read-only native, but this optimization must not change program behavior.
+
+### 4.3 Mutating collection builtins
+
+The builtins that mutate Noxy containers receive reference parameters:
+
+```noxy
+append(ref values, item)
+let last: int = pop(ref values)
+delete(ref mapping, key)
+json_loads(json, ref target)
+```
+
+Their public contracts are:
+
+```text
+append(ref T[], T) -> void
+pop(ref T[]) -> T
+delete(ref map[K, V], K) -> void
+json_loads(string, ref T) -> bool
+```
+
+The compiler continues to type-check these generic builtins specially because Noxy does not yet have user-facing generics. The first argument must be an explicit reference or an existing `ref` value.
+
+Read-only builtins keep ordinary arguments:
+
+```noxy
+length(values)
+contains(values, item)
+keys(mapping)
+has_key(mapping, key)
+json_dumps(value)
+```
+
+### 4.4 Native errors
+
+The Go `NativeFunc` ABI remains unchanged in this feature. A public native descriptor validates arity, parameter modes, and declared value types before invoking the Go closure. Validation failures become structured VM runtime errors and never invoke the closure.
+
+Domain APIs may continue returning Noxy `Result` values when failure is part of their normal contract. Replacing every legacy native's internal `null` error convention is outside this feature; only descriptor-level contract failures are standardized here.
+
+## 5. Static and Dynamic Boundaries
+
+The specification will describe Noxy as a statically typed language with explicit dynamic boundaries, rather than claiming that every type error is detected before execution.
+
+Normative rules:
+
+- exact `func(T...) -> R` calls check arity, argument types, reference modes, and result types at compile time;
+- widening an exact function to bare `func` is allowed;
+- narrowing bare `func` to an exact signature remains forbidden;
+- assigning any concrete value to `any` is allowed;
+- narrowing `any` to a concrete or exact callable type remains forbidden by this feature;
+- calls through bare `func`, untyped plugin exports, and untyped internal native exports validate at runtime;
+- neither static nor dynamic boundaries manufacture references from plain values.
+
+The phrase "immutable types" will be replaced with "type-stable variables": a variable's declared type does not change, although its value may be mutable.
+
+## 6. Diagnostics
+
+Required compile-time diagnostics include:
+
+```text
+argument 1 to 'increment': expected ref int, got int
+hint: use 'ref answer'
+```
+
+```text
+cannot take a reference to temporary value of type int
+hint: store the value in a variable before using 'ref'
+```
+
+```text
+cannot assign int to ref int
+hint: use '*pointer = ...' to update the referenced value
+```
+
+Required runtime diagnostics for dynamic boundaries include:
+
+```text
+function 'dynamic' argument 1: expected ref int, got int
+```
+
+## 7. Migration
+
+This feature requires a semver-major release.
+
+Mechanical migrations:
+
+```diff
+- increment(answer)
++ increment(ref answer)
+
+- append(values, item)
++ append(ref values, item)
+
+- pop(values)
++ pop(ref values)
+
+- delete(mapping, key)
++ delete(ref mapping, key)
+
+- json_loads(json, target)
++ json_loads(json, ref target)
+```
+
+Calls that already pass a `ref T` value remain unchanged:
+
+```noxy
+let pointer: ref int = ref answer
+increment(pointer)
+```
+
+The stdlib, examples, feature fixtures, error fixtures, concurrent runner, and documentation must migrate in the same branch. No compatibility flag or implicit fallback will remain in Noxy 2.0.
+
+## 8. Implementation Boundaries
+
+### Compiler
+
+- Exact-call compilation accepts a plain l-value for `ref T` only when wrapped in an explicit `ref` prefix.
+- Existing `ref T` expressions and reference-valued fields pass directly.
+- Generic mutating builtins receive dedicated compile-time validation.
+- Diagnostics distinguish missing `ref`, non-addressable values, and type mismatch.
+
+### Runtime value model
+
+- Function parameter metadata continues to record `IsRef`.
+- Dynamic script calls validate `IsRef` against the actual `Value` mode.
+- Public native descriptors add parameter-mode and signature metadata without importing AST types into the value package.
+- Native reference arguments are resolved through the existing `ObjRef` mechanisms.
+
+### VM
+
+- User-defined non-reference parameters keep `copyValue` shallow copying.
+- Native public-call preparation applies the declared parameter modes.
+- Runtime mode mismatches return VM errors before invoking script or native code.
+- No new ownership model, collector, or copy opcode is introduced.
+
+## 9. Verification
+
+### Compiler tests
+
+- explicit local/global/property/index references compile;
+- an existing `ref T` value compiles without another `ref`;
+- implicit local/global/property/index address-taking fails with the expected hint;
+- temporaries and literals fail;
+- mutating builtin calls require references and validate element/key/value types;
+- exact calls preserve return types and existing null rules.
+
+### VM tests
+
+- explicit reference calls update the intended local, global, property, and index;
+- dynamic calls accept explicit references and reject plain values for reference parameters;
+- update and rebind remain distinct;
+- null reference dereference returns an error;
+- ordinary parameters retain shallow-copy behavior, including nested sharing;
+- public native value and reference parameters match user-function behavior;
+- mutating collection builtins modify the intended caller container.
+
+### Integration tests
+
+- migrate and run all Noxy examples;
+- add positive and negative reference-conformance fixtures;
+- run `go test ./...`;
+- run `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx`;
+- run `go build ./...` and `go vet ./...` before completion.
+
+## 10. Acceptance Criteria
+
+1. No exact or dynamic call implicitly turns a plain value into a reference.
+2. All newly created references are visible as `ref` in source.
+3. Reading, updating, and rebinding references follow one rule everywhere.
+4. Ordinary user-function shallow-copy behavior is unchanged.
+5. Public native APIs declare and enforce the same parameter modes.
+6. Mutating collection builtins require explicit reference arguments.
+7. Static and dynamic boundaries are accurately documented.
+8. The full Go and Noxy integration suites pass after migration.

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -80,6 +80,7 @@ const (
 	OP_SWAP
 	OP_COPY
 	OP_ADDR
+	OP_MARK_REF_JSON_DYNAMIC
 )
 
 func (op OpCode) String() string {
@@ -188,6 +189,8 @@ func (op OpCode) String() string {
 		return "OP_REF_INDEX"
 	case OP_DEREF:
 		return "OP_DEREF"
+	case OP_MARK_REF_JSON_DYNAMIC:
+		return "OP_MARK_REF_JSON_DYNAMIC"
 	case OP_STORE_VIA_REF:
 		return "OP_STORE_VIA_REF"
 	case OP_DUP:
@@ -423,6 +426,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_COPY", offset)
 	case OP_ADDR:
 		return c.simpleInstruction("OP_ADDR", offset)
+	case OP_MARK_REF_JSON_DYNAMIC:
+		return c.simpleInstruction("OP_MARK_REF_JSON_DYNAMIC", offset)
 	default:
 		fmt.Printf("Unknown opcode %d\n", instruction)
 		return offset + 1

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -374,7 +374,7 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 	case OP_GET_PROPERTY:
 		return c.constantInstruction("OP_GET_PROPERTY", offset)
 	case OP_MARK_REF_TARGET_TYPE:
-		return c.constantInstruction("OP_MARK_REF_TARGET_TYPE", offset)
+		return c.constantLongInstruction("OP_MARK_REF_TARGET_TYPE", offset)
 	case OP_SET_PROPERTY:
 		return c.constantInstruction("OP_SET_PROPERTY", offset)
 	case OP_ZEROS:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -73,6 +73,8 @@ const (
 	OP_REF_GLOBAL
 	OP_REF_PROPERTY
 	OP_REF_INDEX
+	OP_CONTEXT_REF_PROPERTY
+	OP_CONTEXT_REF_INDEX
 	OP_DEREF
 	OP_STORE_VIA_REF
 	OP_STORE_REF
@@ -187,6 +189,10 @@ func (op OpCode) String() string {
 		return "OP_REF_PROPERTY"
 	case OP_REF_INDEX:
 		return "OP_REF_INDEX"
+	case OP_CONTEXT_REF_PROPERTY:
+		return "OP_CONTEXT_REF_PROPERTY"
+	case OP_CONTEXT_REF_INDEX:
+		return "OP_CONTEXT_REF_INDEX"
 	case OP_DEREF:
 		return "OP_DEREF"
 	case OP_MARK_REF_JSON_DYNAMIC:
@@ -412,6 +418,10 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.constantInstruction("OP_REF_PROPERTY", offset)
 	case OP_REF_INDEX:
 		return c.simpleInstruction("OP_REF_INDEX", offset)
+	case OP_CONTEXT_REF_PROPERTY:
+		return c.constantInstruction("OP_CONTEXT_REF_PROPERTY", offset)
+	case OP_CONTEXT_REF_INDEX:
+		return c.simpleInstruction("OP_CONTEXT_REF_INDEX", offset)
 	case OP_DEREF:
 		return c.simpleInstruction("OP_DEREF", offset)
 	case OP_STORE_VIA_REF:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -83,6 +83,7 @@ const (
 	OP_COPY
 	OP_ADDR
 	OP_MARK_REF_JSON_DYNAMIC
+	OP_MARK_REF_TARGET_TYPE
 )
 
 func (op OpCode) String() string {
@@ -197,6 +198,8 @@ func (op OpCode) String() string {
 		return "OP_DEREF"
 	case OP_MARK_REF_JSON_DYNAMIC:
 		return "OP_MARK_REF_JSON_DYNAMIC"
+	case OP_MARK_REF_TARGET_TYPE:
+		return "OP_MARK_REF_TARGET_TYPE"
 	case OP_STORE_VIA_REF:
 		return "OP_STORE_VIA_REF"
 	case OP_DUP:
@@ -370,6 +373,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_SET_INDEX", offset)
 	case OP_GET_PROPERTY:
 		return c.constantInstruction("OP_GET_PROPERTY", offset)
+	case OP_MARK_REF_TARGET_TYPE:
+		return c.constantInstruction("OP_MARK_REF_TARGET_TYPE", offset)
 	case OP_SET_PROPERTY:
 		return c.constantInstruction("OP_SET_PROPERTY", offset)
 	case OP_ZEROS:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -69,6 +69,7 @@ const (
 	OP_CLOSURE       // [const_index] [upvalue_count] [is_local, index]...
 	OP_CLOSE_UPVALUE // Explicit instruction to close upvalues
 	OP_REF_LOCAL
+	OP_REF_UPVALUE
 	OP_REF_GLOBAL
 	OP_REF_PROPERTY
 	OP_REF_INDEX
@@ -177,6 +178,8 @@ func (op OpCode) String() string {
 		return "OP_CLOSE_UPVALUE"
 	case OP_REF_LOCAL:
 		return "OP_REF_LOCAL"
+	case OP_REF_UPVALUE:
+		return "OP_REF_UPVALUE"
 	case OP_REF_GLOBAL:
 		return "OP_REF_GLOBAL"
 	case OP_REF_PROPERTY:
@@ -398,6 +401,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_CLOSE_UPVALUE", offset)
 	case OP_REF_LOCAL:
 		return c.byteInstruction("OP_REF_LOCAL", offset)
+	case OP_REF_UPVALUE:
+		return c.byteInstruction("OP_REF_UPVALUE", offset)
 	case OP_REF_GLOBAL:
 		return c.constantInstruction("OP_REF_GLOBAL", offset)
 	case OP_REF_PROPERTY:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -84,6 +84,7 @@ const (
 	OP_ADDR
 	OP_MARK_REF_JSON_DYNAMIC
 	OP_MARK_REF_TARGET_TYPE
+	OP_MARK_RUNTIME_VALUE_TYPE
 )
 
 func (op OpCode) String() string {
@@ -200,6 +201,8 @@ func (op OpCode) String() string {
 		return "OP_MARK_REF_JSON_DYNAMIC"
 	case OP_MARK_REF_TARGET_TYPE:
 		return "OP_MARK_REF_TARGET_TYPE"
+	case OP_MARK_RUNTIME_VALUE_TYPE:
+		return "OP_MARK_RUNTIME_VALUE_TYPE"
 	case OP_STORE_VIA_REF:
 		return "OP_STORE_VIA_REF"
 	case OP_DUP:
@@ -375,6 +378,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.constantInstruction("OP_GET_PROPERTY", offset)
 	case OP_MARK_REF_TARGET_TYPE:
 		return c.constantLongInstruction("OP_MARK_REF_TARGET_TYPE", offset)
+	case OP_MARK_RUNTIME_VALUE_TYPE:
+		return c.constantLongInstruction("OP_MARK_RUNTIME_VALUE_TYPE", offset)
 	case OP_SET_PROPERTY:
 		return c.constantInstruction("OP_SET_PROPERTY", offset)
 	case OP_ZEROS:

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -95,6 +95,9 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 					c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
 				)
 			}
+			if err := c.emitRuntimeValueType(array.ElementType); err != nil {
+				return true, nil, err
+			}
 		}
 		c.emitBytes(byte(chunk.OP_CALL), 2)
 		return true, builtinType("void"), nil

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -15,7 +15,11 @@ func (c *Compiler) compileBuiltinValueArgument(expression ast.Expression) (ast.N
 	if err != nil {
 		return nil, err
 	}
-	if ref, ok := actual.(*ast.RefType); ok {
+	explicitReference := false
+	if prefix, ok := expression.(*ast.PrefixExpression); ok {
+		explicitReference = prefix.Operator == "ref"
+	}
+	if ref, ok := actual.(*ast.RefType); ok && !explicitReference {
 		c.emitByte(byte(chunk.OP_DEREF))
 		return ref.ElementType, nil
 	}
@@ -41,6 +45,9 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 	if _, declared := c.resolveGlobalType(name); declared {
 		return false, nil, nil
 	}
+	if c.hasWildcardImport {
+		return false, nil, nil
+	}
 
 	wantArity := map[string]int{"append": 2, "pop": 1, "delete": 2, "json_loads": 2}[name]
 	if len(call.Arguments) != wantArity {
@@ -63,15 +70,35 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 		if !ok {
 			return true, nil, fmt.Errorf("[line %d] append expects an array, got %s", c.currentLine, noxyTypeName(container))
 		}
-		item, err := c.compileBuiltinValueArgument(call.Arguments[1])
-		if err != nil {
-			return true, nil, err
-		}
-		if !c.areStrictTypesCompatible(array.ElementType, item) {
-			return true, nil, fmt.Errorf(
-				"[line %d] argument 2 to 'append': expected %s, got %s",
-				c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
-			)
+		if expectedRef, ok := array.ElementType.(*ast.RefType); ok {
+			actualElement, err := c.compileReferenceArgument(call.Arguments[1])
+			if err != nil {
+				return true, nil, err
+			}
+			if !c.areStrictTypesCompatible(expectedRef.ElementType, actualElement) {
+				actual := &ast.RefType{ElementType: actualElement}
+				return true, nil, fmt.Errorf(
+					"[line %d] argument 2 to 'append': expected %s, got %s",
+					c.currentLine, noxyTypeName(array.ElementType), actual.String(),
+				)
+			}
+		} else {
+			item, err := c.compileBuiltinValueArgument(call.Arguments[1])
+			if err != nil {
+				return true, nil, err
+			}
+			if _, explicitRef := item.(*ast.RefType); explicitRef {
+				return true, nil, fmt.Errorf(
+					"[line %d] argument 2 to 'append': expected %s, got %s",
+					c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
+				)
+			}
+			if !c.areStrictTypesCompatible(array.ElementType, item) {
+				return true, nil, fmt.Errorf(
+					"[line %d] argument 2 to 'append': expected %s, got %s",
+					c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
+				)
+			}
 		}
 		c.emitBytes(byte(chunk.OP_CALL), 2)
 		return true, builtinType("void"), nil

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -1,0 +1,129 @@
+package compiler
+
+import (
+	"fmt"
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+)
+
+func builtinType(name string) ast.NoxyType {
+	return &ast.PrimitiveType{Name: name}
+}
+
+func (c *Compiler) compileBuiltinValueArgument(expression ast.Expression) (ast.NoxyType, error) {
+	_, actual, err := c.Compile(expression)
+	if err != nil {
+		return nil, err
+	}
+	if ref, ok := actual.(*ast.RefType); ok {
+		c.emitByte(byte(chunk.OP_DEREF))
+		return ref.ElementType, nil
+	}
+	return actual, nil
+}
+
+func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyType, error) {
+	ident, ok := call.Function.(*ast.Identifier)
+	if !ok {
+		return false, nil, nil
+	}
+
+	name := ident.Value
+	if name != "append" && name != "pop" && name != "delete" && name != "json_loads" {
+		return false, nil, nil
+	}
+	if slot, _ := c.resolveLocal(name); slot != -1 {
+		return false, nil, nil
+	}
+	if upvalue, _ := c.resolveUpvalue(name); upvalue != -1 {
+		return false, nil, nil
+	}
+	if _, declared := c.resolveGlobalType(name); declared {
+		return false, nil, nil
+	}
+
+	wantArity := map[string]int{"append": 2, "pop": 1, "delete": 2, "json_loads": 2}[name]
+	if len(call.Arguments) != wantArity {
+		return true, nil, fmt.Errorf(
+			"[line %d] %s expects %d arguments, got %d",
+			c.currentLine, name, wantArity, len(call.Arguments),
+		)
+	}
+	if _, _, err := c.Compile(call.Function); err != nil {
+		return true, nil, err
+	}
+
+	switch name {
+	case "append":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		array, ok := container.(*ast.ArrayType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] append expects an array, got %s", c.currentLine, noxyTypeName(container))
+		}
+		item, err := c.compileBuiltinValueArgument(call.Arguments[1])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(array.ElementType, item) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 2 to 'append': expected %s, got %s",
+				c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
+			)
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("void"), nil
+	case "pop":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		array, ok := container.(*ast.ArrayType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] pop expects an array, got %s", c.currentLine, noxyTypeName(container))
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 1)
+		return true, array.ElementType, nil
+	case "delete":
+		container, err := c.compileReferenceArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		mapping, ok := container.(*ast.MapType)
+		if !ok {
+			return true, nil, fmt.Errorf("[line %d] delete expects a map, got %s", c.currentLine, noxyTypeName(container))
+		}
+		key, err := c.compileBuiltinValueArgument(call.Arguments[1])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(mapping.KeyType, key) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 2 to 'delete': expected %s, got %s",
+				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
+			)
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("void"), nil
+	case "json_loads":
+		jsonText, err := c.compileBuiltinValueArgument(call.Arguments[0])
+		if err != nil {
+			return true, nil, err
+		}
+		if !c.areStrictTypesCompatible(builtinType("string"), jsonText) {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 1 to 'json_loads': expected string, got %s",
+				c.currentLine, noxyTypeName(jsonText),
+			)
+		}
+		if _, err := c.compileReferenceArgument(call.Arguments[1]); err != nil {
+			return true, nil, err
+		}
+		c.emitBytes(byte(chunk.OP_CALL), 2)
+		return true, builtinType("bool"), nil
+	default:
+		return false, nil, nil
+	}
+}

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -122,6 +122,12 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 		if err != nil {
 			return true, nil, err
 		}
+		if _, explicitRef := key.(*ast.RefType); explicitRef {
+			return true, nil, fmt.Errorf(
+				"[line %d] argument 2 to 'delete': expected %s, got %s",
+				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
+			)
+		}
 		if !c.areStrictTypesCompatible(mapping.KeyType, key) {
 			return true, nil, fmt.Errorf(
 				"[line %d] argument 2 to 'delete': expected %s, got %s",
@@ -141,8 +147,12 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 				c.currentLine, noxyTypeName(jsonText),
 			)
 		}
-		if _, err := c.compileReferenceArgument(call.Arguments[1]); err != nil {
+		targetType, err := c.compileReferenceArgument(call.Arguments[1])
+		if err != nil {
 			return true, nil, err
+		}
+		if primitive, ok := targetType.(*ast.PrimitiveType); ok && primitive.Name == "any" {
+			c.emitByte(byte(chunk.OP_MARK_REF_JSON_DYNAMIC))
 		}
 		c.emitBytes(byte(chunk.OP_CALL), 2)
 		return true, builtinType("bool"), nil

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -45,10 +45,6 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 	if _, declared := c.resolveGlobalType(name); declared {
 		return false, nil, nil
 	}
-	if c.hasWildcardImport {
-		return false, nil, nil
-	}
-
 	wantArity := map[string]int{"append": 2, "pop": 1, "delete": 2, "json_loads": 2}[name]
 	if len(call.Arguments) != wantArity {
 		return true, nil, fmt.Errorf(

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -33,6 +33,43 @@ append(values, "wrong")`)
 	}
 }
 
+func TestAppendAcceptsReferenceValuedElements(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+struct Vertex
+    value: int
+end
+let first: Vertex = Vertex(1)
+let second: Vertex = Vertex(2)
+let existing: ref Vertex = ref second
+let values: (ref Vertex)[] = []
+append(values, ref first)
+append(values, first)
+append(values, existing)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAppendRejectsExplicitReferenceForOrdinaryElement(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let item: int = 1
+let values: int[] = []
+append(values, ref item)`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got ref int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAppendRejectsExplicitReferenceForAnyElement(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let item: int = 1
+let values: any[] = []
+append(values, ref item)`)
+	if err == nil || !strings.Contains(err.Error(), "expected any, got ref int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 func TestMutatingBuiltinNamesCanBeShadowed(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -74,6 +111,118 @@ end`,
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := compileFunctionSource(t, tt.source); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestImportedMutatingBuiltinNamesUseDynamicCallPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "selected append", source: "use fake_module select append\nappend(1, 2)"},
+		{name: "aliased append", source: "use fake_module as append\nappend(1, 2)"},
+		{name: "selected pop", source: "use fake_module select pop\npop(1)"},
+		{name: "aliased pop", source: "use fake_module as pop\npop(1)"},
+		{name: "selected delete", source: "use fake_module select delete\ndelete(1, 2)"},
+		{name: "aliased delete", source: "use fake_module as delete\ndelete(1, 2)"},
+		{name: "selected json_loads", source: "use fake_module select json_loads\njson_loads(1, 2)"},
+		{name: "aliased json_loads", source: "use fake_module as json_loads\njson_loads(1, 2)"},
+		{name: "wildcard import", source: "use fake_module select *\nappend(1, 2)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := compileFunctionSource(t, tt.source); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestMutatingBuiltinArityContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "pop", source: "pop()", want: "pop expects 1 arguments, got 0"},
+		{name: "delete", source: "delete({})", want: "delete expects 2 arguments, got 1"},
+		{name: "json_loads", source: `json_loads("{}")`, want: "json_loads expects 2 arguments, got 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileFunctionSource(t, tt.source)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error=%v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMutatingBuiltinAddressabilityContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "pop", source: "pop([1])"},
+		{name: "delete", source: `delete({"a": 1}, "a")`},
+		{name: "json_loads", source: `json_loads("{}", {"a": 1})`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileFunctionSource(t, tt.source)
+			if err == nil || !strings.Contains(err.Error(), "not addressable") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func TestMutatingBuiltinTypeContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "pop container",
+			source: `
+let mapping: map[string, int] = {"a": 1}
+pop(mapping)`,
+			want: "pop expects an array, got map[string, int]",
+		},
+		{
+			name: "delete container",
+			source: `
+let values: int[] = [1]
+delete(values, 0)`,
+			want: "delete expects a map, got int[]",
+		},
+		{
+			name: "delete key",
+			source: `
+let mapping: map[string, int] = {"a": 1}
+delete(mapping, 0)`,
+			want: "expected string, got int",
+		},
+		{
+			name: "json text",
+			source: `
+let target: map[string, int] = {}
+json_loads(42, target)`,
+			want: "expected string, got int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileFunctionSource(t, tt.source)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error=%v, want %q", err, tt.want)
 			}
 		})
 	}

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -217,15 +217,35 @@ use http_client select *`)
 	}
 }
 
-func TestCachedWildcardWrapperDoesNotShadowLaterUserBinding(t *testing.T) {
+func TestWildcardWrapperCollisionUsesDynamicCallPathOnFirstLoad(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+use http select *
+let url: string = "http://example.invalid"
+delete(url)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCachedWildcardWrapperShadowsLaterUserBinding(t *testing.T) {
 	_, err := compileFunctionSource(t, `
 use http
 func delete(left: int, right: int) -> int
     return left + right
 end
 use http select *
-delete(20)`)
-	if err == nil || !strings.Contains(err.Error(), "function 'delete' expects 2 arguments, got 1") {
+let url: string = "http://example.invalid"
+delete(url)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPlainWrapperImportDoesNotShadowUnqualifiedBuiltin(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+use http
+delete({"a": 1}, "a")`)
+	if err == nil || !strings.Contains(err.Error(), "not addressable") {
 		t.Fatalf("error=%v", err)
 	}
 }

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -147,12 +147,84 @@ func TestUnrelatedWildcardImportKeepsBuiltinLowering(t *testing.T) {
 	}
 }
 
+func TestWildcardImportCollisionUsesDynamicCallPath(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+use http_client select *
+let url: string = "http://example.invalid"
+delete(url)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWildcardImportCollisionIsKnownInsideEarlierFunction(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func remove(url: string) -> void
+    delete(url)
+end
+use http_client select *
+remove("http://example.invalid")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWildcardImportAndFunctionPredeclarationsPreserveRuntimePrecedence(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "later wildcard wins",
+			source: `
+func delete(left: int, right: int) -> int
+    return left + right
+end
+func remove(url: string) -> void
+    delete(url)
+end
+use http_client select *
+remove("http://example.invalid")`,
+		},
+		{
+			name: "later function wins",
+			source: `
+use http_client select *
+func delete(left: int, right: int) -> int
+    return left + right
+end
+func answer() -> int
+    return delete(20, 22)
+end`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := compileFunctionSource(t, tt.source); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestBuiltinCallBeforeLaterWildcardImportUsesSequentialBinding(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+delete({"a": 1}, "a")
+use http_client select *`)
+	if err == nil || !strings.Contains(err.Error(), "not addressable") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 func TestMutatingBuiltinArityContracts(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
 		want   string
 	}{
+		{name: "append too few", source: "append([])", want: "append expects 2 arguments, got 1"},
+		{name: "append too many", source: "append([], 1, 2)", want: "append expects 2 arguments, got 3"},
 		{name: "pop", source: "pop()", want: "pop expects 1 arguments, got 0"},
 		{name: "delete", source: "delete({})", want: "delete expects 2 arguments, got 1"},
 		{name: "json_loads", source: `json_loads("{}")`, want: "json_loads expects 2 arguments, got 1"},
@@ -231,5 +303,26 @@ json_loads(42, target)`,
 				t.Fatalf("error=%v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestDeleteRejectsExplicitReferenceForOrdinaryAnyKey(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let key: string = "a"
+let mapping: map[any, int] = {"a": 1}
+delete(mapping, ref key)`)
+	if err == nil || !strings.Contains(err.Error(), "expected any, got ref string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDeleteAcceptsImplicitReadFromExistingReferenceKey(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let key_value: string = "a"
+let key: ref string = ref key_value
+let mapping: map[any, int] = {"a": 1}
+delete(mapping, key)`)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -217,6 +217,40 @@ use http_client select *`)
 	}
 }
 
+func TestCachedWildcardWrapperDoesNotShadowLaterUserBinding(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+use http
+func delete(left: int, right: int) -> int
+    return left + right
+end
+use http select *
+delete(20)`)
+	if err == nil || !strings.Contains(err.Error(), "function 'delete' expects 2 arguments, got 1") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestUncalledFunctionImportsDoNotShadowOuterBuiltins(t *testing.T) {
+	tests := []struct {
+		name      string
+		importUse string
+	}{
+		{name: "selected", importUse: "use http_client select delete"},
+		{name: "alias", importUse: "use http_client as delete"},
+		{name: "wildcard", importUse: "use http_client select *"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := "func unused() -> void\n    " + tt.importUse + "\nend\ndelete({\"a\": 1}, \"a\")"
+			_, err := compileFunctionSource(t, source)
+			if err == nil || !strings.Contains(err.Error(), "not addressable") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
 func TestMutatingBuiltinArityContracts(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -1,0 +1,80 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMutatingBuiltinsBorrowAddressableArguments(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let values: int[] = [1]
+let mapping: map[string, int] = {"a": 1}
+append(values, 2)
+let removed: int = pop(values)
+delete(mapping, "a")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMutatingBuiltinsRejectNonAddressableArguments(t *testing.T) {
+	_, err := compileFunctionSource(t, `append([1], 2)`)
+	if err == nil || !strings.Contains(err.Error(), "not addressable") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAppendChecksElementType(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let values: int[] = [1]
+append(values, "wrong")`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestMutatingBuiltinNamesCanBeShadowed(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "global function",
+			source: `
+func append(left: int, right: int) -> int
+    return left + right
+end
+let answer: int = append(20, 22)`,
+		},
+		{
+			name: "local function",
+			source: `
+func answer() -> int
+    let append: func(int, int) -> int = func(left: int, right: int) -> int
+        return left + right
+    end
+    return append(20, 22)
+end`,
+		},
+		{
+			name: "captured function",
+			source: `
+func make_answer() -> func() -> int
+    let append: func(int, int) -> int = func(left: int, right: int) -> int
+        return left + right
+    end
+    return func() -> int
+        return append(20, 22)
+    end
+end`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := compileFunctionSource(t, tt.source); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -129,7 +129,6 @@ func TestImportedMutatingBuiltinNamesUseDynamicCallPath(t *testing.T) {
 		{name: "aliased delete", source: "use fake_module as delete\ndelete(1, 2)"},
 		{name: "selected json_loads", source: "use fake_module select json_loads\njson_loads(1, 2)"},
 		{name: "aliased json_loads", source: "use fake_module as json_loads\njson_loads(1, 2)"},
-		{name: "wildcard import", source: "use fake_module select *\nappend(1, 2)"},
 	}
 
 	for _, tt := range tests {
@@ -138,6 +137,13 @@ func TestImportedMutatingBuiltinNamesUseDynamicCallPath(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestUnrelatedWildcardImportKeepsBuiltinLowering(t *testing.T) {
+	_, err := compileFunctionSource(t, "use sys select *\nappend([1], 2)")
+	if err == nil || !strings.Contains(err.Error(), "not addressable") {
+		t.Fatalf("error=%v", err)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -40,6 +40,7 @@ type Compiler struct {
 	funcReturnType      ast.NoxyType // Expected return type for current function context
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
+	hasWildcardImport   bool
 }
 
 func New() *Compiler {
@@ -65,16 +66,17 @@ func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.Struc
 
 func NewChild(parent *Compiler) *Compiler {
 	c := &Compiler{
-		enclosing:    parent,
-		currentChunk: chunk.New(),
-		locals:       []Local{},
-		globals:      parent.globals,
-		structs:      parent.structs,
-		upvalues:     []Upvalue{},
-		scopeDepth:   0,
-		loops:        []*Loop{},
-		currentLine:  parent.currentLine,
-		FileName:     parent.FileName,
+		enclosing:         parent,
+		currentChunk:      chunk.New(),
+		locals:            []Local{},
+		globals:           parent.globals,
+		structs:           parent.structs,
+		upvalues:          []Upvalue{},
+		scopeDepth:        0,
+		loops:             []*Loop{},
+		currentLine:       parent.currentLine,
+		FileName:          parent.FileName,
+		hasWildcardImport: parent.hasWildcardImport,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -1307,10 +1309,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// 3. Handle Result
 		if n.SelectAll {
 			// use pkg select *
+			c.hasWildcardImport = true
 			c.emitByte(byte(chunk.OP_IMPORT_FROM_ALL))
 		} else if len(n.Selectors) > 0 {
 			// use pkg select a, b
 			for _, sel := range n.Selectors {
+				c.globals[sel] = nil
 				// DUP the module
 				c.emitByte(byte(chunk.OP_DUP))
 
@@ -1340,6 +1344,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 
 			nameConst := c.makeConstant(value.NewString(bindName))
+			c.globals[bindName] = nil
 			c.emitBytes(byte(chunk.OP_SET_GLOBAL), byte(nameConst))
 			c.emitByte(byte(chunk.OP_POP)) // Pop module
 		}
@@ -1726,6 +1731,24 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 		if _, ok := indexType.(*ast.RefType); ok {
 			c.emitByte(byte(chunk.OP_DEREF))
 		}
+		indexType = unwrapRefType(indexType)
+		switch collection := unwrapRefType(container).(type) {
+		case *ast.ArrayType:
+			expected := &ast.PrimitiveType{Name: "int"}
+			if !c.areStrictTypesCompatible(expected, indexType) {
+				return nil, fmt.Errorf(
+					"[line %d] array reference index must be int, got %s",
+					c.currentLine, noxyTypeName(indexType),
+				)
+			}
+		case *ast.MapType:
+			if !c.areStrictTypesCompatible(collection.KeyType, indexType) {
+				return nil, fmt.Errorf(
+					"[line %d] map reference key must be %s, got %s",
+					c.currentLine, noxyTypeName(collection.KeyType), noxyTypeName(indexType),
+				)
+			}
+		}
 		c.emitByte(byte(chunk.OP_REF_INDEX))
 		if ref, ok := element.(*ast.RefType); ok {
 			return ref.ElementType, nil
@@ -1734,6 +1757,18 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 	case *ast.NullLiteral:
 		c.emitByte(byte(chunk.OP_NULL))
 		return nil, nil
+	case *ast.CallExpression:
+		_, result, err := c.Compile(target)
+		if err != nil {
+			return nil, err
+		}
+		if ref, ok := result.(*ast.RefType); ok {
+			return ref.ElementType, nil
+		}
+		return nil, fmt.Errorf(
+			"[line %d] reference argument '%s' is not addressable\n  hint: use a variable, property, index, or null",
+			c.currentLine, expression.String(),
+		)
 	default:
 		return nil, fmt.Errorf(
 			"[line %d] reference argument '%s' is not addressable\n  hint: use a variable, property, index, or null",

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -41,6 +41,7 @@ type Compiler struct {
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
 	programBindings     map[string]ast.NoxyType
+	moduleDiscovery     *moduleDiscoveryState
 }
 
 func New() *Compiler {
@@ -65,11 +66,15 @@ func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.Struc
 }
 
 func NewChild(parent *Compiler) *Compiler {
+	childGlobals := make(map[string]ast.NoxyType, len(parent.globals))
+	for name, bindingType := range parent.globals {
+		childGlobals[name] = bindingType
+	}
 	c := &Compiler{
 		enclosing:       parent,
 		currentChunk:    chunk.New(),
 		locals:          []Local{},
-		globals:         parent.globals,
+		globals:         childGlobals,
 		structs:         parent.structs,
 		upvalues:        []Upvalue{},
 		scopeDepth:      0,
@@ -77,6 +82,7 @@ func NewChild(parent *Compiler) *Compiler {
 		currentLine:     parent.currentLine,
 		FileName:        parent.FileName,
 		programBindings: parent.programBindings,
+		moduleDiscovery: parent.moduleDiscovery,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -1730,10 +1736,11 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 			c.emitByte(byte(chunk.OP_DEREF))
 		}
 		name := c.makeConstant(value.NewString(target.Member))
-		c.emitBytes(byte(chunk.OP_REF_PROPERTY), byte(name))
 		if ref, ok := element.(*ast.RefType); ok {
+			c.emitBytes(byte(chunk.OP_CONTEXT_REF_PROPERTY), byte(name))
 			return ref.ElementType, nil
 		}
+		c.emitBytes(byte(chunk.OP_REF_PROPERTY), byte(name))
 		return element, nil
 	case *ast.IndexExpression:
 		_, container, err := c.Compile(target.Left)
@@ -1769,10 +1776,11 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 				)
 			}
 		}
-		c.emitByte(byte(chunk.OP_REF_INDEX))
 		if ref, ok := element.(*ast.RefType); ok {
+			c.emitByte(byte(chunk.OP_CONTEXT_REF_INDEX))
 			return ref.ElementType, nil
 		}
+		c.emitByte(byte(chunk.OP_REF_INDEX))
 		return element, nil
 	case *ast.NullLiteral:
 		c.emitByte(byte(chunk.OP_NULL))

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1672,8 +1672,13 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 			c.locals[slot].IsCaptured = true
 			return declared, nil
 		}
-		if upvalue, _ := c.resolveUpvalue(target.Value); upvalue != -1 {
-			return nil, fmt.Errorf("[line %d] captured variables cannot be passed by reference", c.currentLine)
+		if upvalue, declared := c.resolveUpvalue(target.Value); upvalue != -1 {
+			if ref, ok := declared.(*ast.RefType); ok {
+				c.emitBytes(byte(chunk.OP_GET_UPVALUE), byte(upvalue))
+				return ref.ElementType, nil
+			}
+			c.emitBytes(byte(chunk.OP_REF_UPVALUE), byte(upvalue))
+			return declared, nil
 		}
 		name := c.makeConstant(value.NewString(target.Value))
 		if declared, ok := c.resolveGlobalType(target.Value); ok {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1999,7 +1999,10 @@ func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *a
 		if _, ok := param.Type.(*ast.RefType); ok {
 			isRef = true
 		}
-		paramsInfo = append(paramsInfo, value.ParamInfo{IsRef: isRef})
+		paramsInfo = append(paramsInfo, value.ParamInfo{
+			IsRef:    isRef,
+			TypeName: param.Type.String(),
+		})
 	}
 	if declaredReturn.String() != "void" && !blockGuaranteesReturn(body) {
 		return value.Value{}, nil, fmt.Errorf(

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1333,7 +1333,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// 3. Handle Result
 		if n.SelectAll {
 			// use pkg select *
-			for name := range c.discoverModuleExports(n.Module) {
+			exports, loadable := c.discoverModuleExports(n.Module)
+			if !loadable && c.enclosing == nil {
+				return nil, nil, fmt.Errorf("[line %d] failed to resolve wildcard module '%s'", n.Token.Line, n.Module)
+			}
+			for name := range exports {
 				c.globals[name] = nil
 			}
 			c.emitByte(byte(chunk.OP_IMPORT_FROM_ALL))

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -5,6 +5,7 @@ import (
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
+	"path/filepath"
 	"strings"
 )
 
@@ -37,6 +38,7 @@ type Compiler struct {
 	loops               []*Loop
 	currentLine         int
 	FileName            string
+	moduleRoot          string
 	funcReturnType      ast.NoxyType // Expected return type for current function context
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
@@ -49,6 +51,17 @@ func New() *Compiler {
 }
 
 func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.StructStatement, fileName string) *Compiler {
+	moduleRoot := "."
+	if fileName != "" && fileName != "REPL" {
+		moduleRoot = filepath.Dir(fileName)
+	}
+	return NewWithStateAndRoot(globals, structs, fileName, moduleRoot)
+}
+
+func NewWithStateAndRoot(globals map[string]ast.NoxyType, structs map[string]*ast.StructStatement, fileName, moduleRoot string) *Compiler {
+	if moduleRoot == "" {
+		moduleRoot = "."
+	}
 	c := &Compiler{
 		enclosing:    nil,
 		currentChunk: chunk.New(),
@@ -60,6 +73,7 @@ func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.Struc
 		loops:        []*Loop{},
 		currentLine:  1,
 		FileName:     fileName,
+		moduleRoot:   moduleRoot,
 	}
 	c.currentChunk.FileName = fileName
 	return c
@@ -81,6 +95,7 @@ func NewChild(parent *Compiler) *Compiler {
 		loops:           []*Loop{},
 		currentLine:     parent.currentLine,
 		FileName:        parent.FileName,
+		moduleRoot:      parent.moduleRoot,
 		programBindings: parent.programBindings,
 		moduleDiscovery: parent.moduleDiscovery,
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -40,7 +40,6 @@ type Compiler struct {
 	funcReturnType      ast.NoxyType // Expected return type for current function context
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
-	hasWildcardImport   bool
 }
 
 func New() *Compiler {
@@ -66,17 +65,16 @@ func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.Struc
 
 func NewChild(parent *Compiler) *Compiler {
 	c := &Compiler{
-		enclosing:         parent,
-		currentChunk:      chunk.New(),
-		locals:            []Local{},
-		globals:           parent.globals,
-		structs:           parent.structs,
-		upvalues:          []Upvalue{},
-		scopeDepth:        0,
-		loops:             []*Loop{},
-		currentLine:       parent.currentLine,
-		FileName:          parent.FileName,
-		hasWildcardImport: parent.hasWildcardImport,
+		enclosing:    parent,
+		currentChunk: chunk.New(),
+		locals:       []Local{},
+		globals:      parent.globals,
+		structs:      parent.structs,
+		upvalues:     []Upvalue{},
+		scopeDepth:   0,
+		loops:        []*Loop{},
+		currentLine:  parent.currentLine,
+		FileName:     parent.FileName,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -1309,7 +1307,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// 3. Handle Result
 		if n.SelectAll {
 			// use pkg select *
-			c.hasWildcardImport = true
 			c.emitByte(byte(chunk.OP_IMPORT_FROM_ALL))
 		} else if len(n.Selectors) > 0 {
 			// use pkg select a, b

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -170,6 +170,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if !c.areTypesCompatible(n.Type, valType) {
 				return nil, nil, fmt.Errorf("[line %d] type mismatch in '%s' declaration: expected %s, got %s", c.currentLine, n.Name.Value, n.Type.String(), noxyTypeName(valType))
 			}
+			if err := c.emitRuntimeValueType(n.Type); err != nil {
+				return nil, nil, err
+			}
 		}
 
 		if c.scopeDepth > 0 {
@@ -264,6 +267,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if !c.areTypesCompatible(refT.ElementType, valType) {
 				return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment: expected %s, got %s", c.currentLine, refT.ElementType.String(), valType.String())
 			}
+			if err := c.emitRuntimeValueType(refT.ElementType); err != nil {
+				return nil, nil, err
+			}
 
 			// 4. Emit Store
 			// Stack: [Ref, Val]
@@ -308,6 +314,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							fmt.Printf("warning: rebinding ref parameter '%s' has no effect outside function\n", ident.Value)
 							fmt.Printf("  --> %s:%d\n", c.FileName, c.currentLine)
 						}
+						if err := c.emitRuntimeValueType(localType); err != nil {
+							return nil, nil, err
+						}
 						c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
 						c.emitByte(byte(chunk.OP_POP))
 						return c.currentChunk, nil, nil
@@ -322,6 +331,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					// Standard Value Assignment (int = int)
 					if !c.areTypesCompatible(localType, valType) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s", c.currentLine, ident.Value, localType.String(), valType.String())
+					}
+					if err := c.emitRuntimeValueType(localType); err != nil {
+						return nil, nil, err
 					}
 					c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
 					c.emitByte(byte(chunk.OP_POP))
@@ -338,6 +350,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						"[line %d] type mismatch in assignment to '%s': expected %s, got %s",
 						c.currentLine, ident.Value, noxyTypeName(upvalueType), noxyTypeName(valType),
 					)
+				}
+				if err := c.emitRuntimeValueType(upvalueType); err != nil {
+					return nil, nil, err
 				}
 				c.emitBytes(byte(chunk.OP_SET_UPVALUE), byte(arg))
 				c.emitByte(byte(chunk.OP_POP))
@@ -356,6 +371,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							}
 
 							nameConstant := c.makeConstant(value.NewString(ident.Value))
+							if err := c.emitRuntimeValueType(globalType); err != nil {
+								return nil, nil, err
+							}
 							c.emitBytes(byte(chunk.OP_SET_GLOBAL), byte(nameConstant))
 							c.emitByte(byte(chunk.OP_POP))
 						} else {
@@ -371,6 +389,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					// Standard Global Assignment
 					if !c.areTypesCompatible(globalType, valType) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s", c.currentLine, ident.Value, globalType.String(), valType.String())
+					}
+					if err := c.emitRuntimeValueType(globalType); err != nil {
+						return nil, nil, err
 					}
 				}
 				nameConstant := c.makeConstant(value.NewString(ident.Value))
@@ -419,7 +440,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 
 			// Type Check
+			var assignedType ast.NoxyType
 			if arrType, ok := leftType.(*ast.ArrayType); ok {
+				assignedType = arrType.ElementType
 				if idxType != nil && idxType.String() != "int" {
 					return nil, nil, fmt.Errorf("[line %d] array index must be int, got %s", c.currentLine, idxType.String())
 				}
@@ -438,6 +461,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s", c.currentLine, arrType.ElementType.String(), valType.String())
 				}
 			} else if mapType, ok := leftType.(*ast.MapType); ok {
+				assignedType = mapType.ValueType
 				if !c.areTypesCompatible(mapType.KeyType, idxType) {
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in map key: expected %s, got %s", c.currentLine, mapType.KeyType.String(), idxType.String())
 				}
@@ -453,6 +477,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				if leftType != nil && leftType.String() != "any" {
 					return nil, nil, fmt.Errorf("[line %d] index assignment on non-array/map type: %s", c.currentLine, leftType.String())
 				}
+			}
+			if err := c.emitRuntimeValueType(assignedType); err != nil {
+				return nil, nil, err
 			}
 
 			c.emitByte(byte(chunk.OP_SET_INDEX))
@@ -518,6 +545,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					if !c.areTypesCompatible(fieldType, valType) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in field assignment: expected %s, got %s", c.currentLine, fieldType.String(), valType.String())
 					}
+				}
+				if err := c.emitRuntimeValueType(fieldType); err != nil {
+					return nil, nil, err
 				}
 			}
 
@@ -1438,6 +1468,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				n.Token.Line, functionName, expected.String(), noxyTypeName(actual),
 			)
 		}
+		if err := c.emitRuntimeValueType(expected); err != nil {
+			return nil, nil, err
+		}
 		c.emitByte(byte(chunk.OP_RETURN))
 		return c.currentChunk, nil, nil
 
@@ -1653,6 +1686,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							c.currentLine, i+1, callableName(n.Function), expectedRef.String(), actual.String(),
 						)
 					}
+					if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
+						return nil, nil, err
+					}
 					continue
 				}
 			}
@@ -1675,6 +1711,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					c.currentLine, i+1, callableName(n.Function),
 					funcType.Params[i].String(), noxyTypeName(argType),
 				)
+			}
+			if isExact {
+				if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
+					return nil, nil, err
+				}
 			}
 		}
 
@@ -2131,6 +2172,7 @@ func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *a
 
 	upvalueCount := len(fnCompiler.upvalues)
 	fnObj := value.NewFunction(name, len(params), upvalueCount, paramsInfo, fnCompiler.currentChunk, nil)
+	fnObj.Obj.(*value.ObjFunction).RuntimeType = c.runtimeTypeInfo(newFunctionType(params, declaredReturn))
 
 	return fnObj, fnCompiler, nil
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -276,6 +276,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						return c.currentChunk, nil, nil
 					}
 
+					if c.areTypesCompatible(refType.ElementType, valType) {
+						return nil, nil, referenceAssignmentTypeError(c.currentLine, ident.Value, localType, valType)
+					}
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s", c.currentLine, ident.Value, localType.String(), valType.String())
 
 				} else {
@@ -288,6 +291,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				}
 			} else if arg, upvalueType := c.resolveUpvalue(ident.Value); arg != -1 {
 				// Upvalue Logic
+				if refType, isRef := upvalueType.(*ast.RefType); isRef &&
+					!(isReferenceType(valType) || valType == nil || isNullType(valType)) &&
+					c.areTypesCompatible(refType.ElementType, valType) {
+					return nil, nil, referenceAssignmentTypeError(c.currentLine, ident.Value, upvalueType, valType)
+				}
 				if !c.areTypesCompatible(upvalueType, valType) {
 					return nil, nil, fmt.Errorf(
 						"[line %d] type mismatch in assignment to '%s': expected %s, got %s",
@@ -316,7 +324,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						} else {
 							// User tried `ref = val`. Explicitly FORBID update via name.
 							if c.areTypesCompatible(refType.ElementType, valType) {
-								return nil, nil, fmt.Errorf("[line %d] cannot assign value to global reference '%s'.\n  hint: Did you mean to update the value? Use '*%s = ...'", c.currentLine, ident.Value, ident.Value)
+								return nil, nil, referenceAssignmentTypeError(c.currentLine, ident.Value, globalType, valType)
 							}
 							return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s", c.currentLine, ident.Value, globalType.String(), valType.String())
 						}
@@ -384,12 +392,22 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				// Implict deref/update via assignment is NOT allowed if types don't match.
 				// User must use `*arr[i] = val` for updates.
 
+				if refType, isRef := arrType.ElementType.(*ast.RefType); isRef &&
+					!(isReferenceType(valType) || valType == nil || isNullType(valType)) &&
+					c.areTypesCompatible(refType.ElementType, valType) {
+					return nil, nil, referenceAssignmentTypeError(c.currentLine, assignmentTargetName(indexExp), arrType.ElementType, valType)
+				}
 				if !c.areTypesCompatible(arrType.ElementType, valType) {
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s", c.currentLine, arrType.ElementType.String(), valType.String())
 				}
 			} else if mapType, ok := leftType.(*ast.MapType); ok {
 				if !c.areTypesCompatible(mapType.KeyType, idxType) {
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in map key: expected %s, got %s", c.currentLine, mapType.KeyType.String(), idxType.String())
+				}
+				if refType, isRef := mapType.ValueType.(*ast.RefType); isRef &&
+					!(isReferenceType(valType) || valType == nil || isNullType(valType)) &&
+					c.areTypesCompatible(refType.ElementType, valType) {
+					return nil, nil, referenceAssignmentTypeError(c.currentLine, assignmentTargetName(indexExp), mapType.ValueType, valType)
 				}
 				if !c.areTypesCompatible(mapType.ValueType, valType) {
 					return nil, nil, fmt.Errorf("[line %d] type mismatch in map value: expected %s, got %s", c.currentLine, mapType.ValueType.String(), valType.String())
@@ -441,7 +459,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			// TYPE-BASED ASSIGNMENT LOGIC:
 			if fieldType != nil {
 				// If Field is Ref, Value MUST be compatible Ref (Rebind).
-				if _, isRefField := fieldType.(*ast.RefType); isRefField {
+				if refType, isRefField := fieldType.(*ast.RefType); isRefField {
 					// Check Compatibility
 					isRefVal := false
 					if valType != nil {
@@ -453,9 +471,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						if valType != nil && !c.areTypesCompatible(fieldType, valType) {
 							return nil, nil, fmt.Errorf("[line %d] type mismatch in rebind: expected %s, got %s", c.currentLine, fieldType.String(), valType.String())
 						}
+					} else if c.areTypesCompatible(refType.ElementType, valType) {
+						return nil, nil, referenceAssignmentTypeError(c.currentLine, assignmentTargetName(memberExp), fieldType, valType)
 					} else {
-						// Error: Trying to assign Value to Ref Field
-						return nil, nil, fmt.Errorf("[line %d] cannot assign value to reference field '%s'.\n  hint: Did you mean to update the value? Use '*%s.%s = ...'", c.currentLine, memberExp.Member, "...", memberExp.Member)
+						return nil, nil, fmt.Errorf("[line %d] type mismatch in rebind: expected %s, got %s", c.currentLine, fieldType.String(), valType.String())
 					}
 				} else {
 					// Standard Field
@@ -1850,6 +1869,31 @@ func (c *Compiler) resolveLocal(name string) (int, ast.NoxyType) {
 func (c *Compiler) resolveGlobalType(name string) (ast.NoxyType, bool) {
 	t, ok := c.globals[name]
 	return t, ok
+}
+
+func referenceAssignmentTypeError(line int, name string, expected, actual ast.NoxyType) error {
+	return fmt.Errorf(
+		"[line %d] cannot assign %s to %s\n  hint: use '*%s = ...' to update the referenced value",
+		line, noxyTypeName(actual), noxyTypeName(expected), name,
+	)
+}
+
+func isReferenceType(t ast.NoxyType) bool {
+	_, ok := t.(*ast.RefType)
+	return ok
+}
+
+func assignmentTargetName(expression ast.Expression) string {
+	switch target := expression.(type) {
+	case *ast.Identifier:
+		return target.Value
+	case *ast.MemberAccessExpression:
+		return assignmentTargetName(target.Left) + "." + target.Member
+	case *ast.IndexExpression:
+		return assignmentTargetName(target.Left) + "[" + target.Index.String() + "]"
+	default:
+		return expression.String()
+	}
 }
 
 func (c *Compiler) areTypesCompatible(expected, actual ast.NoxyType) bool {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1720,7 +1720,12 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 	}
 	if runtimeType := c.runtimeTypeInfo(targetType); runtimeType != nil {
 		typeConstant := c.makeConstant(value.NewRuntimeTypeInfo(runtimeType))
-		c.emitBytes(byte(chunk.OP_MARK_REF_TARGET_TYPE), byte(typeConstant))
+		if typeConstant > 65535 {
+			return nil, fmt.Errorf("[line %d] too many constants for reference target metadata", c.currentLine)
+		}
+		c.emitByte(byte(chunk.OP_MARK_REF_TARGET_TYPE))
+		c.emitByte(byte((typeConstant >> 8) & 0xff))
+		c.emitByte(byte(typeConstant & 0xff))
 	}
 	return targetType, nil
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -584,6 +584,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			paramTypes = append(paramTypes, f.Type)
 		}
 		structType := newStructFunctionType(n.Name, paramTypes)
+		structDefinition.ConstructorType = c.runtimeTypeInfo(structType)
 
 		if c.scopeDepth > 0 {
 			// Local scope: struct is a local variable

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1643,6 +1643,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					if err != nil {
 						return nil, nil, err
 					}
+					if _, isNull := arg.(*ast.NullLiteral); isNull {
+						continue
+					}
 					if !c.areStrictTypesCompatible(expectedRef.ElementType, actualElement) {
 						actual := &ast.RefType{ElementType: actualElement}
 						return nil, nil, fmt.Errorf(

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1714,6 +1714,18 @@ func (c *Compiler) memberType(owner ast.NoxyType, member string) ast.NoxyType {
 }
 
 func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.NoxyType, error) {
+	targetType, err := c.compileReferenceArgumentValue(expression)
+	if err != nil || targetType == nil {
+		return targetType, err
+	}
+	if runtimeType := c.runtimeTypeInfo(targetType); runtimeType != nil {
+		typeConstant := c.makeConstant(value.NewRuntimeTypeInfo(runtimeType))
+		c.emitBytes(byte(chunk.OP_MARK_REF_TARGET_TYPE), byte(typeConstant))
+	}
+	return targetType, nil
+}
+
+func (c *Compiler) compileReferenceArgumentValue(expression ast.Expression) (ast.NoxyType, error) {
 	if prefix, ok := expression.(*ast.PrefixExpression); ok && prefix.Operator == "ref" {
 		expression = prefix.Right
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -40,6 +40,7 @@ type Compiler struct {
 	funcReturnType      ast.NoxyType // Expected return type for current function context
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
+	programBindings     map[string]ast.NoxyType
 }
 
 func New() *Compiler {
@@ -65,16 +66,17 @@ func NewWithState(globals map[string]ast.NoxyType, structs map[string]*ast.Struc
 
 func NewChild(parent *Compiler) *Compiler {
 	c := &Compiler{
-		enclosing:    parent,
-		currentChunk: chunk.New(),
-		locals:       []Local{},
-		globals:      parent.globals,
-		structs:      parent.structs,
-		upvalues:     []Upvalue{},
-		scopeDepth:   0,
-		loops:        []*Loop{},
-		currentLine:  parent.currentLine,
-		FileName:     parent.FileName,
+		enclosing:       parent,
+		currentChunk:    chunk.New(),
+		locals:          []Local{},
+		globals:         parent.globals,
+		structs:         parent.structs,
+		upvalues:        []Upvalue{},
+		scopeDepth:      0,
+		loops:           []*Loop{},
+		currentLine:     parent.currentLine,
+		FileName:        parent.FileName,
+		programBindings: parent.programBindings,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -87,9 +89,23 @@ func (c *Compiler) GetGlobals() map[string]ast.NoxyType {
 func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 	switch n := node.(type) {
 	case *ast.Program:
+		sequentialBindings := make(map[string]ast.NoxyType, len(c.globals))
+		for name, bindingType := range c.globals {
+			sequentialBindings[name] = bindingType
+		}
 		c.predeclareStructs(n.Statements)
-		if err := c.predeclareFunctions(n.Statements); err != nil {
+		if err := c.predeclareGlobalBindings(n.Statements); err != nil {
 			return nil, nil, err
+		}
+		c.programBindings = make(map[string]ast.NoxyType, len(c.globals))
+		for name, bindingType := range c.globals {
+			c.programBindings[name] = bindingType
+		}
+		for name := range c.globals {
+			delete(c.globals, name)
+		}
+		for name, bindingType := range sequentialBindings {
+			c.globals[name] = bindingType
 		}
 		for _, stmt := range n.Statements {
 			if _, _, err := c.Compile(stmt); err != nil {
@@ -502,6 +518,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			fields = append(fields, f.Name)
 		}
 		structObj := value.NewStruct(n.Name, fields)
+		structDefinition := structObj.Obj.(*value.ObjStruct)
+		structDefinition.JSONDynamicFields = make(map[string]bool)
+		for _, field := range n.FieldsList {
+			if primitive, ok := field.Type.(*ast.PrimitiveType); ok && primitive.Name == "any" {
+				structDefinition.JSONDynamicFields[field.Name] = true
+			}
+		}
 		c.emitConstant(structObj)
 
 		// Create Constructor Signature
@@ -509,10 +532,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		for _, f := range n.FieldsList {
 			paramTypes = append(paramTypes, f.Type)
 		}
-		structType := &ast.FunctionType{
-			Params: paramTypes,
-			Return: &ast.PrimitiveType{Name: n.Name},
-		}
+		structType := newStructFunctionType(n.Name, paramTypes)
 
 		if c.scopeDepth > 0 {
 			// Local scope: struct is a local variable
@@ -1307,6 +1327,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// 3. Handle Result
 		if n.SelectAll {
 			// use pkg select *
+			for name := range c.discoverModuleExports(n.Module) {
+				c.globals[name] = nil
+			}
 			c.emitByte(byte(chunk.OP_IMPORT_FROM_ALL))
 		} else if len(n.Selectors) > 0 {
 			// use pkg select a, b
@@ -2020,6 +2043,9 @@ func (c *Compiler) addUpvalue(index uint8, isLocal bool, upvalueType ast.NoxyTyp
 }
 
 func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *ast.BlockStatement, returnType ast.NoxyType) (value.Value, *Compiler, error) {
+	restoreBindings := c.applyProgramBindings()
+	defer restoreBindings()
+
 	fnCompiler := NewChild(c)
 	fnCompiler.scopeDepth = 1    // Inside function body
 	fnCompiler.addLocal("", nil) // Reserve slot 0 for function instance
@@ -2060,4 +2086,29 @@ func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *a
 	fnObj := value.NewFunction(name, len(params), upvalueCount, paramsInfo, fnCompiler.currentChunk, nil)
 
 	return fnObj, fnCompiler, nil
+}
+
+func (c *Compiler) applyProgramBindings() func() {
+	if len(c.programBindings) == 0 {
+		return func() {}
+	}
+	type priorBinding struct {
+		typeInfo ast.NoxyType
+		exists   bool
+	}
+	prior := make(map[string]priorBinding, len(c.programBindings))
+	for name, bindingType := range c.programBindings {
+		current, exists := c.globals[name]
+		prior[name] = priorBinding{typeInfo: current, exists: exists}
+		c.globals[name] = bindingType
+	}
+	return func() {
+		for name, binding := range prior {
+			if binding.exists {
+				c.globals[name] = binding.typeInfo
+			} else {
+				delete(c.globals, name)
+			}
+		}
+	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1887,10 +1887,12 @@ func assignmentTargetName(expression ast.Expression) string {
 	switch target := expression.(type) {
 	case *ast.Identifier:
 		return target.Value
+	case *ast.StringLiteral:
+		return fmt.Sprintf("%q", target.Value)
 	case *ast.MemberAccessExpression:
 		return assignmentTargetName(target.Left) + "." + target.Member
 	case *ast.IndexExpression:
-		return assignmentTargetName(target.Left) + "[" + target.Index.String() + "]"
+		return assignmentTargetName(target.Left) + "[" + assignmentTargetName(target.Index) + "]"
 	default:
 		return expression.String()
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -28,6 +28,13 @@ type Upvalue struct {
 	Type    ast.NoxyType
 }
 
+type scopedStructBinding struct {
+	Depth   int
+	Name    string
+	Prior   *ast.StructStatement
+	Existed bool
+}
+
 type Compiler struct {
 	enclosing           *Compiler
 	currentChunk        *chunk.Chunk
@@ -42,6 +49,7 @@ type Compiler struct {
 	funcReturnType      ast.NoxyType // Expected return type for current function context
 	currentFunctionName string
 	structs             map[string]*ast.StructStatement
+	scopedStructs       []scopedStructBinding
 	programBindings     map[string]ast.NoxyType
 	moduleDiscovery     *moduleDiscoveryState
 }
@@ -84,12 +92,16 @@ func NewChild(parent *Compiler) *Compiler {
 	for name, bindingType := range parent.globals {
 		childGlobals[name] = bindingType
 	}
+	childStructs := make(map[string]*ast.StructStatement, len(parent.structs))
+	for name, definition := range parent.structs {
+		childStructs[name] = definition
+	}
 	c := &Compiler{
 		enclosing:       parent,
 		currentChunk:    chunk.New(),
 		locals:          []Local{},
 		globals:         childGlobals,
-		structs:         parent.structs,
+		structs:         childStructs,
 		upvalues:        []Upvalue{},
 		scopeDepth:      0,
 		loops:           []*Loop{},
@@ -563,6 +575,16 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 	case *ast.StructStatement:
 		c.setLine(n.Token.Line)
+		if c.scopeDepth > 0 {
+			prior, existed := c.structs[n.Name]
+			c.scopedStructs = append(c.scopedStructs, scopedStructBinding{
+				Depth:   c.scopeDepth,
+				Name:    n.Name,
+				Prior:   prior,
+				Existed: existed,
+			})
+			c.structs[n.Name] = n
+		}
 
 		fields := []string{}
 		for _, f := range n.FieldsList {
@@ -1950,6 +1972,16 @@ func (c *Compiler) beginScope() {
 }
 
 func (c *Compiler) endScope() {
+	exitingDepth := c.scopeDepth
+	for len(c.scopedStructs) > 0 && c.scopedStructs[len(c.scopedStructs)-1].Depth == exitingDepth {
+		binding := c.scopedStructs[len(c.scopedStructs)-1]
+		c.scopedStructs = c.scopedStructs[:len(c.scopedStructs)-1]
+		if binding.Existed {
+			c.structs[binding.Name] = binding.Prior
+		} else {
+			delete(c.structs, binding.Name)
+		}
+	}
 	c.scopeDepth--
 	// Pop locals from stack
 	for len(c.locals) > 0 && c.locals[len(c.locals)-1].Depth > c.scopeDepth {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1462,6 +1462,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, nil, nil
 
 	case *ast.CallExpression:
+		if handled, resultType, err := c.compileBuiltinCall(n); handled {
+			return c.currentChunk, resultType, err
+		}
+
 		// Check for special functions: chan_send, chan_recv
 		if ident, ok := n.Function.(*ast.Identifier); ok {
 			if ident.Value == "chan_send" {
@@ -1732,8 +1736,8 @@ func (c *Compiler) compileReferenceArgument(expression ast.Expression) (ast.Noxy
 		return nil, nil
 	default:
 		return nil, fmt.Errorf(
-			"[line %d] reference argument must be a variable, property, index, or null",
-			c.currentLine,
+			"[line %d] reference argument '%s' is not addressable\n  hint: use a variable, property, index, or null",
+			c.currentLine, expression.String(),
 		)
 	}
 }

--- a/internal/compiler/function_conformance_examples_test.go
+++ b/internal/compiler/function_conformance_examples_test.go
@@ -47,7 +47,7 @@ func TestTypedFunctionInvalidConformanceExamplesFail(t *testing.T) {
 		{"wrong return", "typed_function_wrong_return.nx", "return type mismatch in 'invalid': expected int, got string"},
 		{"incompatible assignment", "typed_function_incompatible_assignment.nx", "expected func(int) -> int, got func(string) -> int"},
 		{"dynamic narrowing", "typed_function_dynamic_narrowing.nx", "expected func(int) -> int, got func"},
-		{"invalid ref argument", "typed_function_invalid_ref_argument.nx", "reference argument must be a variable, property, index, or null"},
+		{"invalid ref argument", "typed_function_invalid_ref_argument.nx", "reference argument '41' is not addressable\n  hint: use a variable, property, index, or null"},
 	}
 
 	for _, tt := range tests {

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -213,20 +213,36 @@ func commonInferredType(left, right ast.NoxyType) ast.NoxyType {
 	return &ast.PrimitiveType{Name: "any"}
 }
 
-func (c *Compiler) predeclareFunctions(statements []ast.Statement) error {
+func (c *Compiler) predeclareGlobalBindings(statements []ast.Statement) error {
 	seen := make(map[string]struct{})
 	for _, statement := range statements {
-		fn, ok := statement.(*ast.FunctionStatement)
-		if !ok {
-			continue
+		switch declaration := statement.(type) {
+		case *ast.UseStmt:
+			c.predeclareImport(declaration)
+		case *ast.FunctionStatement:
+			if _, duplicate := seen[declaration.Name]; duplicate {
+				return fmt.Errorf("[line %d] duplicate function '%s'", declaration.Token.Line, declaration.Name)
+			}
+			seen[declaration.Name] = struct{}{}
+			c.globals[declaration.Name] = newFunctionType(declaration.Parameters, declaration.ReturnType)
+		case *ast.LetStmt:
+			c.globals[declaration.Name.Value] = declaration.Type
+		case *ast.StructStatement:
+			params := make([]ast.NoxyType, 0, len(declaration.FieldsList))
+			for _, field := range declaration.FieldsList {
+				params = append(params, field.Type)
+			}
+			c.globals[declaration.Name] = newStructFunctionType(declaration.Name, params)
 		}
-		if _, duplicate := seen[fn.Name]; duplicate {
-			return fmt.Errorf("[line %d] duplicate function '%s'", fn.Token.Line, fn.Name)
-		}
-		seen[fn.Name] = struct{}{}
-		c.globals[fn.Name] = newFunctionType(fn.Parameters, fn.ReturnType)
 	}
 	return nil
+}
+
+func newStructFunctionType(name string, params []ast.NoxyType) *ast.FunctionType {
+	return &ast.FunctionType{
+		Params: params,
+		Return: &ast.PrimitiveType{Name: name},
+	}
 }
 
 func (c *Compiler) predeclareStructs(statements []ast.Statement) {

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -484,6 +484,27 @@ accept(null)`)
 	}
 }
 
+func TestExactReferenceCallAcceptsNullForCallableElement(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func accept(value: ref func() -> int) -> void
+end
+accept(null)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExactReferenceCallDoesNotTreatAnyAsNull(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func accept(value: ref func() -> int) -> void
+end
+let dynamic: any = null
+accept(dynamic)`)
+	if err == nil || !strings.Contains(err.Error(), "expected ref func() -> int, got ref any") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 func TestCapturedFunctionReassignmentIsTypeChecked(t *testing.T) {
 	_, err := compileFunctionSource(t, `
 func integer(value: int) -> int

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -544,3 +544,20 @@ end`)
 		t.Fatal(err)
 	}
 }
+
+func TestExactReferenceCallAcceptsCapturedVariable(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+func make_incrementer() -> func() -> int
+    let value: int = 0
+    return func() -> int
+        increment(value)
+        return value
+    end
+end`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -163,7 +163,7 @@ add(x)`, "expected int, got any"},
 		{"ref", `func set(v: ref int) -> void
     return
 end
-set(1)`, "reference argument must be a variable, property, index, or null"},
+set(1)`, "reference argument '1' is not addressable"},
 		{"ref type", `func set(v: ref int) -> void
     return
 end

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -566,6 +566,23 @@ end`)
 	}
 }
 
+func TestLocalStructTypeDoesNotLeakIntoSiblingFunction(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func define_local() -> int
+    struct Hidden
+        value: int
+    end
+    return Hidden(1).value
+end
+func sibling() -> int
+    let makers: (func(int) -> Hidden)[] = [Hidden]
+    return length(makers)
+end`)
+	if err == nil {
+		t.Fatal("local struct type leaked into sibling function")
+	}
+}
+
 func TestExactReferenceCallAcceptsCapturedVariable(t *testing.T) {
 	_, err := compileFunctionSource(t, `
 func increment(value: ref int) -> void

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -274,7 +274,7 @@ items[0] = 1`,
 let number: int = 0
 let items: map[string, ref int] = {"item": ref number}
 items["item"] = 1`,
-			hint: "use '*items[item] = ...'",
+			hint: "use '*items[\"item\"] = ...'",
 		},
 	}
 

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -205,6 +205,92 @@ set(values[0])`)
 	}
 }
 
+func TestReferenceValueAssignmentSuggestsDereference(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func increment(value: ref int) -> void
+    value = value + 1
+end`)
+	if err == nil {
+		t.Fatal("expected reference assignment error")
+	}
+	want := "cannot assign int to ref int"
+	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "use '*value = ...'") {
+		t.Fatalf("error=%q, want %q and dereference hint", err, want)
+	}
+}
+
+func TestReferenceSlotValueAssignmentsSuggestDereference(t *testing.T) {
+	tests := []struct {
+		name, input, hint string
+	}{
+		{
+			name: "local reference parameter",
+			input: `
+func increment(value: ref int) -> void
+    value = value + 1
+end`,
+			hint: "use '*value = ...'",
+		},
+		{
+			name: "global",
+			input: `
+let number: int = 0
+let value: ref int = ref number
+value = 1`,
+			hint: "use '*value = ...'",
+		},
+		{
+			name: "captured reference parameter",
+			input: `
+func outer(value: ref int) -> void
+    func inner() -> void
+        value = value + 1
+    end
+end`,
+			hint: "use '*value = ...'",
+		},
+		{
+			name: "field",
+			input: `
+struct Holder
+    field: ref int
+end
+let number: int = 0
+let holder: Holder = Holder(ref number)
+holder.field = 1`,
+			hint: "use '*holder.field = ...'",
+		},
+		{
+			name: "array element",
+			input: `
+let number: int = 0
+let items: (ref int)[] = [ref number]
+items[0] = 1`,
+			hint: "use '*items[0] = ...'",
+		},
+		{
+			name: "map value",
+			input: `
+let number: int = 0
+let items: map[string, ref int] = {"item": ref number}
+items["item"] = 1`,
+			hint: "use '*items[item] = ...'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileFunctionSource(t, tt.input)
+			if err == nil {
+				t.Fatal("expected reference assignment error")
+			}
+			if !strings.Contains(err.Error(), "cannot assign int to ref int") || !strings.Contains(err.Error(), tt.hint) {
+				t.Fatalf("error=%q, want reference assignment diagnostic with %q", err, tt.hint)
+			}
+		})
+	}
+}
+
 func TestReturnChecking(t *testing.T) {
 	tests := []struct{ name, input, want string }{
 		{"wrong type", `func bad() -> int

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -10,8 +10,60 @@ import (
 	"strings"
 )
 
+type moduleDiscoveryState struct {
+	active   map[string]bool
+	failures int
+}
+
 func (c *Compiler) discoverModuleExports(module string) map[string]struct{} {
-	return c.discoverModuleExportsFrom(module, make(map[string]bool))
+	state := c.moduleDiscovery
+	if state == nil {
+		state = &moduleDiscoveryState{active: make(map[string]bool)}
+	}
+	return c.discoverModuleExportsWithState(module, state)
+}
+
+func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDiscoveryState) map[string]struct{} {
+	exports := make(map[string]struct{})
+	program, directoryExports, ok := c.loadModuleDeclarations(module, state)
+	if !ok {
+		return exports
+	}
+	for _, name := range directoryExports {
+		exports[name] = struct{}{}
+	}
+	if program == nil {
+		return exports
+	}
+
+	for _, statement := range program.Statements {
+		switch declaration := statement.(type) {
+		case *ast.LetStmt:
+			exports[declaration.Name.Value] = struct{}{}
+		case *ast.FunctionStatement:
+			exports[declaration.Name] = struct{}{}
+		case *ast.StructStatement:
+			exports[declaration.Name] = struct{}{}
+		case *ast.UseStmt:
+			switch {
+			case declaration.SelectAll:
+				// OP_IMPORT_FROM_ALL writes shared VM globals, not the module's
+				// returned moduleGlobals map, so wildcard side effects are not exports.
+			case len(declaration.Selectors) > 0:
+				for _, name := range declaration.Selectors {
+					exports[name] = struct{}{}
+				}
+			default:
+				name := declaration.Alias
+				if name == "" {
+					parts := strings.Split(declaration.Module, ".")
+					name = parts[len(parts)-1]
+				}
+				exports[name] = struct{}{}
+			}
+		}
+	}
+	return exports
 }
 
 func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
@@ -34,57 +86,14 @@ func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
 	}
 }
 
-func (c *Compiler) discoverModuleExportsFrom(module string, visiting map[string]bool) map[string]struct{} {
-	exports := make(map[string]struct{})
-	if visiting[module] {
-		return exports
+func (c *Compiler) loadModuleDeclarations(module string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
+	if state.active[module] {
+		state.failures++
+		return nil, nil, false
 	}
-	visiting[module] = true
-	defer delete(visiting, module)
+	state.active[module] = true
+	defer delete(state.active, module)
 
-	program, directoryExports, ok := c.loadModuleDeclarations(module)
-	if !ok {
-		return exports
-	}
-	for _, name := range directoryExports {
-		exports[name] = struct{}{}
-	}
-	if program == nil {
-		return exports
-	}
-
-	for _, statement := range program.Statements {
-		switch declaration := statement.(type) {
-		case *ast.LetStmt:
-			exports[declaration.Name.Value] = struct{}{}
-		case *ast.FunctionStatement:
-			exports[declaration.Name] = struct{}{}
-		case *ast.StructStatement:
-			exports[declaration.Name] = struct{}{}
-		case *ast.UseStmt:
-			switch {
-			case declaration.SelectAll:
-				for name := range c.discoverModuleExportsFrom(declaration.Module, visiting) {
-					exports[name] = struct{}{}
-				}
-			case len(declaration.Selectors) > 0:
-				for _, name := range declaration.Selectors {
-					exports[name] = struct{}{}
-				}
-			default:
-				name := declaration.Alias
-				if name == "" {
-					parts := strings.Split(declaration.Module, ".")
-					name = parts[len(parts)-1]
-				}
-				exports[name] = struct{}{}
-			}
-		}
-	}
-	return exports
-}
-
-func (c *Compiler) loadModuleDeclarations(module string) (*ast.Program, []string, bool) {
 	pathName := strings.ReplaceAll(module, ".", string(filepath.Separator))
 	for _, candidate := range c.moduleFileCandidates(pathName) {
 		info, err := os.Stat(candidate)
@@ -96,7 +105,7 @@ func (c *Compiler) loadModuleDeclarations(module string) (*ast.Program, []string
 			for _, entry := range []string{base + ".nx", "main.nx"} {
 				entryPath := filepath.Join(candidate, entry)
 				if entryInfo, entryErr := os.Stat(entryPath); entryErr == nil && !entryInfo.IsDir() {
-					return parseModuleDeclarationsFile(entryPath)
+					return c.parseModuleDeclarationsFile(entryPath, state)
 				}
 			}
 			entries, readErr := os.ReadDir(candidate)
@@ -106,14 +115,22 @@ func (c *Compiler) loadModuleDeclarations(module string) (*ast.Program, []string
 			names := make([]string, 0, len(entries))
 			for _, entry := range entries {
 				if entry.IsDir() {
-					names = append(names, entry.Name())
+					_, _, loadable := c.loadModuleDeclarations(module+"."+entry.Name(), state)
+					if loadable {
+						names = append(names, entry.Name())
+					}
 				} else if strings.HasSuffix(entry.Name(), ".nx") {
-					names = append(names, strings.TrimSuffix(entry.Name(), ".nx"))
+					name := strings.TrimSuffix(entry.Name(), ".nx")
+					_, _, loadable := c.loadModuleDeclarations(module+"."+name, state)
+					if !loadable {
+						return nil, nil, false
+					}
+					names = append(names, name)
 				}
 			}
 			return nil, names, true
 		}
-		return parseModuleDeclarationsFile(candidate)
+		return c.parseModuleDeclarationsFile(candidate, state)
 	}
 
 	embedPath := strings.ReplaceAll(module, ".", "/") + ".nx"
@@ -121,7 +138,7 @@ func (c *Compiler) loadModuleDeclarations(module string) (*ast.Program, []string
 	if err != nil {
 		return nil, nil, false
 	}
-	return parseModuleDeclarations(content)
+	return c.parseModuleDeclarations(content, module, state)
 }
 
 func (c *Compiler) moduleFileCandidates(pathName string) []string {
@@ -160,18 +177,45 @@ func (c *Compiler) moduleFileCandidates(pathName string) []string {
 	return candidates
 }
 
-func parseModuleDeclarationsFile(path string) (*ast.Program, []string, bool) {
+func (c *Compiler) parseModuleDeclarationsFile(path string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, false
 	}
-	return parseModuleDeclarations(content)
+	return c.parseModuleDeclarations(content, path, state)
 }
 
-func parseModuleDeclarations(content []byte) (*ast.Program, []string, bool) {
+func (c *Compiler) parseModuleDeclarations(content []byte, fileName string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
 	p := parser.New(lexer.New(string(content)))
 	program := p.ParseProgram()
 	if len(p.Errors()) > 0 {
+		return nil, nil, false
+	}
+	failuresBefore := state.failures
+	for _, statement := range program.Statements {
+		declaration, ok := statement.(*ast.UseStmt)
+		if !ok || declaration.SelectAll {
+			continue
+		}
+		if len(declaration.Selectors) > 0 {
+			exports := c.discoverModuleExportsWithState(declaration.Module, state)
+			for _, selector := range declaration.Selectors {
+				if _, exists := exports[selector]; !exists {
+					return nil, nil, false
+				}
+			}
+			continue
+		}
+		if _, _, loadable := c.loadModuleDeclarations(declaration.Module, state); !loadable {
+			return nil, nil, false
+		}
+	}
+	validator := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), fileName)
+	validator.moduleDiscovery = state
+	if _, _, err := validator.Compile(program); err != nil {
+		return nil, nil, false
+	}
+	if state.failures != failuresBefore {
 		return nil, nil, false
 	}
 	return program, nil, true

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -11,11 +11,10 @@ import (
 )
 
 type moduleDiscoveryState struct {
-	active   map[string]bool
-	failures int
+	active map[string]bool
 }
 
-func (c *Compiler) discoverModuleExports(module string) map[string]struct{} {
+func (c *Compiler) discoverModuleExports(module string) (map[string]struct{}, bool) {
 	state := c.moduleDiscovery
 	if state == nil {
 		state = &moduleDiscoveryState{active: make(map[string]bool)}
@@ -23,17 +22,17 @@ func (c *Compiler) discoverModuleExports(module string) map[string]struct{} {
 	return c.discoverModuleExportsWithState(module, state)
 }
 
-func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDiscoveryState) map[string]struct{} {
+func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDiscoveryState) (map[string]struct{}, bool) {
 	exports := make(map[string]struct{})
 	program, directoryExports, ok := c.loadModuleDeclarations(module, state)
 	if !ok {
-		return exports
+		return exports, false
 	}
 	for _, name := range directoryExports {
 		exports[name] = struct{}{}
 	}
 	if program == nil {
-		return exports
+		return exports, true
 	}
 
 	for _, statement := range program.Statements {
@@ -47,8 +46,13 @@ func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDi
 		case *ast.UseStmt:
 			switch {
 			case declaration.SelectAll:
-				// OP_IMPORT_FROM_ALL writes shared VM globals, not the module's
-				// returned moduleGlobals map, so wildcard side effects are not exports.
+				imported, loadable := c.discoverModuleExportsWithState(declaration.Module, state)
+				if !loadable {
+					return make(map[string]struct{}), false
+				}
+				for name := range imported {
+					exports[name] = struct{}{}
+				}
 			case len(declaration.Selectors) > 0:
 				for _, name := range declaration.Selectors {
 					exports[name] = struct{}{}
@@ -63,13 +67,14 @@ func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDi
 			}
 		}
 	}
-	return exports
+	return exports, true
 }
 
 func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
 	switch {
 	case declaration.SelectAll:
-		for name := range c.discoverModuleExports(declaration.Module) {
+		exports, _ := c.discoverModuleExports(declaration.Module)
+		for name := range exports {
 			c.globals[name] = nil
 		}
 	case len(declaration.Selectors) > 0:
@@ -88,7 +93,6 @@ func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
 
 func (c *Compiler) loadModuleDeclarations(module string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
 	if state.active[module] {
-		state.failures++
 		return nil, nil, false
 	}
 	state.active[module] = true
@@ -191,14 +195,22 @@ func (c *Compiler) parseModuleDeclarations(content []byte, fileName string, stat
 	if len(p.Errors()) > 0 {
 		return nil, nil, false
 	}
-	failuresBefore := state.failures
 	for _, statement := range program.Statements {
 		declaration, ok := statement.(*ast.UseStmt)
-		if !ok || declaration.SelectAll {
+		if !ok {
+			continue
+		}
+		if declaration.SelectAll {
+			if _, loadable := c.discoverModuleExportsWithState(declaration.Module, state); !loadable {
+				return nil, nil, false
+			}
 			continue
 		}
 		if len(declaration.Selectors) > 0 {
-			exports := c.discoverModuleExportsWithState(declaration.Module, state)
+			exports, loadable := c.discoverModuleExportsWithState(declaration.Module, state)
+			if !loadable {
+				return nil, nil, false
+			}
 			for _, selector := range declaration.Selectors {
 				if _, exists := exports[selector]; !exists {
 					return nil, nil, false
@@ -213,9 +225,6 @@ func (c *Compiler) parseModuleDeclarations(content []byte, fileName string, stat
 	validator := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), fileName)
 	validator.moduleDiscovery = state
 	if _, _, err := validator.Compile(program); err != nil {
-		return nil, nil, false
-	}
-	if state.failures != failuresBefore {
 		return nil, nil, false
 	}
 	return program, nil, true

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -146,9 +146,9 @@ func (c *Compiler) loadModuleDeclarations(module string, state *moduleDiscoveryS
 }
 
 func (c *Compiler) moduleFileCandidates(pathName string) []string {
-	root := "."
-	if c.FileName != "" && c.FileName != "REPL" {
-		root = filepath.Dir(c.FileName)
+	root := c.moduleRoot
+	if root == "" {
+		root = "."
 	}
 
 	var searchRoots []string
@@ -222,7 +222,7 @@ func (c *Compiler) parseModuleDeclarations(content []byte, fileName string, stat
 			return nil, nil, false
 		}
 	}
-	validator := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), fileName)
+	validator := NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), fileName, c.moduleRoot)
 	validator.moduleDiscovery = state
 	if _, _, err := validator.Compile(program); err != nil {
 		return nil, nil, false

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -1,0 +1,178 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+	"noxy-vm/internal/stdlib"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (c *Compiler) discoverModuleExports(module string) map[string]struct{} {
+	return c.discoverModuleExportsFrom(module, make(map[string]bool))
+}
+
+func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
+	switch {
+	case declaration.SelectAll:
+		for name := range c.discoverModuleExports(declaration.Module) {
+			c.globals[name] = nil
+		}
+	case len(declaration.Selectors) > 0:
+		for _, name := range declaration.Selectors {
+			c.globals[name] = nil
+		}
+	default:
+		name := declaration.Alias
+		if name == "" {
+			parts := strings.Split(declaration.Module, ".")
+			name = parts[len(parts)-1]
+		}
+		c.globals[name] = nil
+	}
+}
+
+func (c *Compiler) discoverModuleExportsFrom(module string, visiting map[string]bool) map[string]struct{} {
+	exports := make(map[string]struct{})
+	if visiting[module] {
+		return exports
+	}
+	visiting[module] = true
+	defer delete(visiting, module)
+
+	program, directoryExports, ok := c.loadModuleDeclarations(module)
+	if !ok {
+		return exports
+	}
+	for _, name := range directoryExports {
+		exports[name] = struct{}{}
+	}
+	if program == nil {
+		return exports
+	}
+
+	for _, statement := range program.Statements {
+		switch declaration := statement.(type) {
+		case *ast.LetStmt:
+			exports[declaration.Name.Value] = struct{}{}
+		case *ast.FunctionStatement:
+			exports[declaration.Name] = struct{}{}
+		case *ast.StructStatement:
+			exports[declaration.Name] = struct{}{}
+		case *ast.UseStmt:
+			switch {
+			case declaration.SelectAll:
+				for name := range c.discoverModuleExportsFrom(declaration.Module, visiting) {
+					exports[name] = struct{}{}
+				}
+			case len(declaration.Selectors) > 0:
+				for _, name := range declaration.Selectors {
+					exports[name] = struct{}{}
+				}
+			default:
+				name := declaration.Alias
+				if name == "" {
+					parts := strings.Split(declaration.Module, ".")
+					name = parts[len(parts)-1]
+				}
+				exports[name] = struct{}{}
+			}
+		}
+	}
+	return exports
+}
+
+func (c *Compiler) loadModuleDeclarations(module string) (*ast.Program, []string, bool) {
+	pathName := strings.ReplaceAll(module, ".", string(filepath.Separator))
+	for _, candidate := range c.moduleFileCandidates(pathName) {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			base := filepath.Base(candidate)
+			for _, entry := range []string{base + ".nx", "main.nx"} {
+				entryPath := filepath.Join(candidate, entry)
+				if entryInfo, entryErr := os.Stat(entryPath); entryErr == nil && !entryInfo.IsDir() {
+					return parseModuleDeclarationsFile(entryPath)
+				}
+			}
+			entries, readErr := os.ReadDir(candidate)
+			if readErr != nil {
+				return nil, nil, false
+			}
+			names := make([]string, 0, len(entries))
+			for _, entry := range entries {
+				if entry.IsDir() {
+					names = append(names, entry.Name())
+				} else if strings.HasSuffix(entry.Name(), ".nx") {
+					names = append(names, strings.TrimSuffix(entry.Name(), ".nx"))
+				}
+			}
+			return nil, names, true
+		}
+		return parseModuleDeclarationsFile(candidate)
+	}
+
+	embedPath := strings.ReplaceAll(module, ".", "/") + ".nx"
+	content, err := stdlib.FS.ReadFile(embedPath)
+	if err != nil {
+		return nil, nil, false
+	}
+	return parseModuleDeclarations(content)
+}
+
+func (c *Compiler) moduleFileCandidates(pathName string) []string {
+	root := "."
+	if c.FileName != "" && c.FileName != "REPL" {
+		root = filepath.Dir(c.FileName)
+	}
+
+	var searchRoots []string
+	if noxyPath := os.Getenv("NOXY_PATH"); noxyPath != "" {
+		searchRoots = append(searchRoots, filepath.SplitList(noxyPath)...)
+	}
+
+	var candidates []string
+	addSuffix := func(suffix string) {
+		for _, searchRoot := range searchRoots {
+			candidates = append(candidates,
+				filepath.Join(searchRoot, suffix, suffix+".nx"),
+				filepath.Join(searchRoot, suffix),
+				filepath.Join(searchRoot, suffix+".nx"),
+			)
+		}
+		candidates = append(candidates,
+			filepath.Join(root, "noxy_libs", suffix, suffix+".nx"),
+			filepath.Join(root, "noxy_libs", suffix),
+			filepath.Join(root, "stdlib", suffix),
+			filepath.Join(root, suffix),
+			filepath.Join("noxy_libs", suffix, suffix+".nx"),
+			filepath.Join("noxy_libs", suffix),
+			filepath.Join("stdlib", suffix),
+			suffix,
+		)
+	}
+	addSuffix(pathName + ".nx")
+	addSuffix(pathName)
+	return candidates
+}
+
+func parseModuleDeclarationsFile(path string) (*ast.Program, []string, bool) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, false
+	}
+	return parseModuleDeclarations(content)
+}
+
+func parseModuleDeclarations(content []byte) (*ast.Program, []string, bool) {
+	p := parser.New(lexer.New(string(content)))
+	program := p.ParseProgram()
+	if len(p.Errors()) > 0 {
+		return nil, nil, false
+	}
+	return program, nil, true
+}

--- a/internal/compiler/module_exports_test.go
+++ b/internal/compiler/module_exports_test.go
@@ -7,15 +7,21 @@ import (
 	"testing"
 )
 
-func TestEmbeddedWildcardExportsOnlyDirectModuleGlobals(t *testing.T) {
+func TestEmbeddedWildcardExportsIncludeDurableWrapperBindings(t *testing.T) {
 	compiler := New()
-	direct := compiler.discoverModuleExports("http_client")
+	direct, loadable := compiler.discoverModuleExports("http_client")
+	if !loadable {
+		t.Fatal("http_client was not loadable")
+	}
 	if _, ok := direct["delete"]; !ok {
 		t.Fatal("http_client direct delete export was not discovered")
 	}
-	wrapper := compiler.discoverModuleExports("http")
-	if _, ok := wrapper["delete"]; ok {
-		t.Fatal("http wildcard side effect was incorrectly modeled as a durable module export")
+	wrapper, loadable := compiler.discoverModuleExports("http")
+	if !loadable {
+		t.Fatal("http wrapper was not loadable")
+	}
+	if _, ok := wrapper["delete"]; !ok {
+		t.Fatal("http wildcard delete export was not discovered")
 	}
 }
 
@@ -26,7 +32,11 @@ func TestFileModuleDirectExportsAreDiscovered(t *testing.T) {
 		t.Fatal(err)
 	}
 	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-	if _, ok := compiler.discoverModuleExports("collision")["delete"]; !ok {
+	exports, loadable := compiler.discoverModuleExports("collision")
+	if !loadable {
+		t.Fatal("direct file module was not loadable")
+	}
+	if _, ok := exports["delete"]; !ok {
 		t.Fatal("direct file-module export was not discovered")
 	}
 }
@@ -45,7 +55,10 @@ func TestDirectoryModuleExportsOnlyLoadableChildren(t *testing.T) {
 	}
 
 	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-	exports := compiler.discoverModuleExports("bundle")
+	exports, loadable := compiler.discoverModuleExports("bundle")
+	if !loadable {
+		t.Fatal("directory module was not loadable")
+	}
 	if _, ok := exports["delete"]; !ok {
 		t.Fatal("loadable file child was not exported")
 	}
@@ -68,7 +81,7 @@ func TestDirectoryModuleWithUnloadableFileHasNoExports(t *testing.T) {
 	}
 
 	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-	if exports := compiler.discoverModuleExports("broken"); len(exports) != 0 {
+	if exports, loadable := compiler.discoverModuleExports("broken"); loadable || len(exports) != 0 {
 		t.Fatalf("unloadable directory module exports=%v, want none", exports)
 	}
 }
@@ -105,8 +118,48 @@ func TestModuleExportDiscoveryRejectsWildcardImportCycles(t *testing.T) {
 				}
 			}
 			compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-			if exports := compiler.discoverModuleExports(tt.root); len(exports) != 0 {
+			if exports, loadable := compiler.discoverModuleExports(tt.root); loadable || len(exports) != 0 {
 				t.Fatalf("cyclic module exports=%v, want none", exports)
+			}
+		})
+	}
+}
+
+func TestCompilerRejectsTopLevelWildcardImportCycles(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		dependency string
+	}{
+		{
+			name: "self cycle",
+			files: map[string]string{
+				"cycle.nx": "use cycle select *\n",
+			},
+			dependency: "cycle",
+		},
+		{
+			name: "mutual cycle",
+			files: map[string]string{
+				"left.nx":  "use right select *\n",
+				"right.nx": "use left select *\n",
+			},
+			dependency: "left",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, source := range tt.files {
+				if err := os.WriteFile(filepath.Join(root, name), []byte(source), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("NOXY_PATH", root)
+			_, err := compileFunctionSource(t, "use "+tt.dependency+" select *")
+			if err == nil {
+				t.Fatal("compiler accepted a cyclic top-level wildcard import")
 			}
 		})
 	}
@@ -119,7 +172,7 @@ func TestFileModuleWithMissingDirectImportHasNoExports(t *testing.T) {
 		t.Fatal(err)
 	}
 	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-	if exports := compiler.discoverModuleExports("collision"); len(exports) != 0 {
+	if exports, loadable := compiler.discoverModuleExports("collision"); loadable || len(exports) != 0 {
 		t.Fatalf("module with missing direct import exports=%v, want none", exports)
 	}
 }
@@ -134,7 +187,70 @@ func TestFileModuleWithMissingSelectedExportHasNoExports(t *testing.T) {
 		t.Fatal(err)
 	}
 	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
-	if exports := compiler.discoverModuleExports("collision"); len(exports) != 0 {
+	if exports, loadable := compiler.discoverModuleExports("collision"); loadable || len(exports) != 0 {
 		t.Fatalf("module with missing selected export exports=%v, want none", exports)
+	}
+}
+
+func TestTopLevelWildcardDependencyMustBeLoadable(t *testing.T) {
+	tests := []struct {
+		name       string
+		dependency string
+		wantDelete bool
+	}{
+		{name: "missing", dependency: "definitely_missing_task5_module"},
+		{name: "compile invalid", dependency: "broken"},
+		{name: "valid empty", dependency: "empty", wantDelete: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "broken.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "empty.nx"), []byte("// deliberately empty\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			wrapper := "use " + tt.dependency + " select *\nfunc delete(url: string) -> void\nend\n"
+			if err := os.WriteFile(filepath.Join(root, "wrapper.nx"), []byte(wrapper), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+			exports, loadable := compiler.discoverModuleExports("wrapper")
+			_, hasDelete := exports["delete"]
+			if loadable != tt.wantDelete || hasDelete != tt.wantDelete {
+				t.Fatalf("exports=%v, loadable=%v, delete present=%v, want %v", exports, loadable, hasDelete, tt.wantDelete)
+			}
+		})
+	}
+}
+
+func TestFunctionBodyOnlyWildcardDoesNotAffectModuleLoadability(t *testing.T) {
+	tests := []struct {
+		name       string
+		dependency string
+	}{
+		{name: "missing", dependency: "definitely_missing_task5_module"},
+		{name: "self cycle", dependency: "safe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			source := "func unused() -> void\n    use " + tt.dependency + " select *\nend\nfunc delete(url: string) -> void\nend\n"
+			if err := os.WriteFile(filepath.Join(root, "safe.nx"), []byte(source), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+			exports, loadable := compiler.discoverModuleExports("safe")
+			if !loadable {
+				t.Fatal("function-body-only wildcard invalidated module loadability")
+			}
+			if _, ok := exports["delete"]; !ok {
+				t.Fatalf("function-body-only wildcard invalidated module exports: %v", exports)
+			}
+		})
 	}
 }

--- a/internal/compiler/module_exports_test.go
+++ b/internal/compiler/module_exports_test.go
@@ -1,0 +1,140 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmbeddedWildcardExportsOnlyDirectModuleGlobals(t *testing.T) {
+	compiler := New()
+	direct := compiler.discoverModuleExports("http_client")
+	if _, ok := direct["delete"]; !ok {
+		t.Fatal("http_client direct delete export was not discovered")
+	}
+	wrapper := compiler.discoverModuleExports("http")
+	if _, ok := wrapper["delete"]; ok {
+		t.Fatal("http wildcard side effect was incorrectly modeled as a durable module export")
+	}
+}
+
+func TestFileModuleDirectExportsAreDiscovered(t *testing.T) {
+	root := t.TempDir()
+	modulePath := filepath.Join(root, "collision.nx")
+	if err := os.WriteFile(modulePath, []byte("func delete(url: string) -> void\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	if _, ok := compiler.discoverModuleExports("collision")["delete"]; !ok {
+		t.Fatal("direct file-module export was not discovered")
+	}
+}
+
+func TestDirectoryModuleExportsOnlyLoadableChildren(t *testing.T) {
+	root := t.TempDir()
+	bundle := filepath.Join(root, "bundle")
+	if err := os.MkdirAll(filepath.Join(bundle, "unloadable"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "delete.nx"), []byte("let marker: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "unloadable", "broken.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	exports := compiler.discoverModuleExports("bundle")
+	if _, ok := exports["delete"]; !ok {
+		t.Fatal("loadable file child was not exported")
+	}
+	if _, ok := exports["unloadable"]; ok {
+		t.Fatal("unloadable directory child was incorrectly exported")
+	}
+}
+
+func TestDirectoryModuleWithUnloadableFileHasNoExports(t *testing.T) {
+	root := t.TempDir()
+	broken := filepath.Join(root, "broken")
+	if err := os.MkdirAll(broken, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "good.nx"), []byte("let marker: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "bad.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	if exports := compiler.discoverModuleExports("broken"); len(exports) != 0 {
+		t.Fatalf("unloadable directory module exports=%v, want none", exports)
+	}
+}
+
+func TestModuleExportDiscoveryRejectsWildcardImportCycles(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		root  string
+	}{
+		{
+			name: "self cycle",
+			files: map[string]string{
+				"cycle.nx": "use cycle select *\nfunc delete(url: string) -> void\nend\n",
+			},
+			root: "cycle",
+		},
+		{
+			name: "mutual cycle",
+			files: map[string]string{
+				"left.nx":  "use right select *\nfunc delete(url: string) -> void\nend\n",
+				"right.nx": "use left select *\nfunc helper() -> void\nend\n",
+			},
+			root: "left",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, source := range tt.files {
+				if err := os.WriteFile(filepath.Join(root, name), []byte(source), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+			if exports := compiler.discoverModuleExports(tt.root); len(exports) != 0 {
+				t.Fatalf("cyclic module exports=%v, want none", exports)
+			}
+		})
+	}
+}
+
+func TestFileModuleWithMissingDirectImportHasNoExports(t *testing.T) {
+	root := t.TempDir()
+	source := "use definitely_missing_task5_module as dependency\nfunc delete(url: string) -> void\nend\n"
+	if err := os.WriteFile(filepath.Join(root, "collision.nx"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	if exports := compiler.discoverModuleExports("collision"); len(exports) != 0 {
+		t.Fatalf("module with missing direct import exports=%v, want none", exports)
+	}
+}
+
+func TestFileModuleWithMissingSelectedExportHasNoExports(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "dependency.nx"), []byte("let present: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := "use dependency select missing\nfunc delete(url: string) -> void\nend\n"
+	if err := os.WriteFile(filepath.Join(root, "collision.nx"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	if exports := compiler.discoverModuleExports("collision"); len(exports) != 0 {
+		t.Fatalf("module with missing selected export exports=%v, want none", exports)
+	}
+}

--- a/internal/compiler/module_exports_test.go
+++ b/internal/compiler/module_exports_test.go
@@ -254,3 +254,43 @@ func TestFunctionBodyOnlyWildcardDoesNotAffectModuleLoadability(t *testing.T) {
 		})
 	}
 }
+
+func TestNestedModuleDiscoveryUsesProgramRoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		shadowDep string
+	}{
+		{name: "dependency only at root"},
+		{name: "invalid divergent nested dependency", shadowDep: "let marker: int = \"wrong\"\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			pkgDir := filepath.Join(root, "pkg")
+			if err := os.MkdirAll(pkgDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "dep.nx"), []byte("func delete(url: string) -> void\nend\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pkgDir, "wrapper.nx"), []byte("use dep select *\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tt.shadowDep != "" {
+				if err := os.WriteFile(filepath.Join(pkgDir, "dep.nx"), []byte(tt.shadowDep), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+			exports, loadable := compiler.discoverModuleExports("pkg.wrapper")
+			if !loadable {
+				t.Fatal("nested wrapper was not loadable from the program root")
+			}
+			if _, ok := exports["delete"]; !ok {
+				t.Fatalf("nested wrapper exports=%v, want root dependency delete", exports)
+			}
+		})
+	}
+}

--- a/internal/compiler/reference_arguments_test.go
+++ b/internal/compiler/reference_arguments_test.go
@@ -1,0 +1,59 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReferenceArgumentValidatesArrayIndexType(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func set(target: ref int) -> void
+    return
+end
+let values: int[] = [1]
+set(values["zero"])`)
+	if err == nil || !strings.Contains(err.Error(), "array reference index must be int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestReferenceArgumentValidatesMapKeyType(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func set(target: ref int) -> void
+    return
+end
+let mapping: map[string, int] = {"value": 1}
+set(mapping[0])`)
+	if err == nil || !strings.Contains(err.Error(), "map reference key must be string, got int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestReferenceArgumentAcceptsReferenceReturningCall(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+let value: int = 1
+func get_reference() -> ref int
+    return ref value
+end
+func set(target: ref int) -> void
+    *target = 2
+end
+set(get_reference())`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReferenceArgumentRejectsOrdinaryCallResult(t *testing.T) {
+	_, err := compileFunctionSource(t, `
+func get_value() -> int
+    return 1
+end
+func set(target: ref int) -> void
+    return
+end
+set(get_value())`)
+	if err == nil || !strings.Contains(err.Error(), "reference argument 'get_value()' is not addressable") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/compiler/reference_arguments_test.go
+++ b/internal/compiler/reference_arguments_test.go
@@ -1,9 +1,26 @@
 package compiler
 
 import (
+	"noxy-vm/internal/chunk"
 	"strings"
 	"testing"
 )
+
+func containsBytecodePattern(code []byte, pattern []int) bool {
+	for start := 0; start+len(pattern) <= len(code); start++ {
+		matches := true
+		for offset, expected := range pattern {
+			if expected >= 0 && code[start+offset] != byte(expected) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
 
 func TestReferenceArgumentValidatesArrayIndexType(t *testing.T) {
 	_, err := compileFunctionSource(t, `
@@ -55,5 +72,98 @@ end
 set(get_value())`)
 	if err == nil || !strings.Contains(err.Error(), "reference argument 'get_value()' is not addressable") {
 		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestReferenceArgumentLoadsStoredReferencesFromPropertiesAndIndexes(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		pattern []int
+	}{
+		{
+			name: "property",
+			source: `
+struct Holder
+    values: ref int[]
+end
+let values: int[] = [1]
+let holder: Holder = Holder(ref values)
+append(holder.values, 2)`,
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONTEXT_REF_PROPERTY), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+		},
+		{
+			name: "array index",
+			source: `
+let values: int[] = [1]
+let stored: (ref int[])[] = [ref values]
+append(stored[0], 2)`,
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+		},
+		{
+			name: "map index",
+			source: `
+let values: int[] = [1]
+let stored: map[string, ref int[]] = {"values": ref values}
+append(stored["values"], 2)`,
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiler, err := compileFunctionSource(t, tt.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !containsBytecodePattern(compiler.currentChunk.Code, tt.pattern) {
+				t.Fatalf("bytecode %v does not contain stored-reference load pattern %v", compiler.currentChunk.Code, tt.pattern)
+			}
+		})
+	}
+}
+
+func TestReferenceArgumentStillBorrowsPlainPropertyAndIndexSlots(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		opcode chunk.OpCode
+	}{
+		{
+			name: "property",
+			source: `
+struct Holder
+    values: int[]
+end
+let holder: Holder = Holder([1])
+append(holder.values, 2)`,
+			opcode: chunk.OP_REF_PROPERTY,
+		},
+		{
+			name: "index",
+			source: `
+let stored: int[][] = [[1]]
+append(stored[0], 2)`,
+			opcode: chunk.OP_REF_INDEX,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiler, err := compileFunctionSource(t, tt.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, instruction := range compiler.currentChunk.Code {
+				if instruction == byte(tt.opcode) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("bytecode %v does not contain %s", compiler.currentChunk.Code, tt.opcode)
+			}
+		})
 	}
 }

--- a/internal/compiler/reference_arguments_test.go
+++ b/internal/compiler/reference_arguments_test.go
@@ -90,7 +90,7 @@ end
 let values: int[] = [1]
 let holder: Holder = Holder(ref values)
 append(holder.values, 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONTEXT_REF_PROPERTY), -1, int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONTEXT_REF_PROPERTY), -1, int(chunk.OP_MARK_REF_TARGET_TYPE), -1, -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 		{
 			name: "array index",
@@ -98,7 +98,7 @@ append(holder.values, 2)`,
 let values: int[] = [1]
 let stored: (ref int[])[] = [ref values]
 append(stored[0], 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 		{
 			name: "map index",
@@ -106,7 +106,7 @@ append(stored[0], 2)`,
 let values: int[] = [1]
 let stored: map[string, ref int[]] = {"values": ref values}
 append(stored["values"], 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 	}
 

--- a/internal/compiler/reference_arguments_test.go
+++ b/internal/compiler/reference_arguments_test.go
@@ -90,7 +90,7 @@ end
 let values: int[] = [1]
 let holder: Holder = Holder(ref values)
 append(holder.values, 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONTEXT_REF_PROPERTY), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONTEXT_REF_PROPERTY), -1, int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 		{
 			name: "array index",
@@ -98,7 +98,7 @@ append(holder.values, 2)`,
 let values: int[] = [1]
 let stored: (ref int[])[] = [ref values]
 append(stored[0], 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 		{
 			name: "map index",
@@ -106,7 +106,7 @@ append(stored[0], 2)`,
 let values: int[] = [1]
 let stored: map[string, ref int[]] = {"values": ref values}
 append(stored["values"], 2)`,
-			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
+			pattern: []int{int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_GET_GLOBAL), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CONTEXT_REF_INDEX), int(chunk.OP_MARK_REF_TARGET_TYPE), -1, int(chunk.OP_CONSTANT), -1, int(chunk.OP_CALL), 2},
 		},
 	}
 

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -16,7 +16,7 @@ func (c *Compiler) runtimeTypeInfo(t ast.NoxyType) *value.RuntimeTypeInfo {
 }
 
 func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
-	if !containsChannelType(t, make(map[string]bool), c.structs) {
+	if !requiresRuntimeValueType(t, make(map[string]bool), c.structs) {
 		return nil
 	}
 	runtimeType := c.runtimeTypeInfo(t)
@@ -33,16 +33,14 @@ func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
 	return nil
 }
 
-func containsChannelType(t ast.NoxyType, visiting map[string]bool, structs map[string]*ast.StructStatement) bool {
+func requiresRuntimeValueType(t ast.NoxyType, visiting map[string]bool, structs map[string]*ast.StructStatement) bool {
 	switch typed := t.(type) {
 	case *ast.ChanType:
 		return true
-	case *ast.ArrayType:
-		return containsChannelType(typed.ElementType, visiting, structs)
-	case *ast.MapType:
-		return containsChannelType(typed.KeyType, visiting, structs) || containsChannelType(typed.ValueType, visiting, structs)
+	case *ast.ArrayType, *ast.MapType:
+		return true
 	case *ast.RefType:
-		return containsChannelType(typed.ElementType, visiting, structs)
+		return requiresRuntimeValueType(typed.ElementType, visiting, structs)
 	case *ast.FunctionType:
 		// Callable signatures carry their own immutable runtime schema. Channels
 		// named by that signature are not values embedded in the callable object.
@@ -55,7 +53,7 @@ func containsChannelType(t ast.NoxyType, visiting map[string]bool, structs map[s
 		visiting[typed.Name] = true
 		defer delete(visiting, typed.Name)
 		for _, field := range definition.FieldsList {
-			if containsChannelType(field.Type, visiting, structs) {
+			if requiresRuntimeValueType(field.Type, visiting, structs) {
 				return true
 			}
 		}

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -116,7 +116,7 @@ func (c *Compiler) runtimeTypeInfoWithStructs(t ast.NoxyType, structs map[string
 		if !ok {
 			return nil, false
 		}
-		return &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: element}, true
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: element, Size: typed.Size}, true
 	case *ast.MapType:
 		key, ok := c.runtimeTypeInfoWithStructs(typed.KeyType, structs)
 		if !ok {

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -1,39 +1,100 @@
 package compiler
 
 import (
+	"fmt"
 	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
 )
 
 func (c *Compiler) runtimeTypeInfo(t ast.NoxyType) *value.RuntimeTypeInfo {
-	return c.runtimeTypeInfoWithStructs(t, make(map[string]*value.RuntimeTypeInfo))
+	info, ok := c.runtimeTypeInfoWithStructs(t, make(map[string]*value.RuntimeTypeInfo))
+	if !ok {
+		return nil
+	}
+	return info
 }
 
-func (c *Compiler) runtimeTypeInfoWithStructs(t ast.NoxyType, structs map[string]*value.RuntimeTypeInfo) *value.RuntimeTypeInfo {
+func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
+	if !containsChannelType(t, make(map[string]bool), c.structs) {
+		return nil
+	}
+	runtimeType := c.runtimeTypeInfo(t)
+	if runtimeType == nil {
+		return nil
+	}
+	typeConstant := c.makeConstant(value.NewRuntimeTypeInfo(runtimeType))
+	if typeConstant > 65535 {
+		return fmt.Errorf("[line %d] too many constants for runtime value metadata", c.currentLine)
+	}
+	c.emitByte(byte(chunk.OP_MARK_RUNTIME_VALUE_TYPE))
+	c.emitByte(byte((typeConstant >> 8) & 0xff))
+	c.emitByte(byte(typeConstant & 0xff))
+	return nil
+}
+
+func containsChannelType(t ast.NoxyType, visiting map[string]bool, structs map[string]*ast.StructStatement) bool {
+	switch typed := t.(type) {
+	case *ast.ChanType:
+		return true
+	case *ast.ArrayType:
+		return containsChannelType(typed.ElementType, visiting, structs)
+	case *ast.MapType:
+		return containsChannelType(typed.KeyType, visiting, structs) || containsChannelType(typed.ValueType, visiting, structs)
+	case *ast.RefType:
+		return containsChannelType(typed.ElementType, visiting, structs)
+	case *ast.FunctionType:
+		// Callable signatures carry their own immutable runtime schema. Channels
+		// named by that signature are not values embedded in the callable object.
+		return false
+	case *ast.PrimitiveType:
+		definition, ok := structs[typed.Name]
+		if !ok || visiting[typed.Name] {
+			return false
+		}
+		visiting[typed.Name] = true
+		defer delete(visiting, typed.Name)
+		for _, field := range definition.FieldsList {
+			if containsChannelType(field.Type, visiting, structs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// runtimeTypeInfoWithStructs returns ok only for a complete runtime schema.
+// A composite carrying an unknown child would otherwise turn that child into
+// an accidental dynamic wildcard at typed native boundaries.
+func (c *Compiler) runtimeTypeInfoWithStructs(t ast.NoxyType, structs map[string]*value.RuntimeTypeInfo) (*value.RuntimeTypeInfo, bool) {
 	switch typed := t.(type) {
 	case *ast.PrimitiveType:
 		switch typed.Name {
 		case "any":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}, true
 		case "null":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_NULL}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_NULL}, true
 		case "bool":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_BOOL}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_BOOL}, true
 		case "int":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_INT}, true
 		case "float":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_FLOAT}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_FLOAT}, true
 		case "string":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}, true
 		case "bytes":
-			return &value.RuntimeTypeInfo{Kind: value.TYPE_BYTES}
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_BYTES}, true
+		case "void":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_VOID}, true
+		case "func":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, CallableBare: true}, true
 		}
 		definition, ok := c.structs[typed.Name]
 		if !ok {
-			return nil
+			return nil, false
 		}
 		if existing, ok := structs[typed.Name]; ok {
-			return existing
+			return existing, true
 		}
 		info := &value.RuntimeTypeInfo{
 			Kind:   value.TYPE_STRUCT,
@@ -42,20 +103,64 @@ func (c *Compiler) runtimeTypeInfoWithStructs(t ast.NoxyType, structs map[string
 		}
 		structs[typed.Name] = info
 		for _, field := range definition.FieldsList {
-			info.Fields[field.Name] = c.runtimeTypeInfoWithStructs(field.Type, structs)
+			fieldInfo, complete := c.runtimeTypeInfoWithStructs(field.Type, structs)
+			if !complete {
+				delete(structs, typed.Name)
+				return nil, false
+			}
+			info.Fields[field.Name] = fieldInfo
 		}
-		return info
+		return info, true
 	case *ast.ArrayType:
-		return &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: c.runtimeTypeInfoWithStructs(typed.ElementType, structs)}
-	case *ast.MapType:
-		return &value.RuntimeTypeInfo{
-			Kind:  value.TYPE_MAP,
-			Key:   c.runtimeTypeInfoWithStructs(typed.KeyType, structs),
-			Value: c.runtimeTypeInfoWithStructs(typed.ValueType, structs),
+		element, ok := c.runtimeTypeInfoWithStructs(typed.ElementType, structs)
+		if !ok {
+			return nil, false
 		}
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: element}, true
+	case *ast.MapType:
+		key, ok := c.runtimeTypeInfoWithStructs(typed.KeyType, structs)
+		if !ok {
+			return nil, false
+		}
+		mapValue, ok := c.runtimeTypeInfoWithStructs(typed.ValueType, structs)
+		if !ok {
+			return nil, false
+		}
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: key, Value: mapValue}, true
 	case *ast.RefType:
-		return &value.RuntimeTypeInfo{Kind: value.TYPE_REF, Element: c.runtimeTypeInfoWithStructs(typed.ElementType, structs)}
+		element, ok := c.runtimeTypeInfoWithStructs(typed.ElementType, structs)
+		if !ok {
+			return nil, false
+		}
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_REF, Element: element}, true
+	case *ast.ChanType:
+		element, ok := c.runtimeTypeInfoWithStructs(typed.ElementType, structs)
+		if !ok {
+			return nil, false
+		}
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_CHANNEL, Element: element}, true
+	case *ast.FunctionType:
+		info := &value.RuntimeTypeInfo{
+			Kind:       value.TYPE_CALLABLE,
+			Params:     make([]*value.RuntimeTypeInfo, len(typed.Params)),
+			ParamIsRef: make([]bool, len(typed.Params)),
+		}
+		for i, param := range typed.Params {
+			paramInfo, ok := c.runtimeTypeInfoWithStructs(param, structs)
+			if !ok {
+				return nil, false
+			}
+			info.Params[i] = paramInfo
+			_, info.ParamIsRef[i] = param.(*ast.RefType)
+		}
+		result := normalizeReturnType(typed.Return)
+		returnInfo, ok := c.runtimeTypeInfoWithStructs(result, structs)
+		if !ok {
+			return nil, false
+		}
+		info.Return = returnInfo
+		return info, true
 	default:
-		return nil
+		return nil, false
 	}
 }

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -1,0 +1,61 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/value"
+)
+
+func (c *Compiler) runtimeTypeInfo(t ast.NoxyType) *value.RuntimeTypeInfo {
+	return c.runtimeTypeInfoWithStructs(t, make(map[string]*value.RuntimeTypeInfo))
+}
+
+func (c *Compiler) runtimeTypeInfoWithStructs(t ast.NoxyType, structs map[string]*value.RuntimeTypeInfo) *value.RuntimeTypeInfo {
+	switch typed := t.(type) {
+	case *ast.PrimitiveType:
+		switch typed.Name {
+		case "any":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}
+		case "null":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_NULL}
+		case "bool":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_BOOL}
+		case "int":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+		case "float":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_FLOAT}
+		case "string":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}
+		case "bytes":
+			return &value.RuntimeTypeInfo{Kind: value.TYPE_BYTES}
+		}
+		definition, ok := c.structs[typed.Name]
+		if !ok {
+			return nil
+		}
+		if existing, ok := structs[typed.Name]; ok {
+			return existing
+		}
+		info := &value.RuntimeTypeInfo{
+			Kind:   value.TYPE_STRUCT,
+			Name:   typed.Name,
+			Fields: make(map[string]*value.RuntimeTypeInfo, len(definition.FieldsList)),
+		}
+		structs[typed.Name] = info
+		for _, field := range definition.FieldsList {
+			info.Fields[field.Name] = c.runtimeTypeInfoWithStructs(field.Type, structs)
+		}
+		return info
+	case *ast.ArrayType:
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: c.runtimeTypeInfoWithStructs(typed.ElementType, structs)}
+	case *ast.MapType:
+		return &value.RuntimeTypeInfo{
+			Kind:  value.TYPE_MAP,
+			Key:   c.runtimeTypeInfoWithStructs(typed.KeyType, structs),
+			Value: c.runtimeTypeInfoWithStructs(typed.ValueType, structs),
+		}
+	case *ast.RefType:
+		return &value.RuntimeTypeInfo{Kind: value.TYPE_REF, Element: c.runtimeTypeInfoWithStructs(typed.ElementType, structs)}
+	default:
+		return nil
+	}
+}

--- a/internal/compiler/runtime_types_test.go
+++ b/internal/compiler/runtime_types_test.go
@@ -1,0 +1,67 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/value"
+	"testing"
+)
+
+func TestRuntimeTypeInfoRepresentsCallableAndChannelSchemas(t *testing.T) {
+	c := New()
+	integer := &ast.PrimitiveType{Name: "int"}
+	callable := &ast.FunctionType{Params: []ast.NoxyType{integer}, Return: integer}
+
+	exact := c.runtimeTypeInfo(callable)
+	if exact == nil || exact.Kind != value.TYPE_CALLABLE || exact.CallableBare || len(exact.Params) != 1 || exact.Return == nil {
+		t.Fatalf("exact callable schema=%#v", exact)
+	}
+	bare := c.runtimeTypeInfo(&ast.PrimitiveType{Name: "func"})
+	if bare == nil || bare.Kind != value.TYPE_CALLABLE || !bare.CallableBare {
+		t.Fatalf("bare callable schema=%#v", bare)
+	}
+	channel := c.runtimeTypeInfo(&ast.ChanType{ElementType: callable})
+	if channel == nil || channel.Kind != value.TYPE_CHANNEL || channel.Element == nil || channel.Element.Kind != value.TYPE_CALLABLE {
+		t.Fatalf("channel schema=%#v", channel)
+	}
+}
+
+func TestRuntimeTypeInfoNeverReturnsPartialComposite(t *testing.T) {
+	c := New()
+	unknown := &ast.PrimitiveType{Name: "Missing"}
+	tests := []ast.NoxyType{
+		&ast.ArrayType{ElementType: unknown},
+		&ast.MapType{KeyType: &ast.PrimitiveType{Name: "string"}, ValueType: unknown},
+		&ast.RefType{ElementType: unknown},
+		&ast.ChanType{ElementType: unknown},
+	}
+	for _, schemaType := range tests {
+		if got := c.runtimeTypeInfo(schemaType); got != nil {
+			t.Fatalf("runtimeTypeInfo(%s)=%#v, want nil", schemaType.String(), got)
+		}
+	}
+
+	c.structs["Partial"] = &ast.StructStatement{
+		Name: "Partial",
+		FieldsList: []*ast.StructField{
+			{Name: "known", Type: &ast.PrimitiveType{Name: "int"}},
+			{Name: "missing", Type: unknown},
+		},
+	}
+	if got := c.runtimeTypeInfo(&ast.PrimitiveType{Name: "Partial"}); got != nil {
+		t.Fatalf("partial struct schema=%#v, want nil", got)
+	}
+}
+
+func TestRuntimeTypeInfoHandlesRecursiveStructSchema(t *testing.T) {
+	c := New()
+	c.structs["Node"] = &ast.StructStatement{
+		Name: "Node",
+		FieldsList: []*ast.StructField{
+			{Name: "next", Type: &ast.PrimitiveType{Name: "Node"}},
+		},
+	}
+	got := c.runtimeTypeInfo(&ast.PrimitiveType{Name: "Node"})
+	if got == nil || got.Kind != value.TYPE_STRUCT || got.Fields["next"] != got {
+		t.Fatalf("recursive struct schema=%#v", got)
+	}
+}

--- a/internal/compiler/runtime_types_test.go
+++ b/internal/compiler/runtime_types_test.go
@@ -65,3 +65,25 @@ func TestRuntimeTypeInfoHandlesRecursiveStructSchema(t *testing.T) {
 		t.Fatalf("recursive struct schema=%#v", got)
 	}
 }
+
+func TestRuntimeTypeInfoUsesCanonicalNestedCallableAndFixedArraySpelling(t *testing.T) {
+	c := New()
+	integer := &ast.PrimitiveType{Name: "int"}
+	callable := &ast.FunctionType{Params: []ast.NoxyType{integer}, Return: integer}
+	tests := []ast.NoxyType{
+		&ast.ArrayType{ElementType: callable},
+		&ast.MapType{KeyType: &ast.PrimitiveType{Name: "string"}, ValueType: callable},
+		&ast.RefType{ElementType: callable},
+		&ast.ChanType{ElementType: callable},
+	}
+	for _, staticType := range tests {
+		runtimeType := c.runtimeTypeInfo(staticType)
+		if runtimeType == nil || runtimeType.String() != staticType.String() {
+			t.Fatalf("runtime spelling=%q, want AST spelling %q", runtimeType.String(), staticType.String())
+		}
+	}
+	fixed := c.runtimeTypeInfo(&ast.ArrayType{ElementType: callable, Size: 4})
+	if fixed == nil || fixed.String() != "(func(int) -> int)[4]" {
+		t.Fatalf("fixed callable array spelling=%q", fixed.String())
+	}
+}

--- a/internal/stdlib/array_utils.nx
+++ b/internal/stdlib/array_utils.nx
@@ -1,21 +1,8 @@
-func slice(array: int[], start: int, _end: int) -> int[]
-    let result: int[] = []
-    let len: int = length(array)
-    
-    if start < 0 then
-        start = 0
+let slice: any = func(native_slice: any) -> func(any, int, int) -> any
+    return func(array: any, start: int, _end: int) -> any
+        return native_slice(array, start, _end)
     end
-    
-    if _end > len then
-        _end = len
-    end
-
-    while start < _end do
-        append(result, array[start])
-        start = start + 1
-    end
-    return result
-end
+end(slice)
 
 
 func range(start: int, stop: int, step: int) -> int[]

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -298,7 +298,8 @@ type ObjRef struct {
 	RefType     RefType
 	JSONDynamic bool // Declared any target: JSON may replace its concrete runtime type.
 	TargetType  *RuntimeTypeInfo
-	Name        string      // For Global or Property Name
+	Name        string // For Global or Property Name
+	GlobalOwner *map[string]Value
 	Ptr         *Value      // For Local (unsafe if escapes)
 	Upvalue     *ObjUpvalue // For Local (safe, captured)
 	Container   Value       // For Property/Index (Object, Array, Map)

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -34,6 +34,13 @@ type ParamInfo struct {
 	TypeName string
 }
 
+type NativeSignature struct {
+	Arity      int
+	Variadic   bool
+	Params     []ParamInfo
+	ReturnType string
+}
+
 type ObjFunction struct {
 	Name         string
 	Arity        int
@@ -66,8 +73,9 @@ func (oc *ObjClosure) Format(f fmt.State, verb rune) {
 type NativeFunc func(args []Value) Value
 
 type ObjNative struct {
-	Name string
-	Fn   NativeFunc
+	Name      string
+	Fn        NativeFunc
+	Signature *NativeSignature
 }
 
 type ObjArray struct {
@@ -372,7 +380,14 @@ func NewClosure(fn *ObjFunction) Value {
 func NewNative(name string, fn NativeFunc) Value {
 	return Value{
 		Type: VAL_NATIVE,
-		Obj:  &ObjNative{Name: name, Fn: fn},
+		Obj:  &ObjNative{Name: name, Fn: fn, Signature: nil},
+	}
+}
+
+func NewNativeWithSignature(name string, signature NativeSignature, fn NativeFunc) Value {
+	return Value{
+		Type: VAL_NATIVE,
+		Obj:  &ObjNative{Name: name, Fn: fn, Signature: &signature},
 	}
 }
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -2,6 +2,7 @@ package value
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -55,17 +56,25 @@ const (
 	TYPE_MAP
 	TYPE_REF
 	TYPE_STRUCT
+	TYPE_VOID
+	TYPE_CALLABLE
+	TYPE_CHANNEL
 )
 
-// RuntimeTypeInfo is narrow metadata carried by references at typed native
-// boundaries. It is not a new parameter mode and does not affect Value identity.
+// RuntimeTypeInfo is narrow metadata used at typed native boundaries and on
+// callable/channel objects whose runtime shape alone cannot prove their static
+// type. It is not a new parameter mode and does not affect Value identity.
 type RuntimeTypeInfo struct {
-	Kind    RuntimeTypeKind
-	Name    string
-	Element *RuntimeTypeInfo
-	Key     *RuntimeTypeInfo
-	Value   *RuntimeTypeInfo
-	Fields  map[string]*RuntimeTypeInfo
+	Kind         RuntimeTypeKind
+	Name         string
+	Element      *RuntimeTypeInfo
+	Key          *RuntimeTypeInfo
+	Value        *RuntimeTypeInfo
+	Fields       map[string]*RuntimeTypeInfo
+	Params       []*RuntimeTypeInfo
+	ParamIsRef   []bool
+	Return       *RuntimeTypeInfo
+	CallableBare bool
 }
 
 func (t *RuntimeTypeInfo) String() string {
@@ -95,6 +104,19 @@ func (t *RuntimeTypeInfo) String() string {
 		return "ref " + t.Element.String()
 	case TYPE_STRUCT:
 		return t.Name
+	case TYPE_VOID:
+		return "void"
+	case TYPE_CALLABLE:
+		if t.CallableBare {
+			return "func"
+		}
+		params := make([]string, len(t.Params))
+		for i, param := range t.Params {
+			params[i] = param.String()
+		}
+		return "func(" + strings.Join(params, ", ") + ") -> " + t.Return.String()
+	case TYPE_CHANNEL:
+		return "chan " + t.Element.String()
 	default:
 		return "unknown"
 	}
@@ -107,6 +129,7 @@ type ObjFunction struct {
 	Params       []ParamInfo
 	Chunk        interface{}
 	Globals      map[string]Value // Module/Context globals
+	RuntimeType  *RuntimeTypeInfo
 }
 
 type ObjUpvalue struct {
@@ -245,9 +268,10 @@ func (oi *ObjInstance) Format(f fmt.State, verb rune) {
 }
 
 type ObjChannel struct {
-	Chan   chan Value
-	Closed bool
-	Lock   sync.Mutex
+	Chan        chan Value
+	Closed      bool
+	Lock        sync.Mutex
+	ElementType *RuntimeTypeInfo
 }
 
 func (oc *ObjChannel) String() string {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -30,7 +30,8 @@ type Value struct {
 }
 
 type ParamInfo struct {
-	IsRef bool
+	IsRef    bool
+	TypeName string
 }
 
 type ObjFunction struct {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -307,6 +307,9 @@ type ObjRef struct {
 }
 
 func (or *ObjRef) String() string {
+	if or == nil {
+		return "<invalid reference>"
+	}
 	switch or.RefType {
 	case REF_GLOBAL:
 		return fmt.Sprintf("<ref global %s>", or.Name)
@@ -375,7 +378,11 @@ func (v Value) String() string {
 	case VAL_WAITGROUP:
 		return v.Obj.(*ObjWaitGroup).String()
 	case VAL_REF:
-		return v.Obj.(*ObjRef).String()
+		ref, ok := v.Obj.(*ObjRef)
+		if !ok || ref == nil {
+			return "<invalid reference>"
+		}
+		return ref.String()
 	default:
 		return "unknown"
 	}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 type ValueType int
@@ -170,7 +171,7 @@ type ObjNative struct {
 
 type ObjArray struct {
 	Elements    []Value
-	RuntimeType *RuntimeTypeInfo
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
 }
 
 func (oa *ObjArray) String() string {
@@ -208,7 +209,7 @@ func (oa *ObjArray) Format(f fmt.State, verb rune) {
 
 type ObjMap struct {
 	Data        map[interface{}]Value
-	RuntimeType *RuntimeTypeInfo
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
 }
 
 func (om *ObjMap) String() string {
@@ -330,8 +331,8 @@ const (
 
 type ObjRef struct {
 	RefType     RefType
-	JSONDynamic bool // Declared any target: JSON may replace its concrete runtime type.
-	TargetType  *RuntimeTypeInfo
+	JSONDynamic atomic.Bool // Declared any target: JSON may replace its concrete runtime type.
+	TargetType  atomic.Pointer[RuntimeTypeInfo]
 	Name        string // For Global or Property Name
 	GlobalOwner *map[string]Value
 	Ptr         *Value      // For Local (unsafe if escapes)

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -71,6 +71,7 @@ type RuntimeTypeInfo struct {
 	Key          *RuntimeTypeInfo
 	Value        *RuntimeTypeInfo
 	Fields       map[string]*RuntimeTypeInfo
+	Size         int
 	Params       []*RuntimeTypeInfo
 	ParamIsRef   []bool
 	Return       *RuntimeTypeInfo
@@ -97,7 +98,14 @@ func (t *RuntimeTypeInfo) String() string {
 	case TYPE_BYTES:
 		return "bytes"
 	case TYPE_ARRAY:
-		return t.Element.String() + "[]"
+		element := t.Element.String()
+		if t.Element != nil && t.Element.Kind == TYPE_CALLABLE && !t.Element.CallableBare {
+			element = "(" + element + ")"
+		}
+		if t.Size > 0 {
+			return fmt.Sprintf("%s[%d]", element, t.Size)
+		}
+		return element + "[]"
 	case TYPE_MAP:
 		return "map[" + t.Key.String() + ", " + t.Value.String() + "]"
 	case TYPE_REF:

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -318,7 +318,15 @@ func (or *ObjRef) String() string {
 	case REF_PROPERTY:
 		return fmt.Sprintf("<ref prop %s>", or.Name)
 	case REF_INDEX:
-		return fmt.Sprintf("<ref index %s>", or.Index.String())
+		switch or.Index.Type {
+		case VAL_INT:
+			return fmt.Sprintf("<ref index %d>", or.Index.AsInt)
+		case VAL_OBJ:
+			if key, ok := or.Index.Obj.(string); ok {
+				return fmt.Sprintf("<ref index %s>", key)
+			}
+		}
+		return "<invalid reference>"
 	default:
 		return fmt.Sprintf("<ref %p>", or.Ptr)
 	}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -41,6 +41,65 @@ type NativeSignature struct {
 	ReturnType string
 }
 
+type RuntimeTypeKind uint8
+
+const (
+	TYPE_ANY RuntimeTypeKind = iota
+	TYPE_NULL
+	TYPE_BOOL
+	TYPE_INT
+	TYPE_FLOAT
+	TYPE_STRING
+	TYPE_BYTES
+	TYPE_ARRAY
+	TYPE_MAP
+	TYPE_REF
+	TYPE_STRUCT
+)
+
+// RuntimeTypeInfo is narrow metadata carried by references at typed native
+// boundaries. It is not a new parameter mode and does not affect Value identity.
+type RuntimeTypeInfo struct {
+	Kind    RuntimeTypeKind
+	Name    string
+	Element *RuntimeTypeInfo
+	Key     *RuntimeTypeInfo
+	Value   *RuntimeTypeInfo
+	Fields  map[string]*RuntimeTypeInfo
+}
+
+func (t *RuntimeTypeInfo) String() string {
+	if t == nil {
+		return "unknown"
+	}
+	switch t.Kind {
+	case TYPE_ANY:
+		return "any"
+	case TYPE_NULL:
+		return "null"
+	case TYPE_BOOL:
+		return "bool"
+	case TYPE_INT:
+		return "int"
+	case TYPE_FLOAT:
+		return "float"
+	case TYPE_STRING:
+		return "string"
+	case TYPE_BYTES:
+		return "bytes"
+	case TYPE_ARRAY:
+		return t.Element.String() + "[]"
+	case TYPE_MAP:
+		return "map[" + t.Key.String() + ", " + t.Value.String() + "]"
+	case TYPE_REF:
+		return "ref " + t.Element.String()
+	case TYPE_STRUCT:
+		return t.Name
+	default:
+		return "unknown"
+	}
+}
+
 type ObjFunction struct {
 	Name         string
 	Arity        int
@@ -237,7 +296,8 @@ const (
 
 type ObjRef struct {
 	RefType     RefType
-	JSONDynamic bool        // Declared any target: JSON may replace its concrete runtime type.
+	JSONDynamic bool // Declared any target: JSON may replace its concrete runtime type.
+	TargetType  *RuntimeTypeInfo
 	Name        string      // For Global or Property Name
 	Ptr         *Value      // For Local (unsafe if escapes)
 	Upvalue     *ObjUpvalue // For Local (safe, captured)
@@ -338,6 +398,10 @@ func NewNull() Value {
 }
 
 func NewString(v string) Value {
+	return Value{Type: VAL_OBJ, Obj: v}
+}
+
+func NewRuntimeTypeInfo(v *RuntimeTypeInfo) Value {
 	return Value{Type: VAL_OBJ, Obj: v}
 }
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -169,7 +169,8 @@ type ObjNative struct {
 }
 
 type ObjArray struct {
-	Elements []Value
+	Elements    []Value
+	RuntimeType *RuntimeTypeInfo
 }
 
 func (oa *ObjArray) String() string {
@@ -206,7 +207,8 @@ func (oa *ObjArray) Format(f fmt.State, verb rune) {
 }
 
 type ObjMap struct {
-	Data map[interface{}]Value
+	Data        map[interface{}]Value
+	RuntimeType *RuntimeTypeInfo
 }
 
 func (om *ObjMap) String() string {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -145,8 +145,9 @@ func (om *ObjMap) Format(f fmt.State, verb rune) {
 }
 
 type ObjStruct struct {
-	Name   string
-	Fields []string
+	Name              string
+	Fields            []string
+	JSONDynamicFields map[string]bool
 }
 
 func (os *ObjStruct) String() string {
@@ -235,12 +236,13 @@ const (
 )
 
 type ObjRef struct {
-	RefType   RefType
-	Name      string      // For Global or Property Name
-	Ptr       *Value      // For Local (unsafe if escapes)
-	Upvalue   *ObjUpvalue // For Local (safe, captured)
-	Container Value       // For Property/Index (Object, Array, Map)
-	Index     Value       // For Index
+	RefType     RefType
+	JSONDynamic bool        // Declared any target: JSON may replace its concrete runtime type.
+	Name        string      // For Global or Property Name
+	Ptr         *Value      // For Local (unsafe if escapes)
+	Upvalue     *ObjUpvalue // For Local (safe, captured)
+	Container   Value       // For Property/Index (Object, Array, Map)
+	Index       Value       // For Index
 }
 
 func (or *ObjRef) String() string {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -241,6 +241,7 @@ type ObjStruct struct {
 	Name              string
 	Fields            []string
 	JSONDynamicFields map[string]bool
+	ConstructorType   *RuntimeTypeInfo
 }
 
 func (os *ObjStruct) String() string {

--- a/internal/vm/call_validation.go
+++ b/internal/vm/call_validation.go
@@ -1,0 +1,51 @@
+package vm
+
+import (
+	"fmt"
+	"noxy-vm/internal/value"
+)
+
+func runtimeValueMode(v value.Value) string {
+	switch v.Type {
+	case value.VAL_BOOL:
+		return "bool"
+	case value.VAL_NULL:
+		return "null"
+	case value.VAL_INT:
+		return "int"
+	case value.VAL_FLOAT:
+		return "float"
+	case value.VAL_OBJ:
+		return "object"
+	case value.VAL_FUNCTION:
+		return "func"
+	case value.VAL_NATIVE:
+		return "native"
+	case value.VAL_BYTES:
+		return "bytes"
+	case value.VAL_CHANNEL:
+		return "chan"
+	case value.VAL_WAITGROUP:
+		return "waitgroup"
+	case value.VAL_REF:
+		return "ref"
+	default:
+		return "unknown"
+	}
+}
+
+func validateParameterModes(name string, params []value.ParamInfo, args []value.Value) error {
+	for i, param := range params {
+		if i >= len(args) {
+			break
+		}
+		actual := args[i]
+		if param.IsRef && actual.Type != value.VAL_REF && actual.Type != value.VAL_NULL {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got %s", name, i+1, param.TypeName, runtimeValueMode(actual))
+		}
+		if !param.IsRef && actual.Type == value.VAL_REF {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got ref", name, i+1, param.TypeName)
+		}
+	}
+	return nil
+}

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -193,3 +193,17 @@ let pointer: ref int = get_reference()
 test_report(pointer)`)
 	testExpectedObject(t, 42, got)
 }
+
+func TestContextualReferenceAcceptsReferenceReturningCall(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let answer: int = 41
+func get_reference() -> ref int
+    return ref answer
+end
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+increment(get_reference())
+test_report(answer)`)
+	testExpectedObject(t, 42, got)
+}

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -5,6 +5,7 @@ import (
 	"noxy-vm/internal/lexer"
 	"noxy-vm/internal/parser"
 	"noxy-vm/internal/value"
+	"strings"
 	"testing"
 )
 
@@ -32,6 +33,68 @@ func runTypedFunctionProgram(t *testing.T, input string) value.Value {
 		t.Fatalf("vm error: %v", err)
 	}
 	return captured
+}
+
+func runTypedFunctionProgramError(t *testing.T, input string) error {
+	t.Helper()
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	bytecode, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+	return New().Interpret(bytecode)
+}
+
+func TestDynamicCallRejectsPlainValueForReferenceParameter(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func increment(value: ref int) -> void
+    return
+end
+let dynamic: func = increment
+let answer: int = 41
+dynamic(answer)`)
+	if err == nil || !strings.Contains(err.Error(), "argument 1: expected ref int, got int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDynamicCallRejectsReferenceForValueParameter(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func consume(value: int) -> void
+    return
+end
+let dynamic: func = consume
+let answer: int = 41
+dynamic(ref answer)`)
+	if err == nil || !strings.Contains(err.Error(), "argument 1: expected int, got ref") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDynamicReferenceParameterAcceptsNull(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func consume(value: ref int) -> void
+    return
+end
+let dynamic: func = consume
+dynamic(null)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdatingNullReferenceFailsClearly(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+let pointer: ref int = null
+*pointer = 1`)
+	if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
+		t.Fatalf("error=%v", err)
+	}
 }
 
 func TestExecutesExactHigherOrderFunction(t *testing.T) {

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -97,3 +97,36 @@ dynamic(ref answer)
 test_report(answer)`)
 	testExpectedObject(t, 42, got)
 }
+
+func TestContextualReferenceUpdatesClosedUpvalue(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func increment(value: ref int) -> void
+    *value = value + 1
+end
+func make_incrementer() -> func() -> int
+    let value: int = 40
+    return func() -> int
+        increment(value)
+        return value
+    end
+end
+let incrementer: func() -> int = make_incrementer()
+incrementer()
+test_report(incrementer())`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestExplicitReferenceToClosedUpvalueCanEscape(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func make_reference_factory() -> func() -> ref int
+    let value: int = 41
+    return func() -> ref int
+        return ref value
+    end
+end
+let get_reference: func() -> ref int = make_reference_factory()
+let pointer: ref int = get_reference()
+*pointer = 42
+test_report(pointer)`)
+	testExpectedObject(t, 42, got)
+}

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -88,6 +88,20 @@ dynamic(null)`)
 	}
 }
 
+func TestExactCallableReferenceParameterReceivesNullValue(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func accept(value: ref func() -> int) -> void
+    test_report(ref value)
+end
+accept(null)`)
+	if got.Type != value.VAL_NULL {
+		t.Fatalf("argument=%v (%v), want VAL_NULL", got, got.Type)
+	}
+	if got.Obj != nil {
+		t.Fatalf("null argument object=%T, want nil (no ObjRef)", got.Obj)
+	}
+}
+
 func TestUpdatingNullReferenceFailsClearly(t *testing.T) {
 	err := runTypedFunctionProgramError(t, `
 let pointer: ref int = null

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -1,0 +1,388 @@
+package vm
+
+import (
+	"math"
+	"noxy-vm/internal/value"
+	"sort"
+)
+
+type jsonCommit func()
+type jsonSetter func(value.Value)
+
+func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeInfo, data interface{}, set jsonSetter) (jsonCommit, bool) {
+	if schema != nil && schema.Kind == value.TYPE_ANY {
+		if set == nil {
+			return nil, false
+		}
+		replacement := goValToNoxy(data)
+		return func() { set(replacement) }, true
+	}
+
+	if schema != nil && schema.Kind == value.TYPE_REF {
+		if data == nil {
+			if set == nil {
+				return nil, false
+			}
+			return func() { set(value.NewNull()) }, true
+		}
+		if current.Type == value.VAL_REF {
+			ref, ok := current.Obj.(*value.ObjRef)
+			if !ok || ref == nil {
+				return nil, false
+			}
+			stored, store, ok := jsonReferenceStorage(vm, ref)
+			if !ok {
+				return nil, false
+			}
+			return prepareJSONMutation(vm, stored, schema.Element, data, store)
+		}
+		// Null and legacy-filled ref slots retain their declared referent type.
+		return prepareJSONMutation(vm, current, schema.Element, data, set)
+	}
+
+	if current.Type == value.VAL_NULL {
+		if schema == nil || set == nil {
+			return nil, false
+		}
+		replacement, ok := buildTypedJSONValue(schema, data)
+		if !ok {
+			return nil, false
+		}
+		return func() { set(replacement) }, true
+	}
+
+	if schema != nil {
+		switch schema.Kind {
+		case value.TYPE_ARRAY:
+			array, ok := current.Obj.(*value.ObjArray)
+			if current.Type != value.VAL_OBJ || !ok {
+				return nil, false
+			}
+			return prepareJSONArrayMutation(vm, array, schema.Element, data)
+		case value.TYPE_MAP:
+			mapping, ok := current.Obj.(*value.ObjMap)
+			if current.Type != value.VAL_OBJ || !ok || !jsonMapKeyCompatible(schema.Key) {
+				return nil, false
+			}
+			return prepareJSONMapMutation(vm, mapping, schema.Value, data)
+		case value.TYPE_STRUCT:
+			instance, ok := current.Obj.(*value.ObjInstance)
+			if current.Type != value.VAL_OBJ || !ok || instance.Struct == nil || instance.Struct.Name != schema.Name {
+				return nil, false
+			}
+			return prepareJSONStructMutation(vm, instance, schema, data)
+		default:
+			if set == nil {
+				return nil, false
+			}
+			replacement, ok := buildTypedJSONValue(schema, data)
+			if !ok {
+				return nil, false
+			}
+			return func() { set(replacement) }, true
+		}
+	}
+
+	if current.Type == value.VAL_OBJ {
+		switch object := current.Obj.(type) {
+		case *value.ObjArray:
+			return prepareJSONArrayMutation(vm, object, nil, data)
+		case *value.ObjMap:
+			return prepareJSONMapMutation(vm, object, nil, data)
+		case *value.ObjInstance:
+			return prepareJSONStructMutation(vm, object, nil, data)
+		}
+	}
+	if set == nil {
+		return nil, false
+	}
+	replacement := goValToNoxy(data)
+	if !jsonReplacementCompatible(current, replacement) {
+		return nil, false
+	}
+	return func() { set(replacement) }, true
+}
+
+func prepareJSONArrayMutation(vm *VM, array *value.ObjArray, elementSchema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+	dataArray, ok := data.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	newElements := make([]value.Value, len(dataArray))
+	commits := make([]jsonCommit, 0, len(dataArray))
+	for i, item := range dataArray {
+		index := i
+		if i < len(array.Elements) {
+			newElements[i] = array.Elements[i]
+			commit, ok := prepareJSONMutation(vm, array.Elements[i], elementSchema, item, func(updated value.Value) {
+				newElements[index] = updated
+			})
+			if !ok {
+				return nil, false
+			}
+			commits = append(commits, commit)
+			continue
+		}
+		if elementSchema == nil {
+			newElements[i] = goValToNoxy(item)
+			continue
+		}
+		created, ok := buildTypedJSONValue(elementSchema, item)
+		if !ok {
+			return nil, false
+		}
+		newElements[i] = created
+	}
+	return func() {
+		for _, commit := range commits {
+			commit()
+		}
+		array.Elements = newElements
+	}, true
+}
+
+func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	newData := make(map[interface{}]value.Value, len(mapping.Data)+len(dataMap))
+	for key, item := range mapping.Data {
+		newData[key] = item
+	}
+	commits := make([]jsonCommit, 0, len(dataMap))
+	for key, item := range dataMap {
+		mapKey := key
+		if current, exists := mapping.Data[mapKey]; exists {
+			commit, ok := prepareJSONMutation(vm, current, valueSchema, item, func(updated value.Value) {
+				newData[mapKey] = updated
+			})
+			if !ok {
+				return nil, false
+			}
+			commits = append(commits, commit)
+			continue
+		}
+		if valueSchema == nil {
+			newData[mapKey] = goValToNoxy(item)
+			continue
+		}
+		created, ok := buildTypedJSONValue(valueSchema, item)
+		if !ok {
+			return nil, false
+		}
+		newData[mapKey] = created
+	}
+	return func() {
+		for _, commit := range commits {
+			commit()
+		}
+		mapping.Data = newData
+	}, true
+}
+
+func prepareJSONStructMutation(vm *VM, instance *value.ObjInstance, schema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+	dataMap, ok := data.(map[string]interface{})
+	if !ok || instance.Struct == nil {
+		return nil, false
+	}
+	newFields := make(map[string]value.Value, len(instance.Fields))
+	for name, field := range instance.Fields {
+		newFields[name] = field
+	}
+	commits := make([]jsonCommit, 0, len(instance.Struct.Fields))
+	for _, fieldName := range instance.Struct.Fields {
+		dataValue, exists := dataMap[fieldName]
+		if !exists {
+			continue
+		}
+		current, exists := instance.Fields[fieldName]
+		if !exists {
+			return nil, false
+		}
+		var fieldSchema *value.RuntimeTypeInfo
+		if schema != nil {
+			fieldSchema = schema.Fields[fieldName]
+		} else if instance.Struct.JSONDynamicFields[fieldName] {
+			fieldSchema = &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}
+		}
+		name := fieldName
+		commit, ok := prepareJSONMutation(vm, current, fieldSchema, dataValue, func(updated value.Value) {
+			newFields[name] = updated
+		})
+		if !ok {
+			return nil, false
+		}
+		commits = append(commits, commit)
+	}
+	return func() {
+		for _, commit := range commits {
+			commit()
+		}
+		instance.Fields = newFields
+	}, true
+}
+
+func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value.Value, bool) {
+	if schema == nil {
+		return value.Value{}, false
+	}
+	switch schema.Kind {
+	case value.TYPE_ANY:
+		return goValToNoxy(data), true
+	case value.TYPE_NULL:
+		if data == nil {
+			return value.NewNull(), true
+		}
+	case value.TYPE_BOOL:
+		if actual, ok := data.(bool); ok {
+			return value.NewBool(actual), true
+		}
+	case value.TYPE_INT:
+		if actual, ok := data.(float64); ok && actual >= math.MinInt64 && actual <= math.MaxInt64 && actual == math.Trunc(actual) {
+			return value.NewInt(int64(actual)), true
+		}
+	case value.TYPE_FLOAT:
+		if actual, ok := data.(float64); ok {
+			return value.NewFloat(actual), true
+		}
+	case value.TYPE_STRING:
+		if actual, ok := data.(string); ok {
+			return value.NewString(actual), true
+		}
+	case value.TYPE_BYTES:
+		if actual, ok := data.(string); ok {
+			return value.NewBytes(actual), true
+		}
+	case value.TYPE_REF:
+		return buildTypedJSONValue(schema.Element, data)
+	case value.TYPE_ARRAY:
+		items, ok := data.([]interface{})
+		if !ok {
+			break
+		}
+		elements := make([]value.Value, len(items))
+		for i, item := range items {
+			created, ok := buildTypedJSONValue(schema.Element, item)
+			if !ok {
+				return value.Value{}, false
+			}
+			elements[i] = created
+		}
+		return value.NewArray(elements), true
+	case value.TYPE_MAP:
+		items, ok := data.(map[string]interface{})
+		if !ok || !jsonMapKeyCompatible(schema.Key) {
+			break
+		}
+		mapping := value.NewMap()
+		mapData := mapping.Obj.(*value.ObjMap).Data
+		for key, item := range items {
+			created, ok := buildTypedJSONValue(schema.Value, item)
+			if !ok {
+				return value.Value{}, false
+			}
+			mapData[key] = created
+		}
+		return mapping, true
+	case value.TYPE_STRUCT:
+		items, ok := data.(map[string]interface{})
+		if !ok {
+			break
+		}
+		fieldNames := make([]string, 0, len(schema.Fields))
+		for name := range schema.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		definition := &value.ObjStruct{
+			Name:              schema.Name,
+			Fields:            fieldNames,
+			JSONDynamicFields: make(map[string]bool),
+		}
+		instance := value.NewInstance(definition)
+		fields := instance.Obj.(*value.ObjInstance).Fields
+		for _, name := range fieldNames {
+			if schema.Fields[name] != nil && schema.Fields[name].Kind == value.TYPE_ANY {
+				definition.JSONDynamicFields[name] = true
+			}
+			item, exists := items[name]
+			if !exists {
+				continue
+			}
+			created, ok := buildTypedJSONValue(schema.Fields[name], item)
+			if !ok {
+				return value.Value{}, false
+			}
+			fields[name] = created
+		}
+		return instance, true
+	}
+	return value.Value{}, false
+}
+
+func jsonMapKeyCompatible(keyType *value.RuntimeTypeInfo) bool {
+	return keyType != nil && (keyType.Kind == value.TYPE_STRING || keyType.Kind == value.TYPE_ANY)
+}
+
+func jsonReferenceStorage(vm *VM, ref *value.ObjRef) (value.Value, jsonSetter, bool) {
+	if ref == nil {
+		return value.Value{}, nil, false
+	}
+	switch ref.RefType {
+	case value.REF_GLOBAL:
+		if vm.currentFrame != nil && vm.currentFrame.Globals != nil {
+			if stored, ok := vm.currentFrame.Globals[ref.Name]; ok {
+				return stored, func(updated value.Value) { vm.currentFrame.Globals[ref.Name] = updated }, true
+			}
+		}
+		stored, ok := vm.GetGlobal(ref.Name)
+		if !ok {
+			return value.Value{}, nil, false
+		}
+		return stored, func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }, true
+	case value.REF_UPVALUE:
+		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
+			return value.Value{}, nil, false
+		}
+		return *ref.Upvalue.Location, func(updated value.Value) { *ref.Upvalue.Location = updated }, true
+	case value.REF_PTR:
+		if ref.Ptr == nil {
+			return value.Value{}, nil, false
+		}
+		return *ref.Ptr, func(updated value.Value) { *ref.Ptr = updated }, true
+	case value.REF_PROPERTY:
+		instance, ok := ref.Container.Obj.(*value.ObjInstance)
+		if ref.Container.Type != value.VAL_OBJ || !ok {
+			return value.Value{}, nil, false
+		}
+		stored, ok := instance.Fields[ref.Name]
+		if !ok {
+			return value.Value{}, nil, false
+		}
+		return stored, func(updated value.Value) { instance.Fields[ref.Name] = updated }, true
+	case value.REF_INDEX:
+		if array, ok := ref.Container.Obj.(*value.ObjArray); ref.Container.Type == value.VAL_OBJ && ok {
+			if ref.Index.Type != value.VAL_INT {
+				return value.Value{}, nil, false
+			}
+			index := int(ref.Index.AsInt)
+			if index < 0 || index >= len(array.Elements) {
+				return value.Value{}, nil, false
+			}
+			return array.Elements[index], func(updated value.Value) { array.Elements[index] = updated }, true
+		}
+		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ref.Container.Type == value.VAL_OBJ && ok {
+			key, err := referenceMapKey(ref.Index)
+			if err != nil {
+				return value.Value{}, nil, false
+			}
+			stored, ok := mapping.Data[key]
+			if !ok {
+				return value.Value{}, nil, false
+			}
+			return stored, func(updated value.Value) { mapping.Data[key] = updated }, true
+		}
+	}
+	return value.Value{}, nil, false
+}

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -301,14 +301,18 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			}
 			elements[i] = created
 		}
-		return value.NewArray(elements), true
+		array := value.NewArray(elements)
+		array.Obj.(*value.ObjArray).RuntimeType = schema
+		return array, true
 	case value.TYPE_MAP:
 		items, ok := data.(map[string]interface{})
 		if !ok || !jsonMapKeyCompatible(schema.Key) {
 			break
 		}
 		mapping := value.NewMap()
-		mapData := mapping.Obj.(*value.ObjMap).Data
+		mapObject := mapping.Obj.(*value.ObjMap)
+		mapObject.RuntimeType = schema
+		mapData := mapObject.Data
 		for key, item := range items {
 			created, ok := buildTypedJSONValue(schema.Value, item)
 			if !ok {

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -302,7 +302,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			elements[i] = created
 		}
 		array := value.NewArray(elements)
-		array.Obj.(*value.ObjArray).RuntimeType = schema
+		array.Obj.(*value.ObjArray).RuntimeType.Store(schema)
 		return array, true
 	case value.TYPE_MAP:
 		items, ok := data.(map[string]interface{})
@@ -311,7 +311,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 		}
 		mapping := value.NewMap()
 		mapObject := mapping.Obj.(*value.ObjMap)
-		mapObject.RuntimeType = schema
+		mapObject.RuntimeType.Store(schema)
 		mapData := mapObject.Data
 		for key, item := range items {
 			created, ok := buildTypedJSONValue(schema.Value, item)

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -435,58 +435,9 @@ func jsonMapKeyCompatible(keyType *value.RuntimeTypeInfo) bool {
 }
 
 func jsonReferenceStorage(vm *VM, ref *value.ObjRef) (value.Value, jsonSetter, bool) {
-	if ref == nil {
+	stored, exists, store, err := vm.referenceStorage(ref)
+	if err != nil || !exists || store == nil {
 		return value.Value{}, nil, false
 	}
-	switch ref.RefType {
-	case value.REF_GLOBAL:
-		stored, err := vm.lookupGlobalReferenceValue(ref)
-		if err != nil {
-			return value.Value{}, nil, false
-		}
-		return stored, func(updated value.Value) { _ = vm.storeGlobalReferenceValue(ref, updated) }, true
-	case value.REF_UPVALUE:
-		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
-			return value.Value{}, nil, false
-		}
-		return *ref.Upvalue.Location, func(updated value.Value) { *ref.Upvalue.Location = updated }, true
-	case value.REF_PTR:
-		if ref.Ptr == nil {
-			return value.Value{}, nil, false
-		}
-		return *ref.Ptr, func(updated value.Value) { *ref.Ptr = updated }, true
-	case value.REF_PROPERTY:
-		instance, ok := ref.Container.Obj.(*value.ObjInstance)
-		if ref.Container.Type != value.VAL_OBJ || !ok {
-			return value.Value{}, nil, false
-		}
-		stored, ok := instance.Fields[ref.Name]
-		if !ok {
-			return value.Value{}, nil, false
-		}
-		return stored, func(updated value.Value) { instance.Fields[ref.Name] = updated }, true
-	case value.REF_INDEX:
-		if array, ok := ref.Container.Obj.(*value.ObjArray); ref.Container.Type == value.VAL_OBJ && ok {
-			if ref.Index.Type != value.VAL_INT {
-				return value.Value{}, nil, false
-			}
-			index := int(ref.Index.AsInt)
-			if index < 0 || index >= len(array.Elements) {
-				return value.Value{}, nil, false
-			}
-			return array.Elements[index], func(updated value.Value) { array.Elements[index] = updated }, true
-		}
-		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ref.Container.Type == value.VAL_OBJ && ok {
-			key, err := referenceMapKey(ref.Index)
-			if err != nil {
-				return value.Value{}, nil, false
-			}
-			stored, ok := mapping.Data[key]
-			if !ok {
-				return value.Value{}, nil, false
-			}
-			return stored, func(updated value.Value) { mapping.Data[key] = updated }, true
-		}
-	}
-	return value.Value{}, nil, false
+	return stored, jsonSetter(store), true
 }

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -334,7 +334,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			}
 			item, exists := items[name]
 			if !exists {
-				continue
+				return value.Value{}, false
 			}
 			created, ok := buildTypedJSONValue(schema.Fields[name], item)
 			if !ok {

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -440,16 +440,11 @@ func jsonReferenceStorage(vm *VM, ref *value.ObjRef) (value.Value, jsonSetter, b
 	}
 	switch ref.RefType {
 	case value.REF_GLOBAL:
-		if vm.currentFrame != nil && vm.currentFrame.Globals != nil {
-			if stored, ok := vm.currentFrame.Globals[ref.Name]; ok {
-				return stored, func(updated value.Value) { vm.currentFrame.Globals[ref.Name] = updated }, true
-			}
-		}
-		stored, ok := vm.GetGlobal(ref.Name)
-		if !ok {
+		stored, err := vm.lookupGlobalReferenceValue(ref)
+		if err != nil {
 			return value.Value{}, nil, false
 		}
-		return stored, func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }, true
+		return stored, func(updated value.Value) { _ = vm.storeGlobalReferenceValue(ref, updated) }, true
 	case value.REF_UPVALUE:
 		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
 			return value.Value{}, nil, false

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -1,7 +1,9 @@
 package vm
 
 import (
+	"encoding/json"
 	"math"
+	"math/big"
 	"noxy-vm/internal/value"
 	"sort"
 )
@@ -14,7 +16,10 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 		if set == nil {
 			return nil, false
 		}
-		replacement := goValToNoxy(data)
+		replacement, ok := dynamicJSONValue(data)
+		if !ok {
+			return nil, false
+		}
 		return func() { set(replacement) }, true
 	}
 
@@ -96,7 +101,10 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 	if set == nil {
 		return nil, false
 	}
-	replacement := goValToNoxy(data)
+	replacement, ok := dynamicJSONValue(data)
+	if !ok {
+		return nil, false
+	}
 	if !jsonReplacementCompatible(current, replacement) {
 		return nil, false
 	}
@@ -124,7 +132,11 @@ func prepareJSONArrayMutation(vm *VM, array *value.ObjArray, elementSchema *valu
 			continue
 		}
 		if elementSchema == nil {
-			newElements[i] = goValToNoxy(item)
+			created, ok := dynamicJSONValue(item)
+			if !ok {
+				return nil, false
+			}
+			newElements[i] = created
 			continue
 		}
 		created, ok := buildTypedJSONValue(elementSchema, item)
@@ -164,7 +176,11 @@ func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.Ru
 			continue
 		}
 		if valueSchema == nil {
-			newData[mapKey] = goValToNoxy(item)
+			created, ok := dynamicJSONValue(item)
+			if !ok {
+				return nil, false
+			}
+			newData[mapKey] = created
 			continue
 		}
 		created, ok := buildTypedJSONValue(valueSchema, item)
@@ -229,7 +245,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 	}
 	switch schema.Kind {
 	case value.TYPE_ANY:
-		return goValToNoxy(data), true
+		return dynamicJSONValue(data)
 	case value.TYPE_NULL:
 		if data == nil {
 			return value.NewNull(), true
@@ -239,12 +255,19 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			return value.NewBool(actual), true
 		}
 	case value.TYPE_INT:
-		if actual, ok := data.(float64); ok && actual >= math.MinInt64 && actual <= math.MaxInt64 && actual == math.Trunc(actual) {
-			return value.NewInt(int64(actual)), true
+		if actual, ok := exactJSONInt(data); ok {
+			return value.NewInt(actual), true
 		}
 	case value.TYPE_FLOAT:
-		if actual, ok := data.(float64); ok {
-			return value.NewFloat(actual), true
+		switch actual := data.(type) {
+		case float64:
+			if !math.IsInf(actual, 0) && !math.IsNaN(actual) {
+				return value.NewFloat(actual), true
+			}
+		case json.Number:
+			if parsed, err := actual.Float64(); err == nil && !math.IsInf(parsed, 0) && !math.IsNaN(parsed) {
+				return value.NewFloat(parsed), true
+			}
 		}
 	case value.TYPE_STRING:
 		if actual, ok := data.(string); ok {
@@ -255,6 +278,9 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			return value.NewBytes(actual), true
 		}
 	case value.TYPE_REF:
+		if data == nil {
+			return value.NewNull(), true
+		}
 		return buildTypedJSONValue(schema.Element, data)
 	case value.TYPE_ARRAY:
 		items, ok := data.([]interface{})
@@ -319,6 +345,80 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 		return instance, true
 	}
 	return value.Value{}, false
+}
+
+func exactJSONInt(data interface{}) (int64, bool) {
+	var rational *big.Rat
+	switch actual := data.(type) {
+	case json.Number:
+		var ok bool
+		rational, ok = new(big.Rat).SetString(actual.String())
+		if !ok {
+			return 0, false
+		}
+	case float64:
+		if math.IsInf(actual, 0) || math.IsNaN(actual) {
+			return 0, false
+		}
+		rational = new(big.Rat).SetFloat64(actual)
+	default:
+		return 0, false
+	}
+	if rational == nil || !rational.IsInt() || !rational.Num().IsInt64() {
+		return 0, false
+	}
+	return rational.Num().Int64(), true
+}
+
+func dynamicJSONValue(data interface{}) (value.Value, bool) {
+	switch actual := data.(type) {
+	case nil:
+		return value.NewNull(), true
+	case bool:
+		return value.NewBool(actual), true
+	case string:
+		return value.NewString(actual), true
+	case float64:
+		if parsed, ok := exactJSONInt(actual); ok {
+			return value.NewInt(parsed), true
+		}
+		if math.IsInf(actual, 0) || math.IsNaN(actual) {
+			return value.Value{}, false
+		}
+		return value.NewFloat(actual), true
+	case json.Number:
+		if parsed, ok := exactJSONInt(actual); ok {
+			return value.NewInt(parsed), true
+		}
+		parsed, err := actual.Float64()
+		if err != nil || math.IsInf(parsed, 0) || math.IsNaN(parsed) {
+			return value.Value{}, false
+		}
+		return value.NewFloat(parsed), true
+	case []interface{}:
+		elements := make([]value.Value, len(actual))
+		for i, item := range actual {
+			converted, ok := dynamicJSONValue(item)
+			if !ok {
+				return value.Value{}, false
+			}
+			elements[i] = converted
+		}
+		return value.NewArray(elements), true
+	case map[string]interface{}:
+		mapping := value.NewMap()
+		dataMap := mapping.Obj.(*value.ObjMap).Data
+		for key, item := range actual {
+			converted, ok := dynamicJSONValue(item)
+			if !ok {
+				return value.Value{}, false
+			}
+			dataMap[key] = converted
+		}
+		return mapping, true
+	default:
+		return value.Value{}, false
+	}
 }
 
 func jsonMapKeyCompatible(keyType *value.RuntimeTypeInfo) bool {

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -44,6 +44,12 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 		// Null and legacy-filled ref slots retain their declared referent type.
 		return prepareJSONMutation(vm, current, schema.Element, data, set)
 	}
+	if schema != nil && schema.Kind == value.TYPE_STRUCT && data == nil {
+		if set == nil {
+			return nil, false
+		}
+		return func() { set(value.NewNull()) }, true
+	}
 
 	if current.Type == value.VAL_NULL {
 		if schema == nil || set == nil {
@@ -312,6 +318,9 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 		}
 		return mapping, true
 	case value.TYPE_STRUCT:
+		if data == nil {
+			return value.NewNull(), true
+		}
 		items, ok := data.(map[string]interface{})
 		if !ok {
 			break

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -177,6 +177,11 @@ func TestMalformedReferenceStringificationIsPanicSafe(t *testing.T) {
 	}{
 		{name: "wrong object", input: value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"}},
 		{name: "typed nil", input: value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)}},
+		{name: "typed nil index metadata", input: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{
+			RefType:   value.REF_INDEX,
+			Container: value.NewArray(nil),
+			Index:     value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjArray)(nil)},
+		}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -61,6 +61,7 @@ dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)
 
 func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
 	moduleGlobals := map[string]value.Value{"present": value.NewInt(1)}
+	nilDataMap := value.Value{Type: value.VAL_OBJ, Obj: &value.ObjMap{}}
 	tests := []struct {
 		name      string
 		malformed value.Value
@@ -75,6 +76,7 @@ func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
 		{name: "array index type", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewBool(false)}}},
 		{name: "array bounds", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewInt(2)}}},
 		{name: "map key", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewMap(), Index: value.Value{Type: value.VAL_OBJ, Obj: []int{1}}}}},
+		{name: "nil map data", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: nilDataMap, Index: value.NewString("key")}}},
 		{name: "index container", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewInt(1), Index: value.NewInt(0)}}},
 	}
 
@@ -216,7 +218,15 @@ func TestReferencesToTypedNilObjectsAreRuntimeErrors(t *testing.T) {
 	}{
 		{name: "array", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjArray)(nil)}},
 		{name: "map", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjMap)(nil)}},
+		{name: "struct", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjStruct)(nil)}},
 		{name: "instance", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjInstance)(nil)}},
+		{name: "function", stored: value.Value{Type: value.VAL_FUNCTION, Obj: (*value.ObjFunction)(nil)}},
+		{name: "closure", stored: value.Value{Type: value.VAL_FUNCTION, Obj: (*value.ObjClosure)(nil)}},
+		{name: "native", stored: value.Value{Type: value.VAL_NATIVE, Obj: (*value.ObjNative)(nil)}},
+		{name: "bytes", stored: value.Value{Type: value.VAL_BYTES, Obj: (*string)(nil)}},
+		{name: "channel", stored: value.Value{Type: value.VAL_CHANNEL, Obj: (*value.ObjChannel)(nil)}},
+		{name: "waitgroup", stored: value.Value{Type: value.VAL_WAITGROUP, Obj: (*value.ObjWaitGroup)(nil)}},
+		{name: "reference", stored: value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,6 +234,43 @@ func TestReferencesToTypedNilObjectsAreRuntimeErrors(t *testing.T) {
 			input := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
 			if _, err := New().resolveReferenceValue(input); err == nil {
 				t.Fatal("typed-nil referenced object resolved without runtime error")
+			}
+		})
+	}
+}
+
+func TestReferencesPreserveValidObjectBackedAndScalarValues(t *testing.T) {
+	storedInt := value.NewInt(7)
+	validRef := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &storedInt}}
+	tests := []struct {
+		name   string
+		stored value.Value
+	}{
+		{name: "string object", stored: value.NewString("value")},
+		{name: "array", stored: value.NewArray(nil)},
+		{name: "map", stored: value.NewMap()},
+		{name: "instance", stored: value.NewInstance(&value.ObjStruct{Name: "Holder"})},
+		{name: "function", stored: value.NewFunction("f", 0, 0, nil, nil, nil)},
+		{name: "native", stored: value.NewNative("n", func(args []value.Value) value.Value { return value.NewNull() })},
+		{name: "bytes", stored: value.NewBytes("ok")},
+		{name: "channel", stored: value.NewChannel(1)},
+		{name: "waitgroup", stored: value.NewWaitGroup()},
+		{name: "reference", stored: validRef},
+		{name: "null", stored: value.NewNull()},
+		{name: "bool", stored: value.NewBool(true)},
+		{name: "int", stored: value.NewInt(42)},
+		{name: "float", stored: value.NewFloat(3.5)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := tt.stored
+			input := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+			got, err := New().resolveReferenceValue(input)
+			if err != nil {
+				t.Fatalf("valid referenced value rejected: %v", err)
+			}
+			if got.Type != tt.stored.Type {
+				t.Fatalf("type=%v, want %v", got.Type, tt.stored.Type)
 			}
 		})
 	}

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -1,0 +1,164 @@
+package vm
+
+import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+	"noxy-vm/internal/value"
+	"strings"
+	"testing"
+)
+
+func runMalformedReferenceProgram(t *testing.T, source string, malformed value.Value) (err error) {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+
+	machine := New()
+	machine.DefineNative("malformed_ref", func(args []value.Value) value.Value {
+		return malformed
+	})
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("malformed reference caused Go panic: %v", recovered)
+		}
+	}()
+	return machine.Interpret(code)
+}
+
+func TestMalformedNativeReferenceReadIsRuntimeError(t *testing.T) {
+	err := runMalformedReferenceProgram(t, `
+func read(value: ref int) -> int
+    return value
+end
+let dynamic: func = read
+dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"})
+	if err == nil || !strings.Contains(err.Error(), "invalid reference value") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestMalformedNativeReferenceWriteIsRuntimeError(t *testing.T) {
+	err := runMalformedReferenceProgram(t, `
+func write(value: ref int) -> void
+    *value = 42
+end
+let dynamic: func = write
+dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)})
+	if err == nil || !strings.Contains(err.Error(), "invalid reference value") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
+	moduleGlobals := map[string]value.Value{"present": value.NewInt(1)}
+	tests := []struct {
+		name      string
+		malformed value.Value
+	}{
+		{name: "invalid kind", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.RefType(99)}}},
+		{name: "nil pointer", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR}}},
+		{name: "nil upvalue", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE}}},
+		{name: "nil upvalue location", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE, Upvalue: &value.ObjUpvalue{}}}},
+		{name: "nil global owner", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "present"}}},
+		{name: "missing global", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: &moduleGlobals}}},
+		{name: "property container", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PROPERTY, Container: value.NewInt(1), Name: "field"}}},
+		{name: "array index type", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewBool(false)}}},
+		{name: "array bounds", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewInt(2)}}},
+		{name: "map key", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewMap(), Index: value.Value{Type: value.VAL_OBJ, Obj: []int{1}}}}},
+		{name: "index container", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewInt(1), Index: value.NewInt(0)}}},
+	}
+
+	readSource := `
+func read(value: ref int) -> int
+    return value
+end
+let dynamic: func = read
+dynamic(malformed_ref())`
+	writeSource := `
+func write(value: ref int) -> void
+    *value = 42
+end
+let dynamic: func = write
+dynamic(malformed_ref())`
+
+	for _, tt := range tests {
+		for _, operation := range []struct {
+			name   string
+			source string
+		}{
+			{name: "read", source: readSource},
+			{name: "write", source: writeSource},
+		} {
+			t.Run(tt.name+"/"+operation.name, func(t *testing.T) {
+				err := runMalformedReferenceProgram(t, operation.source, tt.malformed)
+				if err == nil {
+					t.Fatal("malformed reference completed without runtime error")
+				}
+			})
+		}
+	}
+}
+
+func TestMalformedStoredPropertyReferenceWriteIsRuntimeError(t *testing.T) {
+	code := chunk.New()
+	code.FileName = "malformed_property_reference"
+	holder := value.NewInstance(&value.ObjStruct{Name: "Holder", Fields: []string{"pointer"}})
+	holder.Obj.(*value.ObjInstance).Fields["pointer"] = value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"}
+	holderConstant := code.AddConstant(holder)
+	valueConstant := code.AddConstant(value.NewInt(42))
+	propertyConstant := code.AddConstant(value.NewString("pointer"))
+	for _, instruction := range []byte{
+		byte(chunk.OP_CONSTANT), byte(holderConstant),
+		byte(chunk.OP_CONSTANT), byte(valueConstant),
+		byte(chunk.OP_SET_PROPERTY_DEREF), byte(propertyConstant),
+		byte(chunk.OP_RETURN),
+	} {
+		code.Write(instruction, 1)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("malformed property reference caused Go panic: %v", recovered)
+		}
+	}()
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "invalid reference value") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestMalformedReferenceStoreViaLocalOpcodeIsRuntimeError(t *testing.T) {
+	code := chunk.New()
+	code.FileName = "malformed_store_via_ref"
+	refConstant := code.AddConstant(value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"})
+	valueConstant := code.AddConstant(value.NewInt(42))
+	for _, instruction := range []byte{
+		byte(chunk.OP_CONSTANT), byte(refConstant),
+		byte(chunk.OP_CONSTANT), byte(valueConstant),
+		byte(chunk.OP_STORE_VIA_REF), 0,
+		byte(chunk.OP_NULL),
+		byte(chunk.OP_RETURN),
+	} {
+		code.Write(instruction, 1)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("malformed OP_STORE_VIA_REF caused Go panic: %v", recovered)
+		}
+	}()
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "invalid reference value") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -162,3 +162,107 @@ func TestMalformedReferenceStoreViaLocalOpcodeIsRuntimeError(t *testing.T) {
 		t.Fatalf("error=%v", err)
 	}
 }
+
+func TestMalformedReferencePrintIsPanicSafe(t *testing.T) {
+	err := runMalformedReferenceProgram(t, `print(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"})
+	if err != nil {
+		t.Fatalf("print returned unexpected error: %v", err)
+	}
+}
+
+func TestMalformedReferenceStringificationIsPanicSafe(t *testing.T) {
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{name: "wrong object", input: value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"}},
+		{name: "typed nil", input: value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("malformed reference String panicked: %v", recovered)
+				}
+			}()
+			if got := tt.input.String(); got != "<invalid reference>" {
+				t.Fatalf("String()=%q, want invalid reference marker", got)
+			}
+		})
+	}
+
+	t.Run("nil ObjRef receiver", func(t *testing.T) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("nil ObjRef.String panicked: %v", recovered)
+			}
+		}()
+		var nilRef *value.ObjRef
+		if got := nilRef.String(); got != "<invalid reference>" {
+			t.Fatalf("nil ObjRef.String()=%q, want invalid reference marker", got)
+		}
+	})
+}
+
+func TestReferencesToTypedNilObjectsAreRuntimeErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		stored value.Value
+	}{
+		{name: "array", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjArray)(nil)}},
+		{name: "map", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjMap)(nil)}},
+		{name: "instance", stored: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjInstance)(nil)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := tt.stored
+			input := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+			if _, err := New().resolveReferenceValue(input); err == nil {
+				t.Fatal("typed-nil referenced object resolved without runtime error")
+			}
+		})
+	}
+}
+
+func TestContextualReferenceOpcodesRejectTypedNilContainers(t *testing.T) {
+	arrayIndex := value.NewInt(0)
+	mapIndex := value.NewString("key")
+	tests := []struct {
+		name       string
+		container  value.Value
+		indexValue *value.Value
+	}{
+		{name: "property", container: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjInstance)(nil)}},
+		{name: "array index", container: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjArray)(nil)}, indexValue: &arrayIndex},
+		{name: "map index", container: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjMap)(nil)}, indexValue: &mapIndex},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := chunk.New()
+			code.FileName = "typed_nil_context_reference"
+			containerConstant := code.AddConstant(tt.container)
+			code.Write(byte(chunk.OP_CONSTANT), 1)
+			code.Write(byte(containerConstant), 1)
+			if tt.indexValue == nil {
+				nameConstant := code.AddConstant(value.NewString("field"))
+				code.Write(byte(chunk.OP_CONTEXT_REF_PROPERTY), 1)
+				code.Write(byte(nameConstant), 1)
+			} else {
+				indexConstant := code.AddConstant(*tt.indexValue)
+				code.Write(byte(chunk.OP_CONSTANT), 1)
+				code.Write(byte(indexConstant), 1)
+				code.Write(byte(chunk.OP_CONTEXT_REF_INDEX), 1)
+			}
+			code.Write(byte(chunk.OP_RETURN), 1)
+
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("typed-nil contextual reference caused Go panic: %v", recovered)
+				}
+			}()
+			if err := New().Interpret(code); err == nil {
+				t.Fatal("typed-nil contextual reference completed without runtime error")
+			}
+		})
+	}
+}

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -1,6 +1,10 @@
 package vm
 
 import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
 	"noxy-vm/internal/value"
 	"os"
 	"path/filepath"
@@ -30,6 +34,50 @@ func TestRuntimeEmbeddedWildcardExportsAreDurable(t *testing.T) {
 	data := module.Obj.(*value.ObjMap).Data
 	if _, ok := data["delete"]; !ok {
 		t.Fatal("runtime http module omitted wildcard-imported delete")
+	}
+}
+
+func TestRuntimeModuleCachePreservesStructConstructorCallableSchema(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "constructors.nx"), []byte("struct Box\n    value: int\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	machine := NewWithConfig(VMConfig{RootPath: root})
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	expected := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{integer},
+		ParamIsRef: []bool{false},
+		Return:     &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Box", Fields: map[string]*value.RuntimeTypeInfo{"value": integer}},
+	}
+	l := lexer.New("use constructors as first\nuse constructors as second\n")
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"), root).Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := machine.Interpret(code); err != nil {
+		t.Fatal(err)
+	}
+	first, ok := machine.GetGlobal("first")
+	if !ok {
+		t.Fatal("missing first module alias")
+	}
+	second, ok := machine.GetGlobal("second")
+	if !ok {
+		t.Fatal("missing cached module alias")
+	}
+	firstConstructor := first.Obj.(*value.ObjMap).Data["Box"]
+	secondConstructor := second.Obj.(*value.ObjMap).Data["Box"]
+	if firstConstructor.Obj != secondConstructor.Obj {
+		t.Fatal("cached import replaced the constructor definition")
+	}
+	if !runtimeCallableMatchesType(firstConstructor, expected) {
+		t.Fatal("cached constructor did not satisfy exact schema")
 	}
 }
 

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -192,3 +192,59 @@ func TestRuntimeRejectsTopLevelWildcardImportCycles(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeNestedModuleCompilerUsesVMRoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		shadowDep string
+	}{
+		{name: "dependency only at root"},
+		{
+			name: "divergent nested dependency",
+			shadowDep: `
+func append(value: int) -> void
+end
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			pkgDir := filepath.Join(root, "pkg")
+			if err := os.MkdirAll(pkgDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "dep.nx"), []byte("func delete(url: string) -> void\nend\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			wrapper := `
+use dep select *
+func forward(url: string) -> void
+    delete(url)
+end
+`
+			if err := os.WriteFile(filepath.Join(pkgDir, "wrapper.nx"), []byte(wrapper), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tt.shadowDep != "" {
+				if err := os.WriteFile(filepath.Join(pkgDir, "dep.nx"), []byte(tt.shadowDep), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			module, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("pkg.wrapper")
+			if err != nil {
+				t.Fatal(err)
+			}
+			deleteBinding, ok := module.Obj.(*value.ObjMap).Data["delete"]
+			if !ok {
+				t.Fatal("nested wrapper omitted root dependency delete")
+			}
+			closure, ok := deleteBinding.Obj.(*value.ObjClosure)
+			if deleteBinding.Type != value.VAL_FUNCTION || !ok || closure.Function.Arity != 1 {
+				t.Fatalf("delete binding=%v, want root one-argument closure", deleteBinding)
+			}
+		})
+	}
+}

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -1,0 +1,92 @@
+package vm
+
+import (
+	"noxy-vm/internal/value"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeFileModuleGlobalsContainDirectExports(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "collision.nx"), []byte("func delete(url: string) -> void\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	module, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("collision")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := module.Obj.(*value.ObjMap).Data
+	if _, ok := data["delete"]; !ok {
+		t.Fatal("runtime file module omitted direct delete export")
+	}
+}
+
+func TestRuntimeDirectoryModuleGlobalsContainOnlyLoadableChildren(t *testing.T) {
+	root := t.TempDir()
+	bundle := filepath.Join(root, "bundle")
+	if err := os.MkdirAll(filepath.Join(bundle, "unloadable"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "delete.nx"), []byte("let marker: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "unloadable", "broken.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	module, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := module.Obj.(*value.ObjMap).Data
+	if _, ok := data["delete"]; !ok {
+		t.Fatal("runtime directory module omitted loadable file child")
+	}
+	if _, ok := data["unloadable"]; ok {
+		t.Fatal("runtime directory module retained unloadable directory child")
+	}
+}
+
+func TestRuntimeDirectoryModuleFailsForUnloadableFileChild(t *testing.T) {
+	root := t.TempDir()
+	broken := filepath.Join(root, "broken")
+	if err := os.MkdirAll(broken, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "good.nx"), []byte("let marker: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "bad.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("broken"); err == nil {
+		t.Fatal("runtime directory module accepted unloadable file child")
+	}
+}
+
+func TestRuntimeFileModuleFailsForMissingDirectImport(t *testing.T) {
+	root := t.TempDir()
+	source := "use definitely_missing_task5_module as dependency\nfunc delete(url: string) -> void\nend\n"
+	if err := os.WriteFile(filepath.Join(root, "collision.nx"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("collision"); err == nil {
+		t.Fatal("runtime file module accepted a missing direct import")
+	}
+}
+
+func TestRuntimeFileModuleFailsForMissingSelectedExport(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "dependency.nx"), []byte("let present: int = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := "use dependency select missing\nfunc delete(url: string) -> void\nend\n"
+	if err := os.WriteFile(filepath.Join(root, "collision.nx"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("collision"); err == nil {
+		t.Fatal("runtime file module accepted a missing selected export")
+	}
+}

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -22,6 +22,17 @@ func TestRuntimeFileModuleGlobalsContainDirectExports(t *testing.T) {
 	}
 }
 
+func TestRuntimeEmbeddedWildcardExportsAreDurable(t *testing.T) {
+	module, err := New().loadModule("http")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := module.Obj.(*value.ObjMap).Data
+	if _, ok := data["delete"]; !ok {
+		t.Fatal("runtime http module omitted wildcard-imported delete")
+	}
+}
+
 func TestRuntimeDirectoryModuleGlobalsContainOnlyLoadableChildren(t *testing.T) {
 	root := t.TempDir()
 	bundle := filepath.Join(root, "bundle")
@@ -88,5 +99,96 @@ func TestRuntimeFileModuleFailsForMissingSelectedExport(t *testing.T) {
 	}
 	if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("collision"); err == nil {
 		t.Fatal("runtime file module accepted a missing selected export")
+	}
+}
+
+func TestRuntimeFileModuleFailsForInvalidTopLevelWildcardDependency(t *testing.T) {
+	tests := []struct {
+		name       string
+		dependency string
+	}{
+		{name: "missing", dependency: "definitely_missing_task5_module"},
+		{name: "compile invalid", dependency: "broken"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "broken.nx"), []byte("let marker: int = \"wrong\"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			wrapper := "use " + tt.dependency + " select *\nfunc delete(url: string) -> void\nend\n"
+			if err := os.WriteFile(filepath.Join(root, "wrapper.nx"), []byte(wrapper), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("wrapper"); err == nil {
+				t.Fatal("runtime module accepted invalid top-level wildcard dependency")
+			}
+		})
+	}
+}
+
+func TestRuntimeFunctionBodyOnlyWildcardDoesNotInvalidateModule(t *testing.T) {
+	tests := []struct {
+		name       string
+		dependency string
+	}{
+		{name: "missing", dependency: "definitely_missing_task5_module"},
+		{name: "self cycle", dependency: "safe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			source := "func unused() -> void\n    use " + tt.dependency + " select *\nend\nfunc delete(url: string) -> void\nend\n"
+			if err := os.WriteFile(filepath.Join(root, "safe.nx"), []byte(source), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			module, err := NewWithConfig(VMConfig{RootPath: root}).loadModule("safe")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := module.Obj.(*value.ObjMap).Data["delete"]; !ok {
+				t.Fatal("runtime module omitted direct delete export")
+			}
+		})
+	}
+}
+
+func TestRuntimeRejectsTopLevelWildcardImportCycles(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		root  string
+	}{
+		{
+			name: "self cycle",
+			files: map[string]string{
+				"cycle.nx": "use cycle select *\n",
+			},
+			root: "cycle",
+		},
+		{
+			name: "mutual cycle",
+			files: map[string]string{
+				"left.nx":  "use right select *\n",
+				"right.nx": "use left select *\n",
+			},
+			root: "left",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, source := range tt.files {
+				if err := os.WriteFile(filepath.Join(root, name), []byte(source), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := NewWithConfig(VMConfig{RootPath: root}).loadModule(tt.root); err == nil {
+				t.Fatal("runtime accepted a cyclic top-level wildcard import")
+			}
+		})
 	}
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -635,6 +635,129 @@ test_report(values[0][0])`)
 	testExpectedObject(t, 42, got)
 }
 
+func TestDynamicAppendSpecializesItemModeFromTargetType(t *testing.T) {
+	t.Run("reject reference for plain element", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let values: int[] = [1]
+let item: int = 2
+invoke(ref values, ref item)
+test_report(length(values))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("reject incompatible plain value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let values: int[] = [1]
+invoke(ref values, "bad")
+test_report(length(values))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("reject plain value for reference element", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Vertex
+    value: int
+end
+let invoke: any = append
+let values: (ref Vertex)[] = []
+let item: Vertex = Vertex(2)
+invoke(ref values, item)
+test_report(length(values))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("reject reference to incompatible value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Vertex
+    value: int
+end
+let invoke: any = append
+let values: (ref Vertex)[] = []
+let item: int = 2
+invoke(ref values, ref item)
+test_report(length(values))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("accept plain value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let values: int[] = [1]
+invoke(ref values, 2)
+test_report(values[1])`)
+		testExpectedObject(t, 2, got)
+	})
+
+	t.Run("accept and retain reference value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Vertex
+    value: int
+end
+let invoke: any = append
+let values: (ref Vertex)[] = []
+let item: Vertex = Vertex(2)
+invoke(ref values, ref item)
+values[0].value = 42
+test_report(item.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("accept null reference element", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let values: (ref int)[] = []
+invoke(ref values, null)
+test_report(length(values))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("forward existing target reference", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let values: int[] = [1]
+let forwarded: ref int[] = ref values
+invoke(ref forwarded, 2)
+test_report(length(values))`)
+		testExpectedObject(t, 2, got)
+	})
+}
+
+func TestDynamicAppendRejectsMalformedReferenceItemWithoutMutation(t *testing.T) {
+	source := `
+let invoke: any = append
+let values: (ref int)[] = []
+invoke(ref values, malformed_ref())
+test_report(length(values))`
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("malformed_ref", func(args []value.Value) value.Value {
+		return value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"}
+	})
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) > 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("malformed append item must fail as a legacy no-op, got %v", err)
+	}
+	testExpectedObject(t, 0, captured)
+}
+
 func TestUnrelatedWildcardImportKeepsBuiltinRuntimeContract(t *testing.T) {
 	got := runTypedFunctionProgram(t, `
 use sys select *

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1110,6 +1110,199 @@ func TestRuntimeCallableValidationProjectsOnlyCompleteNativeSignatures(t *testin
 	}
 }
 
+func TestRuntimeCallableValidationMatchesExactCallableArraySpelling(t *testing.T) {
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	callback := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{integer},
+		ParamIsRef: []bool{false},
+		Return:     integer,
+	}
+	callbacks := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: callback}
+	expected := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{callbacks},
+		ParamIsRef: []bool{false},
+		Return:     callbacks,
+	}
+	typed := value.NewNativeWithSignature("callbacks", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{TypeName: "(func(int) -> int)[]"}},
+		ReturnType: "(func(int) -> int)[]",
+	}, func(args []value.Value) value.Value { return args[0] })
+	if !runtimeCallableMatchesType(typed, expected) {
+		t.Fatal("typed native callable-array signature did not match canonical type spelling")
+	}
+}
+
+func TestDynamicAppendRequiresInvariantExactCallableSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "any parameter does not accept concrete declaration",
+			source: `
+func seed(value: any) -> int return 1 end
+func wrong(value: int) -> int return value end
+let invoke: any = append
+let target: (func(any) -> int)[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+		{
+			name: "concrete parameter does not accept any declaration",
+			source: `
+func seed(value: int) -> int return value end
+func wrong(value: any) -> int return 1 end
+let invoke: any = append
+let target: (func(int) -> int)[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+		{
+			name: "any return does not accept concrete declaration",
+			source: `
+func seed() -> any return 1 end
+func wrong() -> int return 1 end
+let invoke: any = append
+let target: (func() -> any)[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+		{
+			name: "concrete return does not accept any declaration",
+			source: `
+func seed() -> int return 1 end
+func wrong() -> any return 1 end
+let invoke: any = append
+let target: (func() -> int)[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+		{
+			name: "fixed array parameter size is exact",
+			source: `
+func seed(values: int[4]) -> int return length(values) end
+func wrong(values: int[5]) -> int return length(values) end
+let invoke: any = append
+let target: (func(int[4]) -> int)[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+		{
+			name: "fixed array return size is exact",
+			source: `
+func seed() -> int[4]
+    let values: int[4]
+    return values
+end
+func wrong() -> int[5]
+    let values: int[5]
+    return values
+end
+let invoke: any = append
+let target: (func() -> int[4])[] = [seed]
+pop(target)
+invoke(ref target, wrong)
+test_report(length(target))`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testExpectedObject(t, 0, runTypedFunctionProgram(t, tt.source))
+		})
+	}
+}
+
+func TestRuntimeCallableValidationIsInvariantAndFailClosed(t *testing.T) {
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	dynamic := &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}
+	fixedFour := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer, Size: 4}
+	tests := []struct {
+		name      string
+		expected  *value.RuntimeTypeInfo
+		signature value.NativeSignature
+		fn        value.NativeFunc
+		want      bool
+	}{
+		{
+			name:      "matching any parameter and return",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{dynamic}, ParamIsRef: []bool{false}, Return: dynamic},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "any"}}, ReturnType: "any"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+			want:      true,
+		},
+		{
+			name:      "any parameter rejects concrete native declaration",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{dynamic}, ParamIsRef: []bool{false}, Return: integer},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "int"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "concrete parameter rejects any native declaration",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}, Return: integer},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "any"}}, ReturnType: "int"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "any return rejects concrete native declaration",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}, Return: dynamic},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "int"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "concrete return rejects any native declaration",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}, Return: integer},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "any"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "matching fixed array size",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{fixedFour}, ParamIsRef: []bool{false}, Return: fixedFour},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int[4]"}}, ReturnType: "int[4]"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+			want:      true,
+		},
+		{
+			name:      "wrong fixed array size",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{fixedFour}, ParamIsRef: []bool{false}, Return: fixedFour},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int[5]"}}, ReturnType: "int[4]"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "wrong fixed array return size",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{fixedFour}, ParamIsRef: []bool{false}, Return: fixedFour},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int[4]"}}, ReturnType: "int[5]"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+		{
+			name:      "nil native function",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}, Return: integer},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "int"},
+		},
+		{
+			name:      "partial parameter schema",
+			expected:  &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{nil}, ParamIsRef: []bool{false}, Return: integer},
+			signature: value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "unknown"}}, ReturnType: "int"},
+			fn:        func(args []value.Value) value.Value { return args[0] },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			native := value.NewNativeWithSignature("typed", tt.signature, tt.fn)
+			if got := runtimeCallableMatchesType(native, tt.expected); got != tt.want {
+				t.Fatalf("runtimeCallableMatchesType=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTypedJSONLoadsRejectsCallableAndChannelConstruction(t *testing.T) {
 	t.Run("empty bare function array after pop", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"noxy-vm/internal/compiler"
@@ -96,8 +97,9 @@ typed_test(ref forwarded)`
 	if received != stored {
 		t.Fatal("target metadata marker copied or rebound the forwarded reference")
 	}
-	if stored.TargetType == nil || stored.TargetType.Kind != value.TYPE_INT {
-		t.Fatalf("target metadata=%v, want int", stored.TargetType)
+	targetType := stored.TargetType.Load()
+	if targetType == nil || targetType.Kind != value.TYPE_INT {
+		t.Fatalf("target metadata=%v, want int", targetType)
 	}
 }
 
@@ -370,7 +372,9 @@ func TestPopulateTargetSupportsCompatibleAndNullScalarReplacement(t *testing.T) 
 
 	t.Run("marked dynamic null", func(t *testing.T) {
 		stored := value.NewNull()
-		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored, JSONDynamic: true}}
+		ref := &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}
+		ref.JSONDynamic.Store(true)
+		target := value.Value{Type: value.VAL_REF, Obj: ref}
 		if !populateTarget(New(), target, float64(42)) {
 			t.Fatal("null target rejected dynamic scalar replacement")
 		}
@@ -1447,20 +1451,20 @@ func TestCollectionRuntimeMetadataPreservesShallowCopyAndIdentity(t *testing.T) 
 
 	array := value.NewArray([]value.Value{shared})
 	arrayObject := array.Obj.(*value.ObjArray)
-	arrayObject.RuntimeType = arraySchema
+	arrayObject.RuntimeType.Store(arraySchema)
 	arrayCopy := machine.copyValue(array)
 	arrayCopyObject := arrayCopy.Obj.(*value.ObjArray)
-	if arrayCopyObject == arrayObject || arrayCopyObject.RuntimeType != arraySchema || arrayCopyObject.Elements[0].Obj != shared.Obj {
+	if arrayCopyObject == arrayObject || arrayCopyObject.RuntimeType.Load() != arraySchema || arrayCopyObject.Elements[0].Obj != shared.Obj {
 		t.Fatal("array shallow copy lost collection schema or nested identity")
 	}
 
 	mapping := value.NewMap()
 	mapObject := mapping.Obj.(*value.ObjMap)
 	mapObject.Data["item"] = shared
-	mapObject.RuntimeType = mapSchema
+	mapObject.RuntimeType.Store(mapSchema)
 	mapCopy := machine.copyValue(mapping)
 	mapCopyObject := mapCopy.Obj.(*value.ObjMap)
-	if mapCopyObject == mapObject || mapCopyObject.RuntimeType != mapSchema || mapCopyObject.Data["item"].Obj != shared.Obj {
+	if mapCopyObject == mapObject || mapCopyObject.RuntimeType.Load() != mapSchema || mapCopyObject.Data["item"].Obj != shared.Obj {
 		t.Fatal("map shallow copy lost collection schema or nested identity")
 	}
 }
@@ -1473,8 +1477,8 @@ func TestRuntimeValueMarkerRejectsConflictsWithoutOverwriteOrRefMutation(t *test
 	fixedArray := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer, Size: 4}
 	array := value.NewArray([]value.Value{value.NewInt(1)})
 	arrayObject := array.Obj.(*value.ObjArray)
-	arrayObject.RuntimeType = dynamicArray
-	if machine.markRuntimeValueType(array, fixedArray) || arrayObject.RuntimeType != dynamicArray {
+	arrayObject.RuntimeType.Store(dynamicArray)
+	if machine.markRuntimeValueType(array, fixedArray) || arrayObject.RuntimeType.Load() != dynamicArray {
 		t.Fatal("array conflict overwrote existing runtime schema")
 	}
 
@@ -1482,8 +1486,8 @@ func TestRuntimeValueMarkerRejectsConflictsWithoutOverwriteOrRefMutation(t *test
 	intMap := &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: integer, Value: text}
 	mapping := value.NewMap()
 	mapObject := mapping.Obj.(*value.ObjMap)
-	mapObject.RuntimeType = stringMap
-	if machine.markRuntimeValueType(mapping, intMap) || mapObject.RuntimeType != stringMap {
+	mapObject.RuntimeType.Store(stringMap)
+	if machine.markRuntimeValueType(mapping, intMap) || mapObject.RuntimeType.Load() != stringMap {
 		t.Fatal("map conflict overwrote existing runtime schema")
 	}
 
@@ -1500,7 +1504,7 @@ func TestRuntimeValueMarkerRejectsConflictsWithoutOverwriteOrRefMutation(t *test
 	if !machine.markRuntimeValueType(refValue, &value.RuntimeTypeInfo{Kind: value.TYPE_REF, Element: dynamicArray}) {
 		t.Fatal("compatible reference value marker was rejected")
 	}
-	if ref.TargetType != nil || refValue.Obj != ref {
+	if ref.TargetType.Load() != nil || refValue.Obj != ref {
 		t.Fatal("runtime value marker mutated or rebound ObjRef")
 	}
 }
@@ -1591,11 +1595,11 @@ test_report(length(target))`,
 				t.Fatal(err)
 			}
 			testExpectedObject(t, 1, captured)
-			backingSchema := backing.Obj.(*value.ObjArray).RuntimeType
+			backingSchema := backing.Obj.(*value.ObjArray).RuntimeType.Load()
 			if backingSchema == nil || backingSchema.Kind != value.TYPE_ARRAY || backingSchema.Element == nil || backingSchema.Element.Kind != value.TYPE_INT {
 				t.Fatalf("backing schema=%#v", backingSchema)
 			}
-			if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+			if originalRef.Ptr != &backing || originalRef.TargetType.Load() != nil {
 				t.Fatal("runtime value marker mutated or rebound the ObjRef")
 			}
 		})
@@ -1635,11 +1639,11 @@ test_report(length(target))`
 			t.Fatal(err)
 		}
 		testExpectedObject(t, 1, captured)
-		backingSchema := backing.Obj.(*value.ObjMap).RuntimeType
+		backingSchema := backing.Obj.(*value.ObjMap).RuntimeType.Load()
 		if backingSchema == nil || backingSchema.Kind != value.TYPE_MAP || backingSchema.Key.Kind != value.TYPE_STRING || backingSchema.Value.Kind != value.TYPE_INT {
 			t.Fatalf("backing schema=%#v", backingSchema)
 		}
-		if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+		if originalRef.Ptr != &backing || originalRef.TargetType.Load() != nil {
 			t.Fatal("runtime value marker mutated or rebound the map ObjRef")
 		}
 	})
@@ -1682,10 +1686,142 @@ test_report(length(target))`
 		if channel.ElementType == nil || channel.ElementType.Kind != value.TYPE_INT {
 			t.Fatalf("channel element schema=%#v", channel.ElementType)
 		}
-		if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+		if originalRef.Ptr != &backing || originalRef.TargetType.Load() != nil {
 			t.Fatal("runtime value marker mutated or rebound the channel ObjRef")
 		}
 	})
+}
+
+func TestConcurrentCollectionRuntimeMetadataPublication(t *testing.T) {
+	machine := New()
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	arraySchema := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer}
+	mapSchema := &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}, Value: integer}
+
+	tests := []struct {
+		name        string
+		actual      value.Value
+		schema      *value.RuntimeTypeInfo
+		conflicting *value.RuntimeTypeInfo
+	}{
+		{
+			name:        "array",
+			actual:      value.NewArray(nil),
+			schema:      arraySchema,
+			conflicting: &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}},
+		},
+		{
+			name:        "map",
+			actual:      value.NewMap(),
+			schema:      mapSchema,
+			conflicting: &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: integer, Value: integer},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := make(chan struct{})
+			var workers sync.WaitGroup
+			for i := 0; i < 16; i++ {
+				workers.Add(2)
+				go func() {
+					defer workers.Done()
+					<-start
+					for j := 0; j < 100; j++ {
+						machine.markRuntimeValueType(tt.actual, tt.schema)
+					}
+				}()
+				go func() {
+					defer workers.Done()
+					<-start
+					for j := 0; j < 100; j++ {
+						machine.runtimeValueMatchesType(tt.actual, tt.schema)
+					}
+				}()
+			}
+			close(start)
+			workers.Wait()
+			if !machine.markRuntimeValueType(tt.actual, tt.schema) {
+				t.Fatal("compatible concurrent marker was not published")
+			}
+
+			failures := make(chan string, 2400)
+			workers = sync.WaitGroup{}
+			for i := 0; i < 8; i++ {
+				workers.Add(3)
+				go func() {
+					defer workers.Done()
+					for j := 0; j < 100; j++ {
+						if !machine.markRuntimeValueType(tt.actual, tt.schema) {
+							failures <- "compatible marker was rejected"
+						}
+					}
+				}()
+				go func() {
+					defer workers.Done()
+					for j := 0; j < 100; j++ {
+						if machine.markRuntimeValueType(tt.actual, tt.conflicting) {
+							failures <- "conflicting marker was accepted"
+						}
+					}
+				}()
+				go func() {
+					defer workers.Done()
+					for j := 0; j < 100; j++ {
+						if !machine.runtimeValueMatchesType(tt.actual, tt.schema) {
+							failures <- "dynamic validation lost the published schema"
+						}
+					}
+				}()
+			}
+			workers.Wait()
+			close(failures)
+			for failure := range failures {
+				t.Error(failure)
+			}
+		})
+	}
+}
+
+func TestConcurrentReferenceTargetMetadataPublication(t *testing.T) {
+	machine := New()
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	arraySchema := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer}
+	conflicting := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}}
+	stored := value.NewArray(nil)
+	ref := &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		workers.Add(2)
+		go func() {
+			defer workers.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				if !markReferenceTargetType(ref, arraySchema) {
+					t.Errorf("compatible reference schema was rejected")
+					return
+				}
+			}
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				machine.appendItemCompatible(ref, value.NewInt(1))
+				ref.JSONDynamic.Store(true)
+				_ = ref.JSONDynamic.Load()
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	if ref.TargetType.Load() != arraySchema {
+		t.Fatal("compatible concurrent marker did not preserve the published schema")
+	}
+	if markReferenceTargetType(ref, conflicting) || ref.TargetType.Load() != arraySchema {
+		t.Fatal("conflicting reference marker succeeded or overwrote the published schema")
+	}
 }
 
 func TestTypedJSONLoadsRejectsCallableAndChannelConstruction(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1824,6 +1824,64 @@ func TestConcurrentReferenceTargetMetadataPublication(t *testing.T) {
 	}
 }
 
+func TestArrayUtilsSlicePreservesGenericCollectionRuntimeSchema(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+use array_utils
+struct Node
+    value: int
+end
+let node: Node = Node(1)
+let values: (ref Node)[] = [ref node]
+let sliced: (ref Node)[] = array_utils.slice(values, 0, 1)
+test_report(length(sliced))`)
+	testExpectedObject(t, 1, got)
+}
+
+func TestArrayUtilsWildcardExportsRemainStableAcrossModuleCache(t *testing.T) {
+	source := `
+use array_utils select *
+let numbers: int[] = [1, 2, 3]
+let sliced: int[] = slice(numbers, 1, 3)
+let generated: int[] = range(1, 4, 1)
+test_report(length(sliced) * 10 + length(generated))`
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := New()
+	results := make([]int64, 0, 2)
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		results = append(results, args[0].AsInt)
+		return value.NewNull()
+	})
+	for i := 0; i < 2; i++ {
+		if err := machine.Interpret(code); err != nil {
+			t.Fatalf("iteration %d: %v", i+1, err)
+		}
+	}
+	if len(results) != 2 || results[0] != 23 || results[1] != 23 {
+		t.Fatalf("wildcard first/cache results=%v, want [23 23]", results)
+	}
+	module, ok := machine.shared.Modules["array_utils"]
+	if !ok {
+		t.Fatal("array_utils was not cached")
+	}
+	exports := module.Obj.(*value.ObjMap).Data
+	if _, ok := exports["slice"]; !ok {
+		t.Fatal("array_utils omitted slice export")
+	}
+	if _, ok := exports["native_slice"]; ok {
+		t.Fatal("array_utils leaked closure capture as a public export")
+	}
+}
+
 func TestTypedJSONLoadsRejectsCallableAndChannelConstruction(t *testing.T) {
 	t.Run("empty bare function array after pop", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -348,3 +348,12 @@ item[0] = 42
 test_report(values[0][0])`)
 	testExpectedObject(t, 42, got)
 }
+
+func TestUnrelatedWildcardImportKeepsBuiltinRuntimeContract(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+use sys select *
+let values: int[] = [1]
+append(values, 2)
+test_report(length(values))`)
+	testExpectedObject(t, 2, got)
+}

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -100,6 +100,16 @@ typed_test(ref forwarded)`
 	}
 }
 
+func TestReferenceTargetMetadataSupportsLongConstantIndex(t *testing.T) {
+	var source strings.Builder
+	source.WriteString("func stress() -> void\n    let value: int = 1\n")
+	for i := 0; i < 260; i++ {
+		source.WriteString("    ref value\n")
+	}
+	source.WriteString("end\nstress()\ntest_report(42)")
+	testExpectedObject(t, 42, runTypedFunctionProgram(t, source.String()))
+}
+
 func TestTypedNativeRejectsIncorrectExactArityBeforeInvocation(t *testing.T) {
 	called := false
 	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "void"}
@@ -525,6 +535,56 @@ else
     test_report(target.a * 10 + target.b)
 end`)
 	testExpectedObject(t, 12, got)
+}
+
+func TestTypedJSONLoadsRequiresAllFieldsWhenBuildingNewStruct(t *testing.T) {
+	t.Run("missing field", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Pair
+    a: int
+    b: int
+end
+let target: (ref Pair)[] = []
+let ok: bool = json_loads("[{\"a\":1}]", target)
+if ok then
+    test_report(999)
+else
+    test_report(length(target))
+end`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("complete new struct", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Pair
+    a: int
+    b: int
+end
+let target: (ref Pair)[] = []
+let ok: bool = json_loads("[{\"a\":3,\"b\":4}]", target)
+if ok then
+    test_report(target[0].a * 10 + target[0].b)
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 34, got)
+	})
+
+	t.Run("partial existing struct preserves omitted field", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Pair
+    a: int
+    b: int
+end
+let target: Pair = Pair(1, 2)
+let ok: bool = json_loads("{\"a\":3}", target)
+if ok then
+    test_report(target.a * 10 + target.b)
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 32, got)
+	})
 }
 
 func TestTypedJSONLoadsReplacesNonNullAnyComposite(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -172,6 +172,110 @@ test_report(target["answer"])`)
 	testExpectedObject(t, 42, got)
 }
 
+func TestTypedJSONLoadsPopulatesMapIndexTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let targets: map[string, map[string, int]] = {"slot": {"old": 0}}
+let ok: bool = json_loads("{\"answer\":42}", targets["slot"])
+test_report(targets["slot"]["answer"])`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
+	machine := New()
+	moduleTarget := value.NewMapWithData(map[string]value.Value{"old": value.NewInt(0)})
+	moduleGlobals := map[string]value.Value{"target": moduleTarget}
+	machine.currentFrame = &CallFrame{Globals: moduleGlobals}
+	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "target"}}
+
+	jsonLoadsValue, ok := machine.GetGlobal("json_loads")
+	if !ok {
+		t.Fatal("missing json_loads native")
+	}
+	jsonLoads := jsonLoadsValue.Obj.(*value.ObjNative)
+	if result := jsonLoads.Fn([]value.Value{value.NewString(`{"answer":42}`), target}); result.Type != value.VAL_BOOL || !result.AsBool {
+		t.Fatal("module-frame global target was rejected")
+	}
+	got := moduleGlobals["target"].Obj.(*value.ObjMap).Data["answer"]
+	if got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("module target=%v, want answer=42", moduleGlobals["target"])
+	}
+	if _, leaked := machine.GetGlobal("target"); leaked {
+		t.Fatal("module target must not be written to shared globals")
+	}
+}
+
+func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
+	machine := New()
+	instance := value.NewInstance(&value.ObjStruct{Name: "Holder", Fields: []string{"known"}})
+	instance.Obj.(*value.ObjInstance).Fields["known"] = value.NewInt(1)
+	tests := []struct {
+		name string
+		ref  *value.ObjRef
+	}{
+		{
+			name: "missing global",
+			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing"},
+		},
+		{
+			name: "missing property",
+			ref:  &value.ObjRef{RefType: value.REF_PROPERTY, Container: instance, Name: "missing"},
+		},
+		{
+			name: "property container",
+			ref:  &value.ObjRef{RefType: value.REF_PROPERTY, Container: value.NewInt(1), Name: "missing"},
+		},
+		{
+			name: "array bounds",
+			ref: &value.ObjRef{
+				RefType: value.REF_INDEX,
+				Container: value.NewArray([]value.Value{
+					value.NewInt(1),
+				}),
+				Index: value.NewInt(2),
+			},
+		},
+		{
+			name: "array index type",
+			ref: &value.ObjRef{
+				RefType: value.REF_INDEX,
+				Container: value.NewArray([]value.Value{
+					value.NewInt(1),
+				}),
+				Index: value.NewBool(true),
+			},
+		},
+		{
+			name: "map key",
+			ref: &value.ObjRef{
+				RefType:   value.REF_INDEX,
+				Container: value.NewMap(),
+				Index:     value.NewBool(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := value.Value{Type: value.VAL_REF, Obj: tt.ref}
+			if populateTarget(machine, target, float64(42)) {
+				t.Fatal("invalid reference target reported successful population")
+			}
+		})
+	}
+}
+
+func TestPopulateTargetRejectsMalformedReferenceValue(t *testing.T) {
+	target := value.Value{Type: value.VAL_REF, Obj: "not an ObjRef"}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("populateTarget panicked for malformed reference: %v", recovered)
+		}
+	}()
+	if populateTarget(New(), target, float64(42)) {
+		t.Fatal("malformed reference reported successful population")
+	}
+}
+
 func TestTypedMutatingBuiltinResolvesCapturedTarget(t *testing.T) {
 	got := runTypedFunctionProgram(t, `
 func make_mutator() -> func() -> int
@@ -216,4 +320,31 @@ append(nested["values"], 2)
 let removed: int = pop(nested["values"])
 test_report(length(nested["values"]) * 10 + removed)`)
 	testExpectedObject(t, 12, got)
+}
+
+func TestTypedAppendPreservesReferenceValuedElements(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Vertex
+    value: int
+end
+let first: Vertex = Vertex(1)
+let second: Vertex = Vertex(2)
+let existing: ref Vertex = ref second
+let values: (ref Vertex)[] = []
+append(values, ref first)
+append(values, existing)
+values[0].value = 41
+values[1].value = 42
+test_report(first.value + second.value)`)
+	testExpectedObject(t, 83, got)
+}
+
+func TestTypedAppendStoresOrdinaryCompositeItemWithoutNativeCopy(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let item: int[] = [1]
+let values: int[][] = []
+append(values, item)
+item[0] = 42
+test_report(values[0][0])`)
+	testExpectedObject(t, 42, got)
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -489,3 +489,127 @@ use http_client select *`)
 		t.Fatalf("error=%v", err)
 	}
 }
+
+func TestUncalledFunctionImportDoesNotChangeOuterBuiltinCompilation(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func unused() -> void
+    use http_client select delete
+end
+let mapping: map[string, int] = {"a": 1}
+delete(mapping, "a")
+test_report(length(keys(mapping)))`)
+	testExpectedObject(t, 0, got)
+}
+
+func TestCachedWildcardWrapperKeepsLaterUserBindingAtRuntime(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+use http
+func delete(left: int, right: int) -> int
+    return left + right
+end
+use http select *
+test_report(delete(20, 22))`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestContextualReferenceCallsForwardStoredReferences(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "property",
+			source: `
+struct Holder
+    values: ref int[]
+end
+let values: int[] = [1]
+let holder: Holder = Holder(ref values)
+func push(target: ref int[]) -> void
+    append(target, 2)
+end
+push(holder.values)
+test_report(length(values))`,
+		},
+		{
+			name: "array index",
+			source: `
+let values: int[] = [1]
+let stored: (ref int[])[] = [ref values]
+func push(target: ref int[]) -> void
+    append(target, 2)
+end
+push(stored[0])
+test_report(length(values))`,
+		},
+		{
+			name: "map index",
+			source: `
+let values: int[] = [1]
+let stored: map[string, ref int[]] = {"values": ref values}
+func push(target: ref int[]) -> void
+    append(target, 2)
+end
+push(stored["values"])
+test_report(length(values))`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testExpectedObject(t, 2, runTypedFunctionProgram(t, tt.source))
+		})
+	}
+}
+
+func TestContextualReferenceCallPreservesStoredNullReference(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Holder
+    values: ref int[]
+end
+let holder: Holder = Holder(null)
+func push(target: ref int[]) -> void
+    append(target, 2)
+end
+push(holder.values)
+test_report(42)`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestContextualReferenceCallsCanFillNullIndexSlots(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "array index",
+			source: `
+func fill(target: ref int) -> void
+    if target == null then
+        *target = 42
+    end
+end
+let stored: (ref int)[] = [null]
+fill(stored[0])
+test_report(stored[0])`,
+		},
+		{
+			name: "map index",
+			source: `
+func fill(target: ref int) -> void
+    if target == null then
+        *target = 42
+    end
+end
+let stored: map[string, ref int] = {"answer": null}
+fill(stored["answer"])
+test_report(stored["answer"])`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testExpectedObject(t, 42, runTypedFunctionProgram(t, tt.source))
+		})
+	}
+}

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -501,15 +501,37 @@ test_report(length(keys(mapping)))`)
 	testExpectedObject(t, 0, got)
 }
 
-func TestCachedWildcardWrapperKeepsLaterUserBindingAtRuntime(t *testing.T) {
-	got := runTypedFunctionProgram(t, `
+func TestWildcardWrapperFirstAndCachedLoadsExposeImportedBinding(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "first load", source: "use http select *\ntest_report(delete)"},
+		{name: "cached load", source: `
 use http
 func delete(left: int, right: int) -> int
     return left + right
 end
 use http select *
-test_report(delete(20, 22))`)
-	testExpectedObject(t, 42, got)
+test_report(delete)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runTypedFunctionProgram(t, tt.source)
+			closure, ok := got.Obj.(*value.ObjClosure)
+			if got.Type != value.VAL_FUNCTION || !ok || closure.Function.Arity != 1 {
+				t.Fatalf("delete binding=%v, want imported one-argument closure", got)
+			}
+		})
+	}
+}
+
+func TestPlainWrapperImportDoesNotLeakUnqualifiedBindings(t *testing.T) {
+	got := runTypedFunctionProgram(t, "use http\ntest_report(delete)")
+	if got.Type != value.VAL_NATIVE {
+		t.Fatalf("delete binding=%v, want shared native builtin", got)
+	}
 }
 
 func TestContextualReferenceCallsForwardStoredReferences(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -55,6 +55,51 @@ func TestTypedNativeAcceptsExplicitReference(t *testing.T) {
 	}
 }
 
+func TestReferenceTargetMetadataPreservesForwardedReferenceIdentity(t *testing.T) {
+	source := `
+let value: int = 1
+let forwarded: ref int = ref value
+typed_test(ref forwarded)`
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := New()
+	var received *value.ObjRef
+	machine.DefineNativeWithSignature("typed_test", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "void",
+	}, func(args []value.Value) value.Value {
+		received, _ = args[0].Obj.(*value.ObjRef)
+		return value.NewNull()
+	})
+	if err := machine.Interpret(code); err != nil {
+		t.Fatal(err)
+	}
+	forwarded, ok := machine.GetGlobal("forwarded")
+	if !ok {
+		t.Fatal("missing forwarded reference")
+	}
+	stored, ok := forwarded.Obj.(*value.ObjRef)
+	if forwarded.Type != value.VAL_REF || !ok || stored == nil {
+		t.Fatalf("forwarded=%v, want reference", forwarded)
+	}
+	if received != stored {
+		t.Fatal("target metadata marker copied or rebound the forwarded reference")
+	}
+	if stored.TargetType == nil || stored.TargetType.Kind != value.TYPE_INT {
+		t.Fatalf("target metadata=%v, want int", stored.TargetType)
+	}
+}
+
 func TestTypedNativeRejectsIncorrectExactArityBeforeInvocation(t *testing.T) {
 	called := false
 	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "void"}
@@ -311,14 +356,25 @@ func TestPopulateTargetSupportsCompatibleAndNullScalarReplacement(t *testing.T) 
 		}
 	})
 
-	t.Run("null remains dynamic", func(t *testing.T) {
+	t.Run("marked dynamic null", func(t *testing.T) {
 		stored := value.NewNull()
-		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored, JSONDynamic: true}}
 		if !populateTarget(New(), target, float64(42)) {
 			t.Fatal("null target rejected dynamic scalar replacement")
 		}
 		if stored.Type != value.VAL_INT || stored.AsInt != 42 {
 			t.Fatalf("stored=%v, want int 42", stored)
+		}
+	})
+
+	t.Run("untyped null is conservative", func(t *testing.T) {
+		stored := value.NewNull()
+		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+		if populateTarget(New(), target, float64(42)) {
+			t.Fatal("untyped null target accepted an unprovable replacement")
+		}
+		if stored.Type != value.VAL_NULL {
+			t.Fatalf("stored=%v, want unchanged null", stored)
 		}
 	})
 }
@@ -340,6 +396,135 @@ let target: Holder = Holder("before")
 json_loads("{\"data\":42}", target)
 test_report(target.data)`)
 	testExpectedObject(t, 42, got)
+}
+
+func TestTypedJSONLoadsRejectsInvalidArrayElementAtomically(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: int[] = [1, 2]
+let ok: bool = json_loads("[10,\"bad\"]", target)
+if ok then
+    test_report(999)
+else
+    test_report(target[0] * 10 + target[1])
+end`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedJSONLoadsRejectsInvalidMapValueAtomically(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: map[string, int] = {"a": 1, "b": 2}
+let ok: bool = json_loads("{\"a\":10,\"b\":\"bad\"}", target)
+if ok then
+    test_report(999)
+else
+    test_report(target["a"] * 10 + target["b"])
+end`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedJSONLoadsPreservesReferenceElementTypeForNullSlot(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: (ref int)[] = [null]
+let ok: bool = json_loads("[\"bad\"]", target)
+if ok then
+    test_report(999)
+elif target[0] == null then
+    test_report(42)
+else
+    test_report(0)
+end`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestTypedJSONLoadsAcceptsCompatibleReferenceElementPayloads(t *testing.T) {
+	t.Run("fill null slot with referent value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: (ref int)[] = [null]
+let ok: bool = json_loads("[42]", target)
+if ok then
+    test_report(target[0])
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("json null clears reference slot", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let backing: int = 7
+let target: (ref int)[] = [ref backing]
+let ok: bool = json_loads("[null]", target)
+if ok then
+    if target[0] == null then
+        test_report(backing)
+    else
+        test_report(998)
+    end
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 7, got)
+	})
+}
+
+func TestTypedJSONLoadsRejectsPartialStructAtomically(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Pair
+    a: int
+    b: int
+end
+let target: Pair = Pair(1, 2)
+let ok: bool = json_loads("{\"a\":10,\"b\":\"bad\"}", target)
+if ok then
+    test_report(999)
+else
+    test_report(target.a * 10 + target.b)
+end`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedJSONLoadsReplacesNonNullAnyComposite(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: any = [1]
+let ok: bool = json_loads("42", target)
+if ok then
+    test_report(target)
+else
+    test_report(999)
+end`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestTypedJSONLoadsPreservesCompositeIdentityForAliases(t *testing.T) {
+	t.Run("struct", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Pair
+    a: int
+    b: int
+end
+let target: Pair = Pair(1, 2)
+let alias: ref Pair = ref target
+let ok: bool = json_loads("{\"a\":3,\"b\":4}", target)
+if ok then
+    test_report(alias.a * 10 + alias.b)
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 34, got)
+	})
+
+	t.Run("array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: int[] = [1, 2]
+let alias: ref int[] = ref target
+let ok: bool = json_loads("[3,4]", target)
+if ok then
+    test_report(alias[0] * 10 + alias[1])
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 34, got)
+	})
 }
 
 func TestPopulateTargetRetainsCompatibleCompositeFields(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -681,6 +681,17 @@ test_report(length(values))`)
 		testExpectedObject(t, 0, got)
 	})
 
+	t.Run("reject nested reference to incompatible value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let targets: ((ref int)[])[] = []
+let text: string = "bad"
+let wrong: (ref string)[] = [ref text]
+invoke(ref targets, wrong)
+test_report(length(targets))`)
+		testExpectedObject(t, 0, got)
+	})
+
 	t.Run("accept plain value", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `
 let invoke: any = append

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1449,6 +1449,241 @@ func TestRuntimeCallableValidationRejectsMalformedStructConstructors(t *testing.
 	}
 }
 
+func TestLocalStructConstructorsPublishScopedCallableSchemas(t *testing.T) {
+	t.Run("matching and nominal mismatch", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func run() -> int
+    struct Local
+        value: int
+    end
+    struct Other
+        value: int
+    end
+    let makers: (func(int) -> Local)[] = [Local]
+    pop(makers)
+    let invoke: any = append
+    invoke(ref makers, Local)
+    invoke(ref makers, Other)
+    return length(makers)
+end
+test_report(run())`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("bare callable", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func run() -> int
+    struct Local
+        value: int
+    end
+    let makers: func[] = [Local]
+    return makers[0](42).value
+end
+test_report(run())`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("nested function captures registry snapshot", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func run() -> int
+    struct Local
+        value: int
+    end
+    struct Other
+        value: int
+    end
+    func make_local(value: int) -> Local
+        return Local(value)
+    end
+    let makers: (func(int) -> Local)[] = [make_local]
+    pop(makers)
+    let invoke: any = append
+    invoke(ref makers, Local)
+    invoke(ref makers, Other)
+    return length(makers)
+end
+test_report(run())`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("shadow restores outer definition", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func run() -> int
+    struct Item
+        value: int
+    end
+    let makers: (func(int) -> Item)[] = [Item]
+    pop(makers)
+    if true then
+        struct Item
+            value: string
+        end
+        let inner: (func(string) -> Item)[] = [Item]
+        let made: Item = inner[0]("ok")
+    end
+    let invoke: any = append
+    invoke(ref makers, Item)
+    return length(makers)
+end
+test_report(run())`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("sibling functions isolate registries", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func first() -> int
+    struct Local
+        value: int
+    end
+    let makers: (func(int) -> Local)[] = [Local]
+    return makers[0](4).value
+end
+func second() -> int
+    struct Local
+        value: string
+    end
+    let makers: (func(string) -> Local)[] = [Local]
+    return length(makers[0]("ok").value)
+end
+test_report(first() * 10 + second())`)
+		testExpectedObject(t, 42, got)
+	})
+}
+
+func TestLocalStructSchemaPreservesReferenceAndJSONFields(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func run() -> int
+    struct Node
+        value: int
+    end
+    struct Local
+        node: ref Node
+        count: int
+    end
+    let makers: (func(ref Node, int) -> Local)[] = [Local]
+    let node: Node = Node(42)
+    let target: Local = makers[0](ref node, 1)
+    let ok: bool = json_loads("{\"count\":2}", target)
+    if ok then return target.node.value + target.count else return 0 end
+end
+test_report(run())`)
+	testExpectedObject(t, 44, got)
+}
+
+func TestDynamicStructConstructorValidatesModesAndTypesBeforeConstruction(t *testing.T) {
+	t.Run("plain passed to ref field", func(t *testing.T) {
+		err := runTypedFunctionProgramError(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: ref Node
+end
+let dynamic: func = Holder
+let node: Node = Node(1)
+dynamic(node)`)
+		if err == nil || !strings.Contains(err.Error(), "expected ref Node") {
+			t.Fatalf("error=%v, want ref mode rejection", err)
+		}
+	})
+
+	t.Run("ref passed to ordinary field", func(t *testing.T) {
+		err := runTypedFunctionProgramError(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: Node
+end
+let dynamic: func = Holder
+let node: Node = Node(1)
+dynamic(ref node)`)
+		if err == nil || !strings.Contains(err.Error(), "expected Node, got ref") {
+			t.Fatalf("error=%v, want ordinary mode rejection", err)
+		}
+	})
+
+	t.Run("wrong ordinary type", func(t *testing.T) {
+		err := runTypedFunctionProgramError(t, `
+struct Box
+    value: int
+end
+let dynamic: func = Box
+dynamic("wrong")`)
+		if err == nil || !strings.Contains(err.Error(), "expected int") {
+			t.Fatalf("error=%v, want runtime type rejection", err)
+		}
+	})
+
+	t.Run("valid explicit ref", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: ref Node
+end
+let dynamic: func = Holder
+let node: Node = Node(42)
+let made: any = dynamic(ref node)
+test_report(made.node.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("valid null ref", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: ref Node
+end
+let dynamic: func = Holder
+let made: any = dynamic(null)
+if made.node == null then test_report(42) else test_report(0) end`)
+		testExpectedObject(t, 42, got)
+	})
+}
+
+func TestStructConstructorValidationFailureLeavesStackUntouched(t *testing.T) {
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	constructorType := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{integer},
+		ParamIsRef: []bool{false},
+		Return:     &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Box", Fields: map[string]*value.RuntimeTypeInfo{"value": integer}},
+	}
+	definition := &value.ObjStruct{Name: "Box", Fields: []string{"value"}, ConstructorType: constructorType}
+	constructor := value.Value{Type: value.VAL_OBJ, Obj: definition}
+	argument := value.NewString("wrong")
+	machine := New()
+	machine.push(constructor)
+	machine.push(argument)
+	before := machine.stackTop
+	ok, err := machine.callValue(constructor, 1, nil, 0)
+	if ok || err == nil || !strings.Contains(err.Error(), "expected int") {
+		t.Fatalf("ok=%v error=%v, want type rejection", ok, err)
+	}
+	if machine.stackTop != before || machine.stack[0].Obj != definition || machine.stack[1].Obj != argument.Obj {
+		t.Fatal("constructor validation failure mutated stack or constructed an instance")
+	}
+}
+
+func TestDynamicStructConstructorRejectsMalformedReference(t *testing.T) {
+	err := runMalformedReferenceProgram(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: ref Node
+end
+let dynamic: func = Holder
+dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR}})
+	if err == nil {
+		t.Fatal("dynamic constructor accepted malformed reference")
+	}
+}
+
 func TestDynamicAppendUsesDeclaredCollectionSchemas(t *testing.T) {
 	t.Run("fixed array positive", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -252,6 +252,14 @@ func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 				Index:     value.NewBool(true),
 			},
 		},
+		{
+			name: "missing map key",
+			ref: &value.ObjRef{
+				RefType:   value.REF_INDEX,
+				Container: value.NewMap(),
+				Index:     value.NewString("missing"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +269,99 @@ func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 				t.Fatal("invalid reference target reported successful population")
 			}
 		})
+	}
+}
+
+func TestPopulateTargetPropagatesNestedObjectFailure(t *testing.T) {
+	inner := value.NewInstance(&value.ObjStruct{Name: "Inner", Fields: []string{"name"}})
+	inner.Obj.(*value.ObjInstance).Fields["name"] = value.NewString("keep")
+	outer := value.NewInstance(&value.ObjStruct{Name: "Outer", Fields: []string{"inner"}})
+	outer.Obj.(*value.ObjInstance).Fields["inner"] = inner
+
+	if populateTarget(New(), outer, map[string]interface{}{"inner": []interface{}{}}) {
+		t.Fatal("nested object population failure reported success")
+	}
+	got := inner.Obj.(*value.ObjInstance).Fields["name"]
+	if got.Type != value.VAL_OBJ || got.Obj != "keep" {
+		t.Fatalf("nested field=%v, want unchanged string", got)
+	}
+}
+
+func TestPopulateTargetRejectsIncompatibleScalarReplacementWithoutMutation(t *testing.T) {
+	stored := value.NewString("keep")
+	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+
+	if populateTarget(New(), target, float64(42)) {
+		t.Fatal("incompatible scalar replacement reported success")
+	}
+	if stored.Type != value.VAL_OBJ || stored.Obj != "keep" {
+		t.Fatalf("stored=%v, want unchanged string", stored)
+	}
+}
+
+func TestPopulateTargetSupportsCompatibleAndNullScalarReplacement(t *testing.T) {
+	t.Run("compatible string", func(t *testing.T) {
+		stored := value.NewString("before")
+		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+		if !populateTarget(New(), target, "after") {
+			t.Fatal("compatible scalar replacement failed")
+		}
+		if stored.Type != value.VAL_OBJ || stored.Obj != "after" {
+			t.Fatalf("stored=%v, want after", stored)
+		}
+	})
+
+	t.Run("null remains dynamic", func(t *testing.T) {
+		stored := value.NewNull()
+		target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+		if !populateTarget(New(), target, float64(42)) {
+			t.Fatal("null target rejected dynamic scalar replacement")
+		}
+		if stored.Type != value.VAL_INT || stored.AsInt != 42 {
+			t.Fatalf("stored=%v, want int 42", stored)
+		}
+	})
+}
+
+func TestTypedJSONLoadsAllowsNonNullAnyTargetToChangeType(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: any = "before"
+json_loads("42", target)
+test_report(target)`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestTypedJSONLoadsAllowsNonNullAnyStructFieldToChangeType(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Holder
+    data: any
+end
+let target: Holder = Holder("before")
+json_loads("{\"data\":42}", target)
+test_report(target.data)`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestPopulateTargetRetainsCompatibleCompositeFields(t *testing.T) {
+	outer := value.NewInstance(&value.ObjStruct{Name: "Outer", Fields: []string{"items", "metadata"}})
+	fields := outer.Obj.(*value.ObjInstance).Fields
+	fields["items"] = value.NewArray(nil)
+	fields["metadata"] = value.NewMap()
+
+	data := map[string]interface{}{
+		"items":    []interface{}{float64(42)},
+		"metadata": map[string]interface{}{"answer": float64(42)},
+	}
+	if !populateTarget(New(), outer, data) {
+		t.Fatal("compatible composite fields were rejected")
+	}
+	items := fields["items"].Obj.(*value.ObjArray)
+	if len(items.Elements) != 1 || items.Elements[0].Type != value.VAL_INT || items.Elements[0].AsInt != 42 {
+		t.Fatalf("items=%v, want [42]", fields["items"])
+	}
+	metadata := fields["metadata"].Obj.(*value.ObjMap)
+	if got := metadata.Data["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("metadata=%v, want answer=42", fields["metadata"])
 	}
 }
 
@@ -356,4 +457,35 @@ let values: int[] = [1]
 append(values, 2)
 test_report(length(values))`)
 	testExpectedObject(t, 2, got)
+}
+
+func TestWildcardImportInstallsCollidingBuiltinNameAtRuntime(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+use http_client select *
+test_report(delete)`)
+	closure, ok := got.Obj.(*value.ObjClosure)
+	if got.Type != value.VAL_FUNCTION || !ok || closure.Function.Name != "delete" {
+		t.Fatalf("delete binding=%v, want imported function", got)
+	}
+}
+
+func TestBuiltinCallBeforeLaterWildcardImportUsesRuntimeBuiltin(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let mapping: map[string, int] = {"a": 1}
+delete(mapping, "a")
+use http_client select *
+test_report(length(keys(mapping)))`)
+	testExpectedObject(t, 0, got)
+}
+
+func TestFunctionUsingLaterWildcardCollisionFailsWhenCalledBeforeImport(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func remove(url: string) -> void
+    delete(url)
+end
+remove("http://example.invalid")
+use http_client select *`)
+	if err == nil || !strings.Contains(err.Error(), "expects 2 arguments, got 1") {
+		t.Fatalf("error=%v", err)
+	}
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1300,6 +1300,155 @@ func TestRuntimeCallableValidationIsInvariantAndFailClosed(t *testing.T) {
 	}
 }
 
+func TestStructConstructorExactAssignmentAndCallRemainSupported(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+let make_box: func(int) -> Box = Box
+let made: Box = make_box(42)
+test_report(made.value)`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestStructConstructorsSatisfyCallableCollectionSchemas(t *testing.T) {
+	t.Run("exact array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+let makers: (func(int) -> Box)[] = [Box]
+let made: Box = makers[0](42)
+test_report(made.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("exact map", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+let makers: map[string, func(int) -> Box] = {"box": Box}
+let made: Box = makers["box"](42)
+test_report(made.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("bare array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+let makers: func[] = [Box]
+let made: any = makers[0](42)
+test_report(made.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("bare map", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+let makers: map[string, func] = {"box": Box}
+let made: any = makers["box"](42)
+test_report(made.value)`)
+		testExpectedObject(t, 42, got)
+	})
+}
+
+func TestStructConstructorsSatisfyExactAndDynamicAppendSchemas(t *testing.T) {
+	t.Run("exact append", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+func make_box(value: int) -> Box
+    return Box(value)
+end
+let makers: (func(int) -> Box)[] = [make_box]
+pop(makers)
+append(makers, Box)
+test_report(length(makers))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("dynamic matching and nominal return mismatch", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Box
+    value: int
+end
+struct Other
+    value: int
+end
+func make_box(value: int) -> Box
+    return Box(value)
+end
+let makers: (func(int) -> Box)[] = [make_box]
+pop(makers)
+let invoke: any = append
+invoke(ref makers, Box)
+invoke(ref makers, Other)
+test_report(length(makers))`)
+		testExpectedObject(t, 1, got)
+	})
+}
+
+func TestStructConstructorCallableSchemaPreservesReferenceFields(t *testing.T) {
+	t.Run("nested struct reference", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Node
+    value: int
+end
+struct Holder
+    node: ref Node
+end
+let makers: (func(ref Node) -> Holder)[] = [Holder]
+let node: Node = Node(42)
+let made: Holder = makers[0](ref node)
+test_report(made.node.value)`)
+		testExpectedObject(t, 42, got)
+	})
+
+	t.Run("recursive struct reference", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+struct Node
+    value: int
+    next: ref Node
+end
+let makers: (func(int, ref Node) -> Node)[] = [Node]
+let made: Node = makers[0](42, null)
+test_report(made.value)`)
+		testExpectedObject(t, 42, got)
+	})
+}
+
+func TestRuntimeCallableValidationRejectsMalformedStructConstructors(t *testing.T) {
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	expected := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{integer},
+		ParamIsRef: []bool{false},
+		Return:     &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Box", Fields: map[string]*value.RuntimeTypeInfo{"value": integer}},
+	}
+	bare := &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, CallableBare: true}
+	malformed := []struct {
+		name   string
+		actual value.Value
+	}{
+		{name: "wrong object", actual: value.Value{Type: value.VAL_OBJ, Obj: "not a struct"}},
+		{name: "typed nil", actual: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjStruct)(nil)}},
+		{name: "missing schema", actual: value.NewStruct("Box", []string{"value"})},
+	}
+	for _, tt := range malformed {
+		t.Run(tt.name, func(t *testing.T) {
+			if runtimeCallableMatchesType(tt.actual, bare) || runtimeCallableMatchesType(tt.actual, expected) {
+				t.Fatalf("malformed constructor %v satisfied callable schema", tt.actual)
+			}
+		})
+	}
+}
+
 func TestDynamicAppendUsesDeclaredCollectionSchemas(t *testing.T) {
 	t.Run("fixed array positive", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -410,6 +410,34 @@ end`)
 	testExpectedObject(t, 12, got)
 }
 
+func TestTypedJSONLoadsParsesIntegersExactlyAndRejectsOverflow(t *testing.T) {
+	t.Run("maximum int", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: int[] = [1]
+let ok: bool = json_loads("[9223372036854775807]", target)
+if ok then
+    test_report(target[0])
+else
+    test_report(0)
+end`)
+		if got.Type != value.VAL_INT || got.AsInt != int64(9223372036854775807) {
+			t.Fatalf("got=%v, want MaxInt64", got)
+		}
+	})
+
+	t.Run("overflow leaves target unchanged", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: int[] = [7]
+let ok: bool = json_loads("[9223372036854775808]", target)
+if ok then
+    test_report(999)
+else
+    test_report(target[0])
+end`)
+		testExpectedObject(t, 7, got)
+	})
+}
+
 func TestTypedJSONLoadsRejectsInvalidMapValueAtomically(t *testing.T) {
 	got := runTypedFunctionProgram(t, `
 let target: map[string, int] = {"a": 1, "b": 2}
@@ -464,6 +492,22 @@ else
     test_report(999)
 end`)
 		testExpectedObject(t, 7, got)
+	})
+
+	t.Run("json null creates reference slot", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: (ref int)[] = []
+let ok: bool = json_loads("[null]", target)
+if ok then
+    if target[0] == null then
+        test_report(length(target))
+    else
+        test_report(998)
+    end
+else
+    test_report(999)
+end`)
+		testExpectedObject(t, 1, got)
 	})
 }
 

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1425,13 +1425,17 @@ test_report(made.value)`)
 
 func TestRuntimeCallableValidationRejectsMalformedStructConstructors(t *testing.T) {
 	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	boxReturn := &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Box", Fields: map[string]*value.RuntimeTypeInfo{"value": integer}}
 	expected := &value.RuntimeTypeInfo{
 		Kind:       value.TYPE_CALLABLE,
 		Params:     []*value.RuntimeTypeInfo{integer},
 		ParamIsRef: []bool{false},
-		Return:     &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Box", Fields: map[string]*value.RuntimeTypeInfo{"value": integer}},
+		Return:     boxReturn,
 	}
 	bare := &value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, CallableBare: true}
+	constructor := func(schema *value.RuntimeTypeInfo) value.Value {
+		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjStruct{Name: "Box", Fields: []string{"value"}, ConstructorType: schema}}
+	}
 	malformed := []struct {
 		name   string
 		actual value.Value
@@ -1439,6 +1443,12 @@ func TestRuntimeCallableValidationRejectsMalformedStructConstructors(t *testing.
 		{name: "wrong object", actual: value.Value{Type: value.VAL_OBJ, Obj: "not a struct"}},
 		{name: "typed nil", actual: value.Value{Type: value.VAL_OBJ, Obj: (*value.ObjStruct)(nil)}},
 		{name: "missing schema", actual: value.NewStruct("Box", []string{"value"})},
+		{name: "wrong schema kind", actual: constructor(integer)},
+		{name: "bare constructor schema", actual: constructor(&value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, CallableBare: true})},
+		{name: "nil return", actual: constructor(&value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}})},
+		{name: "wrong nominal return", actual: constructor(&value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, ParamIsRef: []bool{false}, Return: &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Other"}})},
+		{name: "wrong arity", actual: constructor(&value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Return: boxReturn})},
+		{name: "wrong mode length", actual: constructor(&value.RuntimeTypeInfo{Kind: value.TYPE_CALLABLE, Params: []*value.RuntimeTypeInfo{integer}, Return: boxReturn})},
 	}
 	for _, tt := range malformed {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -895,6 +895,281 @@ test_report(length(values))`)
 	})
 }
 
+func TestTypedAppendAcceptsExactFunctionElement(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+let values: (func(int) -> int)[] = [identity]
+append(values, identity)
+test_report(length(values))`)
+	testExpectedObject(t, 2, got)
+}
+
+func TestDynamicAppendValidatesCallableElementTypes(t *testing.T) {
+	t.Run("reject nested non-callable array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+let invoke: any = append
+let seed: (func(int) -> int)[] = [identity]
+let targets: ((func(int) -> int)[])[] = [seed]
+pop(targets)
+let wrong: int[] = [1]
+invoke(ref targets, wrong)
+test_report(length(targets))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("reject incompatible exact signature", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func text(value: string) -> int
+    return 1
+end
+func identity(value: int) -> int
+    return value
+end
+let invoke: any = append
+let targets: (func(int) -> int)[] = [identity]
+pop(targets)
+invoke(ref targets, text)
+test_report(length(targets))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("reject incompatible return and reference mode", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+func wrong_return(value: int) -> string
+    return "bad"
+end
+func wrong_mode(value: ref int) -> int
+    return value
+end
+let invoke: any = append
+let targets: (func(int) -> int)[] = [identity]
+pop(targets)
+invoke(ref targets, wrong_return)
+invoke(ref targets, wrong_mode)
+test_report(length(targets))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("accept callable in bare function array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+let invoke: any = append
+let targets: func[] = [identity]
+pop(targets)
+invoke(ref targets, identity)
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+}
+
+func TestTypedAndDynamicAppendValidateChannelElementTypes(t *testing.T) {
+	t.Run("exact typed channel", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let channel: chan int = make_chan(1)
+let targets: (chan int)[] = [channel]
+pop(targets)
+append(targets, channel)
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("dynamic incompatible typed channel", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let wrong: chan string = make_chan(1)
+let seed: chan int = make_chan(1)
+let targets: (chan int)[] = [seed]
+pop(targets)
+invoke(ref targets, wrong)
+test_report(length(targets))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("assignment annotates previously untyped channel", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let raw: any = make_chan(1)
+let typed: chan int = make_chan(1)
+typed = raw
+let seed: chan int = make_chan(1)
+let targets: (chan int)[] = [seed]
+pop(targets)
+invoke(ref targets, typed)
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("conflicting assignment preserves original metadata", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let text: chan string = make_chan(1)
+let dynamic: any = text
+let integer: chan int = make_chan(1)
+integer = dynamic
+let string_seed: chan string = make_chan(1)
+let string_targets: (chan string)[] = [string_seed]
+pop(string_targets)
+let int_seed: chan int = make_chan(1)
+let int_targets: (chan int)[] = [int_seed]
+pop(int_targets)
+invoke(ref string_targets, dynamic)
+invoke(ref int_targets, dynamic)
+test_report(length(string_targets) * 10 + length(int_targets))`)
+		testExpectedObject(t, 10, got)
+	})
+
+	t.Run("array declaration propagates channel metadata", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let raw: any = make_chan(1)
+let channels: (chan int)[] = [raw]
+let seed: (chan int)[] = [make_chan(1)]
+let targets: ((chan int)[])[] = [seed]
+pop(targets)
+invoke(ref targets, channels)
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("exact append annotates channel expression", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let seed: chan int = make_chan(1)
+let targets: (chan int)[] = [seed]
+pop(targets)
+append(targets, make_chan(1))
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("exact parameter propagates channel metadata", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func store(channel: chan int, targets: ref (chan int)[]) -> void
+    let invoke: any = append
+    invoke(ref targets, channel)
+end
+let seed: chan int = make_chan(1)
+let targets: (chan int)[] = [seed]
+pop(targets)
+store(make_chan(1), targets)
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("return propagates channel metadata", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func create() -> chan int
+    return make_chan(1)
+end
+let invoke: any = append
+let seed: chan int = make_chan(1)
+let targets: (chan int)[] = [seed]
+pop(targets)
+invoke(ref targets, create())
+test_report(length(targets))`)
+		testExpectedObject(t, 1, got)
+	})
+}
+
+func TestRuntimeCallableValidationProjectsOnlyCompleteNativeSignatures(t *testing.T) {
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	expected := &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     []*value.RuntimeTypeInfo{integer},
+		ParamIsRef: []bool{false},
+		Return:     integer,
+	}
+	typed := value.NewNativeWithSignature("identity", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{TypeName: "int"}},
+		ReturnType: "int",
+	}, func(args []value.Value) value.Value { return args[0] })
+	if !runtimeCallableMatchesType(typed, expected) {
+		t.Fatal("complete typed native did not satisfy exact callable schema")
+	}
+	untyped := value.NewNative("identity", func(args []value.Value) value.Value { return args[0] })
+	if runtimeCallableMatchesType(untyped, expected) {
+		t.Fatal("untyped native satisfied exact callable schema")
+	}
+	wrongMode := value.NewNativeWithSignature("identity", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "int",
+	}, func(args []value.Value) value.Value { return args[0] })
+	if runtimeCallableMatchesType(wrongMode, expected) {
+		t.Fatal("native with incompatible reference mode satisfied exact callable schema")
+	}
+}
+
+func TestTypedJSONLoadsRejectsCallableAndChannelConstruction(t *testing.T) {
+	t.Run("empty bare function array after pop", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+let target: func[] = [identity]
+pop(target)
+let ok: bool = json_loads("[42]", target)
+if ok then test_report(999) else test_report(length(target)) end`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("callable map value", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+let target: map[string, func] = {"seed": identity}
+delete(target, "seed")
+let ok: bool = json_loads("{\"item\":42}", target)
+if ok then test_report(999) else test_report(length(keys(target))) end`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("reference callable element", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let target: (ref func)[] = [null]
+pop(target)
+let ok: bool = json_loads("[42]", target)
+if ok then test_report(999) else test_report(length(target)) end`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("typed channel element", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let channel: chan int = make_chan(1)
+let target: (chan int)[] = [channel]
+pop(target)
+let ok: bool = json_loads("[42]", target)
+if ok then test_report(999) else test_report(length(target)) end`)
+		testExpectedObject(t, 0, got)
+	})
+}
+
+func TestTypedJSONLoadsPreservesOmittedCallableStructField(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func identity(value: int) -> int
+    return value
+end
+struct Holder
+    version: int
+    callback: func(int) -> int
+end
+let target: Holder = Holder(1, identity)
+let ok: bool = json_loads("{\"version\":2}", target)
+if ok then test_report(target.callback(7)) else test_report(999) end`)
+	testExpectedObject(t, 7, got)
+}
+
 func TestDynamicAppendRejectsMalformedReferenceItemWithoutMutation(t *testing.T) {
 	source := `
 let invoke: any = append

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -146,3 +146,74 @@ func TestTypedNativeShallowCopiesOrdinaryComposite(t *testing.T) {
 		t.Fatalf("caller value=%d, want 1", got)
 	}
 }
+
+func TestTypedMutatingBuiltinsPreserveSourceSyntax(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let values: int[] = [1]
+append(values, 2)
+let removed: int = pop(values)
+test_report(length(values) * 10 + removed)`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedDeleteMutatesCallerMap(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let mapping: map[string, int] = {"a": 1}
+delete(mapping, "a")
+test_report(length(keys(mapping)))`)
+	testExpectedObject(t, 0, got)
+}
+
+func TestTypedJSONLoadsPopulatesCallerTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let target: map[string, int] = {"old": 0}
+let ok: bool = json_loads("{\"answer\":42}", target)
+test_report(target["answer"])`)
+	testExpectedObject(t, 42, got)
+}
+
+func TestTypedMutatingBuiltinResolvesCapturedTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+func make_mutator() -> func() -> int
+    let values: int[] = [1]
+    return func() -> int
+        append(values, 2)
+        let removed: int = pop(values)
+        return length(values) * 10 + removed
+    end
+end
+let mutate: func() -> int = make_mutator()
+test_report(mutate())`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedMutatingBuiltinsResolvePropertyTargets(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Collections
+    values: int[]
+    mapping: map[string, int]
+end
+let collections: Collections = Collections([1], {"a": 1})
+append(collections.values, 2)
+delete(collections.mapping, "a")
+test_report(length(collections.values) * 10 + length(keys(collections.mapping)))`)
+	testExpectedObject(t, 20, got)
+}
+
+func TestTypedMutatingBuiltinResolvesArrayIndexTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let nested: int[][] = [[1]]
+append(nested[0], 2)
+let removed: int = pop(nested[0])
+test_report(length(nested[0]) * 10 + removed)`)
+	testExpectedObject(t, 12, got)
+}
+
+func TestTypedMutatingBuiltinResolvesMapIndexTarget(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+let nested: map[string, int[]] = {"values": [1]}
+append(nested["values"], 2)
+let removed: int = pop(nested["values"])
+test_report(length(nested["values"]) * 10 + removed)`)
+	testExpectedObject(t, 12, got)
+}

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -240,7 +240,7 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 	moduleTarget := value.NewMapWithData(map[string]value.Value{"old": value.NewInt(0)})
 	moduleGlobals := map[string]value.Value{"target": moduleTarget}
 	machine.currentFrame = &CallFrame{Globals: moduleGlobals}
-	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "target"}}
+	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "target", GlobalOwner: &moduleGlobals}}
 
 	jsonLoadsValue, ok := machine.GetGlobal("json_loads")
 	if !ok {
@@ -261,6 +261,7 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 
 func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 	machine := New()
+	missingGlobals := map[string]value.Value{}
 	instance := value.NewInstance(&value.ObjStruct{Name: "Holder", Fields: []string{"known"}})
 	instance.Obj.(*value.ObjInstance).Fields["known"] = value.NewInt(1)
 	tests := []struct {
@@ -269,7 +270,7 @@ func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 	}{
 		{
 			name: "missing global",
-			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing"},
+			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: &missingGlobals},
 		},
 		{
 			name: "missing property",

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1009,23 +1010,15 @@ test_report(length(targets))`)
 		testExpectedObject(t, 1, got)
 	})
 
-	t.Run("conflicting assignment preserves original metadata", func(t *testing.T) {
-		got := runTypedFunctionProgram(t, `
-let invoke: any = append
+	t.Run("conflicting assignment fails", func(t *testing.T) {
+		err := runTypedFunctionProgramError(t, `
 let text: chan string = make_chan(1)
 let dynamic: any = text
 let integer: chan int = make_chan(1)
-integer = dynamic
-let string_seed: chan string = make_chan(1)
-let string_targets: (chan string)[] = [string_seed]
-pop(string_targets)
-let int_seed: chan int = make_chan(1)
-let int_targets: (chan int)[] = [int_seed]
-pop(int_targets)
-invoke(ref string_targets, dynamic)
-invoke(ref int_targets, dynamic)
-test_report(length(string_targets) * 10 + length(int_targets))`)
-		testExpectedObject(t, 10, got)
+integer = dynamic`)
+		if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
+			t.Fatalf("error=%v", err)
+		}
 	})
 
 	t.Run("array declaration propagates channel metadata", func(t *testing.T) {
@@ -1301,6 +1294,398 @@ func TestRuntimeCallableValidationIsInvariantAndFailClosed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDynamicAppendUsesDeclaredCollectionSchemas(t *testing.T) {
+	t.Run("fixed array positive", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let invoke: any = append
+let item: int[4] = [1, 2, 3, 4]
+let target: int[4][] = [item]
+pop(target)
+invoke(ref target, item)
+test_report(length(target))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	for _, tt := range []struct {
+		name     string
+		itemType string
+		literal  string
+	}{
+		{name: "dynamic array with matching length", itemType: "int[]", literal: "[1, 2, 3, 4]"},
+		{name: "different fixed array size", itemType: "int[5]", literal: "[1, 2, 3, 4, 5]"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source := fmt.Sprintf(`
+let invoke: any = append
+let seed: int[4] = [1, 2, 3, 4]
+let target: int[4][] = [seed]
+pop(target)
+let item: %s = %s
+invoke(ref target, item)
+test_report(length(target))`, tt.itemType, tt.literal)
+			testExpectedObject(t, 0, runTypedFunctionProgram(t, source))
+		})
+	}
+
+	t.Run("empty nested callable array mismatch", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func integer(value: int) -> int return value end
+func text(value: string) -> int return 1 end
+let expected_item: (func(int) -> int)[] = [integer]
+pop(expected_item)
+let target: ((func(int) -> int)[])[] = [expected_item]
+pop(target)
+let wrong: (func(string) -> int)[] = [text]
+pop(wrong)
+let invoke: any = append
+invoke(ref target, wrong)
+test_report(length(target))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("empty nested callable array positive", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func integer(value: int) -> int return value end
+let item: (func(int) -> int)[] = [integer]
+pop(item)
+let target: ((func(int) -> int)[])[] = [item]
+pop(target)
+let invoke: any = append
+invoke(ref target, item)
+test_report(length(target))`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("empty map mismatch", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let seed: map[string, int] = {"value": 1}
+let target: map[string, int][] = [seed]
+pop(target)
+let wrong: map[int, string] = {}
+let invoke: any = append
+invoke(ref target, wrong)
+test_report(length(target))`)
+		testExpectedObject(t, 0, got)
+	})
+
+	t.Run("empty map positive", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let seed: map[string, int] = {"value": 1}
+let target: map[string, int][] = [seed]
+pop(target)
+let item: map[string, int] = {}
+let invoke: any = append
+invoke(ref target, item)
+test_report(length(target))`)
+		testExpectedObject(t, 1, got)
+	})
+}
+
+func TestCollectionSchemaSurvivesShallowCopyAndMutation(t *testing.T) {
+	t.Run("array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func forward(item: int[4], target: ref int[4][]) -> void
+    pop(item)
+    let invoke: any = append
+    invoke(ref target, item)
+end
+let item: int[4] = [1, 2, 3, 4]
+let target: int[4][] = [item]
+pop(target)
+forward(item, target)
+test_report(length(target) * 10 + length(item))`)
+		testExpectedObject(t, 14, got)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+func forward(item: map[string, int], target: ref map[string, int][]) -> void
+    delete(item, "value")
+    let invoke: any = append
+    invoke(ref target, item)
+end
+let item: map[string, int] = {"value": 1}
+let target: map[string, int][] = [item]
+pop(target)
+forward(item, target)
+test_report(length(target) * 10 + length(keys(item)))`)
+		testExpectedObject(t, 11, got)
+	})
+}
+
+func TestConflictingCollectionAndChannelMetadataFailsWithoutOverwrite(t *testing.T) {
+	tests := []string{
+		`let dynamic: int[] = [1, 2, 3, 4]
+let fixed: int[4] = [1, 2, 3, 4]
+let erased: any = dynamic
+fixed = erased`,
+		`let text: map[string, int] = {"value": 1}
+let integer: map[int, string] = {1: "value"}
+let erased: any = integer
+text = erased`,
+		`let text: chan string = make_chan(1)
+let integer: chan int = make_chan(1)
+let erased: any = text
+integer = erased`,
+	}
+	for _, source := range tests {
+		err := runTypedFunctionProgramError(t, source)
+		if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
+			t.Fatalf("error=%v", err)
+		}
+	}
+}
+
+func TestCollectionRuntimeMetadataPreservesShallowCopyAndIdentity(t *testing.T) {
+	machine := New()
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	arraySchema := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer, Size: 4}
+	mapSchema := &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}, Value: integer}
+	shared := value.NewChannel(1)
+
+	array := value.NewArray([]value.Value{shared})
+	arrayObject := array.Obj.(*value.ObjArray)
+	arrayObject.RuntimeType = arraySchema
+	arrayCopy := machine.copyValue(array)
+	arrayCopyObject := arrayCopy.Obj.(*value.ObjArray)
+	if arrayCopyObject == arrayObject || arrayCopyObject.RuntimeType != arraySchema || arrayCopyObject.Elements[0].Obj != shared.Obj {
+		t.Fatal("array shallow copy lost collection schema or nested identity")
+	}
+
+	mapping := value.NewMap()
+	mapObject := mapping.Obj.(*value.ObjMap)
+	mapObject.Data["item"] = shared
+	mapObject.RuntimeType = mapSchema
+	mapCopy := machine.copyValue(mapping)
+	mapCopyObject := mapCopy.Obj.(*value.ObjMap)
+	if mapCopyObject == mapObject || mapCopyObject.RuntimeType != mapSchema || mapCopyObject.Data["item"].Obj != shared.Obj {
+		t.Fatal("map shallow copy lost collection schema or nested identity")
+	}
+}
+
+func TestRuntimeValueMarkerRejectsConflictsWithoutOverwriteOrRefMutation(t *testing.T) {
+	machine := New()
+	integer := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	text := &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}
+	dynamicArray := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer}
+	fixedArray := &value.RuntimeTypeInfo{Kind: value.TYPE_ARRAY, Element: integer, Size: 4}
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	arrayObject := array.Obj.(*value.ObjArray)
+	arrayObject.RuntimeType = dynamicArray
+	if machine.markRuntimeValueType(array, fixedArray) || arrayObject.RuntimeType != dynamicArray {
+		t.Fatal("array conflict overwrote existing runtime schema")
+	}
+
+	stringMap := &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: text, Value: integer}
+	intMap := &value.RuntimeTypeInfo{Kind: value.TYPE_MAP, Key: integer, Value: text}
+	mapping := value.NewMap()
+	mapObject := mapping.Obj.(*value.ObjMap)
+	mapObject.RuntimeType = stringMap
+	if machine.markRuntimeValueType(mapping, intMap) || mapObject.RuntimeType != stringMap {
+		t.Fatal("map conflict overwrote existing runtime schema")
+	}
+
+	stringChannel := &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}
+	channel := value.NewChannel(1)
+	channelObject := channel.Obj.(*value.ObjChannel)
+	channelObject.ElementType = stringChannel
+	if machine.markRuntimeValueType(channel, &value.RuntimeTypeInfo{Kind: value.TYPE_CHANNEL, Element: integer}) || channelObject.ElementType != stringChannel {
+		t.Fatal("channel conflict overwrote existing runtime schema")
+	}
+
+	ref := &value.ObjRef{RefType: value.REF_PTR, Ptr: &array}
+	refValue := value.Value{Type: value.VAL_REF, Obj: ref}
+	if !machine.markRuntimeValueType(refValue, &value.RuntimeTypeInfo{Kind: value.TYPE_REF, Element: dynamicArray}) {
+		t.Fatal("compatible reference value marker was rejected")
+	}
+	if ref.TargetType != nil || refValue.Obj != ref {
+		t.Fatal("runtime value marker mutated or rebound ObjRef")
+	}
+}
+
+func TestTypedJSONLoadsBuildsCollectionRuntimeSchemas(t *testing.T) {
+	t.Run("empty nested array", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let decoded: int[][] = [[1]]
+let ok: bool = json_loads("[[]]", decoded)
+let seed: int[] = [1]
+let target: int[][] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, decoded[0])
+if ok then test_report(length(target)) else test_report(999) end`)
+		testExpectedObject(t, 1, got)
+	})
+
+	t.Run("empty nested map", func(t *testing.T) {
+		got := runTypedFunctionProgram(t, `
+let decoded: map[string, int][] = [{"seed": 1}]
+let ok: bool = json_loads("[{}]", decoded)
+let seed: map[string, int] = {"seed": 1}
+let target: map[string, int][] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, decoded[0])
+if ok then test_report(length(target)) else test_report(999) end`)
+		testExpectedObject(t, 1, got)
+	})
+}
+
+func TestRuntimeValueMarkerPropagatesThroughReferenceWithoutMutatingIt(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "typed declaration",
+			source: `
+let typed: ref int[] = unknown_ref()
+let seed: int[] = [1]
+let target: int[][] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, typed)
+test_report(length(target))`,
+		},
+		{
+			name: "reference rebind",
+			source: `
+let initial: int[] = [1]
+let typed: ref int[] = ref initial
+typed = unknown_ref()
+let seed: int[] = [1]
+let target: int[][] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, typed)
+test_report(length(target))`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := lexer.New(tt.source)
+			p := parser.New(l)
+			program := p.ParseProgram()
+			if len(p.Errors()) != 0 {
+				t.Fatalf("parser errors: %v", p.Errors())
+			}
+			code, _, err := compiler.New().Compile(program)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			machine := New()
+			backing := value.NewArray(nil)
+			originalRef := &value.ObjRef{RefType: value.REF_PTR, Ptr: &backing}
+			captured := value.NewNull()
+			machine.DefineNative("unknown_ref", func(args []value.Value) value.Value {
+				return value.Value{Type: value.VAL_REF, Obj: originalRef}
+			})
+			machine.DefineNative("test_report", func(args []value.Value) value.Value {
+				captured = args[0]
+				return value.NewNull()
+			})
+			if err := machine.Interpret(code); err != nil {
+				t.Fatal(err)
+			}
+			testExpectedObject(t, 1, captured)
+			backingSchema := backing.Obj.(*value.ObjArray).RuntimeType
+			if backingSchema == nil || backingSchema.Kind != value.TYPE_ARRAY || backingSchema.Element == nil || backingSchema.Element.Kind != value.TYPE_INT {
+				t.Fatalf("backing schema=%#v", backingSchema)
+			}
+			if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+				t.Fatal("runtime value marker mutated or rebound the ObjRef")
+			}
+		})
+	}
+
+	t.Run("map referent", func(t *testing.T) {
+		source := `
+let typed: ref map[string, int] = unknown_ref()
+let seed: map[string, int] = {"seed": 1}
+let target: map[string, int][] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, typed)
+test_report(length(target))`
+		l := lexer.New(source)
+		p := parser.New(l)
+		program := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Fatalf("parser errors: %v", p.Errors())
+		}
+		code, _, err := compiler.New().Compile(program)
+		if err != nil {
+			t.Fatal(err)
+		}
+		machine := New()
+		backing := value.NewMap()
+		originalRef := &value.ObjRef{RefType: value.REF_PTR, Ptr: &backing}
+		captured := value.NewNull()
+		machine.DefineNative("unknown_ref", func(args []value.Value) value.Value {
+			return value.Value{Type: value.VAL_REF, Obj: originalRef}
+		})
+		machine.DefineNative("test_report", func(args []value.Value) value.Value {
+			captured = args[0]
+			return value.NewNull()
+		})
+		if err := machine.Interpret(code); err != nil {
+			t.Fatal(err)
+		}
+		testExpectedObject(t, 1, captured)
+		backingSchema := backing.Obj.(*value.ObjMap).RuntimeType
+		if backingSchema == nil || backingSchema.Kind != value.TYPE_MAP || backingSchema.Key.Kind != value.TYPE_STRING || backingSchema.Value.Kind != value.TYPE_INT {
+			t.Fatalf("backing schema=%#v", backingSchema)
+		}
+		if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+			t.Fatal("runtime value marker mutated or rebound the map ObjRef")
+		}
+	})
+
+	t.Run("channel referent", func(t *testing.T) {
+		source := `
+let typed: ref chan int = unknown_ref()
+let seed: chan int = make_chan(1)
+let target: (chan int)[] = [seed]
+pop(target)
+let invoke: any = append
+invoke(ref target, typed)
+test_report(length(target))`
+		l := lexer.New(source)
+		p := parser.New(l)
+		program := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Fatalf("parser errors: %v", p.Errors())
+		}
+		code, _, err := compiler.New().Compile(program)
+		if err != nil {
+			t.Fatal(err)
+		}
+		machine := New()
+		backing := value.NewChannel(1)
+		originalRef := &value.ObjRef{RefType: value.REF_PTR, Ptr: &backing}
+		captured := value.NewNull()
+		machine.DefineNative("unknown_ref", func(args []value.Value) value.Value {
+			return value.Value{Type: value.VAL_REF, Obj: originalRef}
+		})
+		machine.DefineNative("test_report", func(args []value.Value) value.Value {
+			captured = args[0]
+			return value.NewNull()
+		})
+		if err := machine.Interpret(code); err != nil {
+			t.Fatal(err)
+		}
+		testExpectedObject(t, 1, captured)
+		channel := backing.Obj.(*value.ObjChannel)
+		if channel.ElementType == nil || channel.ElementType.Kind != value.TYPE_INT {
+			t.Fatalf("channel element schema=%#v", channel.ElementType)
+		}
+		if originalRef.Ptr != &backing || originalRef.TargetType != nil {
+			t.Fatal("runtime value marker mutated or rebound the channel ObjRef")
+		}
+	})
 }
 
 func TestTypedJSONLoadsRejectsCallableAndChannelConstruction(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -587,6 +587,61 @@ end`)
 	})
 }
 
+func TestTypedJSONLoadsAcceptsNullForStructSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "target",
+			source: `
+struct Vertex
+    value: int
+end
+let target: Vertex = Vertex(1)
+let ok: bool = json_loads("null", target)
+if ok then
+    if target == null then test_report(1) else test_report(998) end
+else
+    test_report(999)
+end`,
+		},
+		{
+			name: "array element",
+			source: `
+struct Vertex
+    value: int
+end
+let target: Vertex[] = [Vertex(1)]
+let ok: bool = json_loads("[null]", target)
+if ok then
+    if target[0] == null then test_report(length(target)) else test_report(998) end
+else
+    test_report(999)
+end`,
+		},
+		{
+			name: "map value",
+			source: `
+struct Vertex
+    value: int
+end
+let target: map[string, Vertex] = {"item": Vertex(1)}
+let ok: bool = json_loads("{\"item\":null}", target)
+if ok then
+    if target["item"] == null then test_report(1) else test_report(998) end
+else
+    test_report(999)
+end`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testExpectedObject(t, 1, runTypedFunctionProgram(t, tt.source))
+		})
+	}
+}
+
 func TestTypedJSONLoadsReplacesNonNullAnyComposite(t *testing.T) {
 	got := runTypedFunctionProgram(t, `
 let target: any = [1]

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1,0 +1,148 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+	"noxy-vm/internal/value"
+)
+
+func runWithTypedTestNative(t *testing.T, input string, sig value.NativeSignature, called *bool) error {
+	t.Helper()
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+	machine := New()
+	machine.DefineNativeWithSignature("typed_test", sig, func(args []value.Value) value.Value {
+		*called = true
+		return value.NewNull()
+	})
+	return machine.Interpret(code)
+}
+
+func TestTypedNativeRejectsModeBeforeInvocation(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "void",
+	}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(n)", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "expected ref int") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after contract failure")
+	}
+}
+
+func TestTypedNativeAcceptsExplicitReference(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{IsRef: true, TypeName: "ref int"}}, ReturnType: "void"}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(ref n)", sig, &called)
+	if err != nil || !called {
+		t.Fatalf("called=%v error=%v", called, err)
+	}
+}
+
+func TestTypedNativeRejectsIncorrectExactArityBeforeInvocation(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int"}}, ReturnType: "void"}
+	err := runWithTypedTestNative(t, "typed_test()", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "native 'typed_test' expects 1 arguments, got 0") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after arity failure")
+	}
+}
+
+func TestTypedNativeRejectsFewerThanMinimumVariadicArityBeforeInvocation(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{
+		Arity:      2,
+		Variadic:   true,
+		Params:     []value.ParamInfo{{TypeName: "int"}, {TypeName: "int"}},
+		ReturnType: "void",
+	}
+	err := runWithTypedTestNative(t, "typed_test(1)", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "native 'typed_test' expects at least 2 arguments, got 1") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after arity failure")
+	}
+}
+
+func TestTypedNativeRejectsReferenceForOrdinaryParameterBeforeInvocation(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{IsRef: false, TypeName: "int"}}, ReturnType: "void"}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(ref n)", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got ref") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after contract failure")
+	}
+}
+
+func TestTypedNativeExpandsFinalVariadicParameterMode(t *testing.T) {
+	called := false
+	sig := value.NativeSignature{
+		Arity:      1,
+		Variadic:   true,
+		Params:     []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "void",
+	}
+	err := runWithTypedTestNative(t, "let n: int = 1\ntyped_test(ref n, n)", sig, &called)
+	if err == nil || !strings.Contains(err.Error(), "argument 2: expected ref int") {
+		t.Fatalf("error=%v", err)
+	}
+	if called {
+		t.Fatal("native closure must not run after contract failure")
+	}
+}
+
+func TestTypedNativeShallowCopiesOrdinaryComposite(t *testing.T) {
+	source := "let values: int[] = [1]\ntyped_test(values)"
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := New()
+	machine.DefineNativeWithSignature("typed_test", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{IsRef: false, TypeName: "int[]"}},
+		ReturnType: "void",
+	}, func(args []value.Value) value.Value {
+		args[0].Obj.(*value.ObjArray).Elements[0] = value.NewInt(9)
+		return value.NewNull()
+	})
+	if err := machine.Interpret(code); err != nil {
+		t.Fatal(err)
+	}
+	global, ok := machine.GetGlobal("values")
+	if !ok {
+		t.Fatal("missing values global")
+	}
+	if got := global.Obj.(*value.ObjArray).Elements[0].AsInt; got != 1 {
+		t.Fatalf("caller value=%d, want 1", got)
+	}
+}

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
 	"testing"
 )
 
@@ -12,4 +14,28 @@ rand.rng.state = 10
 rand.new_random(ref rng)
 test_report(rng.state * 100 + rand.rng.state)`)
 	testExpectedObject(t, 510, got)
+}
+
+func TestModuleFrameGlobalReferenceCapturesSharedFallbackOwner(t *testing.T) {
+	code := chunk.New()
+	code.FileName = "shared_global_reference"
+	name := code.AddConstant(value.NewString("shared_value"))
+	for _, instruction := range []byte{
+		byte(chunk.OP_REF_GLOBAL), byte(name),
+		byte(chunk.OP_DEREF),
+		byte(chunk.OP_RETURN),
+	} {
+		code.Write(instruction, 1)
+	}
+
+	machine := New()
+	machine.SetGlobal("shared_value", value.NewInt(42))
+	moduleGlobals := map[string]value.Value{"module_only": value.NewInt(1)}
+	if err := machine.InterpretWithGlobals(code, moduleGlobals); err != nil {
+		t.Fatal(err)
+	}
+	got := machine.pop()
+	if got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("shared fallback=%v, want 42", got)
+	}
 }

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -1,0 +1,15 @@
+package vm
+
+import (
+	"testing"
+)
+
+func TestImportedFunctionUsesCallerGlobalReferenceOwner(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+use rand
+let rng: rand.RandomGenerator = rand.RandomGenerator(1, 2, 3, 100)
+rand.rng.state = 10
+rand.new_random(ref rng)
+test_report(rng.state * 100 + rand.rng.state)`)
+	testExpectedObject(t, 510, got)
+}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -2,8 +2,9 @@ package vm
 
 import (
 	"fmt"
-	"noxy-vm/internal/value"
 	"reflect"
+
+	"noxy-vm/internal/value"
 )
 
 func referenceMapKey(index value.Value) (interface{}, error) {
@@ -23,11 +24,15 @@ func referenceMapKey(index value.Value) (interface{}, error) {
 type referenceSetter func(value.Value)
 
 func validateReferencedValue(stored value.Value) error {
-	if stored.Type != value.VAL_OBJ || stored.Obj == nil {
-		if stored.Type == value.VAL_OBJ {
-			return fmt.Errorf("invalid referenced object")
-		}
+	switch stored.Type {
+	case value.VAL_OBJ, value.VAL_FUNCTION, value.VAL_NATIVE, value.VAL_BYTES,
+		value.VAL_CHANNEL, value.VAL_WAITGROUP, value.VAL_REF:
+		// These tags require a concrete payload in Obj.
+	default:
 		return nil
+	}
+	if stored.Obj == nil {
+		return fmt.Errorf("invalid referenced object")
 	}
 	object := reflect.ValueOf(stored.Obj)
 	switch object.Kind() {
@@ -112,6 +117,9 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 			return array.Elements[index], true, func(updated value.Value) { array.Elements[index] = updated }, nil
 		}
 		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ref.Container.Type == value.VAL_OBJ && ok && mapping != nil {
+			if mapping.Data == nil {
+				return value.Value{}, false, nil, fmt.Errorf("invalid map reference container")
+			}
 			key, err := referenceMapKey(ref.Index)
 			if err != nil {
 				return value.Value{}, false, nil, err

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -19,96 +19,131 @@ func referenceMapKey(index value.Value) (interface{}, error) {
 	}
 }
 
-func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
-	if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
-		return value.Value{}, fmt.Errorf("invalid global reference owner")
+type referenceSetter func(value.Value)
+
+func extractReferenceValue(input value.Value) (*value.ObjRef, error) {
+	if input.Type != value.VAL_REF {
+		return nil, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
 	}
-	if ref.GlobalOwner == &vm.shared.Globals {
-		if result, ok := vm.GetGlobal(ref.Name); ok {
-			return result, nil
+	ref, ok := input.Obj.(*value.ObjRef)
+	if !ok || ref == nil {
+		return nil, fmt.Errorf("invalid reference value")
+	}
+	return ref, nil
+}
+
+func (vm *VM) referenceStorage(ref *value.ObjRef) (value.Value, bool, referenceSetter, error) {
+	if ref == nil {
+		return value.Value{}, false, nil, fmt.Errorf("invalid reference value")
+	}
+	switch ref.RefType {
+	case value.REF_GLOBAL:
+		if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
+			return value.Value{}, false, nil, fmt.Errorf("invalid global reference owner")
 		}
-	} else if result, ok := (*ref.GlobalOwner)[ref.Name]; ok {
-		return result, nil
+		if ref.GlobalOwner == &vm.shared.Globals {
+			stored, ok := vm.GetGlobal(ref.Name)
+			if !ok {
+				return value.Value{}, false, nil, fmt.Errorf("undefined global variable '%s'", ref.Name)
+			}
+			return stored, true, func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }, nil
+		}
+		owner := *ref.GlobalOwner
+		stored, ok := owner[ref.Name]
+		if !ok {
+			return value.Value{}, false, nil, fmt.Errorf("undefined global variable '%s'", ref.Name)
+		}
+		return stored, true, func(updated value.Value) { owner[ref.Name] = updated }, nil
+	case value.REF_UPVALUE:
+		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
+			return value.Value{}, false, nil, fmt.Errorf("invalid upvalue reference")
+		}
+		return *ref.Upvalue.Location, true, func(updated value.Value) { *ref.Upvalue.Location = updated }, nil
+	case value.REF_PTR:
+		if ref.Ptr == nil {
+			return value.Value{}, false, nil, fmt.Errorf("invalid pointer reference")
+		}
+		return *ref.Ptr, true, func(updated value.Value) { *ref.Ptr = updated }, nil
+	case value.REF_PROPERTY:
+		instance, ok := ref.Container.Obj.(*value.ObjInstance)
+		if ref.Container.Type != value.VAL_OBJ || !ok || instance == nil {
+			return value.Value{}, false, nil, fmt.Errorf("Target is not an instance")
+		}
+		stored, ok := instance.Fields[ref.Name]
+		if !ok {
+			return value.Value{}, false, nil, fmt.Errorf("undefined property '%s'", ref.Name)
+		}
+		return stored, true, func(updated value.Value) { instance.Fields[ref.Name] = updated }, nil
+	case value.REF_INDEX:
+		if array, ok := ref.Container.Obj.(*value.ObjArray); ref.Container.Type == value.VAL_OBJ && ok && array != nil {
+			if ref.Index.Type != value.VAL_INT {
+				return value.Value{}, false, nil, fmt.Errorf("array reference index must be integer")
+			}
+			index := int(ref.Index.AsInt)
+			if index < 0 || index >= len(array.Elements) {
+				return value.Value{}, false, nil, fmt.Errorf("Index out of bounds")
+			}
+			return array.Elements[index], true, func(updated value.Value) { array.Elements[index] = updated }, nil
+		}
+		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ref.Container.Type == value.VAL_OBJ && ok && mapping != nil {
+			key, err := referenceMapKey(ref.Index)
+			if err != nil {
+				return value.Value{}, false, nil, err
+			}
+			stored, exists := mapping.Data[key]
+			if !exists {
+				stored = value.NewNull()
+			}
+			return stored, exists, func(updated value.Value) { mapping.Data[key] = updated }, nil
+		}
+		return value.Value{}, false, nil, fmt.Errorf("Target is not indexable")
+	default:
+		return value.Value{}, false, nil, fmt.Errorf("invalid reference target")
 	}
-	return value.Value{}, fmt.Errorf("undefined global variable '%s'", ref.Name)
+}
+
+func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
+	stored, _, _, err := vm.referenceStorage(ref)
+	return stored, err
 }
 
 func (vm *VM) storeGlobalReferenceValue(ref *value.ObjRef, updated value.Value) error {
-	if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
-		return fmt.Errorf("invalid global reference owner")
+	_, _, store, err := vm.referenceStorage(ref)
+	if err != nil {
+		return err
 	}
-	if ref.GlobalOwner == &vm.shared.Globals {
-		vm.SetGlobal(ref.Name, updated)
-		return nil
-	}
-	(*ref.GlobalOwner)[ref.Name] = updated
+	store(updated)
 	return nil
 }
 
 func (vm *VM) lookupReferenceValue(ref *value.ObjRef) (value.Value, error) {
-	if ref == nil {
-		return value.Value{}, fmt.Errorf("invalid reference value")
+	stored, _, _, err := vm.referenceStorage(ref)
+	return stored, err
+}
+
+func (vm *VM) storeReferenceValue(input value.Value, updated value.Value) error {
+	if input.Type == value.VAL_NULL {
+		return fmt.Errorf("cannot update null reference")
 	}
-	switch ref.RefType {
-	case value.REF_GLOBAL:
-		return vm.lookupGlobalReferenceValue(ref)
-	case value.REF_UPVALUE:
-		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
-			return value.Value{}, fmt.Errorf("invalid upvalue reference")
-		}
-		return *ref.Upvalue.Location, nil
-	case value.REF_PTR:
-		if ref.Ptr == nil {
-			return value.Value{}, fmt.Errorf("invalid pointer reference")
-		}
-		return *ref.Ptr, nil
-	case value.REF_PROPERTY:
-		instance, ok := ref.Container.Obj.(*value.ObjInstance)
-		if !ok {
-			return value.Value{}, fmt.Errorf("Target is not an instance")
-		}
-		if result, ok := instance.Fields[ref.Name]; ok {
-			return result, nil
-		}
-		return value.NewNull(), nil
-	case value.REF_INDEX:
-		if array, ok := ref.Container.Obj.(*value.ObjArray); ok {
-			if ref.Index.Type != value.VAL_INT {
-				return value.Value{}, fmt.Errorf("array reference index must be integer")
-			}
-			index := int(ref.Index.AsInt)
-			if index < 0 || index >= len(array.Elements) {
-				return value.Value{}, fmt.Errorf("Index out of bounds")
-			}
-			return array.Elements[index], nil
-		}
-		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ok {
-			key, err := referenceMapKey(ref.Index)
-			if err != nil {
-				return value.Value{}, err
-			}
-			if result, ok := mapping.Data[key]; ok {
-				return result, nil
-			}
-			return value.NewNull(), nil
-		}
-		return value.Value{}, fmt.Errorf("Target is not indexable")
-	default:
-		return value.Value{}, fmt.Errorf("invalid reference target")
+	ref, err := extractReferenceValue(input)
+	if err != nil {
+		return err
 	}
+	_, _, store, err := vm.referenceStorage(ref)
+	if err != nil {
+		return err
+	}
+	store(updated)
+	return nil
 }
 
 func (vm *VM) resolveReferenceValue(input value.Value) (value.Value, error) {
 	if input.Type == value.VAL_NULL {
 		return value.Value{}, fmt.Errorf("cannot dereference null reference")
 	}
-	if input.Type != value.VAL_REF {
-		return value.Value{}, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
-	}
-
-	ref, ok := input.Obj.(*value.ObjRef)
-	if !ok || ref == nil {
-		return value.Value{}, fmt.Errorf("invalid reference value")
+	ref, err := extractReferenceValue(input)
+	if err != nil {
+		return value.Value{}, err
 	}
 	return vm.lookupReferenceValue(ref)
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -13,13 +13,16 @@ func referenceMapKey(index value.Value) (interface{}, error) {
 		if key, ok := index.Obj.(string); ok {
 			return key, nil
 		}
-		return index.Obj, nil
+		return nil, fmt.Errorf("map reference key must be int or string")
 	default:
-		return nil, fmt.Errorf("Map key type not fully supported in ref yet")
+		return nil, fmt.Errorf("map reference key must be int or string")
 	}
 }
 
 func (vm *VM) lookupReferenceValue(ref *value.ObjRef, frameGlobals map[string]value.Value) (value.Value, error) {
+	if ref == nil {
+		return value.Value{}, fmt.Errorf("invalid reference value")
+	}
 	switch ref.RefType {
 	case value.REF_GLOBAL:
 		if result, ok := frameGlobals[ref.Name]; ok {
@@ -30,8 +33,14 @@ func (vm *VM) lookupReferenceValue(ref *value.ObjRef, frameGlobals map[string]va
 		}
 		return value.Value{}, fmt.Errorf("undefined global variable '%s'", ref.Name)
 	case value.REF_UPVALUE:
+		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
+			return value.Value{}, fmt.Errorf("invalid upvalue reference")
+		}
 		return *ref.Upvalue.Location, nil
 	case value.REF_PTR:
+		if ref.Ptr == nil {
+			return value.Value{}, fmt.Errorf("invalid pointer reference")
+		}
 		return *ref.Ptr, nil
 	case value.REF_PROPERTY:
 		instance, ok := ref.Container.Obj.(*value.ObjInstance)
@@ -44,6 +53,9 @@ func (vm *VM) lookupReferenceValue(ref *value.ObjRef, frameGlobals map[string]va
 		return value.NewNull(), nil
 	case value.REF_INDEX:
 		if array, ok := ref.Container.Obj.(*value.ObjArray); ok {
+			if ref.Index.Type != value.VAL_INT {
+				return value.Value{}, fmt.Errorf("array reference index must be integer")
+			}
 			index := int(ref.Index.AsInt)
 			if index < 0 || index >= len(array.Elements) {
 				return value.Value{}, fmt.Errorf("Index out of bounds")
@@ -78,5 +90,9 @@ func (vm *VM) resolveReferenceValue(input value.Value) (value.Value, error) {
 	if vm.currentFrame != nil {
 		frameGlobals = vm.currentFrame.Globals
 	}
-	return vm.lookupReferenceValue(input.Obj.(*value.ObjRef), frameGlobals)
+	ref, ok := input.Obj.(*value.ObjRef)
+	if !ok || ref == nil {
+		return value.Value{}, fmt.Errorf("invalid reference value")
+	}
+	return vm.lookupReferenceValue(ref, frameGlobals)
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -19,19 +19,39 @@ func referenceMapKey(index value.Value) (interface{}, error) {
 	}
 }
 
-func (vm *VM) lookupReferenceValue(ref *value.ObjRef, frameGlobals map[string]value.Value) (value.Value, error) {
+func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
+	if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
+		return value.Value{}, fmt.Errorf("invalid global reference owner")
+	}
+	if ref.GlobalOwner == &vm.shared.Globals {
+		if result, ok := vm.GetGlobal(ref.Name); ok {
+			return result, nil
+		}
+	} else if result, ok := (*ref.GlobalOwner)[ref.Name]; ok {
+		return result, nil
+	}
+	return value.Value{}, fmt.Errorf("undefined global variable '%s'", ref.Name)
+}
+
+func (vm *VM) storeGlobalReferenceValue(ref *value.ObjRef, updated value.Value) error {
+	if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
+		return fmt.Errorf("invalid global reference owner")
+	}
+	if ref.GlobalOwner == &vm.shared.Globals {
+		vm.SetGlobal(ref.Name, updated)
+		return nil
+	}
+	(*ref.GlobalOwner)[ref.Name] = updated
+	return nil
+}
+
+func (vm *VM) lookupReferenceValue(ref *value.ObjRef) (value.Value, error) {
 	if ref == nil {
 		return value.Value{}, fmt.Errorf("invalid reference value")
 	}
 	switch ref.RefType {
 	case value.REF_GLOBAL:
-		if result, ok := frameGlobals[ref.Name]; ok {
-			return result, nil
-		}
-		if result, ok := vm.GetGlobal(ref.Name); ok {
-			return result, nil
-		}
-		return value.Value{}, fmt.Errorf("undefined global variable '%s'", ref.Name)
+		return vm.lookupGlobalReferenceValue(ref)
 	case value.REF_UPVALUE:
 		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
 			return value.Value{}, fmt.Errorf("invalid upvalue reference")
@@ -86,13 +106,9 @@ func (vm *VM) resolveReferenceValue(input value.Value) (value.Value, error) {
 		return value.Value{}, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
 	}
 
-	var frameGlobals map[string]value.Value
-	if vm.currentFrame != nil {
-		frameGlobals = vm.currentFrame.Globals
-	}
 	ref, ok := input.Obj.(*value.ObjRef)
 	if !ok || ref == nil {
 		return value.Value{}, fmt.Errorf("invalid reference value")
 	}
-	return vm.lookupReferenceValue(ref, frameGlobals)
+	return vm.lookupReferenceValue(ref)
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 	"noxy-vm/internal/value"
+	"reflect"
 )
 
 func referenceMapKey(index value.Value) (interface{}, error) {
@@ -21,6 +22,23 @@ func referenceMapKey(index value.Value) (interface{}, error) {
 
 type referenceSetter func(value.Value)
 
+func validateReferencedValue(stored value.Value) error {
+	if stored.Type != value.VAL_OBJ || stored.Obj == nil {
+		if stored.Type == value.VAL_OBJ {
+			return fmt.Errorf("invalid referenced object")
+		}
+		return nil
+	}
+	object := reflect.ValueOf(stored.Obj)
+	switch object.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if object.IsNil() {
+			return fmt.Errorf("invalid referenced object")
+		}
+	}
+	return nil
+}
+
 func extractReferenceValue(input value.Value) (*value.ObjRef, error) {
 	if input.Type != value.VAL_REF {
 		return nil, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
@@ -32,7 +50,15 @@ func extractReferenceValue(input value.Value) (*value.ObjRef, error) {
 	return ref, nil
 }
 
-func (vm *VM) referenceStorage(ref *value.ObjRef) (value.Value, bool, referenceSetter, error) {
+func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bool, store referenceSetter, err error) {
+	defer func() {
+		if err == nil && exists {
+			if validationErr := validateReferencedValue(stored); validationErr != nil {
+				err = validationErr
+				store = nil
+			}
+		}
+	}()
 	if ref == nil {
 		return value.Value{}, false, nil, fmt.Errorf("invalid reference value")
 	}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -1,0 +1,82 @@
+package vm
+
+import (
+	"fmt"
+	"noxy-vm/internal/value"
+)
+
+func referenceMapKey(index value.Value) (interface{}, error) {
+	switch index.Type {
+	case value.VAL_INT:
+		return index.AsInt, nil
+	case value.VAL_OBJ:
+		if key, ok := index.Obj.(string); ok {
+			return key, nil
+		}
+		return index.Obj, nil
+	default:
+		return nil, fmt.Errorf("Map key type not fully supported in ref yet")
+	}
+}
+
+func (vm *VM) lookupReferenceValue(ref *value.ObjRef, frameGlobals map[string]value.Value) (value.Value, error) {
+	switch ref.RefType {
+	case value.REF_GLOBAL:
+		if result, ok := frameGlobals[ref.Name]; ok {
+			return result, nil
+		}
+		if result, ok := vm.GetGlobal(ref.Name); ok {
+			return result, nil
+		}
+		return value.Value{}, fmt.Errorf("undefined global variable '%s'", ref.Name)
+	case value.REF_UPVALUE:
+		return *ref.Upvalue.Location, nil
+	case value.REF_PTR:
+		return *ref.Ptr, nil
+	case value.REF_PROPERTY:
+		instance, ok := ref.Container.Obj.(*value.ObjInstance)
+		if !ok {
+			return value.Value{}, fmt.Errorf("Target is not an instance")
+		}
+		if result, ok := instance.Fields[ref.Name]; ok {
+			return result, nil
+		}
+		return value.NewNull(), nil
+	case value.REF_INDEX:
+		if array, ok := ref.Container.Obj.(*value.ObjArray); ok {
+			index := int(ref.Index.AsInt)
+			if index < 0 || index >= len(array.Elements) {
+				return value.Value{}, fmt.Errorf("Index out of bounds")
+			}
+			return array.Elements[index], nil
+		}
+		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ok {
+			key, err := referenceMapKey(ref.Index)
+			if err != nil {
+				return value.Value{}, err
+			}
+			if result, ok := mapping.Data[key]; ok {
+				return result, nil
+			}
+			return value.NewNull(), nil
+		}
+		return value.Value{}, fmt.Errorf("Target is not indexable")
+	default:
+		return value.Value{}, fmt.Errorf("invalid reference target")
+	}
+}
+
+func (vm *VM) resolveReferenceValue(input value.Value) (value.Value, error) {
+	if input.Type == value.VAL_NULL {
+		return value.Value{}, fmt.Errorf("cannot dereference null reference")
+	}
+	if input.Type != value.VAL_REF {
+		return value.Value{}, fmt.Errorf("expected reference value, got %s", runtimeValueMode(input))
+	}
+
+	var frameGlobals map[string]value.Value
+	if vm.currentFrame != nil {
+		frameGlobals = vm.currentFrame.Globals
+	}
+	return vm.lookupReferenceValue(input.Obj.(*value.ObjRef), frameGlobals)
+}

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -45,7 +45,7 @@ func TestResolveReferenceValueRejectsMalformedReferences(t *testing.T) {
 }
 
 func TestLookupReferenceValueRejectsNilReference(t *testing.T) {
-	if _, err := New().lookupReferenceValue(nil, nil); err == nil {
+	if _, err := New().lookupReferenceValue(nil); err == nil {
 		t.Fatal("nil reference resolved without error")
 	}
 }

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -1,0 +1,100 @@
+package vm
+
+import (
+	"noxy-vm/internal/value"
+	"testing"
+)
+
+func TestResolveReferenceValueRejectsMalformedReferences(t *testing.T) {
+	malformedArrayIndex := value.Value{
+		Type: value.VAL_REF,
+		Obj: &value.ObjRef{
+			RefType:   value.REF_INDEX,
+			Container: value.NewArray([]value.Value{value.NewInt(1)}),
+			Index:     value.NewBool(false),
+		},
+	}
+	malformedMapKey := value.Value{
+		Type: value.VAL_REF,
+		Obj: &value.ObjRef{
+			RefType:   value.REF_INDEX,
+			Container: value.NewMap(),
+			Index:     value.Value{Type: value.VAL_OBJ, Obj: []int{1}},
+		},
+	}
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{name: "wrong object", input: value.Value{Type: value.VAL_REF, Obj: "not a reference"}},
+		{name: "nil reference", input: value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)}},
+		{name: "nil upvalue", input: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE}}},
+		{name: "nil upvalue location", input: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE, Upvalue: &value.ObjUpvalue{}}}},
+		{name: "nil pointer", input: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR}}},
+		{name: "array index type", input: malformedArrayIndex},
+		{name: "unhashable map key", input: malformedMapKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := New().resolveReferenceValue(tt.input); err == nil {
+				t.Fatal("malformed reference resolved without error")
+			}
+		})
+	}
+}
+
+func TestLookupReferenceValueRejectsNilReference(t *testing.T) {
+	if _, err := New().lookupReferenceValue(nil, nil); err == nil {
+		t.Fatal("nil reference resolved without error")
+	}
+}
+
+func TestMutatingNativesTreatMalformedReferencesAsLegacyNoOps(t *testing.T) {
+	machine := New()
+	malformed := []struct {
+		name  string
+		value value.Value
+	}{
+		{name: "wrong object", value: value.Value{Type: value.VAL_REF, Obj: "not a reference"}},
+		{
+			name: "array index type",
+			value: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{
+				RefType:   value.REF_INDEX,
+				Container: value.NewArray([]value.Value{value.NewInt(1)}),
+				Index:     value.NewBool(false),
+			}},
+		},
+		{
+			name: "unhashable map key",
+			value: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{
+				RefType:   value.REF_INDEX,
+				Container: value.NewMap(),
+				Index:     value.Value{Type: value.VAL_OBJ, Obj: []int{1}},
+			}},
+		},
+	}
+	natives := []struct {
+		name string
+		args func(value.Value) []value.Value
+	}{
+		{name: "append", args: func(target value.Value) []value.Value { return []value.Value{target, value.NewInt(1)} }},
+		{name: "pop", args: func(target value.Value) []value.Value { return []value.Value{target} }},
+		{name: "delete", args: func(target value.Value) []value.Value { return []value.Value{target, value.NewString("key")} }},
+	}
+
+	for _, target := range malformed {
+		for _, native := range natives {
+			t.Run(target.name+"/"+native.name, func(t *testing.T) {
+				nativeValue, ok := machine.GetGlobal(native.name)
+				if !ok {
+					t.Fatalf("missing native %s", native.name)
+				}
+				result := nativeValue.Obj.(*value.ObjNative).Fn(native.args(target.value))
+				if result.Type != value.VAL_NULL {
+					t.Fatalf("result=%v, want null", result)
+				}
+			})
+		}
+	}
+}

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -21,7 +21,7 @@ func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool 
 		if item.Type == value.VAL_REF {
 			return false
 		}
-		return runtimeValueMatchesType(item, elementType)
+		return vm.runtimeValueMatchesType(item, elementType)
 	}
 	if item.Type == value.VAL_NULL {
 		return true
@@ -33,10 +33,10 @@ func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool 
 	if err != nil {
 		return false
 	}
-	return runtimeValueMatchesType(resolved, elementType.Element)
+	return vm.runtimeValueMatchesType(resolved, elementType.Element)
 }
 
-func runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
+func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
 	if expected == nil || expected.Kind == value.TYPE_ANY {
 		return true
 	}
@@ -66,7 +66,7 @@ func runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo
 			return false
 		}
 		for _, element := range array.Elements {
-			if !runtimeValueMatchesType(element, expected.Element) {
+			if !vm.runtimeValueMatchesType(element, expected.Element) {
 				return false
 			}
 		}
@@ -77,14 +77,18 @@ func runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo
 			return false
 		}
 		for key, element := range mapping.Data {
-			if !runtimeMapKeyMatchesType(key, expected.Key) || !runtimeValueMatchesType(element, expected.Value) {
+			if !runtimeMapKeyMatchesType(key, expected.Key) || !vm.runtimeValueMatchesType(element, expected.Value) {
 				return false
 			}
 		}
 		return true
 	case value.TYPE_REF:
 		ref, ok := actual.Obj.(*value.ObjRef)
-		return actual.Type == value.VAL_REF && ok && ref != nil
+		if actual.Type != value.VAL_REF || !ok || ref == nil || expected.Element == nil {
+			return false
+		}
+		resolved, err := vm.resolveReferenceValue(actual)
+		return err == nil && vm.runtimeValueMatchesType(resolved, expected.Element)
 	case value.TYPE_STRUCT:
 		instance, ok := actual.Obj.(*value.ObjInstance)
 		return actual.Type == value.VAL_OBJ && ok && instance.Struct != nil && instance.Struct.Name == expected.Name

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -58,11 +58,11 @@ func markReferenceTargetType(ref *value.ObjRef, targetType *value.RuntimeTypeInf
 }
 
 func (vm *VM) validateStructConstructorArguments(definition *value.ObjStruct, args []value.Value) error {
-	if definition == nil || !runtimeTypeComplete(definition.ConstructorType, make(map[*value.RuntimeTypeInfo]bool)) {
+	schema, valid := validStructConstructorType(definition)
+	if !valid {
 		return fmt.Errorf("struct constructor has incomplete runtime type metadata")
 	}
-	schema := definition.ConstructorType
-	if schema.Kind != value.TYPE_CALLABLE || schema.CallableBare || len(schema.Params) != len(args) || len(schema.ParamIsRef) != len(schema.Params) {
+	if len(schema.Params) != len(args) {
 		return fmt.Errorf("struct '%s' constructor has invalid runtime type metadata", definition.Name)
 	}
 	params := make([]value.ParamInfo, len(schema.Params))
@@ -78,6 +78,19 @@ func (vm *VM) validateStructConstructorArguments(definition *value.ObjStruct, ar
 		}
 	}
 	return nil
+}
+
+func validStructConstructorType(definition *value.ObjStruct) (*value.RuntimeTypeInfo, bool) {
+	if definition == nil {
+		return nil, false
+	}
+	schema := definition.ConstructorType
+	if !runtimeTypeComplete(schema, make(map[*value.RuntimeTypeInfo]bool)) || schema.Kind != value.TYPE_CALLABLE || schema.CallableBare ||
+		len(schema.Params) != len(definition.Fields) || len(schema.ParamIsRef) != len(schema.Params) || schema.Return == nil ||
+		schema.Return.Kind != value.TYPE_STRUCT || schema.Return.Name != definition.Name {
+		return nil, false
+	}
+	return schema, true
 }
 
 func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
@@ -201,7 +214,8 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 		switch actual.Type {
 		case value.VAL_OBJ:
 			constructor, ok := actual.Obj.(*value.ObjStruct)
-			return ok && constructor != nil && runtimeTypeComplete(constructor.ConstructorType, make(map[*value.RuntimeTypeInfo]bool))
+			_, valid := validStructConstructorType(constructor)
+			return ok && valid
 		case value.VAL_FUNCTION:
 			switch callable := actual.Obj.(type) {
 			case *value.ObjClosure:
@@ -219,8 +233,8 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 	switch actual.Type {
 	case value.VAL_OBJ:
 		constructor, ok := actual.Obj.(*value.ObjStruct)
-		return ok && constructor != nil && runtimeTypeComplete(constructor.ConstructorType, make(map[*value.RuntimeTypeInfo]bool)) &&
-			runtimeTypeAccepts(expected, constructor.ConstructorType, make(map[runtimeTypePair]bool))
+		constructorType, valid := validStructConstructorType(constructor)
+		return ok && valid && runtimeTypeAccepts(expected, constructorType, make(map[runtimeTypePair]bool))
 	case value.VAL_FUNCTION:
 		var actualType *value.RuntimeTypeInfo
 		switch callable := actual.Obj.(type) {

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -68,6 +68,13 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 		if actual.Type != value.VAL_OBJ || !ok {
 			return false
 		}
+		if array.RuntimeType != nil {
+			if !runtimeTypeComplete(array.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, array.RuntimeType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+		} else if expected.Size > 0 || len(array.Elements) == 0 {
+			return false
+		}
 		for _, element := range array.Elements {
 			if !vm.runtimeValueMatchesType(element, expected.Element) {
 				return false
@@ -77,6 +84,13 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 	case value.TYPE_MAP:
 		mapping, ok := actual.Obj.(*value.ObjMap)
 		if actual.Type != value.VAL_OBJ || !ok {
+			return false
+		}
+		if mapping.RuntimeType != nil {
+			if !runtimeTypeComplete(mapping.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, mapping.RuntimeType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+		} else if len(mapping.Data) == 0 {
 			return false
 		}
 		for key, element := range mapping.Data {
@@ -204,6 +218,9 @@ type runtimeValueTypePair struct {
 // complete value graph compatible. It never replaces a conflicting marker or
 // changes the identity of the marked value.
 func (vm *VM) markRuntimeValueType(actual value.Value, schema *value.RuntimeTypeInfo) bool {
+	if !runtimeTypeComplete(schema, make(map[*value.RuntimeTypeInfo]bool)) {
+		return false
+	}
 	if !vm.walkRuntimeValueType(actual, schema, false, make(map[runtimeValueTypePair]bool)) {
 		return false
 	}
@@ -229,8 +246,17 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 		if runtimeValueTypeSeen(array, schema, seen) {
 			return true
 		}
+		effectiveSchema := schema
+		if array.RuntimeType != nil {
+			if !runtimeTypeComplete(array.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, array.RuntimeType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+			effectiveSchema = array.RuntimeType
+		} else if apply {
+			array.RuntimeType = schema
+		}
 		for _, element := range array.Elements {
-			if !vm.walkRuntimeValueType(element, schema.Element, apply, seen) {
+			if !vm.walkRuntimeValueType(element, effectiveSchema.Element, apply, seen) {
 				return false
 			}
 		}
@@ -243,8 +269,17 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 		if runtimeValueTypeSeen(mapping, schema, seen) {
 			return true
 		}
+		effectiveSchema := schema
+		if mapping.RuntimeType != nil {
+			if !runtimeTypeComplete(mapping.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, mapping.RuntimeType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+			effectiveSchema = mapping.RuntimeType
+		} else if apply {
+			mapping.RuntimeType = schema
+		}
 		for key, element := range mapping.Data {
-			if !runtimeMapKeyMatchesType(key, schema.Key) || !vm.walkRuntimeValueType(element, schema.Value, apply, seen) {
+			if !runtimeMapKeyMatchesType(key, effectiveSchema.Key) || !vm.walkRuntimeValueType(element, effectiveSchema.Value, apply, seen) {
 				return false
 			}
 		}
@@ -258,7 +293,13 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 			return true
 		}
 		resolved, err := vm.resolveReferenceValue(actual)
-		return err == nil && vm.walkRuntimeValueType(resolved, schema.Element, apply, seen)
+		if err != nil {
+			return false
+		}
+		if resolved.Type == value.VAL_NULL {
+			return true
+		}
+		return vm.walkRuntimeValueType(resolved, schema.Element, apply, seen)
 	case value.TYPE_STRUCT:
 		instance, ok := actual.Obj.(*value.ObjInstance)
 		if actual.Type != value.VAL_OBJ || !ok || instance == nil || instance.Struct == nil || instance.Struct.Name != schema.Name {

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -173,6 +173,9 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 	}
 	if expected.CallableBare {
 		switch actual.Type {
+		case value.VAL_OBJ:
+			constructor, ok := actual.Obj.(*value.ObjStruct)
+			return ok && constructor != nil && runtimeTypeComplete(constructor.ConstructorType, make(map[*value.RuntimeTypeInfo]bool))
 		case value.VAL_FUNCTION:
 			switch callable := actual.Obj.(type) {
 			case *value.ObjClosure:
@@ -188,6 +191,10 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 	}
 
 	switch actual.Type {
+	case value.VAL_OBJ:
+		constructor, ok := actual.Obj.(*value.ObjStruct)
+		return ok && constructor != nil && runtimeTypeComplete(constructor.ConstructorType, make(map[*value.RuntimeTypeInfo]bool)) &&
+			runtimeTypeAccepts(expected, constructor.ConstructorType, make(map[runtimeTypePair]bool))
 	case value.VAL_FUNCTION:
 		var actualType *value.RuntimeTypeInfo
 		switch callable := actual.Obj.(type) {

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -169,14 +169,14 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 		return actualType != nil && runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool))
 	case value.VAL_NATIVE:
 		native, ok := actual.Obj.(*value.ObjNative)
-		return ok && native != nil && nativeSignatureMatchesRuntimeType(native.Signature, expected)
+		return ok && native != nil && native.Fn != nil && nativeSignatureMatchesRuntimeType(native.Signature, expected)
 	default:
 		return false
 	}
 }
 
 func nativeSignatureMatchesRuntimeType(signature *value.NativeSignature, expected *value.RuntimeTypeInfo) bool {
-	if signature == nil || signature.Variadic || signature.Arity != len(expected.Params) || len(signature.Params) != len(expected.Params) || len(expected.ParamIsRef) != len(expected.Params) || expected.Return == nil {
+	if signature == nil || !runtimeTypeComplete(expected, make(map[*value.RuntimeTypeInfo]bool)) || signature.Variadic || signature.Arity != len(expected.Params) || len(signature.Params) != len(expected.Params) || len(expected.ParamIsRef) != len(expected.Params) || expected.Return == nil {
 		return false
 	}
 	if signature.ReturnType == "" || signature.ReturnType != expected.Return.String() {
@@ -325,7 +325,9 @@ func runtimeTypeAccepts(expected, actual *value.RuntimeTypeInfo, seen map[runtim
 	}
 	seen[pair] = true
 	switch expected.Kind {
-	case value.TYPE_ARRAY, value.TYPE_REF, value.TYPE_CHANNEL:
+	case value.TYPE_ARRAY:
+		return (expected.Size == 0 || expected.Size == actual.Size) && runtimeTypeAccepts(expected.Element, actual.Element, seen)
+	case value.TYPE_REF, value.TYPE_CHANNEL:
 		return runtimeTypeAccepts(expected.Element, actual.Element, seen)
 	case value.TYPE_MAP:
 		return runtimeTypeAccepts(expected.Key, actual.Key, seen) && runtimeTypeAccepts(expected.Value, actual.Value, seen)
@@ -335,16 +337,87 @@ func runtimeTypeAccepts(expected, actual *value.RuntimeTypeInfo, seen map[runtim
 		if expected.CallableBare {
 			return true
 		}
-		if actual.CallableBare || len(expected.Params) != len(actual.Params) || len(expected.ParamIsRef) != len(expected.Params) || len(actual.ParamIsRef) != len(actual.Params) {
+		return runtimeTypesEqual(expected, actual, make(map[runtimeTypePair]bool))
+	default:
+		return true
+	}
+}
+
+func runtimeTypesEqual(left, right *value.RuntimeTypeInfo, seen map[runtimeTypePair]bool) bool {
+	if left == nil || right == nil || left.Kind != right.Kind {
+		return false
+	}
+	pair := runtimeTypePair{expected: left, actual: right}
+	if seen[pair] {
+		return true
+	}
+	seen[pair] = true
+	switch left.Kind {
+	case value.TYPE_ARRAY:
+		return left.Size == right.Size && runtimeTypesEqual(left.Element, right.Element, seen)
+	case value.TYPE_MAP:
+		return runtimeTypesEqual(left.Key, right.Key, seen) && runtimeTypesEqual(left.Value, right.Value, seen)
+	case value.TYPE_REF, value.TYPE_CHANNEL:
+		return runtimeTypesEqual(left.Element, right.Element, seen)
+	case value.TYPE_STRUCT:
+		return left.Name == right.Name
+	case value.TYPE_CALLABLE:
+		if left.CallableBare || right.CallableBare {
+			return left.CallableBare == right.CallableBare
+		}
+		if len(left.Params) != len(right.Params) || len(left.ParamIsRef) != len(left.Params) || len(right.ParamIsRef) != len(right.Params) {
 			return false
 		}
-		for i := range expected.Params {
-			if expected.ParamIsRef[i] != actual.ParamIsRef[i] || !runtimeTypeAccepts(expected.Params[i], actual.Params[i], seen) {
+		for i := range left.Params {
+			if left.ParamIsRef[i] != right.ParamIsRef[i] || !runtimeTypesEqual(left.Params[i], right.Params[i], seen) {
 				return false
 			}
 		}
-		return runtimeTypeAccepts(expected.Return, actual.Return, seen)
+		return runtimeTypesEqual(left.Return, right.Return, seen)
 	default:
 		return true
+	}
+}
+
+func runtimeTypeComplete(schema *value.RuntimeTypeInfo, seen map[*value.RuntimeTypeInfo]bool) bool {
+	if schema == nil {
+		return false
+	}
+	if seen[schema] {
+		return true
+	}
+	seen[schema] = true
+	switch schema.Kind {
+	case value.TYPE_ARRAY, value.TYPE_REF, value.TYPE_CHANNEL:
+		return runtimeTypeComplete(schema.Element, seen)
+	case value.TYPE_MAP:
+		return runtimeTypeComplete(schema.Key, seen) && runtimeTypeComplete(schema.Value, seen)
+	case value.TYPE_STRUCT:
+		if schema.Name == "" {
+			return false
+		}
+		for _, field := range schema.Fields {
+			if !runtimeTypeComplete(field, seen) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_CALLABLE:
+		if schema.CallableBare {
+			return true
+		}
+		if len(schema.ParamIsRef) != len(schema.Params) || !runtimeTypeComplete(schema.Return, seen) {
+			return false
+		}
+		for _, param := range schema.Params {
+			if !runtimeTypeComplete(param, seen) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_ANY, value.TYPE_NULL, value.TYPE_BOOL, value.TYPE_INT, value.TYPE_FLOAT, value.TYPE_STRING, value.TYPE_BYTES, value.TYPE_VOID:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -1,6 +1,9 @@
 package vm
 
-import "noxy-vm/internal/value"
+import (
+	"fmt"
+	"noxy-vm/internal/value"
+)
 
 func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool {
 	if item.Type == value.VAL_REF {
@@ -52,6 +55,29 @@ func markReferenceTargetType(ref *value.ObjRef, targetType *value.RuntimeTypeInf
 			return true
 		}
 	}
+}
+
+func (vm *VM) validateStructConstructorArguments(definition *value.ObjStruct, args []value.Value) error {
+	if definition == nil || !runtimeTypeComplete(definition.ConstructorType, make(map[*value.RuntimeTypeInfo]bool)) {
+		return fmt.Errorf("struct constructor has incomplete runtime type metadata")
+	}
+	schema := definition.ConstructorType
+	if schema.Kind != value.TYPE_CALLABLE || schema.CallableBare || len(schema.Params) != len(args) || len(schema.ParamIsRef) != len(schema.Params) {
+		return fmt.Errorf("struct '%s' constructor has invalid runtime type metadata", definition.Name)
+	}
+	params := make([]value.ParamInfo, len(schema.Params))
+	for i, expected := range schema.Params {
+		params[i] = value.ParamInfo{IsRef: schema.ParamIsRef[i], TypeName: expected.String()}
+	}
+	if err := validateParameterModes(definition.Name, params, args); err != nil {
+		return err
+	}
+	for i, expected := range schema.Params {
+		if !vm.runtimeValueMatchesType(args[i], expected) {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got %s", definition.Name, i+1, expected.String(), runtimeValueMode(args[i]))
+		}
+	}
+	return nil
 }
 
 func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -1,0 +1,110 @@
+package vm
+
+import "noxy-vm/internal/value"
+
+func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool {
+	if item.Type == value.VAL_REF {
+		itemRef, ok := item.Obj.(*value.ObjRef)
+		if !ok || itemRef == nil {
+			return false
+		}
+	}
+	if target == nil || target.TargetType == nil {
+		return true
+	}
+	arrayType := target.TargetType
+	if arrayType.Kind != value.TYPE_ARRAY || arrayType.Element == nil {
+		return false
+	}
+	elementType := arrayType.Element
+	if elementType.Kind != value.TYPE_REF {
+		if item.Type == value.VAL_REF {
+			return false
+		}
+		return runtimeValueMatchesType(item, elementType)
+	}
+	if item.Type == value.VAL_NULL {
+		return true
+	}
+	if item.Type != value.VAL_REF || elementType.Element == nil {
+		return false
+	}
+	resolved, err := vm.resolveReferenceValue(item)
+	if err != nil {
+		return false
+	}
+	return runtimeValueMatchesType(resolved, elementType.Element)
+}
+
+func runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
+	if expected == nil || expected.Kind == value.TYPE_ANY {
+		return true
+	}
+	if actual.Type == value.VAL_NULL {
+		return expected.Kind == value.TYPE_NULL || expected.Kind == value.TYPE_REF || expected.Kind == value.TYPE_STRUCT
+	}
+	switch expected.Kind {
+	case value.TYPE_NULL:
+		return false
+	case value.TYPE_BOOL:
+		return actual.Type == value.VAL_BOOL
+	case value.TYPE_INT:
+		return actual.Type == value.VAL_INT
+	case value.TYPE_FLOAT:
+		return actual.Type == value.VAL_FLOAT
+	case value.TYPE_STRING:
+		if actual.Type != value.VAL_OBJ {
+			return false
+		}
+		_, ok := actual.Obj.(string)
+		return ok
+	case value.TYPE_BYTES:
+		return actual.Type == value.VAL_BYTES
+	case value.TYPE_ARRAY:
+		array, ok := actual.Obj.(*value.ObjArray)
+		if actual.Type != value.VAL_OBJ || !ok {
+			return false
+		}
+		for _, element := range array.Elements {
+			if !runtimeValueMatchesType(element, expected.Element) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_MAP:
+		mapping, ok := actual.Obj.(*value.ObjMap)
+		if actual.Type != value.VAL_OBJ || !ok {
+			return false
+		}
+		for key, element := range mapping.Data {
+			if !runtimeMapKeyMatchesType(key, expected.Key) || !runtimeValueMatchesType(element, expected.Value) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_REF:
+		ref, ok := actual.Obj.(*value.ObjRef)
+		return actual.Type == value.VAL_REF && ok && ref != nil
+	case value.TYPE_STRUCT:
+		instance, ok := actual.Obj.(*value.ObjInstance)
+		return actual.Type == value.VAL_OBJ && ok && instance.Struct != nil && instance.Struct.Name == expected.Name
+	default:
+		return false
+	}
+}
+
+func runtimeMapKeyMatchesType(key interface{}, expected *value.RuntimeTypeInfo) bool {
+	if expected == nil || expected.Kind == value.TYPE_ANY {
+		return true
+	}
+	switch expected.Kind {
+	case value.TYPE_INT:
+		_, ok := key.(int64)
+		return ok
+	case value.TYPE_STRING:
+		_, ok := key.(string)
+		return ok
+	default:
+		return false
+	}
+}

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -37,7 +37,10 @@ func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool 
 }
 
 func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
-	if expected == nil || expected.Kind == value.TYPE_ANY {
+	if expected == nil {
+		return false
+	}
+	if expected.Kind == value.TYPE_ANY {
 		return true
 	}
 	if actual.Type == value.VAL_NULL {
@@ -92,13 +95,30 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 	case value.TYPE_STRUCT:
 		instance, ok := actual.Obj.(*value.ObjInstance)
 		return actual.Type == value.VAL_OBJ && ok && instance.Struct != nil && instance.Struct.Name == expected.Name
+	case value.TYPE_CALLABLE:
+		return runtimeCallableMatchesType(actual, expected)
+	case value.TYPE_CHANNEL:
+		channel, ok := actual.Obj.(*value.ObjChannel)
+		if actual.Type != value.VAL_CHANNEL || !ok || channel == nil || expected.Element == nil {
+			return false
+		}
+		channel.Lock.Lock()
+		elementType := channel.ElementType
+		channel.Lock.Unlock()
+		if elementType == nil {
+			return expected.Element.Kind == value.TYPE_ANY
+		}
+		return runtimeTypeAccepts(expected.Element, elementType, make(map[runtimeTypePair]bool))
 	default:
 		return false
 	}
 }
 
 func runtimeMapKeyMatchesType(key interface{}, expected *value.RuntimeTypeInfo) bool {
-	if expected == nil || expected.Kind == value.TYPE_ANY {
+	if expected == nil {
+		return false
+	}
+	if expected.Kind == value.TYPE_ANY {
 		return true
 	}
 	switch expected.Kind {
@@ -110,5 +130,221 @@ func runtimeMapKeyMatchesType(key interface{}, expected *value.RuntimeTypeInfo) 
 		return ok
 	default:
 		return false
+	}
+}
+
+func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
+	if expected == nil || expected.Kind != value.TYPE_CALLABLE {
+		return false
+	}
+	if expected.CallableBare {
+		switch actual.Type {
+		case value.VAL_FUNCTION:
+			switch callable := actual.Obj.(type) {
+			case *value.ObjClosure:
+				return callable != nil && callable.Function != nil
+			case *value.ObjFunction:
+				return callable != nil
+			}
+		case value.VAL_NATIVE:
+			native, ok := actual.Obj.(*value.ObjNative)
+			return ok && native != nil && native.Fn != nil
+		}
+		return false
+	}
+
+	switch actual.Type {
+	case value.VAL_FUNCTION:
+		var actualType *value.RuntimeTypeInfo
+		switch callable := actual.Obj.(type) {
+		case *value.ObjClosure:
+			if callable != nil && callable.Function != nil {
+				actualType = callable.Function.RuntimeType
+			}
+		case *value.ObjFunction:
+			if callable != nil {
+				actualType = callable.RuntimeType
+			}
+		}
+		return actualType != nil && runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool))
+	case value.VAL_NATIVE:
+		native, ok := actual.Obj.(*value.ObjNative)
+		return ok && native != nil && nativeSignatureMatchesRuntimeType(native.Signature, expected)
+	default:
+		return false
+	}
+}
+
+func nativeSignatureMatchesRuntimeType(signature *value.NativeSignature, expected *value.RuntimeTypeInfo) bool {
+	if signature == nil || signature.Variadic || signature.Arity != len(expected.Params) || len(signature.Params) != len(expected.Params) || len(expected.ParamIsRef) != len(expected.Params) || expected.Return == nil {
+		return false
+	}
+	if signature.ReturnType == "" || signature.ReturnType != expected.Return.String() {
+		return false
+	}
+	for i, param := range signature.Params {
+		if param.TypeName == "" || param.IsRef != expected.ParamIsRef[i] || param.TypeName != expected.Params[i].String() {
+			return false
+		}
+	}
+	return true
+}
+
+type runtimeTypePair struct {
+	expected *value.RuntimeTypeInfo
+	actual   *value.RuntimeTypeInfo
+}
+
+type runtimeValueTypePair struct {
+	object interface{}
+	schema *value.RuntimeTypeInfo
+}
+
+// markRuntimeValueType records channel element metadata only after proving the
+// complete value graph compatible. It never replaces a conflicting marker or
+// changes the identity of the marked value.
+func (vm *VM) markRuntimeValueType(actual value.Value, schema *value.RuntimeTypeInfo) bool {
+	if !vm.walkRuntimeValueType(actual, schema, false, make(map[runtimeValueTypePair]bool)) {
+		return false
+	}
+	return vm.walkRuntimeValueType(actual, schema, true, make(map[runtimeValueTypePair]bool))
+}
+
+func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeTypeInfo, apply bool, seen map[runtimeValueTypePair]bool) bool {
+	if schema == nil {
+		return false
+	}
+	if schema.Kind == value.TYPE_ANY {
+		return true
+	}
+	if actual.Type == value.VAL_NULL {
+		return schema.Kind == value.TYPE_NULL || schema.Kind == value.TYPE_REF || schema.Kind == value.TYPE_STRUCT
+	}
+	switch schema.Kind {
+	case value.TYPE_ARRAY:
+		array, ok := actual.Obj.(*value.ObjArray)
+		if actual.Type != value.VAL_OBJ || !ok || array == nil || schema.Element == nil {
+			return false
+		}
+		if runtimeValueTypeSeen(array, schema, seen) {
+			return true
+		}
+		for _, element := range array.Elements {
+			if !vm.walkRuntimeValueType(element, schema.Element, apply, seen) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_MAP:
+		mapping, ok := actual.Obj.(*value.ObjMap)
+		if actual.Type != value.VAL_OBJ || !ok || mapping == nil || schema.Key == nil || schema.Value == nil {
+			return false
+		}
+		if runtimeValueTypeSeen(mapping, schema, seen) {
+			return true
+		}
+		for key, element := range mapping.Data {
+			if !runtimeMapKeyMatchesType(key, schema.Key) || !vm.walkRuntimeValueType(element, schema.Value, apply, seen) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_REF:
+		ref, ok := actual.Obj.(*value.ObjRef)
+		if actual.Type != value.VAL_REF || !ok || ref == nil || schema.Element == nil {
+			return false
+		}
+		if runtimeValueTypeSeen(ref, schema, seen) {
+			return true
+		}
+		resolved, err := vm.resolveReferenceValue(actual)
+		return err == nil && vm.walkRuntimeValueType(resolved, schema.Element, apply, seen)
+	case value.TYPE_STRUCT:
+		instance, ok := actual.Obj.(*value.ObjInstance)
+		if actual.Type != value.VAL_OBJ || !ok || instance == nil || instance.Struct == nil || instance.Struct.Name != schema.Name {
+			return false
+		}
+		if runtimeValueTypeSeen(instance, schema, seen) {
+			return true
+		}
+		for name, fieldSchema := range schema.Fields {
+			field, exists := instance.Fields[name]
+			if !exists || !vm.walkRuntimeValueType(field, fieldSchema, apply, seen) {
+				return false
+			}
+		}
+		return true
+	case value.TYPE_CHANNEL:
+		channel, ok := actual.Obj.(*value.ObjChannel)
+		if actual.Type != value.VAL_CHANNEL || !ok || channel == nil || schema.Element == nil {
+			return false
+		}
+		if runtimeValueTypeSeen(channel, schema, seen) {
+			return true
+		}
+		channel.Lock.Lock()
+		defer channel.Lock.Unlock()
+		if channel.ElementType != nil && !runtimeTypeAccepts(schema.Element, channel.ElementType, make(map[runtimeTypePair]bool)) {
+			return false
+		}
+		if apply && channel.ElementType == nil {
+			channel.ElementType = schema.Element
+		}
+		return true
+	case value.TYPE_CALLABLE:
+		return runtimeCallableMatchesType(actual, schema)
+	default:
+		return vm.runtimeValueMatchesType(actual, schema)
+	}
+}
+
+func runtimeValueTypeSeen(object interface{}, schema *value.RuntimeTypeInfo, seen map[runtimeValueTypePair]bool) bool {
+	pair := runtimeValueTypePair{object: object, schema: schema}
+	if seen[pair] {
+		return true
+	}
+	seen[pair] = true
+	return false
+}
+
+// runtimeTypeAccepts compares runtime schemas without following recursive
+// struct definitions forever. TYPE_ANY is the sole schema wildcard.
+func runtimeTypeAccepts(expected, actual *value.RuntimeTypeInfo, seen map[runtimeTypePair]bool) bool {
+	if expected == nil || actual == nil {
+		return false
+	}
+	if expected.Kind == value.TYPE_ANY {
+		return true
+	}
+	if expected.Kind != actual.Kind {
+		return false
+	}
+	pair := runtimeTypePair{expected: expected, actual: actual}
+	if seen[pair] {
+		return true
+	}
+	seen[pair] = true
+	switch expected.Kind {
+	case value.TYPE_ARRAY, value.TYPE_REF, value.TYPE_CHANNEL:
+		return runtimeTypeAccepts(expected.Element, actual.Element, seen)
+	case value.TYPE_MAP:
+		return runtimeTypeAccepts(expected.Key, actual.Key, seen) && runtimeTypeAccepts(expected.Value, actual.Value, seen)
+	case value.TYPE_STRUCT:
+		return expected.Name == actual.Name
+	case value.TYPE_CALLABLE:
+		if expected.CallableBare {
+			return true
+		}
+		if actual.CallableBare || len(expected.Params) != len(actual.Params) || len(expected.ParamIsRef) != len(expected.Params) || len(actual.ParamIsRef) != len(actual.Params) {
+			return false
+		}
+		for i := range expected.Params {
+			if expected.ParamIsRef[i] != actual.ParamIsRef[i] || !runtimeTypeAccepts(expected.Params[i], actual.Params[i], seen) {
+				return false
+			}
+		}
+		return runtimeTypeAccepts(expected.Return, actual.Return, seen)
+	default:
+		return true
 	}
 }

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -9,10 +9,13 @@ func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool 
 			return false
 		}
 	}
-	if target == nil || target.TargetType == nil {
+	if target == nil {
 		return true
 	}
-	arrayType := target.TargetType
+	arrayType := target.TargetType.Load()
+	if arrayType == nil {
+		return true
+	}
 	if arrayType.Kind != value.TYPE_ARRAY || arrayType.Element == nil {
 		return false
 	}
@@ -34,6 +37,21 @@ func (vm *VM) appendItemCompatible(target *value.ObjRef, item value.Value) bool 
 		return false
 	}
 	return vm.runtimeValueMatchesType(resolved, elementType.Element)
+}
+
+func markReferenceTargetType(ref *value.ObjRef, targetType *value.RuntimeTypeInfo) bool {
+	if ref == nil || targetType == nil {
+		return false
+	}
+	for {
+		existing := ref.TargetType.Load()
+		if existing != nil {
+			return runtimeTypeAccepts(targetType, existing, make(map[runtimeTypePair]bool))
+		}
+		if ref.TargetType.CompareAndSwap(nil, targetType) {
+			return true
+		}
+	}
 }
 
 func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.RuntimeTypeInfo) bool {
@@ -68,8 +86,9 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 		if actual.Type != value.VAL_OBJ || !ok {
 			return false
 		}
-		if array.RuntimeType != nil {
-			if !runtimeTypeComplete(array.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, array.RuntimeType, make(map[runtimeTypePair]bool)) {
+		actualType := array.RuntimeType.Load()
+		if actualType != nil {
+			if !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool)) {
 				return false
 			}
 		} else if expected.Size > 0 || len(array.Elements) == 0 {
@@ -86,8 +105,9 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 		if actual.Type != value.VAL_OBJ || !ok {
 			return false
 		}
-		if mapping.RuntimeType != nil {
-			if !runtimeTypeComplete(mapping.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, mapping.RuntimeType, make(map[runtimeTypePair]bool)) {
+		actualType := mapping.RuntimeType.Load()
+		if actualType != nil {
+			if !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool)) {
 				return false
 			}
 		} else if len(mapping.Data) == 0 {
@@ -247,13 +267,18 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 			return true
 		}
 		effectiveSchema := schema
-		if array.RuntimeType != nil {
-			if !runtimeTypeComplete(array.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, array.RuntimeType, make(map[runtimeTypePair]bool)) {
+		actualType := array.RuntimeType.Load()
+		if actualType != nil {
+			if !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, actualType, make(map[runtimeTypePair]bool)) {
 				return false
 			}
-			effectiveSchema = array.RuntimeType
-		} else if apply {
-			array.RuntimeType = schema
+			effectiveSchema = actualType
+		} else if apply && !array.RuntimeType.CompareAndSwap(nil, schema) {
+			actualType = array.RuntimeType.Load()
+			if actualType == nil || !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, actualType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+			effectiveSchema = actualType
 		}
 		for _, element := range array.Elements {
 			if !vm.walkRuntimeValueType(element, effectiveSchema.Element, apply, seen) {
@@ -270,13 +295,18 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 			return true
 		}
 		effectiveSchema := schema
-		if mapping.RuntimeType != nil {
-			if !runtimeTypeComplete(mapping.RuntimeType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, mapping.RuntimeType, make(map[runtimeTypePair]bool)) {
+		actualType := mapping.RuntimeType.Load()
+		if actualType != nil {
+			if !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, actualType, make(map[runtimeTypePair]bool)) {
 				return false
 			}
-			effectiveSchema = mapping.RuntimeType
-		} else if apply {
-			mapping.RuntimeType = schema
+			effectiveSchema = actualType
+		} else if apply && !mapping.RuntimeType.CompareAndSwap(nil, schema) {
+			actualType = mapping.RuntimeType.Load()
+			if actualType == nil || !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(schema, actualType, make(map[runtimeTypePair]bool)) {
+				return false
+			}
+			effectiveSchema = actualType
 		}
 		for key, element := range mapping.Data {
 			if !runtimeMapKeyMatchesType(key, effectiveSchema.Key) || !vm.walkRuntimeValueType(element, effectiveSchema.Value, apply, seen) {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -4724,10 +4724,14 @@ func (vm *VM) run(minFrameCount int) error {
 
 func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
 	if callee.Type == value.VAL_OBJ {
-		if structDef, ok := callee.Obj.(*value.ObjStruct); ok {
+		if structDef, ok := callee.Obj.(*value.ObjStruct); ok && structDef != nil {
 			// Instantiate
 			if argCount != len(structDef.Fields) {
 				return false, vm.runtimeError(c, ip, "expected %d arguments for struct %s but got %d", len(structDef.Fields), structDef.Name, argCount)
+			}
+			args := vm.stack[vm.stackTop-argCount : vm.stackTop]
+			if err := vm.validateStructConstructorArguments(structDef, args); err != nil {
+				return false, vm.runtimeError(c, ip, "%s", err)
 			}
 
 			instance := value.NewInstance(structDef)

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3372,72 +3372,8 @@ func populateObj(vm *VM, currentVal value.Value, data interface{}) bool {
 
 // Helper: Populate a Reference with Go Data (Deeply)
 func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
-	var currentVal value.Value
-	var store func(value.Value)
-
-	// Dereference
-	switch ref.RefType {
-	case value.REF_GLOBAL:
-		var err error
-		currentVal, err = vm.lookupGlobalReferenceValue(ref)
-		if err != nil {
-			return false
-		}
-		store = func(updated value.Value) { _ = vm.storeGlobalReferenceValue(ref, updated) }
-	case value.REF_UPVALUE:
-		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
-			return false
-		}
-		currentVal = *ref.Upvalue.Location
-		store = func(updated value.Value) { *ref.Upvalue.Location = updated }
-	case value.REF_PTR:
-		if ref.Ptr == nil {
-			return false
-		}
-		currentVal = *ref.Ptr
-		store = func(updated value.Value) { *ref.Ptr = updated }
-	case value.REF_PROPERTY:
-		inst, ok := ref.Container.Obj.(*value.ObjInstance)
-		if !ok {
-			return false
-		}
-		currentVal, ok = inst.Fields[ref.Name]
-		if !ok {
-			return false
-		}
-		store = func(updated value.Value) { inst.Fields[ref.Name] = updated }
-	case value.REF_INDEX:
-		if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-			if ref.Index.Type != value.VAL_INT {
-				return false
-			}
-			idx := int(ref.Index.AsInt)
-			if idx < 0 || idx >= len(arr.Elements) {
-				return false
-			}
-			currentVal = arr.Elements[idx]
-			store = func(updated value.Value) { arr.Elements[idx] = updated }
-			break
-		}
-		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ok {
-			key, err := referenceMapKey(ref.Index)
-			if err != nil {
-				return false
-			}
-			var exists bool
-			currentVal, exists = mapping.Data[key]
-			if !exists {
-				return false
-			}
-			store = func(updated value.Value) { mapping.Data[key] = updated }
-			break
-		}
-		return false
-	default:
-		return false
-	}
-
-	if store == nil {
+	currentVal, exists, store, err := vm.referenceStorage(ref)
+	if err != nil || !exists || store == nil {
 		return false
 	}
 	if ref.JSONDynamic {
@@ -3448,7 +3384,7 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 		store(replacement)
 		return true
 	}
-	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType, data, store)
+	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType, data, jsonSetter(store))
 	if !ok {
 		return false
 	}
@@ -3658,7 +3594,13 @@ func (vm *VM) run(minFrameCount int) error {
 		case chunk.OP_ADDR:
 			val := vm.pop()
 			if val.Type == value.VAL_REF {
-				ref := val.Obj.(*value.ObjRef)
+				ref, err := extractReferenceValue(val)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				if _, _, _, err := vm.referenceStorage(ref); err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
 				addrStr := ""
 				switch ref.RefType {
 				case value.REF_PTR:
@@ -3785,34 +3727,11 @@ func (vm *VM) run(minFrameCount int) error {
 
 			// Auto-dereference if container is a ref
 			if container.Type == value.VAL_REF {
-				ref := container.Obj.(*value.ObjRef)
-				switch ref.RefType {
-				case value.REF_GLOBAL:
-					val, err := vm.lookupGlobalReferenceValue(ref)
-					if err != nil {
-						return vm.runtimeError(c, ip, "%s", err)
-					}
-					container = val
-				case value.REF_UPVALUE:
-					container = *ref.Upvalue.Location
-				case value.REF_PTR:
-					container = *ref.Ptr
-				case value.REF_PROPERTY:
-					if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-						if val, ok := inst.Fields[ref.Name]; ok {
-							container = val
-						} else {
-							container = value.NewNull()
-						}
-					}
-				case value.REF_INDEX:
-					if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-						idx := int(ref.Index.AsInt)
-						if idx >= 0 && idx < len(arr.Elements) {
-							container = arr.Elements[idx]
-						}
-					}
+				resolved, err := vm.resolveReferenceValue(container)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
+				container = resolved
 			}
 
 			// Now check container type
@@ -3954,7 +3873,7 @@ func (vm *VM) run(minFrameCount int) error {
 				// Not a ref - pass through as-is (already dereferenced)
 				vm.push(refVal)
 			} else {
-				resolved, err := vm.lookupReferenceValue(refVal.Obj.(*value.ObjRef))
+				resolved, err := vm.resolveReferenceValue(refVal)
 				if err != nil {
 					return vm.runtimeError(c, ip, "%s", err)
 				}
@@ -3968,99 +3887,15 @@ func (vm *VM) run(minFrameCount int) error {
 			// The reference itself is in a local variable (e.g., parameter 'x')
 			refVal := vm.stack[frame.Slots+slot]
 
-			if refVal.Type != value.VAL_REF {
-				return vm.runtimeError(c, ip, "Cannot store via non-ref variable")
-			}
-
-			ref := refVal.Obj.(*value.ObjRef)
-
-			switch ref.RefType {
-			case value.REF_GLOBAL:
-				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-			case value.REF_UPVALUE:
-				// Write to Upvalue
-				*ref.Upvalue.Location = val
-			case value.REF_PTR:
-				// Local assignment: Write to Ptr
-				*ref.Ptr = val
-			case value.REF_PROPERTY:
-				if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-					inst.Fields[ref.Name] = val
-				} else {
-					return vm.runtimeError(c, ip, "Target is not an instance")
-				}
-			case value.REF_INDEX:
-				if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-					idx := int(ref.Index.AsInt)
-					if idx < 0 || idx >= len(arr.Elements) {
-						return vm.runtimeError(c, ip, "Index out of bounds")
-					}
-					arr.Elements[idx] = val
-				} else if m, ok := ref.Container.Obj.(*value.ObjMap); ok {
-					// Map Write
-					var key interface{}
-					if ref.Index.Type == value.VAL_OBJ {
-						if s, ok := ref.Index.Obj.(string); ok {
-							key = s
-						} else {
-							return vm.runtimeError(c, ip, "Map key must be string (simple ref support)")
-						}
-					} else if ref.Index.Type == value.VAL_INT {
-						key = ref.Index.AsInt
-					}
-					m.Data[key] = val
-				}
+			if err := vm.storeReferenceValue(refVal, val); err != nil {
+				return vm.runtimeError(c, ip, "%s", err)
 			}
 		case chunk.OP_STORE_REF:
 			val := vm.pop()    // Value to assign
 			refVal := vm.pop() // The reference itself (popped from stack)
 
-			if refVal.Type == value.VAL_NULL {
-				return vm.runtimeError(c, ip, "cannot update null reference")
-			}
-			if refVal.Type != value.VAL_REF {
-				return vm.runtimeError(c, ip, "cannot store via non-reference value")
-			}
-
-			ref := refVal.Obj.(*value.ObjRef)
-
-			switch ref.RefType {
-			case value.REF_GLOBAL:
-				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-			case value.REF_UPVALUE:
-				*ref.Upvalue.Location = val
-			case value.REF_PTR:
-				*ref.Ptr = val
-			case value.REF_PROPERTY:
-				if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-					inst.Fields[ref.Name] = val
-				} else {
-					return vm.runtimeError(c, ip, "Target is not an instance")
-				}
-			case value.REF_INDEX:
-				if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-					idx := int(ref.Index.AsInt)
-					if idx < 0 || idx >= len(arr.Elements) {
-						return vm.runtimeError(c, ip, "Index out of bounds")
-					}
-					arr.Elements[idx] = val
-				} else if m, ok := ref.Container.Obj.(*value.ObjMap); ok {
-					var key interface{}
-					if ref.Index.Type == value.VAL_OBJ {
-						if s, ok := ref.Index.Obj.(string); ok {
-							key = s
-						} else {
-							return vm.runtimeError(c, ip, "Map key must be string")
-						}
-					} else if ref.Index.Type == value.VAL_INT {
-						key = ref.Index.AsInt
-					}
-					m.Data[key] = val
-				}
+			if err := vm.storeReferenceValue(refVal, val); err != nil {
+				return vm.runtimeError(c, ip, "%s", err)
 			}
 
 		case chunk.OP_ADD:
@@ -4748,34 +4583,11 @@ func (vm *VM) run(minFrameCount int) error {
 
 			// Auto-dereference if instance is a ref
 			if instanceVal.Type == value.VAL_REF {
-				ref := instanceVal.Obj.(*value.ObjRef)
-				switch ref.RefType {
-				case value.REF_GLOBAL:
-					v, err := vm.lookupGlobalReferenceValue(ref)
-					if err != nil {
-						return vm.runtimeError(c, ip, "%s", err)
-					}
-					instanceVal = v
-				case value.REF_UPVALUE:
-					instanceVal = *ref.Upvalue.Location
-				case value.REF_PTR:
-					instanceVal = *ref.Ptr
-				case value.REF_PROPERTY:
-					if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-						if v, ok := inst.Fields[ref.Name]; ok {
-							instanceVal = v
-						} else {
-							instanceVal = value.NewNull()
-						}
-					}
-				case value.REF_INDEX:
-					if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-						idx := int(ref.Index.AsInt)
-						if idx >= 0 && idx < len(arr.Elements) {
-							instanceVal = arr.Elements[idx]
-						}
-					}
+				resolved, err := vm.resolveReferenceValue(instanceVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
+				instanceVal = resolved
 			}
 
 			if instanceVal.Type != value.VAL_OBJ {
@@ -4811,34 +4623,11 @@ func (vm *VM) run(minFrameCount int) error {
 			// Auto-dereference if instance is a ref
 
 			if instanceVal.Type == value.VAL_REF {
-				ref := instanceVal.Obj.(*value.ObjRef)
-				switch ref.RefType {
-				case value.REF_GLOBAL:
-					v, err := vm.lookupGlobalReferenceValue(ref)
-					if err != nil {
-						return vm.runtimeError(c, ip, "%s", err)
-					}
-					instanceVal = v
-				case value.REF_UPVALUE:
-					instanceVal = *ref.Upvalue.Location
-				case value.REF_PTR:
-					instanceVal = *ref.Ptr
-				case value.REF_PROPERTY:
-					if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-						if v, ok := inst.Fields[ref.Name]; ok {
-							instanceVal = v
-						} else {
-							instanceVal = value.NewNull()
-						}
-					}
-				case value.REF_INDEX:
-					if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-						idx := int(ref.Index.AsInt)
-						if idx >= 0 && idx < len(arr.Elements) {
-							instanceVal = arr.Elements[idx]
-						}
-					}
+				resolved, err := vm.resolveReferenceValue(instanceVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
+				instanceVal = resolved
 			}
 
 			if instanceVal.Type != value.VAL_OBJ {
@@ -4863,26 +4652,11 @@ func (vm *VM) run(minFrameCount int) error {
 
 			// Expect Instance (Can be Ref to Instance)
 			if instanceVal.Type == value.VAL_REF {
-				// Deref container first
-				ref := instanceVal.Obj.(*value.ObjRef)
-				switch ref.RefType {
-				case value.REF_GLOBAL:
-					v, err := vm.lookupGlobalReferenceValue(ref)
-					if err != nil {
-						return vm.runtimeError(c, ip, "%s", err)
-					}
-					instanceVal = v
-				case value.REF_UPVALUE:
-					instanceVal = *ref.Upvalue.Location
-				case value.REF_PTR:
-					instanceVal = *ref.Ptr
-				case value.REF_PROPERTY:
-					if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-						if v, ok := inst.Fields[ref.Name]; ok {
-							instanceVal = v
-						}
-					}
+				resolved, err := vm.resolveReferenceValue(instanceVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
+				instanceVal = resolved
 			}
 
 			if instanceVal.Type != value.VAL_OBJ {
@@ -4902,33 +4676,8 @@ func (vm *VM) run(minFrameCount int) error {
 			if fieldVal.Type != value.VAL_REF {
 				return vm.runtimeError(c, ip, "property '%s' is not a reference", name)
 			}
-
-			// Write Value to Reference -> Duplicate OP_STORE_REF logic
-			ref := fieldVal.Obj.(*value.ObjRef)
-			switch ref.RefType {
-			case value.REF_GLOBAL:
-				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-			case value.REF_UPVALUE:
-				*ref.Upvalue.Location = val
-			case value.REF_PTR:
-				*ref.Ptr = val
-			case value.REF_PROPERTY:
-				if targetInst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-					targetInst.Fields[ref.Name] = val
-				} else {
-					return vm.runtimeError(c, ip, "Target is not an instance")
-				}
-			case value.REF_INDEX:
-				// ... (Dup logic) ...
-				if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-					idx := int(ref.Index.AsInt)
-					if idx < 0 || idx >= len(arr.Elements) {
-						return vm.runtimeError(c, ip, "Index out of bounds")
-					}
-					arr.Elements[idx] = val
-				}
+			if err := vm.storeReferenceValue(fieldVal, val); err != nil {
+				return vm.runtimeError(c, ip, "%s", err)
 			}
 			vm.push(val)
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3877,7 +3877,9 @@ func (vm *VM) run(minFrameCount int) error {
 			if typeValue.Type != value.VAL_OBJ || !ok || runtimeType == nil {
 				return vm.runtimeError(c, ip, "runtime value marker requires type metadata")
 			}
-			vm.markRuntimeValueType(vm.peek(0), runtimeType)
+			if !vm.markRuntimeValueType(vm.peek(0), runtimeType) {
+				return vm.runtimeError(c, ip, "runtime value metadata conflicts with static context")
+			}
 
 		case chunk.OP_DEREF:
 			refVal := vm.pop()
@@ -4844,13 +4846,13 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 	case *value.ObjArray:
 		newElems := make([]value.Value, len(obj.Elements))
 		copy(newElems, obj.Elements)
-		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjArray{Elements: newElems}}
+		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjArray{Elements: newElems, RuntimeType: obj.RuntimeType}}
 	case *value.ObjMap:
 		newData := make(map[interface{}]value.Value)
 		for k, val := range obj.Data {
 			newData[k] = val
 		}
-		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjMap{Data: newData}}
+		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjMap{Data: newData, RuntimeType: obj.RuntimeType}}
 	case *value.ObjInstance:
 		newFields := make(map[string]value.Value)
 		for k, val := range obj.Fields {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3378,21 +3378,12 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 	// Dereference
 	switch ref.RefType {
 	case value.REF_GLOBAL:
-		if vm.currentFrame != nil && vm.currentFrame.Globals != nil {
-			if frameValue, ok := vm.currentFrame.Globals[ref.Name]; ok {
-				currentVal = frameValue
-				store = func(updated value.Value) {
-					vm.currentFrame.Globals[ref.Name] = updated
-				}
-				break
-			}
-		}
-		sharedValue, ok := vm.GetGlobal(ref.Name)
-		if !ok {
+		var err error
+		currentVal, err = vm.lookupGlobalReferenceValue(ref)
+		if err != nil {
 			return false
 		}
-		currentVal = sharedValue
-		store = func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }
+		store = func(updated value.Value) { _ = vm.storeGlobalReferenceValue(ref, updated) }
 	case value.REF_UPVALUE:
 		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
 			return false
@@ -3762,11 +3753,16 @@ func (vm *VM) run(minFrameCount int) error {
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
 
+			owner := &frame.Globals
+			if frame.Globals == nil {
+				owner = &vm.shared.Globals
+			}
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
-					RefType: value.REF_GLOBAL,
-					Name:    name,
+					RefType:     value.REF_GLOBAL,
+					Name:        name,
+					GlobalOwner: owner,
 				},
 			})
 
@@ -3784,12 +3780,9 @@ func (vm *VM) run(minFrameCount int) error {
 				ref := container.Obj.(*value.ObjRef)
 				switch ref.RefType {
 				case value.REF_GLOBAL:
-					val, ok := frame.Globals[ref.Name]
-					if !ok {
-						val, ok = vm.GetGlobal(ref.Name)
-						if !ok {
-							return vm.runtimeError(c, ip, "undefined global variable '%s'", ref.Name)
-						}
+					val, err := vm.lookupGlobalReferenceValue(ref)
+					if err != nil {
+						return vm.runtimeError(c, ip, "%s", err)
 					}
 					container = val
 				case value.REF_UPVALUE:
@@ -3953,7 +3946,7 @@ func (vm *VM) run(minFrameCount int) error {
 				// Not a ref - pass through as-is (already dereferenced)
 				vm.push(refVal)
 			} else {
-				resolved, err := vm.lookupReferenceValue(refVal.Obj.(*value.ObjRef), frame.Globals)
+				resolved, err := vm.lookupReferenceValue(refVal.Obj.(*value.ObjRef))
 				if err != nil {
 					return vm.runtimeError(c, ip, "%s", err)
 				}
@@ -3975,11 +3968,8 @@ func (vm *VM) run(minFrameCount int) error {
 
 			switch ref.RefType {
 			case value.REF_GLOBAL:
-				// Global assignment
-				if _, ok := frame.Globals[ref.Name]; ok {
-					frame.Globals[ref.Name] = val
-				} else {
-					vm.SetGlobal(ref.Name, val)
+				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
 			case value.REF_UPVALUE:
 				// Write to Upvalue
@@ -4030,11 +4020,8 @@ func (vm *VM) run(minFrameCount int) error {
 
 			switch ref.RefType {
 			case value.REF_GLOBAL:
-				// Global assignment
-				if _, ok := frame.Globals[ref.Name]; ok {
-					frame.Globals[ref.Name] = val
-				} else {
-					vm.SetGlobal(ref.Name, val)
+				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
 			case value.REF_UPVALUE:
 				*ref.Upvalue.Location = val
@@ -4756,12 +4743,9 @@ func (vm *VM) run(minFrameCount int) error {
 				ref := instanceVal.Obj.(*value.ObjRef)
 				switch ref.RefType {
 				case value.REF_GLOBAL:
-					v, ok := frame.Globals[ref.Name]
-					if !ok {
-						v, ok = vm.GetGlobal(ref.Name)
-						if !ok {
-							return vm.runtimeError(c, ip, "undefined global variable '%s'", ref.Name)
-						}
+					v, err := vm.lookupGlobalReferenceValue(ref)
+					if err != nil {
+						return vm.runtimeError(c, ip, "%s", err)
 					}
 					instanceVal = v
 				case value.REF_UPVALUE:
@@ -4822,12 +4806,9 @@ func (vm *VM) run(minFrameCount int) error {
 				ref := instanceVal.Obj.(*value.ObjRef)
 				switch ref.RefType {
 				case value.REF_GLOBAL:
-					v, ok := frame.Globals[ref.Name]
-					if !ok {
-						v, ok = vm.GetGlobal(ref.Name)
-						if !ok {
-							return vm.runtimeError(c, ip, "undefined global variable '%s'", ref.Name)
-						}
+					v, err := vm.lookupGlobalReferenceValue(ref)
+					if err != nil {
+						return vm.runtimeError(c, ip, "%s", err)
 					}
 					instanceVal = v
 				case value.REF_UPVALUE:
@@ -4878,12 +4859,9 @@ func (vm *VM) run(minFrameCount int) error {
 				ref := instanceVal.Obj.(*value.ObjRef)
 				switch ref.RefType {
 				case value.REF_GLOBAL:
-					v, ok := frame.Globals[ref.Name]
-					if !ok {
-						v, ok = vm.GetGlobal(ref.Name)
-						if !ok {
-							return vm.runtimeError(c, ip, "undefined global variable '%s'", ref.Name)
-						}
+					v, err := vm.lookupGlobalReferenceValue(ref)
+					if err != nil {
+						return vm.runtimeError(c, ip, "%s", err)
 					}
 					instanceVal = v
 				case value.REF_UPVALUE:
@@ -4921,10 +4899,8 @@ func (vm *VM) run(minFrameCount int) error {
 			ref := fieldVal.Obj.(*value.ObjRef)
 			switch ref.RefType {
 			case value.REF_GLOBAL:
-				if _, ok := frame.Globals[ref.Name]; ok {
-					frame.Globals[ref.Name] = val
-				} else {
-					vm.SetGlobal(ref.Name, val)
+				if err := vm.storeGlobalReferenceValue(ref, val); err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
 			case value.REF_UPVALUE:
 				*ref.Upvalue.Location = val

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -4643,7 +4643,11 @@ func (vm *VM) run(minFrameCount int) error {
 				if modMap, ok := modVal.Obj.(*value.ObjMap); ok {
 					for k, v := range modMap.Data {
 						if keyStr, ok := k.(string); ok {
-							vm.SetGlobal(keyStr, v)
+							if frame.Globals != nil {
+								frame.Globals[keyStr] = v
+							} else {
+								vm.SetGlobal(keyStr, v)
+							}
 						}
 					}
 				} else {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3240,8 +3240,13 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		target := args[1]
 
 		var result interface{}
-		err := json.Unmarshal([]byte(jsonStr), &result)
-		if err != nil {
+		decoder := json.NewDecoder(strings.NewReader(jsonStr))
+		decoder.UseNumber()
+		if err := decoder.Decode(&result); err != nil {
+			return value.NewBool(false)
+		}
+		var trailing interface{}
+		if err := decoder.Decode(&trailing); err != io.EOF {
 			return value.NewBool(false)
 		}
 
@@ -3314,6 +3319,14 @@ func goValToNoxy(i interface{}) value.Value {
 			return value.NewInt(int64(v))
 		}
 		return value.NewFloat(v)
+	case json.Number:
+		if parsed, ok := exactJSONInt(v); ok {
+			return value.NewInt(parsed)
+		}
+		if parsed, err := v.Float64(); err == nil {
+			return value.NewFloat(parsed)
+		}
+		return value.NewNull()
 	case string:
 		return value.NewString(v)
 	case []interface{}:
@@ -3437,7 +3450,11 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 		return false
 	}
 	if ref.JSONDynamic {
-		store(goValToNoxy(data))
+		replacement, ok := dynamicJSONValue(data)
+		if !ok {
+			return false
+		}
+		store(replacement)
 		return true
 	}
 	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType, data, store)

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3779,7 +3779,7 @@ func (vm *VM) run(minFrameCount int) error {
 			container := vm.pop()
 
 			instance, ok := container.Obj.(*value.ObjInstance)
-			if container.Type != value.VAL_OBJ || !ok {
+			if container.Type != value.VAL_OBJ || !ok || instance == nil {
 				return vm.runtimeError(c, ip, "contextual property reference base must be an instance")
 			}
 			stored, ok := instance.Fields[name]
@@ -3807,7 +3807,7 @@ func (vm *VM) run(minFrameCount int) error {
 			}
 
 			var stored value.Value
-			if array, ok := container.Obj.(*value.ObjArray); ok {
+			if array, ok := container.Obj.(*value.ObjArray); ok && array != nil {
 				if idx.Type != value.VAL_INT {
 					return vm.runtimeError(c, ip, "array index must be integer")
 				}
@@ -3816,7 +3816,7 @@ func (vm *VM) run(minFrameCount int) error {
 					return vm.runtimeError(c, ip, "array index out of bounds")
 				}
 				stored = array.Elements[arrayIndex]
-			} else if mapObj, ok := container.Obj.(*value.ObjMap); ok {
+			} else if mapObj, ok := container.Obj.(*value.ObjMap); ok && mapObj != nil {
 				key, err := referenceMapKey(idx)
 				if err != nil {
 					return vm.runtimeError(c, ip, "%s", err)
@@ -4288,6 +4288,15 @@ func (vm *VM) run(minFrameCount int) error {
 			vm.push(value.NewBool(a.AsInt == b.AsInt))
 		case chunk.OP_PRINT:
 			v := vm.pop()
+			if v.Type == value.VAL_REF {
+				ref, err := extractReferenceValue(v)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				if _, _, _, err := vm.referenceStorage(ref); err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+			}
 			fmt.Println(v)
 
 		case chunk.OP_CALL:

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3354,13 +3354,23 @@ func populateObj(vm *VM, currentVal value.Value, data interface{}) bool {
 			if val, exists := dataMap[fieldName]; exists {
 				// Check if field is instance -> recurse
 				fieldType := inst.Fields[fieldName]
+				if inst.Struct.JSONDynamicFields[fieldName] {
+					inst.Fields[fieldName] = goValToNoxy(val)
+					continue
+				}
 				if fieldType.Type == value.VAL_OBJ {
 					if _, isInst := fieldType.Obj.(*value.ObjInstance); isInst {
-						populateObj(vm, fieldType, val)
+						if !populateObj(vm, fieldType, val) {
+							return false
+						}
 						continue
 					}
 				}
-				inst.Fields[fieldName] = goValToNoxy(val)
+				replacement := goValToNoxy(val)
+				if !jsonReplacementCompatible(fieldType, replacement) {
+					return false
+				}
+				inst.Fields[fieldName] = replacement
 			}
 		}
 		return true
@@ -3456,7 +3466,11 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 			if err != nil {
 				return false
 			}
-			currentVal = mapping.Data[key]
+			var exists bool
+			currentVal, exists = mapping.Data[key]
+			if !exists {
+				return false
+			}
 			store = func(updated value.Value) { mapping.Data[key] = updated }
 			break
 		}
@@ -3477,8 +3491,40 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 	if store == nil {
 		return false
 	}
-	store(goValToNoxy(data))
+	replacement := goValToNoxy(data)
+	if !ref.JSONDynamic && !jsonReplacementCompatible(currentVal, replacement) {
+		return false
+	}
+	store(replacement)
 	return true
+}
+
+func jsonReplacementCompatible(current, replacement value.Value) bool {
+	if current.Type == value.VAL_NULL {
+		return true
+	}
+	if current.Type != replacement.Type {
+		return false
+	}
+	if current.Type != value.VAL_OBJ {
+		return true
+	}
+	switch current.Obj.(type) {
+	case string:
+		_, ok := replacement.Obj.(string)
+		return ok
+	case *value.ObjArray:
+		_, ok := replacement.Obj.(*value.ObjArray)
+		return ok
+	case *value.ObjMap:
+		_, ok := replacement.Obj.(*value.ObjMap)
+		return ok
+	case *value.ObjInstance:
+		_, ok := replacement.Obj.(*value.ObjInstance)
+		return ok
+	default:
+		return false
+	}
 }
 
 func (vm *VM) DefineNative(name string, fn value.NativeFunc) {
@@ -3838,6 +3884,14 @@ func (vm *VM) run(minFrameCount int) error {
 					Index:     idx,
 				},
 			})
+
+		case chunk.OP_MARK_REF_JSON_DYNAMIC:
+			refValue := vm.peek(0)
+			ref, ok := refValue.Obj.(*value.ObjRef)
+			if refValue.Type != value.VAL_REF || !ok || ref == nil {
+				return vm.runtimeError(c, ip, "dynamic target marker requires a reference")
+			}
+			ref.JSONDynamic = true
 
 		case chunk.OP_DEREF:
 			refVal := vm.pop()

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3642,6 +3642,20 @@ func (vm *VM) run(minFrameCount int) error {
 				},
 			})
 
+		case chunk.OP_REF_UPVALUE:
+			slot := int(c.Code[ip])
+			ip++
+			if slot < 0 || slot >= len(frame.Closure.Upvalues) {
+				return vm.runtimeError(c, ip, "upvalue reference index out of bounds: %d", slot)
+			}
+			vm.push(value.Value{
+				Type: value.VAL_REF,
+				Obj: &value.ObjRef{
+					RefType: value.REF_UPVALUE,
+					Upvalue: frame.Closure.Upvalues[slot],
+				},
+			})
+
 		case chunk.OP_REF_GLOBAL:
 			index := c.Code[ip]
 			ip++

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3885,6 +3885,74 @@ func (vm *VM) run(minFrameCount int) error {
 				},
 			})
 
+		case chunk.OP_CONTEXT_REF_PROPERTY:
+			index := c.Code[ip]
+			ip++
+			nameVal := c.Constants[index]
+			name := nameVal.Obj.(string)
+			container := vm.pop()
+
+			instance, ok := container.Obj.(*value.ObjInstance)
+			if container.Type != value.VAL_OBJ || !ok {
+				return vm.runtimeError(c, ip, "contextual property reference base must be an instance")
+			}
+			stored, ok := instance.Fields[name]
+			if !ok {
+				return vm.runtimeError(c, ip, "undefined property '%s'", name)
+			}
+			if stored.Type == value.VAL_REF {
+				vm.push(stored)
+				continue
+			}
+			vm.push(value.Value{
+				Type: value.VAL_REF,
+				Obj: &value.ObjRef{
+					RefType:   value.REF_PROPERTY,
+					Container: container,
+					Name:      name,
+				},
+			})
+
+		case chunk.OP_CONTEXT_REF_INDEX:
+			idx := vm.pop()
+			container := vm.pop()
+			if container.Type != value.VAL_OBJ {
+				return vm.runtimeError(c, ip, "contextual index reference base must be an array or map")
+			}
+
+			var stored value.Value
+			if array, ok := container.Obj.(*value.ObjArray); ok {
+				if idx.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				arrayIndex := int(idx.AsInt)
+				if arrayIndex < 0 || arrayIndex >= len(array.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				stored = array.Elements[arrayIndex]
+			} else if mapObj, ok := container.Obj.(*value.ObjMap); ok {
+				key, err := referenceMapKey(idx)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				stored = mapObj.Data[key]
+			} else {
+				return vm.runtimeError(c, ip, "contextual index reference base must be an array or map")
+			}
+
+			if stored.Type == value.VAL_REF {
+				vm.push(stored)
+				continue
+			}
+			vm.push(value.Value{
+				Type: value.VAL_REF,
+				Obj: &value.ObjRef{
+					RefType:   value.REF_INDEX,
+					Container: container,
+					Index:     idx,
+				},
+			})
+
 		case chunk.OP_MARK_REF_JSON_DYNAMIC:
 			refValue := vm.peek(0)
 			ref, ok := refValue.Obj.(*value.ObjRef)

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -5269,7 +5269,7 @@ func (vm *VM) loadModule(name string) (value.Value, error) {
 			if len(p.Errors()) > 0 {
 				return value.NewNull(), fmt.Errorf("parse error in embedded module %s: %v", name, p.Errors())
 			}
-			c := compiler.NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), name)
+			c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), name, vm.Config.RootPath)
 			chunk, _, err := c.Compile(prog)
 			if err != nil {
 				return value.NewNull(), err
@@ -5363,7 +5363,7 @@ FileImport:
 		return value.NewNull(), fmt.Errorf("parse error in module %s: %v", name, p.Errors())
 	}
 
-	c := compiler.NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), path)
+	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), path, vm.Config.RootPath)
 	chunk, _, err := c.Compile(prog)
 	if err != nil {
 		return value.NewNull(), err

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3895,8 +3895,11 @@ func (vm *VM) run(minFrameCount int) error {
 			val := vm.pop()    // Value to assign
 			refVal := vm.pop() // The reference itself (popped from stack)
 
+			if refVal.Type == value.VAL_NULL {
+				return vm.runtimeError(c, ip, "cannot update null reference")
+			}
 			if refVal.Type != value.VAL_REF {
-				return vm.runtimeError(c, ip, "Cannot store via non-ref value")
+				return vm.runtimeError(c, ip, "cannot store via non-reference value")
 			}
 
 			ref := refVal.Obj.(*value.ObjRef)
@@ -4887,6 +4890,10 @@ func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip i
 	// Handle Pass-by-Value (Copy) for non-ref parameters
 	// Args are at vm.stackTop - argCount
 	baseArgs := vm.stackTop - argCount
+	args := vm.stack[baseArgs:vm.stackTop]
+	if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
+		return false, vm.runtimeError(c, ip, "%s", err)
+	}
 	for i := 0; i < argCount; i++ {
 		if i < len(fn.Params) {
 			param := fn.Params[i]

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3408,6 +3408,13 @@ func (vm *VM) DefineNative(name string, fn value.NativeFunc) {
 	vm.SetGlobal(name, value.NewNative(name, fn))
 }
 
+func (vm *VM) DefineNativeWithSignature(name string, signature value.NativeSignature, fn value.NativeFunc) {
+	if _, ok := vm.GetGlobal(name); ok {
+		return
+	}
+	vm.SetGlobal(name, value.NewNativeWithSignature(name, signature, fn))
+}
+
 func (vm *VM) SetGlobal(name string, val value.Value) {
 	vm.shared.GlobalsLock.Lock()
 	defer vm.shared.GlobalsLock.Unlock()
@@ -4865,6 +4872,40 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 	if callee.Type == value.VAL_NATIVE {
 		native := callee.Obj.(*value.ObjNative)
 		args := vm.stack[vm.stackTop-argCount : vm.stackTop]
+		if native.Signature != nil {
+			sig := native.Signature
+			if !sig.Variadic && argCount != sig.Arity {
+				return false, vm.runtimeError(c, ip, "native '%s' expects %d arguments, got %d", native.Name, sig.Arity, argCount)
+			}
+			if sig.Variadic && argCount < sig.Arity {
+				return false, vm.runtimeError(c, ip, "native '%s' expects at least %d arguments, got %d", native.Name, sig.Arity, argCount)
+			}
+
+			params := sig.Params
+			if sig.Variadic && len(params) > 0 && argCount > len(params) {
+				expanded := make([]value.ParamInfo, argCount)
+				copy(expanded, params)
+				for i := len(params); i < argCount; i++ {
+					expanded[i] = params[len(params)-1]
+				}
+				params = expanded
+			}
+			if err := validateParameterModes(native.Name, params, args); err != nil {
+				return false, vm.runtimeError(c, ip, "%s", err)
+			}
+
+			callArgs := make([]value.Value, len(args))
+			copy(callArgs, args)
+			for i, param := range params {
+				if i >= len(callArgs) {
+					break
+				}
+				if !param.IsRef {
+					callArgs[i] = vm.copyValue(callArgs[i])
+				}
+			}
+			args = callArgs
+		}
 		// fmt.Printf("Calling native %s with args: %v\n", native.Name, args)
 		result := native.Fn(args)
 		vm.stackTop -= argCount + 1 // args + function

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3753,8 +3753,16 @@ func (vm *VM) run(minFrameCount int) error {
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
 
-			owner := &frame.Globals
-			if frame.Globals == nil {
+			var owner *map[string]value.Value
+			if frame.Globals != nil {
+				if _, ok := frame.Globals[name]; ok {
+					owner = &frame.Globals
+				}
+			}
+			if owner == nil {
+				if _, ok := vm.GetGlobal(name); !ok {
+					return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
+				}
 				owner = &vm.shared.Globals
 			}
 			vm.push(value.Value{

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1830,7 +1830,6 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		Arity: 2,
 		Params: []value.ParamInfo{
 			{IsRef: true, TypeName: "ref array"},
-			{IsRef: false, TypeName: "any"},
 		},
 		ReturnType: "void",
 	}
@@ -3332,112 +3331,154 @@ func goValToNoxy(i interface{}) value.Value {
 // Helper: Populate Target
 func populateTarget(vm *VM, target value.Value, data interface{}) bool {
 	if target.Type == value.VAL_REF {
-		ref := target.Obj.(*value.ObjRef)
-		populateRef(vm, ref, data)
-		return true
+		ref, ok := target.Obj.(*value.ObjRef)
+		if !ok || ref == nil {
+			return false
+		}
+		return populateRef(vm, ref, data)
 	} else if target.Type == value.VAL_OBJ {
 		// Populate Object In-Place
-		populateObj(vm, target, data)
-		return true
+		return populateObj(vm, target, data)
 	}
 	// Cannot populate primitive value passed by value
 	return false
 }
 
-func populateObj(vm *VM, currentVal value.Value, data interface{}) {
+func populateObj(vm *VM, currentVal value.Value, data interface{}) bool {
 	if inst, ok := currentVal.Obj.(*value.ObjInstance); ok {
-		if dataMap, ok := data.(map[string]interface{}); ok {
-			for _, fieldName := range inst.Struct.Fields {
-				if val, exists := dataMap[fieldName]; exists {
-					// Check if field is instance -> recurse
-					fieldType := inst.Fields[fieldName]
-					if fieldType.Type == value.VAL_OBJ {
-						if _, isInst := fieldType.Obj.(*value.ObjInstance); isInst {
-							populateObj(vm, fieldType, val)
-							continue
-						}
+		dataMap, ok := data.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		for _, fieldName := range inst.Struct.Fields {
+			if val, exists := dataMap[fieldName]; exists {
+				// Check if field is instance -> recurse
+				fieldType := inst.Fields[fieldName]
+				if fieldType.Type == value.VAL_OBJ {
+					if _, isInst := fieldType.Obj.(*value.ObjInstance); isInst {
+						populateObj(vm, fieldType, val)
+						continue
 					}
-					inst.Fields[fieldName] = goValToNoxy(val)
 				}
+				inst.Fields[fieldName] = goValToNoxy(val)
 			}
 		}
+		return true
 	} else if m, ok := currentVal.Obj.(*value.ObjMap); ok {
-		if dataMap, ok := data.(map[string]interface{}); ok {
-			// Clear logic? Or merge? Go unmarshal merges.
-			for k, v := range dataMap {
-				m.Data[k] = goValToNoxy(v)
-			}
+		dataMap, ok := data.(map[string]interface{})
+		if !ok {
+			return false
 		}
+		// Clear logic? Or merge? Go unmarshal merges.
+		for k, v := range dataMap {
+			m.Data[k] = goValToNoxy(v)
+		}
+		return true
 	} else if arr, ok := currentVal.Obj.(*value.ObjArray); ok {
-		if dataArr, ok := data.([]interface{}); ok {
-			// Replace array content (slice behavior)
-			// Or should we merge? slice unmarshal replaces.
-			// But we can't resize easily in place?
-			// Actually we can just replace Elements slice.
-			newElems := make([]value.Value, len(dataArr))
-			for i, el := range dataArr {
-				newElems[i] = goValToNoxy(el)
-			}
-			arr.Elements = newElems
+		dataArr, ok := data.([]interface{})
+		if !ok {
+			return false
 		}
+		// Replace array content (slice behavior)
+		// Or should we merge? slice unmarshal replaces.
+		// But we can't resize easily in place?
+		// Actually we can just replace Elements slice.
+		newElems := make([]value.Value, len(dataArr))
+		for i, el := range dataArr {
+			newElems[i] = goValToNoxy(el)
+		}
+		arr.Elements = newElems
+		return true
 	}
+	return false
 }
 
 // Helper: Populate a Reference with Go Data (Deeply)
-func populateRef(vm *VM, ref *value.ObjRef, data interface{}) {
+func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 	var currentVal value.Value
+	var store func(value.Value)
 
 	// Dereference
 	switch ref.RefType {
 	case value.REF_GLOBAL:
-		v, ok := vm.GetGlobal(ref.Name)
-		if ok {
-			currentVal = v
-		}
-	case value.REF_UPVALUE:
-		currentVal = *ref.Upvalue.Location
-	case value.REF_PTR:
-		currentVal = *ref.Ptr
-	case value.REF_PROPERTY:
-		if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-			currentVal = inst.Fields[ref.Name]
-		}
-	case value.REF_INDEX:
-		if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-			idx := int(ref.Index.AsInt)
-			if idx >= 0 && idx < len(arr.Elements) {
-				currentVal = arr.Elements[idx]
+		if vm.currentFrame != nil && vm.currentFrame.Globals != nil {
+			if frameValue, ok := vm.currentFrame.Globals[ref.Name]; ok {
+				currentVal = frameValue
+				store = func(updated value.Value) {
+					vm.currentFrame.Globals[ref.Name] = updated
+				}
+				break
 			}
 		}
+		sharedValue, ok := vm.GetGlobal(ref.Name)
+		if !ok {
+			return false
+		}
+		currentVal = sharedValue
+		store = func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }
+	case value.REF_UPVALUE:
+		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
+			return false
+		}
+		currentVal = *ref.Upvalue.Location
+		store = func(updated value.Value) { *ref.Upvalue.Location = updated }
+	case value.REF_PTR:
+		if ref.Ptr == nil {
+			return false
+		}
+		currentVal = *ref.Ptr
+		store = func(updated value.Value) { *ref.Ptr = updated }
+	case value.REF_PROPERTY:
+		inst, ok := ref.Container.Obj.(*value.ObjInstance)
+		if !ok {
+			return false
+		}
+		currentVal, ok = inst.Fields[ref.Name]
+		if !ok {
+			return false
+		}
+		store = func(updated value.Value) { inst.Fields[ref.Name] = updated }
+	case value.REF_INDEX:
+		if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
+			if ref.Index.Type != value.VAL_INT {
+				return false
+			}
+			idx := int(ref.Index.AsInt)
+			if idx < 0 || idx >= len(arr.Elements) {
+				return false
+			}
+			currentVal = arr.Elements[idx]
+			store = func(updated value.Value) { arr.Elements[idx] = updated }
+			break
+		}
+		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ok {
+			key, err := referenceMapKey(ref.Index)
+			if err != nil {
+				return false
+			}
+			currentVal = mapping.Data[key]
+			store = func(updated value.Value) { mapping.Data[key] = updated }
+			break
+		}
+		return false
+	default:
+		return false
 	}
 
 	// Logic to update: if object, update in place
 	if currentVal.Type == value.VAL_OBJ {
-		populateObj(vm, currentVal, data)
-		return
+		switch currentVal.Obj.(type) {
+		case *value.ObjInstance, *value.ObjMap, *value.ObjArray:
+			return populateObj(vm, currentVal, data)
+		}
 	}
 
 	// Replace reference
-	newValue := goValToNoxy(data)
-	switch ref.RefType {
-	case value.REF_GLOBAL:
-		vm.SetGlobal(ref.Name, newValue)
-	case value.REF_UPVALUE:
-		*ref.Upvalue.Location = newValue
-	case value.REF_PTR:
-		*ref.Ptr = newValue
-	case value.REF_PROPERTY:
-		if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-			inst.Fields[ref.Name] = newValue
-		}
-	case value.REF_INDEX:
-		if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-			idx := int(ref.Index.AsInt)
-			if idx >= 0 && idx < len(arr.Elements) {
-				arr.Elements[idx] = newValue
-			}
-		}
+	if store == nil {
+		return false
 	}
+	store(goValToNoxy(data))
+	return true
 }
 
 func (vm *VM) DefineNative(name string, fn value.NativeFunc) {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1792,11 +1792,22 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		return value.NewArray(nil)
 	})
 
-	vm.DefineNative("delete", func(args []value.Value) value.Value {
+	deleteSignature := value.NativeSignature{
+		Arity: 2,
+		Params: []value.ParamInfo{
+			{IsRef: true, TypeName: "ref map"},
+			{IsRef: false, TypeName: "any"},
+		},
+		ReturnType: "void",
+	}
+	vm.DefineNativeWithSignature("delete", deleteSignature, func(args []value.Value) value.Value {
 		if len(args) != 2 {
 			return value.NewNull()
 		}
-		mapVal := args[0]
+		mapVal, err := vm.resolveReferenceValue(args[0])
+		if err != nil {
+			return value.NewNull()
+		}
 		keyVal := args[1]
 		if mapVal.Type == value.VAL_OBJ {
 			if m, ok := mapVal.Obj.(*value.ObjMap); ok {
@@ -1815,11 +1826,22 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		}
 		return value.NewNull()
 	})
-	vm.DefineNative("append", func(args []value.Value) value.Value {
+	appendSignature := value.NativeSignature{
+		Arity: 2,
+		Params: []value.ParamInfo{
+			{IsRef: true, TypeName: "ref array"},
+			{IsRef: false, TypeName: "any"},
+		},
+		ReturnType: "void",
+	}
+	vm.DefineNativeWithSignature("append", appendSignature, func(args []value.Value) value.Value {
 		if len(args) != 2 {
 			return value.NewNull()
 		}
-		arrVal := args[0]
+		arrVal, err := vm.resolveReferenceValue(args[0])
+		if err != nil {
+			return value.NewNull()
+		}
 		item := args[1]
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
@@ -1828,11 +1850,21 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		}
 		return value.NewNull()
 	})
-	vm.DefineNative("pop", func(args []value.Value) value.Value {
+	popSignature := value.NativeSignature{
+		Arity: 1,
+		Params: []value.ParamInfo{
+			{IsRef: true, TypeName: "ref array"},
+		},
+		ReturnType: "any",
+	}
+	vm.DefineNativeWithSignature("pop", popSignature, func(args []value.Value) value.Value {
 		if len(args) != 1 {
 			return value.NewNull()
 		}
-		arrVal := args[0]
+		arrVal, err := vm.resolveReferenceValue(args[0])
+		if err != nil {
+			return value.NewNull()
+		}
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
 				if len(arr.Elements) == 0 {
@@ -3189,7 +3221,15 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 	})
 
 	// json_loads(str, target) -> Bool
-	vm.DefineNative("json_loads", func(args []value.Value) value.Value {
+	jsonLoadsSignature := value.NativeSignature{
+		Arity: 2,
+		Params: []value.ParamInfo{
+			{IsRef: false, TypeName: "string"},
+			{IsRef: true, TypeName: "ref any"},
+		},
+		ReturnType: "bool",
+	}
+	vm.DefineNativeWithSignature("json_loads", jsonLoadsSignature, func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewBool(false)
 		}
@@ -3766,81 +3806,11 @@ func (vm *VM) run(minFrameCount int) error {
 				// Not a ref - pass through as-is (already dereferenced)
 				vm.push(refVal)
 			} else {
-				// VAL_REF - dereference it
-				ref := refVal.Obj.(*value.ObjRef)
-
-				switch ref.RefType {
-				case value.REF_GLOBAL:
-					// Global lookup (Read)
-					val, ok := frame.Globals[ref.Name]
-					if !ok {
-						val, ok = vm.GetGlobal(ref.Name)
-						if !ok {
-							return vm.runtimeError(c, ip, "undefined global variable '%s'", ref.Name)
-						}
-					}
-					vm.push(val)
-				case value.REF_UPVALUE:
-					// Read from Upvalue
-					vm.push(*ref.Upvalue.Location)
-				case value.REF_PTR:
-					// Local pointer read
-					vm.push(*ref.Ptr)
-				case value.REF_PROPERTY:
-					// Read property from container
-					// Assume ObjInstance for now. Could be Map (if string key?) or Module?
-					if inst, ok := ref.Container.Obj.(*value.ObjInstance); ok {
-						if val, ok := inst.Fields[ref.Name]; ok {
-							vm.push(val)
-						} else {
-							// Default value or null? Or error?
-							// Struct fields should exist if type checked.
-							// If dynamic, maybe null.
-							vm.push(value.NewNull())
-						}
-					} else {
-						return vm.runtimeError(c, ip, "Target is not an instance")
-					}
-				case value.REF_INDEX:
-					// Read index from container (Array or Map)
-					if arr, ok := ref.Container.Obj.(*value.ObjArray); ok {
-						idx := int(ref.Index.AsInt)
-						if idx < 0 || idx >= len(arr.Elements) {
-							return vm.runtimeError(c, ip, "Index out of bounds")
-						}
-						vm.push(arr.Elements[idx])
-					} else if m, ok := ref.Container.Obj.(*value.ObjMap); ok {
-						// Map key
-						// Need to hash key? ObjMap uses interface{} key or Value key?
-						// ObjMap keys are interface{}. We need Value->Interface conversion or map stores Values?
-						// value.go: Data map[interface{}]Value
-						var key interface{}
-						// Minimal key conversion logic (duplicated from elsewhere? or simple)
-						if ref.Index.Type == value.VAL_OBJ {
-							if s, ok := ref.Index.Obj.(string); ok {
-								key = s
-							} else {
-								key = ref.Index.Obj // Pointer/etc
-							}
-						} else {
-							// Primitive
-							if ref.Index.Type == value.VAL_INT {
-								key = ref.Index.AsInt
-							} else {
-								key = ref.Index.AsInt
-								return vm.runtimeError(c, ip, "Map key type not fully supported in ref yet")
-							}
-						}
-
-						if val, ok := m.Data[key]; ok {
-							vm.push(val)
-						} else {
-							vm.push(value.NewNull())
-						}
-					} else {
-						return vm.runtimeError(c, ip, "Target is not indexable")
-					}
+				resolved, err := vm.lookupReferenceValue(refVal.Obj.(*value.ObjRef), frame.Globals)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
 				}
+				vm.push(resolved)
 			}
 		case chunk.OP_STORE_VIA_REF:
 			slot := int(c.Code[ip])

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3376,7 +3376,7 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 	if err != nil || !exists || store == nil {
 		return false
 	}
-	if ref.JSONDynamic {
+	if ref.JSONDynamic.Load() {
 		replacement, ok := dynamicJSONValue(data)
 		if !ok {
 			return false
@@ -3384,7 +3384,7 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 		store(replacement)
 		return true
 	}
-	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType, data, jsonSetter(store))
+	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType.Load(), data, jsonSetter(store))
 	if !ok {
 		return false
 	}
@@ -3849,7 +3849,7 @@ func (vm *VM) run(minFrameCount int) error {
 			if refValue.Type != value.VAL_REF || !ok || ref == nil {
 				return vm.runtimeError(c, ip, "dynamic target marker requires a reference")
 			}
-			ref.JSONDynamic = true
+			ref.JSONDynamic.Store(true)
 
 		case chunk.OP_MARK_REF_TARGET_TYPE:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
@@ -3867,7 +3867,9 @@ func (vm *VM) run(minFrameCount int) error {
 			if refValue.Type != value.VAL_REF || !ok || ref == nil {
 				return vm.runtimeError(c, ip, "reference target marker requires a reference")
 			}
-			ref.TargetType = targetType
+			if !markReferenceTargetType(ref, targetType) {
+				return vm.runtimeError(c, ip, "reference target metadata conflicts with static context")
+			}
 
 		case chunk.OP_MARK_RUNTIME_VALUE_TYPE:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
@@ -4846,13 +4848,19 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 	case *value.ObjArray:
 		newElems := make([]value.Value, len(obj.Elements))
 		copy(newElems, obj.Elements)
-		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjArray{Elements: newElems, RuntimeType: obj.RuntimeType}}
+		copied := value.NewArray(newElems)
+		copied.Obj.(*value.ObjArray).RuntimeType.Store(obj.RuntimeType.Load())
+		return copied
 	case *value.ObjMap:
 		newData := make(map[interface{}]value.Value)
 		for k, val := range obj.Data {
 			newData[k] = val
 		}
-		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjMap{Data: newData, RuntimeType: obj.RuntimeType}}
+		copied := value.NewMap()
+		copiedMap := copied.Obj.(*value.ObjMap)
+		copiedMap.Data = newData
+		copiedMap.RuntimeType.Store(obj.RuntimeType.Load())
+		return copied
 	case *value.ObjInstance:
 		newFields := make(map[string]value.Value)
 		for k, val := range obj.Fields {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3525,11 +3525,13 @@ func (vm *VM) run(minFrameCount int) error {
 				fn := constant.Obj.(*value.ObjFunction)
 				// Clone to bind globals
 				boundFn := &value.ObjFunction{
-					Name:    fn.Name,
-					Arity:   fn.Arity,
-					Params:  fn.Params,
-					Chunk:   fn.Chunk,
-					Globals: frame.Globals,
+					Name:         fn.Name,
+					Arity:        fn.Arity,
+					UpvalueCount: fn.UpvalueCount,
+					Params:       fn.Params,
+					Chunk:        fn.Chunk,
+					Globals:      frame.Globals,
+					RuntimeType:  fn.RuntimeType,
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
 			} else {
@@ -3544,11 +3546,13 @@ func (vm *VM) run(minFrameCount int) error {
 			if constant.Type == value.VAL_FUNCTION {
 				fn := constant.Obj.(*value.ObjFunction)
 				boundFn := &value.ObjFunction{
-					Name:    fn.Name,
-					Arity:   fn.Arity,
-					Params:  fn.Params,
-					Chunk:   fn.Chunk,
-					Globals: frame.Globals,
+					Name:         fn.Name,
+					Arity:        fn.Arity,
+					UpvalueCount: fn.UpvalueCount,
+					Params:       fn.Params,
+					Chunk:        fn.Chunk,
+					Globals:      frame.Globals,
+					RuntimeType:  fn.RuntimeType,
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
 			} else {
@@ -3864,6 +3868,16 @@ func (vm *VM) run(minFrameCount int) error {
 				return vm.runtimeError(c, ip, "reference target marker requires a reference")
 			}
 			ref.TargetType = targetType
+
+		case chunk.OP_MARK_RUNTIME_VALUE_TYPE:
+			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			typeValue := c.Constants[index]
+			runtimeType, ok := typeValue.Obj.(*value.RuntimeTypeInfo)
+			if typeValue.Type != value.VAL_OBJ || !ok || runtimeType == nil {
+				return vm.runtimeError(c, ip, "runtime value marker requires type metadata")
+			}
+			vm.markRuntimeValueType(vm.peek(0), runtimeType)
 
 		case chunk.OP_DEREF:
 			refVal := vm.pop()

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3928,8 +3928,8 @@ func (vm *VM) run(minFrameCount int) error {
 			ref.JSONDynamic = true
 
 		case chunk.OP_MARK_REF_TARGET_TYPE:
-			index := c.Code[ip]
-			ip++
+			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
 			typeValue := c.Constants[index]
 			targetType, ok := typeValue.Obj.(*value.RuntimeTypeInfo)
 			if typeValue.Type != value.VAL_OBJ || !ok || targetType == nil {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1837,11 +1837,15 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		if len(args) != 2 {
 			return value.NewNull()
 		}
+		targetRef, _ := args[0].Obj.(*value.ObjRef)
 		arrVal, err := vm.resolveReferenceValue(args[0])
 		if err != nil {
 			return value.NewNull()
 		}
 		item := args[1]
+		if !vm.appendItemCompatible(targetRef, item) {
+			return value.NewNull()
+		}
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
 				arr.Elements = append(arr.Elements, item)

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3345,62 +3345,12 @@ func populateTarget(vm *VM, target value.Value, data interface{}) bool {
 }
 
 func populateObj(vm *VM, currentVal value.Value, data interface{}) bool {
-	if inst, ok := currentVal.Obj.(*value.ObjInstance); ok {
-		dataMap, ok := data.(map[string]interface{})
-		if !ok {
-			return false
-		}
-		for _, fieldName := range inst.Struct.Fields {
-			if val, exists := dataMap[fieldName]; exists {
-				// Check if field is instance -> recurse
-				fieldType := inst.Fields[fieldName]
-				if inst.Struct.JSONDynamicFields[fieldName] {
-					inst.Fields[fieldName] = goValToNoxy(val)
-					continue
-				}
-				if fieldType.Type == value.VAL_OBJ {
-					if _, isInst := fieldType.Obj.(*value.ObjInstance); isInst {
-						if !populateObj(vm, fieldType, val) {
-							return false
-						}
-						continue
-					}
-				}
-				replacement := goValToNoxy(val)
-				if !jsonReplacementCompatible(fieldType, replacement) {
-					return false
-				}
-				inst.Fields[fieldName] = replacement
-			}
-		}
-		return true
-	} else if m, ok := currentVal.Obj.(*value.ObjMap); ok {
-		dataMap, ok := data.(map[string]interface{})
-		if !ok {
-			return false
-		}
-		// Clear logic? Or merge? Go unmarshal merges.
-		for k, v := range dataMap {
-			m.Data[k] = goValToNoxy(v)
-		}
-		return true
-	} else if arr, ok := currentVal.Obj.(*value.ObjArray); ok {
-		dataArr, ok := data.([]interface{})
-		if !ok {
-			return false
-		}
-		// Replace array content (slice behavior)
-		// Or should we merge? slice unmarshal replaces.
-		// But we can't resize easily in place?
-		// Actually we can just replace Elements slice.
-		newElems := make([]value.Value, len(dataArr))
-		for i, el := range dataArr {
-			newElems[i] = goValToNoxy(el)
-		}
-		arr.Elements = newElems
-		return true
+	commit, ok := prepareJSONMutation(vm, currentVal, nil, data, nil)
+	if !ok {
+		return false
 	}
-	return false
+	commit()
+	return true
 }
 
 // Helper: Populate a Reference with Go Data (Deeply)
@@ -3479,23 +3429,18 @@ func populateRef(vm *VM, ref *value.ObjRef, data interface{}) bool {
 		return false
 	}
 
-	// Logic to update: if object, update in place
-	if currentVal.Type == value.VAL_OBJ {
-		switch currentVal.Obj.(type) {
-		case *value.ObjInstance, *value.ObjMap, *value.ObjArray:
-			return populateObj(vm, currentVal, data)
-		}
-	}
-
-	// Replace reference
 	if store == nil {
 		return false
 	}
-	replacement := goValToNoxy(data)
-	if !ref.JSONDynamic && !jsonReplacementCompatible(currentVal, replacement) {
+	if ref.JSONDynamic {
+		store(goValToNoxy(data))
+		return true
+	}
+	commit, ok := prepareJSONMutation(vm, currentVal, ref.TargetType, data, store)
+	if !ok {
 		return false
 	}
-	store(replacement)
+	commit()
 	return true
 }
 
@@ -3960,6 +3905,24 @@ func (vm *VM) run(minFrameCount int) error {
 				return vm.runtimeError(c, ip, "dynamic target marker requires a reference")
 			}
 			ref.JSONDynamic = true
+
+		case chunk.OP_MARK_REF_TARGET_TYPE:
+			index := c.Code[ip]
+			ip++
+			typeValue := c.Constants[index]
+			targetType, ok := typeValue.Obj.(*value.RuntimeTypeInfo)
+			if typeValue.Type != value.VAL_OBJ || !ok || targetType == nil {
+				return vm.runtimeError(c, ip, "reference target marker requires runtime type metadata")
+			}
+			refValue := vm.peek(0)
+			if refValue.Type == value.VAL_NULL {
+				continue
+			}
+			ref, ok := refValue.Obj.(*value.ObjRef)
+			if refValue.Type != value.VAL_REF || !ok || ref == nil {
+				return vm.runtimeError(c, ip, "reference target marker requires a reference")
+			}
+			ref.TargetType = targetType
 
 		case chunk.OP_DEREF:
 			refVal := vm.pop()

--- a/noxy_examples/dynamodb_example.nx
+++ b/noxy_examples/dynamodb_example.nx
@@ -54,7 +54,7 @@ let key: map[string, any] = {
 }
 
 print(f"Reading user {USER_ID}...")
-let user: map[string, any] = dynamodb.get_item(client, TABLE_NAME, key)
+let user: any = dynamodb.get_item(client, TABLE_NAME, key)
 
 if user != null then
     print(f"Found user: {user['name']} (Email: {user['email']}, Age: {user['age']})")
@@ -79,7 +79,7 @@ let updated: bool = dynamodb.update_item(client, TABLE_NAME, key, updateExpr, ex
 if updated then
     print("User updated successfully.")
     // Verify update
-    let updatedUser: map[string, any] = dynamodb.get_item(client, TABLE_NAME, key)
+    let updatedUser: any = dynamodb.get_item(client, TABLE_NAME, key)
     if updatedUser != null then
         print(f"Updated Data -> Age: {updatedUser['age']}, Active: {updatedUser['active']}")
     end

--- a/noxy_examples/repro_list.nx
+++ b/noxy_examples/repro_list.nx
@@ -9,7 +9,7 @@ print("Test 1: Declaration with empty list")
 
 print("Test 2: Declaration with typed element")
 let v: Vertex = Vertex(1)
-let l2: ref Vertex[] = [ref v]
+let l2: (ref Vertex)[] = [ref v]
 print("L2 created. Len: " + to_str(length(l2)))
 
 print("Test 5: Typed array assignment")

--- a/noxy_examples/test_sys.nx
+++ b/noxy_examples/test_sys.nx
@@ -41,7 +41,7 @@ print("")
 
 // Teste 5: Argumentos
 print("Teste 5: Argumentos da linha de comando")
-let args: string[100] = argv()
+let args: string[] = argv()
 print(f"Programa: {args[0]}")
 if strlen(args[1]) > 0 then
     print(f"Arg 1: {args[1]}")

--- a/noxy_examples/typed_function_conformance.nx
+++ b/noxy_examples/typed_function_conformance.nx
@@ -25,6 +25,14 @@ func increment(value: ref int) -> void
     *value = value + 1
 end
 
+func make_counter() -> func() -> int
+    let count: int = 40
+    return func() -> int
+        increment(count)
+        return count
+    end
+end
+
 let operation: func(int, int) -> int = add
 assert(apply(operation, 20, 22) == 42, "exact higher-order function must return 42")
 
@@ -34,6 +42,10 @@ assert(double(21) == 42, "typed closure must preserve its signature")
 let answer: int = 41
 increment(answer)
 assert(answer == 42, "ref parameter must update the caller")
+
+let counter: func() -> int = make_counter()
+assert(counter() == 41, "first captured ref update must produce 41")
+assert(counter() == 42, "second captured ref update must produce 42")
 
 let dynamic_operation: func = operation
 assert(dynamic_operation(20, 22) == 42, "exact function must widen to bare func")

--- a/noxy_examples/use_statics.nx
+++ b/noxy_examples/use_statics.nx
@@ -7,8 +7,9 @@ func main()
     // s is type 'ref Statics'
     let s: ref statics.Statics = statics.new_statics(data)
     
-    // Pass the reference directly
-    statics.compute(s)
+    // Module members are dynamic calls, so keep the reference explicit.
+    // Since s is already ref Statics, ref s forwards it without nesting.
+    statics.compute(ref s)
     
     // Access fields (auto-dereference handles the pointer)
     print("Mean: " + to_str(s.mean))


### PR DESCRIPTION
## Summary
- Consolidates Noxy reference semantics around contextual exact calls, explicit dynamic boundaries, update, and rebind.
- Adds typed native contracts, runtime mode validation, safe upvalue/global references, and defensive malformed-reference handling.
- Makes mutating builtins and `json_loads` type-safe, atomic, and consistent for nested callable, channel, array, map, struct, and reference schemas.
- Updates the language specification, reference guide, changelog, standard-library boundary, and conformance fixtures.

## Motivation and impact
- Closes compiler/runtime gaps that could silently select the wrong storage, accept incompatible reference modes, partially mutate JSON targets, or lose type metadata at dynamic boundaries.
- Includes intentional compatibility changes where existing examples declared types that did not match their dynamic behavior.

## Components
- Compiler type checking, contextual reference lowering, module export discovery, and runtime type metadata.
- VM call validation, references, native descriptors, JSON prepare/commit, and global ownership.
- Standard library, examples, documentation, and regression/conformance tests.

## Related Issues
- No Jira or GitHub issue was identified for this branch.

## Test Plan
- [x] Implementação
- [x] Testes unitários passando (`go test ./... -count=1`)
- [x] Race tests passando (`go test -race ./internal/compiler ./internal/vm -count=1`)
- [x] Build e vet passando
- [x] Testado integrado com binário local do HEAD (`157/157`)