### PR TITLE
feat/NO-CARD - Add transactional Noxy version update skill

### DIFF
--- a/.agents/skills/updating-noxy-version/SKILL.md
+++ b/.agents/skills/updating-noxy-version/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: updating-noxy-version
+description: Use when changing, bumping, releasing, or synchronizing the Noxy VM semantic version across runtime metadata, noxy.mod, README, language specification, and changelog.
+---
+
+# Updating Noxy Version
+
+## Overview
+
+Use the bundled updater from the Noxy repository root. Preserve unrelated user changes and stop on any validation or test failure.
+
+## Workflow
+
+1. Inspect `git status --short`. Note pre-existing changes, especially in the five release files.
+2. Normalize the requested target to `vX.Y.Z` for reporting.
+3. Preview changes:
+   `python .agents/skills/updating-noxy-version/scripts/update_version.py <version> --dry-run`
+   Add `--date YYYY-MM-DD` only when the user specifies a release date.
+4. Review the preview. It must touch only the five expected release files.
+5. Apply by rerunning the same command without `--dry-run`.
+6. Review `git diff` and confirm historical changelog and dependency versions remain unchanged.
+7. Run every verification command below. Do not skip failures.
+8. Report the new version, changed files, and exact verification results.
+
+## Required verification
+
+| Check | Command |
+|---|---|
+| CLI version | `go run cmd/noxy/main.go --version` |
+| Internal tests | `go test ./internal/...` |
+| Integration suite | `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx` |
+| Patch integrity | `git diff --check` |
+
+The CLI output must equal `Noxy vX.Y.Z`, and the integration report must contain zero failures.
+
+## Failure handling
+
+- If the updater reports inconsistent or missing surfaces, inspect the files and report the conflict. Do not bypass the check with manual broad replacements.
+- If a target release heading already exists, do not create a duplicate.
+- If any verification fails, report the actual failure and leave the changes available for diagnosis.
+- Do not commit, tag, push, or open a pull request unless the user separately requests it.
+
+## Common mistakes
+
+- Changing historical `CHANGELOG.md` entries or dependency versions.
+- Updating only the runtime constant and leaving docs or `noxy.mod` stale.
+- Claiming completion after a dry run or partial test suite.

--- a/.agents/skills/updating-noxy-version/SKILL.md
+++ b/.agents/skills/updating-noxy-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: updating-noxy-version
-description: Use when changing, bumping, releasing, or synchronizing the Noxy VM semantic version across runtime metadata, noxy.mod, README, language specification, and changelog.
+description: Use when changing, bumping, releasing, or synchronizing the Noxy VM semantic version by major, minor, patch, or explicit target across runtime metadata, noxy.mod, README, language specification, and changelog.
 ---
 
 # Updating Noxy Version
@@ -12,10 +12,13 @@ Use the bundled updater from the Noxy repository root. Preserve unrelated user c
 ## Workflow
 
 1. Inspect `git status --short`. Note pre-existing changes, especially in the five release files.
-2. Normalize the requested target to `vX.Y.Z` for reporting.
+2. Resolve the target:
+   - Use an explicit `X.Y.Z` or `vX.Y.Z` when supplied.
+   - Otherwise use the requested `major`, `minor`, or `patch` component.
+   - Default to `minor` when the request does not name a target.
 3. Preview changes:
-   `python .agents/skills/updating-noxy-version/scripts/update_version.py <version> --dry-run`
-   Add `--date YYYY-MM-DD` only when the user specifies a release date.
+   `python .agents/skills/updating-noxy-version/scripts/update_version.py [target] --dry-run`
+   Omit `[target]` to use the default minor bump. Add `--date YYYY-MM-DD` only when the user specifies a release date.
 4. Review the preview. It must touch only the five expected release files.
 5. Apply by rerunning the same command without `--dry-run`.
 6. Review `git diff` and confirm historical changelog and dependency versions remain unchanged.

--- a/.agents/skills/updating-noxy-version/agents/openai.yaml
+++ b/.agents/skills/updating-noxy-version/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Update Noxy Version"
   short_description: "Update and validate Noxy release versions"
-  default_prompt: "Use $updating-noxy-version to update Noxy to v1.6.0 and run all required checks."
+  default_prompt: "Use $updating-noxy-version to update Noxy's minor version by default, or apply a major or patch bump when requested, and run all required checks."

--- a/.agents/skills/updating-noxy-version/agents/openai.yaml
+++ b/.agents/skills/updating-noxy-version/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Update Noxy Version"
+  short_description: "Update and validate Noxy release versions"
+  default_prompt: "Use $updating-noxy-version to update Noxy to v1.6.0 and run all required checks."

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -1,0 +1,132 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from update_version import UpdateError, execute_update, normalize_version
+
+
+TARGET_FILES = (
+    "internal/version/version.go",
+    "noxy.mod",
+    "README.md",
+    "docs/NOXY_LANGUAGE_SPEC.md",
+    "CHANGELOG.md",
+)
+
+
+def create_fixture(root: Path, version: str = "1.5.0") -> None:
+    contents = {
+        "internal/version/version.go": (
+            f'package version\n\nconst Version = "v{version}"\n'
+        ),
+        "noxy.mod": (
+            f"module noxy\n\nnoxy v{version}\n\n"
+            "require example.org/library v1.4.0\n"
+        ),
+        "README.md": f"# Noxy\n\n```noxy\nNoxy REPL v{version}\n```\n",
+        "docs/NOXY_LANGUAGE_SPEC.md": (
+            f"# Language\n\n---\n*Version: {version}*\n*Language: Noxy*\n"
+        ),
+        "CHANGELOG.md": (
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n\n"
+            "- Pending feature.\n\n## [1.5.0] - 2026-08-08\n\n"
+            "- Previous release.\n\n## [1.4.0] - 2026-08-01\n"
+        ),
+    }
+    for relative, content in contents.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content.encode("utf-8"))
+
+
+def snapshot(root: Path) -> dict[str, bytes]:
+    return {relative: (root / relative).read_bytes() for relative in TARGET_FILES}
+
+
+class UpdateVersionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        create_fixture(self.root)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_normalizes_prefixed_and_plain_semver(self) -> None:
+        self.assertEqual(normalize_version("1.6.0"), ("1.6.0", (1, 6, 0)))
+        self.assertEqual(normalize_version("v1.6.0"), ("1.6.0", (1, 6, 0)))
+
+    def test_updates_all_surfaces_and_preserves_history_and_dependencies(self) -> None:
+        diff = execute_update(self.root, "v1.6.0", "2026-08-09", False)
+
+        self.assertIn('const Version = "v1.6.0"', (self.root / TARGET_FILES[0]).read_text())
+        self.assertIn("noxy v1.6.0", (self.root / TARGET_FILES[1]).read_text())
+        self.assertIn("require example.org/library v1.4.0", (self.root / TARGET_FILES[1]).read_text())
+        self.assertIn("Noxy REPL v1.6.0", (self.root / TARGET_FILES[2]).read_text())
+        self.assertIn("*Version: 1.6.0*", (self.root / TARGET_FILES[3]).read_text())
+        changelog = (self.root / TARGET_FILES[4]).read_text()
+        self.assertIn("## [1.6.0] - 2026-08-09", changelog)
+        self.assertIn("## [1.4.0] - 2026-08-01", changelog)
+        self.assertIn("a/internal/version/version.go", diff)
+
+    def test_dry_run_returns_diff_without_writing(self) -> None:
+        before = snapshot(self.root)
+
+        diff = execute_update(self.root, "1.6.0", "2026-08-09", True)
+
+        self.assertEqual(snapshot(self.root), before)
+        for relative in TARGET_FILES:
+            self.assertIn(relative.replace("\\", "/"), diff)
+
+    def test_rejects_invalid_semver_and_date(self) -> None:
+        with self.assertRaisesRegex(UpdateError, "semantic version"):
+            normalize_version("1.6")
+        with self.assertRaisesRegex(UpdateError, "release date"):
+            execute_update(self.root, "1.6.0", "09-08-2026", False)
+
+    def test_rejects_equal_and_lower_versions_without_writing(self) -> None:
+        for target in ("1.5.0", "1.4.9"):
+            with self.subTest(target=target):
+                before = snapshot(self.root)
+                with self.assertRaisesRegex(UpdateError, "greater than current"):
+                    execute_update(self.root, target, "2026-08-09", False)
+                self.assertEqual(snapshot(self.root), before)
+
+    def test_rejects_inconsistent_current_versions_without_writing(self) -> None:
+        readme = self.root / "README.md"
+        readme.write_text(readme.read_text().replace("v1.5.0", "v1.4.0"))
+        before = snapshot(self.root)
+
+        with self.assertRaisesRegex(UpdateError, "inconsistent current versions"):
+            execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+        self.assertEqual(snapshot(self.root), before)
+
+    def test_rejects_missing_surface_without_writing(self) -> None:
+        spec = self.root / "docs/NOXY_LANGUAGE_SPEC.md"
+        spec.write_text(spec.read_text().replace("*Version: 1.5.0*\n", ""))
+        before = snapshot(self.root)
+
+        with self.assertRaisesRegex(UpdateError, "expected exactly one active version"):
+            execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+        self.assertEqual(snapshot(self.root), before)
+
+    def test_rejects_duplicate_target_release_without_writing(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text() + "\n## [1.6.0] - 2026-07-01\n"
+        )
+        before = snapshot(self.root)
+
+        with self.assertRaisesRegex(UpdateError, "already exists"):
+            execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+        self.assertEqual(snapshot(self.root), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -122,6 +122,23 @@ class UpdateVersionTests(unittest.TestCase):
         self.assertIn("## [1.4.0] - 2026-08-01", changelog)
         self.assertIn("a/internal/version/version.go", diff)
 
+    def test_updates_changelog_when_unreleased_heading_uses_lf_in_mixed_eol_file(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_bytes(
+            b"# Changelog\r\n\r\n## [Unreleased]\n\n### Added\r\n\r\n"
+            b"- Pending feature.\r\n\r\n## [1.5.0] - 2026-08-08\r\n"
+        )
+
+        execute_update(self.root, "minor", "2026-08-09", False)
+
+        updated = changelog.read_bytes()
+        self.assertIn(b"# Changelog\r\n", updated)
+        self.assertIn(
+            b"## [Unreleased]\n\n## [1.6.0] - 2026-08-09\n\n",
+            updated,
+        )
+        self.assertIn(b"### Added\r\n", updated)
+
     def test_dry_run_returns_diff_without_writing(self) -> None:
         before = snapshot(self.root)
 

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -1,7 +1,10 @@
+import os
+import re
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -58,6 +61,10 @@ class UpdateVersionTests(unittest.TestCase):
     def test_normalizes_prefixed_and_plain_semver(self) -> None:
         self.assertEqual(normalize_version("1.6.0"), ("1.6.0", (1, 6, 0)))
         self.assertEqual(normalize_version("v1.6.0"), ("1.6.0", (1, 6, 0)))
+
+    def test_rejects_semver_with_unicode_decimal_digits(self) -> None:
+        with self.assertRaisesRegex(UpdateError, "semantic version"):
+            normalize_version("1.6.1١")
 
     def test_updates_all_surfaces_and_preserves_history_and_dependencies(self) -> None:
         diff = execute_update(self.root, "v1.6.0", "2026-08-09", False)
@@ -134,6 +141,53 @@ class UpdateVersionTests(unittest.TestCase):
             execute_update(self.root, "1.6.0", "2026-08-09", False)
 
         self.assertEqual(snapshot(self.root), before)
+
+    def test_rejects_any_target_release_heading_without_writing(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        original_changelog = changelog.read_bytes()
+
+        for heading in ("## [1.6.0]", "## [1.6.0] - TBD"):
+            with self.subTest(heading=heading):
+                create_fixture(self.root)
+                changelog.write_bytes(
+                    original_changelog + f"\n{heading}\n".encode("utf-8")
+                )
+                before = snapshot(self.root)
+
+                with self.assertRaisesRegex(UpdateError, "already exists"):
+                    execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+                self.assertEqual(snapshot(self.root), before)
+
+    def test_mid_commit_failure_restores_every_file_and_removes_artifacts(self) -> None:
+        readme = self.root / "README.md"
+        readme.write_bytes(readme.read_bytes().replace(b"\n", b"\r\n"))
+        before = snapshot(self.root)
+        files_before = {
+            path.relative_to(self.root) for path in self.root.rglob("*") if path.is_file()
+        }
+        real_replace = os.replace
+        target_paths = {(self.root / relative).resolve() for relative in TARGET_FILES}
+        replacements = 0
+
+        def fail_third_target_replace(source, destination) -> None:
+            nonlocal replacements
+            if Path(destination).resolve() in target_paths:
+                replacements += 1
+                if replacements == 3:
+                    raise OSError("injected mid-commit failure")
+            real_replace(source, destination)
+
+        failed_path = self.root / TARGET_FILES[2]
+        with mock.patch("os.replace", side_effect=fail_third_target_replace):
+            with self.assertRaisesRegex(UpdateError, re.escape(str(failed_path))):
+                execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+        self.assertEqual(snapshot(self.root), before)
+        files_after = {
+            path.relative_to(self.root) for path in self.root.rglob("*") if path.is_file()
+        }
+        self.assertEqual(files_after, files_before)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -87,6 +87,14 @@ class UpdateVersionTests(unittest.TestCase):
         with self.assertRaisesRegex(UpdateError, "release date"):
             execute_update(self.root, "1.6.0", "09-08-2026", False)
 
+    def test_rejects_explicit_empty_release_date_without_writing(self) -> None:
+        before = snapshot(self.root)
+
+        with self.assertRaisesRegex(UpdateError, "release date"):
+            execute_update(self.root, "1.6.0", "", False)
+
+        self.assertEqual(snapshot(self.root), before)
+
     def test_rejects_equal_and_lower_versions_without_writing(self) -> None:
         for target in ("1.5.0", "1.4.9"):
             with self.subTest(target=target):

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -189,6 +189,44 @@ class UpdateVersionTests(unittest.TestCase):
         }
         self.assertEqual(files_after, files_before)
 
+    def test_rollback_failure_preserves_original_for_manual_recovery(self) -> None:
+        before = snapshot(self.root)
+        real_replace = os.replace
+        failed_commit_path = (self.root / TARGET_FILES[2]).resolve()
+        failed_restore_path = (self.root / TARGET_FILES[1]).resolve()
+
+        def fail_commit_and_restore(source, destination) -> None:
+            source_path = Path(source)
+            destination_path = Path(destination).resolve()
+            if source_path.name == "2.new" and destination_path == failed_commit_path:
+                raise OSError("injected mid-commit failure")
+            if (
+                source_path.name == "1.original"
+                and destination_path == failed_restore_path
+            ):
+                raise OSError("injected rollback failure")
+            real_replace(source, destination)
+
+        with mock.patch("os.replace", side_effect=fail_commit_and_restore):
+            with self.assertRaises(UpdateError) as raised:
+                execute_update(self.root, "1.6.0", "2026-08-09", False)
+
+        message = str(raised.exception)
+        self.assertIn(str(failed_commit_path), message)
+        self.assertIn(str(failed_restore_path), message)
+        recovery_match = re.search(
+            r"recovery files preserved at (?P<path>.+)$", message
+        )
+        self.assertIsNotNone(recovery_match)
+        recovery_dir = Path(recovery_match.group("path"))
+        self.assertTrue(recovery_dir.is_dir())
+        self.assertEqual(
+            (recovery_dir / "1.original").read_bytes(), before[TARGET_FILES[1]]
+        )
+        for relative in (TARGET_FILES[0], *TARGET_FILES[2:]):
+            with self.subTest(relative=relative):
+                self.assertEqual((self.root / relative).read_bytes(), before[relative])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -8,7 +8,13 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from update_version import UpdateError, execute_update, normalize_version
+from update_version import (
+    UpdateError,
+    execute_update,
+    normalize_version,
+    parse_args,
+    resolve_target,
+)
 
 
 TARGET_FILES = (
@@ -61,6 +67,43 @@ class UpdateVersionTests(unittest.TestCase):
     def test_normalizes_prefixed_and_plain_semver(self) -> None:
         self.assertEqual(normalize_version("1.6.0"), ("1.6.0", (1, 6, 0)))
         self.assertEqual(normalize_version("v1.6.0"), ("1.6.0", (1, 6, 0)))
+
+    def test_resolves_named_and_explicit_targets(self) -> None:
+        current = (1, 5, 7)
+
+        self.assertEqual(resolve_target("major", current), ("2.0.0", (2, 0, 0)))
+        self.assertEqual(resolve_target("minor", current), ("1.6.0", (1, 6, 0)))
+        self.assertEqual(resolve_target("patch", current), ("1.5.8", (1, 5, 8)))
+        self.assertEqual(resolve_target(" MiNoR ", current), ("1.6.0", (1, 6, 0)))
+        self.assertEqual(resolve_target("v2.3.4", current), ("2.3.4", (2, 3, 4)))
+
+    def test_named_minor_bump_updates_every_surface(self) -> None:
+        diff = execute_update(self.root, "minor", "2026-08-09", False)
+
+        self.assertIn('const Version = "v1.6.0"', (self.root / TARGET_FILES[0]).read_text())
+        self.assertIn("noxy v1.6.0", (self.root / TARGET_FILES[1]).read_text())
+        self.assertIn("require example.org/library v1.4.0", (self.root / TARGET_FILES[1]).read_text())
+        self.assertIn("Noxy REPL v1.6.0", (self.root / TARGET_FILES[2]).read_text())
+        self.assertIn("*Version: 1.6.0*", (self.root / TARGET_FILES[3]).read_text())
+        changelog = (self.root / TARGET_FILES[4]).read_text()
+        self.assertIn("## [1.6.0] - 2026-08-09", changelog)
+        self.assertIn("## [1.4.0] - 2026-08-01", changelog)
+        self.assertIn("a/internal/version/version.go", diff)
+
+    def test_rejects_invalid_target_without_writing(self) -> None:
+        before = snapshot(self.root)
+
+        with self.assertRaisesRegex(
+            UpdateError, "major, minor, patch, X.Y.Z, or vX.Y.Z"
+        ):
+            execute_update(self.root, "feature", "2026-08-09", False)
+
+        self.assertEqual(snapshot(self.root), before)
+
+    def test_cli_defaults_omitted_target_to_minor(self) -> None:
+        args = parse_args([])
+
+        self.assertEqual(args.version, "minor")
 
     def test_rejects_semver_with_unicode_decimal_digits(self) -> None:
         with self.assertRaisesRegex(UpdateError, "semantic version"):

--- a/.agents/skills/updating-noxy-version/scripts/test_update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/test_update_version.py
@@ -124,20 +124,30 @@ class UpdateVersionTests(unittest.TestCase):
 
     def test_updates_changelog_when_unreleased_heading_uses_lf_in_mixed_eol_file(self) -> None:
         changelog = self.root / "CHANGELOG.md"
-        changelog.write_bytes(
-            b"# Changelog\r\n\r\n## [Unreleased]\n\n### Added\r\n\r\n"
-            b"- Pending feature.\r\n\r\n## [1.5.0] - 2026-08-08\r\n"
+        original = (
+            b"# Changelog\r\n\r\n"
+            b"Inline note: ## [Unreleased]\n"
+            b"must remain text.\r\n\r\n"
+            b"## [Unreleased]\n\n"
+            b"### Added\r\n\r\n"
+            b"- Pending feature.\r\n\r\n"
+            b"## [1.5.0] - 2026-08-08\r\n"
         )
+        changelog.write_bytes(original)
 
         execute_update(self.root, "minor", "2026-08-09", False)
 
-        updated = changelog.read_bytes()
-        self.assertIn(b"# Changelog\r\n", updated)
-        self.assertIn(
-            b"## [Unreleased]\n\n## [1.6.0] - 2026-08-09\n\n",
-            updated,
+        self.assertEqual(
+            changelog.read_bytes(),
+            b"# Changelog\r\n\r\n"
+            b"Inline note: ## [Unreleased]\n"
+            b"must remain text.\r\n\r\n"
+            b"## [Unreleased]\n\n"
+            b"## [1.6.0] - 2026-08-09\n\n"
+            b"### Added\r\n\r\n"
+            b"- Pending feature.\r\n\r\n"
+            b"## [1.5.0] - 2026-08-08\r\n",
         )
-        self.assertIn(b"### Added\r\n", updated)
 
     def test_dry_run_returns_diff_without_writing(self) -> None:
         before = snapshot(self.root)

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 import argparse
 import difflib
+import os
 import re
+import shutil
 import sys
+import tempfile
 from datetime import date
 from pathlib import Path
 
 
-SEMVER = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+SEMVER = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
 TARGET_VERSION = re.compile(rf"^v?(?P<version>{SEMVER})$")
 RELEASE_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 RELEASE_HEADING = re.compile(
     rf"(?m)^## \[(?P<version>{SEMVER})\] - \d{{4}}-\d{{2}}-\d{{2}}\r?$"
+)
+RELEASE_VERSION_HEADING = re.compile(
+    rf"(?m)^## \[(?P<version>{SEMVER})\][^\r\n]*\r?$"
 )
 SURFACES = (
     (
@@ -108,7 +114,10 @@ def build_updates(
         updated[relative] = value
 
     changelog = contents[CHANGELOG]
-    if any(match.group("version") == target for match in RELEASE_HEADING.finditer(changelog)):
+    if any(
+        match.group("version") == target
+        for match in RELEASE_VERSION_HEADING.finditer(changelog)
+    ):
         raise UpdateError(f"{CHANGELOG}: release {target} already exists")
     newline = "\r\n" if "\r\n" in changelog else "\n"
     marker = "## [Unreleased]"
@@ -138,6 +147,74 @@ def render_diff(original: dict[str, str], updated: dict[str, str]) -> str:
     return "".join(chunks)
 
 
+def _write_updates(
+    root: Path, original: dict[str, str], updated: dict[str, str]
+) -> None:
+    try:
+        transaction_dir = Path(
+            tempfile.mkdtemp(prefix=".noxy-version-update-", dir=root)
+        )
+    except OSError as error:
+        raise UpdateError(
+            f"failed to create staging directory in {root}: {error}"
+        ) from error
+
+    staged: dict[str, Path] = {}
+    backups: dict[str, Path] = {}
+    operation_error: UpdateError | None = None
+
+    try:
+        for index, relative in enumerate(TARGET_FILES):
+            target_path = root / relative
+            staged_path = transaction_dir / f"{index}.new"
+            backup_path = transaction_dir / f"{index}.original"
+            try:
+                staged_path.write_bytes(updated[relative].encode("utf-8"))
+                backup_path.write_bytes(original[relative].encode("utf-8"))
+            except OSError as error:
+                raise UpdateError(
+                    f"failed to stage update for {target_path}: {error}"
+                ) from error
+            staged[relative] = staged_path
+            backups[relative] = backup_path
+
+        replaced: list[str] = []
+        for relative in TARGET_FILES:
+            target_path = root / relative
+            try:
+                os.replace(staged[relative], target_path)
+            except OSError as error:
+                rollback_errors = []
+                for replaced_relative in reversed(replaced):
+                    replaced_path = root / replaced_relative
+                    try:
+                        os.replace(backups[replaced_relative], replaced_path)
+                    except OSError as rollback_error:
+                        rollback_errors.append(
+                            f"failed to restore {replaced_path}: {rollback_error}"
+                        )
+                message = f"failed to replace {target_path}: {error}"
+                if rollback_errors:
+                    message += "; " + "; ".join(rollback_errors)
+                raise UpdateError(message) from error
+            replaced.append(relative)
+    except UpdateError as error:
+        operation_error = error
+
+    try:
+        shutil.rmtree(transaction_dir)
+    except OSError as error:
+        cleanup_error = UpdateError(
+            f"failed to remove transaction artifacts at {transaction_dir}: {error}"
+        )
+        if operation_error is not None:
+            raise UpdateError(f"{operation_error}; {cleanup_error}") from operation_error
+        raise cleanup_error from error
+
+    if operation_error is not None:
+        raise operation_error
+
+
 def execute_update(
     root: Path, target: str, release_date: str | None = None, dry_run: bool = False
 ) -> str:
@@ -155,8 +232,7 @@ def execute_update(
     updated = build_updates(original, normalized, normalized_date)
     diff = render_diff(original, updated)
     if not dry_run:
-        for relative in TARGET_FILES:
-            (root / relative).write_bytes(updated[relative].encode("utf-8"))
+        _write_updates(root, original, updated)
     return diff
 
 

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -162,6 +162,7 @@ def _write_updates(
     staged: dict[str, Path] = {}
     backups: dict[str, Path] = {}
     operation_error: UpdateError | None = None
+    preserve_transaction = False
 
     try:
         for index, relative in enumerate(TARGET_FILES):
@@ -195,11 +196,16 @@ def _write_updates(
                         )
                 message = f"failed to replace {target_path}: {error}"
                 if rollback_errors:
+                    preserve_transaction = True
                     message += "; " + "; ".join(rollback_errors)
+                    message += f"; recovery files preserved at {transaction_dir}"
                 raise UpdateError(message) from error
             replaced.append(relative)
     except UpdateError as error:
         operation_error = error
+
+    if preserve_transaction:
+        raise operation_error
 
     try:
         shutil.rmtree(transaction_dir)

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -57,6 +57,31 @@ def normalize_version(value: str) -> tuple[str, tuple[int, int, int]]:
     return normalized, tuple(int(part) for part in normalized.split("."))
 
 
+def resolve_target(
+    value: str, current: tuple[int, int, int]
+) -> tuple[str, tuple[int, int, int]]:
+    normalized = value.strip()
+    kind = normalized.lower()
+    major, minor, patch = current
+
+    if kind == "major":
+        target = (major + 1, 0, 0)
+    elif kind == "minor":
+        target = (major, minor + 1, 0)
+    elif kind == "patch":
+        target = (major, minor, patch + 1)
+    else:
+        try:
+            return normalize_version(normalized)
+        except UpdateError as error:
+            raise UpdateError(
+                f"invalid version target: {value!r}; expected "
+                "major, minor, patch, X.Y.Z, or vX.Y.Z"
+            ) from error
+
+    return ".".join(str(part) for part in target), target
+
+
 def normalize_date(value: str | None) -> str:
     normalized = date.today().isoformat() if value is None else value
     if not RELEASE_DATE.fullmatch(normalized):
@@ -225,11 +250,11 @@ def execute_update(
     root: Path, target: str, release_date: str | None = None, dry_run: bool = False
 ) -> str:
     root = root.resolve()
-    normalized, target_tuple = normalize_version(target)
     normalized_date = normalize_date(release_date)
     original = read_targets(root)
     current = inspect_current_versions(original)
     _current_text, current_tuple = normalize_version(current)
+    normalized, target_tuple = resolve_target(target, current_tuple)
     if target_tuple <= current_tuple:
         raise UpdateError(
             f"target version {normalized} must be greater than current version {current}"
@@ -250,7 +275,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Update all active Noxy release version surfaces."
     )
-    parser.add_argument("version", help="target semantic version, with optional v prefix")
+    parser.add_argument(
+        "version",
+        nargs="?",
+        default="minor",
+        help="target version: major, minor, patch, X.Y.Z, or vX.Y.Z (default: minor)",
+    )
     parser.add_argument("--date", dest="release_date", help="release date as YYYY-MM-DD")
     parser.add_argument("--dry-run", action="store_true", help="print diff without writing")
     parser.add_argument("--root", type=Path, default=default_root(), help="Noxy repository root")

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -52,7 +52,7 @@ def normalize_version(value: str) -> tuple[str, tuple[int, int, int]]:
 
 
 def normalize_date(value: str | None) -> str:
-    normalized = value or date.today().isoformat()
+    normalized = date.today().isoformat() if value is None else value
     if not RELEASE_DATE.fullmatch(normalized):
         raise UpdateError(f"invalid release date: {normalized!r}; expected YYYY-MM-DD")
     try:

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -151,10 +151,13 @@ def build_updates(
     if marker_match is None:
         raise UpdateError(f"{CHANGELOG}: {marker} heading must end with a newline")
     newline = marker_match.group("newline")
-    anchor = marker_match.group(0)
     heading = f"## [{target}] - {release_date}"
-    updated[CHANGELOG] = changelog.replace(
-        anchor, anchor + newline + heading + newline, 1
+    updated[CHANGELOG] = (
+        changelog[: marker_match.end()]
+        + newline
+        + heading
+        + newline
+        + changelog[marker_match.end() :]
     )
     return updated
 

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+import argparse
+import difflib
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+SEMVER = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+TARGET_VERSION = re.compile(rf"^v?(?P<version>{SEMVER})$")
+RELEASE_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+RELEASE_HEADING = re.compile(
+    rf"(?m)^## \[(?P<version>{SEMVER})\] - \d{{4}}-\d{{2}}-\d{{2}}\r?$"
+)
+SURFACES = (
+    (
+        "internal/version/version.go",
+        re.compile(rf'(?m)^const Version = "v(?P<version>{SEMVER})"(?=\r?$)'),
+        lambda version: f'const Version = "v{version}"',
+    ),
+    (
+        "noxy.mod",
+        re.compile(rf"(?m)^noxy v(?P<version>{SEMVER})(?=\r?$)"),
+        lambda version: f"noxy v{version}",
+    ),
+    (
+        "README.md",
+        re.compile(rf"(?m)^Noxy REPL v(?P<version>{SEMVER})(?=\r?$)"),
+        lambda version: f"Noxy REPL v{version}",
+    ),
+    (
+        "docs/NOXY_LANGUAGE_SPEC.md",
+        re.compile(rf"(?m)^\*Version: (?P<version>{SEMVER})\*(?=\r?$)"),
+        lambda version: f"*Version: {version}*",
+    ),
+)
+CHANGELOG = "CHANGELOG.md"
+TARGET_FILES = tuple(item[0] for item in SURFACES) + (CHANGELOG,)
+
+
+class UpdateError(ValueError):
+    pass
+
+
+def normalize_version(value: str) -> tuple[str, tuple[int, int, int]]:
+    match = TARGET_VERSION.fullmatch(value.strip())
+    if not match:
+        raise UpdateError(f"invalid semantic version: {value!r}; expected X.Y.Z or vX.Y.Z")
+    normalized = match.group("version")
+    return normalized, tuple(int(part) for part in normalized.split("."))
+
+
+def normalize_date(value: str | None) -> str:
+    normalized = value or date.today().isoformat()
+    if not RELEASE_DATE.fullmatch(normalized):
+        raise UpdateError(f"invalid release date: {normalized!r}; expected YYYY-MM-DD")
+    try:
+        date.fromisoformat(normalized)
+    except ValueError as error:
+        raise UpdateError(f"invalid release date: {normalized!r}") from error
+    return normalized
+
+
+def read_targets(root: Path) -> dict[str, str]:
+    contents = {}
+    for relative in TARGET_FILES:
+        path = root / relative
+        try:
+            contents[relative] = path.read_bytes().decode("utf-8")
+        except FileNotFoundError as error:
+            raise UpdateError(f"required file not found: {relative}") from error
+        except UnicodeDecodeError as error:
+            raise UpdateError(f"required file is not UTF-8: {relative}") from error
+    return contents
+
+
+def inspect_current_versions(contents: dict[str, str]) -> str:
+    current = []
+    for relative, pattern, _replacement in SURFACES:
+        matches = list(pattern.finditer(contents[relative]))
+        if len(matches) != 1:
+            raise UpdateError(
+                f"{relative}: expected exactly one active version, found {len(matches)}"
+            )
+        current.append((relative, matches[0].group("version")))
+
+    releases = list(RELEASE_HEADING.finditer(contents[CHANGELOG]))
+    if not releases:
+        raise UpdateError(f"{CHANGELOG}: expected at least one dated release heading")
+    current.append((CHANGELOG, releases[0].group("version")))
+
+    versions = {version for _relative, version in current}
+    if len(versions) != 1:
+        details = ", ".join(f"{relative}={version}" for relative, version in current)
+        raise UpdateError(f"inconsistent current versions: {details}")
+    return current[0][1]
+
+
+def build_updates(
+    contents: dict[str, str], target: str, release_date: str
+) -> dict[str, str]:
+    updated = {}
+    for relative, pattern, replacement in SURFACES:
+        value, count = pattern.subn(lambda _match: replacement(target), contents[relative])
+        if count != 1:
+            raise UpdateError(f"{relative}: expected exactly one replacement, found {count}")
+        updated[relative] = value
+
+    changelog = contents[CHANGELOG]
+    if any(match.group("version") == target for match in RELEASE_HEADING.finditer(changelog)):
+        raise UpdateError(f"{CHANGELOG}: release {target} already exists")
+    newline = "\r\n" if "\r\n" in changelog else "\n"
+    marker = "## [Unreleased]"
+    if changelog.splitlines().count(marker) != 1:
+        raise UpdateError(f"{CHANGELOG}: expected exactly one {marker} heading")
+    anchor = marker + newline
+    if anchor not in changelog:
+        raise UpdateError(f"{CHANGELOG}: {marker} heading must end with a newline")
+    heading = f"## [{target}] - {release_date}"
+    updated[CHANGELOG] = changelog.replace(
+        anchor, anchor + newline + heading + newline, 1
+    )
+    return updated
+
+
+def render_diff(original: dict[str, str], updated: dict[str, str]) -> str:
+    chunks = []
+    for relative in TARGET_FILES:
+        chunks.extend(
+            difflib.unified_diff(
+                original[relative].splitlines(keepends=True),
+                updated[relative].splitlines(keepends=True),
+                fromfile=f"a/{relative}",
+                tofile=f"b/{relative}",
+            )
+        )
+    return "".join(chunks)
+
+
+def execute_update(
+    root: Path, target: str, release_date: str | None = None, dry_run: bool = False
+) -> str:
+    root = root.resolve()
+    normalized, target_tuple = normalize_version(target)
+    normalized_date = normalize_date(release_date)
+    original = read_targets(root)
+    current = inspect_current_versions(original)
+    _current_text, current_tuple = normalize_version(current)
+    if target_tuple <= current_tuple:
+        raise UpdateError(
+            f"target version {normalized} must be greater than current version {current}"
+        )
+
+    updated = build_updates(original, normalized, normalized_date)
+    diff = render_diff(original, updated)
+    if not dry_run:
+        for relative in TARGET_FILES:
+            (root / relative).write_bytes(updated[relative].encode("utf-8"))
+    return diff
+
+
+def default_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update all active Noxy release version surfaces."
+    )
+    parser.add_argument("version", help="target semantic version, with optional v prefix")
+    parser.add_argument("--date", dest="release_date", help="release date as YYYY-MM-DD")
+    parser.add_argument("--dry-run", action="store_true", help="print diff without writing")
+    parser.add_argument("--root", type=Path, default=default_root(), help="Noxy repository root")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        diff = execute_update(args.root, args.version, args.release_date, args.dry_run)
+    except UpdateError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(diff, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/updating-noxy-version/scripts/update_version.py
+++ b/.agents/skills/updating-noxy-version/scripts/update_version.py
@@ -144,13 +144,14 @@ def build_updates(
         for match in RELEASE_VERSION_HEADING.finditer(changelog)
     ):
         raise UpdateError(f"{CHANGELOG}: release {target} already exists")
-    newline = "\r\n" if "\r\n" in changelog else "\n"
     marker = "## [Unreleased]"
     if changelog.splitlines().count(marker) != 1:
         raise UpdateError(f"{CHANGELOG}: expected exactly one {marker} heading")
-    anchor = marker + newline
-    if anchor not in changelog:
+    marker_match = re.search(r"(?m)^## \[Unreleased\](?P<newline>\r?\n)", changelog)
+    if marker_match is None:
         raise UpdateError(f"{CHANGELOG}: {marker} heading must end with a newline")
+    newline = marker_match.group("newline")
+    anchor = marker_match.group(0)
     heading = f"## [{target}] - {release_date}"
     updated[CHANGELOG] = changelog.replace(
         anchor, anchor + newline + heading + newline, 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Repository-local skill for safe, transactional Noxy version updates with dry-run validation and rollback coverage. `#tooling` @estevaofon
+- Repository-local skill for safe, transactional Noxy version updates by major, minor, patch, or explicit target, with default-minor behavior, dry-run validation, and rollback coverage. `#tooling` @estevaofon
 
 ## [1.5.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Repository-local skill for safe, transactional Noxy version updates with dry-run validation and rollback coverage. `#tooling` @estevaofon
+
 ## [1.5.0] - 2026-08-09
 
 ### Added

--- a/docs/superpowers/plans/2026-08-09-updating-noxy-version-bump-kinds.md
+++ b/docs/superpowers/plans/2026-08-09-updating-noxy-version-bump-kinds.md
@@ -1,0 +1,377 @@
+# Updating Noxy Version Bump Kinds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `$updating-noxy-version` so users can request `major`, `minor`, `patch`, or an explicit semantic version, with `minor` as the default when no target is supplied.
+
+**Architecture:** Keep all version calculation in the bundled Python updater. Add a small target-resolution function that derives named bumps from the already validated current version, then reuse the existing monotonicity, five-surface replacement, dry-run, transactional write, rollback, and recovery pipeline. Update the skill workflow and UI prompt to expose the new natural-language behavior without a hardcoded release number.
+
+**Tech Stack:** Python 3 standard library, `unittest`, Markdown skill instructions, Codex skill-authoring utilities, Go/Noxy project verification.
+
+## Global Constraints
+
+- Accept `major`, `minor`, `patch`, `X.Y.Z`, and `vX.Y.Z`.
+- Default an omitted CLI target and an unspecified natural-language request to `minor`.
+- Apply SemVer component rules: major resets minor/patch, minor resets patch, and patch preserves major/minor.
+- Accept bump keywords case-insensitively after trimming surrounding whitespace.
+- Keep explicit SemVer restricted to ASCII digits and require explicit targets to be greater than the current version.
+- Update only `internal/version/version.go`, `noxy.mod`, `README.md`, `docs/NOXY_LANGUAGE_SPEC.md`, and `CHANGELOG.md`.
+- Preserve history, dependency versions, unrelated content, transactional rollback, recovery artifacts, `--date`, `--dry-run`, and all existing public behavior.
+- Keep the skill under 500 words and remove the hardcoded `v1.6.0` UI prompt.
+- Do not apply a real Noxy version bump while implementing this feature.
+- Update the existing pull request by pushing the current branch; do not open a second PR.
+
+---
+
+### Task 1: Add named and default bump targets to the updater
+
+**Files:**
+- Modify: `.agents/skills/updating-noxy-version/scripts/test_update_version.py`
+- Modify: `.agents/skills/updating-noxy-version/scripts/update_version.py`
+
+**Interfaces:**
+- Consumes: the current version tuple returned by `normalize_version(current)`.
+- Produces: `resolve_target(value: str, current: tuple[int, int, int]) -> tuple[str, tuple[int, int, int]]`.
+- Preserves: `execute_update(root: Path, target: str, release_date: str | None = None, dry_run: bool = False) -> str`.
+- Changes CLI: positional `version` becomes optional with default `minor`.
+
+- [ ] **Step 1: Add imports and failing target-resolution tests**
+
+Extend the updater import in `test_update_version.py`:
+
+```python
+from update_version import (
+    UpdateError,
+    execute_update,
+    normalize_version,
+    parse_args,
+    resolve_target,
+)
+```
+
+Add these test methods to `UpdateVersionTests`:
+
+```python
+def test_resolves_named_and_explicit_targets(self) -> None:
+    current = (1, 5, 7)
+
+    self.assertEqual(resolve_target("major", current), ("2.0.0", (2, 0, 0)))
+    self.assertEqual(resolve_target("minor", current), ("1.6.0", (1, 6, 0)))
+    self.assertEqual(resolve_target("patch", current), ("1.5.8", (1, 5, 8)))
+    self.assertEqual(resolve_target(" MiNoR ", current), ("1.6.0", (1, 6, 0)))
+    self.assertEqual(resolve_target("v2.3.4", current), ("2.3.4", (2, 3, 4)))
+
+def test_named_minor_bump_updates_every_surface(self) -> None:
+    diff = execute_update(self.root, "minor", "2026-08-09", False)
+
+    self.assertIn('const Version = "v1.6.0"', (self.root / TARGET_FILES[0]).read_text())
+    self.assertIn("noxy v1.6.0", (self.root / TARGET_FILES[1]).read_text())
+    self.assertIn("require example.org/library v1.4.0", (self.root / TARGET_FILES[1]).read_text())
+    self.assertIn("Noxy REPL v1.6.0", (self.root / TARGET_FILES[2]).read_text())
+    self.assertIn("*Version: 1.6.0*", (self.root / TARGET_FILES[3]).read_text())
+    changelog = (self.root / TARGET_FILES[4]).read_text()
+    self.assertIn("## [1.6.0] - 2026-08-09", changelog)
+    self.assertIn("## [1.4.0] - 2026-08-01", changelog)
+    self.assertIn("a/internal/version/version.go", diff)
+
+def test_rejects_invalid_target_without_writing(self) -> None:
+    before = snapshot(self.root)
+
+    with self.assertRaisesRegex(
+        UpdateError, "major, minor, patch, X.Y.Z, or vX.Y.Z"
+    ):
+        execute_update(self.root, "feature", "2026-08-09", False)
+
+    self.assertEqual(snapshot(self.root), before)
+
+def test_cli_defaults_omitted_target_to_minor(self) -> None:
+    args = parse_args([])
+
+    self.assertEqual(args.version, "minor")
+```
+
+- [ ] **Step 2: Run the updater suite and verify RED**
+
+Run:
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/test_update_version.py -v
+```
+
+Expected: import fails with `ImportError: cannot import name 'resolve_target'`. The failure must come from the missing target resolver.
+
+- [ ] **Step 3: Add the minimal target resolver**
+
+Add below `normalize_version` in `update_version.py`:
+
+```python
+def resolve_target(
+    value: str, current: tuple[int, int, int]
+) -> tuple[str, tuple[int, int, int]]:
+    normalized = value.strip()
+    kind = normalized.lower()
+    major, minor, patch = current
+
+    if kind == "major":
+        target = (major + 1, 0, 0)
+    elif kind == "minor":
+        target = (major, minor + 1, 0)
+    elif kind == "patch":
+        target = (major, minor, patch + 1)
+    else:
+        try:
+            return normalize_version(normalized)
+        except UpdateError as error:
+            raise UpdateError(
+                f"invalid version target: {value!r}; expected "
+                "major, minor, patch, X.Y.Z, or vX.Y.Z"
+            ) from error
+
+    return ".".join(str(part) for part in target), target
+```
+
+Do not add new dependencies or an unused keyword constant.
+
+- [ ] **Step 4: Resolve the target after validating current surfaces**
+
+Replace the beginning of `execute_update` through the monotonicity check with:
+
+```python
+def execute_update(
+    root: Path, target: str, release_date: str | None = None, dry_run: bool = False
+) -> str:
+    root = root.resolve()
+    normalized_date = normalize_date(release_date)
+    original = read_targets(root)
+    current = inspect_current_versions(original)
+    _current_text, current_tuple = normalize_version(current)
+    normalized, target_tuple = resolve_target(target, current_tuple)
+    if target_tuple <= current_tuple:
+        raise UpdateError(
+            f"target version {normalized} must be greater than current version {current}"
+        )
+
+    updated = build_updates(original, normalized, normalized_date)
+    diff = render_diff(original, updated)
+    if not dry_run:
+        _write_updates(root, original, updated)
+    return diff
+```
+
+This ordering ensures named bumps are derived only from a current version that agrees across every active surface.
+
+- [ ] **Step 5: Make the CLI target optional and default it to minor**
+
+Replace the positional argument in `parse_args` with:
+
+```python
+parser.add_argument(
+    "version",
+    nargs="?",
+    default="minor",
+    help="target version: major, minor, patch, X.Y.Z, or vX.Y.Z (default: minor)",
+)
+```
+
+Keep `main` passing `args.version` to `execute_update`.
+
+- [ ] **Step 6: Run the updater suite and verify GREEN**
+
+Run:
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/test_update_version.py -v
+python -m py_compile .agents/skills/updating-noxy-version/scripts/update_version.py .agents/skills/updating-noxy-version/scripts/test_update_version.py
+git diff --check
+```
+
+Expected: `Ran 17 tests`, `OK`, Python compilation exit 0, and no patch errors.
+
+- [ ] **Step 7: Commit the updater behavior**
+
+```powershell
+git add -- .agents/skills/updating-noxy-version/scripts/update_version.py .agents/skills/updating-noxy-version/scripts/test_update_version.py
+git commit -m "feat: support semantic version bump targets"
+```
+
+---
+
+### Task 2: Update the skill workflow, UI prompt, and changelog
+
+**Files:**
+- Modify: `.agents/skills/updating-noxy-version/SKILL.md`
+- Modify: `.agents/skills/updating-noxy-version/agents/openai.yaml`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `update_version.py [major|minor|patch|X.Y.Z|vX.Y.Z] [--date YYYY-MM-DD] [--dry-run]`.
+- Produces: natural-language default-minor behavior and generic UI metadata without a concrete release number.
+
+- [ ] **Step 1: Capture the current-skill baseline before editing**
+
+Dispatch a fresh-context agent with:
+
+```text
+Use $updating-noxy-version at .agents/skills/updating-noxy-version to explain the exact commands you would run for each request: "update the Noxy version", "bump the patch version", "bump the major version", and "update to v2.3.4". Do not modify files. Report the default used when no target is named.
+```
+
+Expected current failure: the skill requires a concrete `<version>`, has no default-minor rule, does not define named component commands, and its UI prompt hardcodes `v1.6.0`. Record the transcript in the ignored SDD workspace.
+
+- [ ] **Step 2: Replace the target-resolution portion of SKILL.md**
+
+Change the frontmatter description to:
+
+```yaml
+description: Use when changing, bumping, releasing, or synchronizing the Noxy VM semantic version by major, minor, patch, or explicit target across runtime metadata, noxy.mod, README, language specification, and changelog.
+```
+
+Replace Workflow steps 2 and 3 with:
+
+```markdown
+2. Resolve the target:
+   - Use an explicit `X.Y.Z` or `vX.Y.Z` when supplied.
+   - Otherwise use the requested `major`, `minor`, or `patch` component.
+   - Default to `minor` when the request does not name a target.
+3. Preview changes:
+   `python .agents/skills/updating-noxy-version/scripts/update_version.py [target] --dry-run`
+   Omit `[target]` to use the default minor bump. Add `--date YYYY-MM-DD` only when the user specifies a release date.
+```
+
+Keep the remaining preview review, apply, verification, failure handling, and no-release-Git-operation rules unchanged.
+
+- [ ] **Step 3: Regenerate generic UI metadata**
+
+Run:
+
+```powershell
+python 'C:/Users/estev/.codex/skills/.system/skill-creator/scripts/generate_openai_yaml.py' .agents/skills/updating-noxy-version --interface 'display_name=Update Noxy Version' --interface 'short_description=Update and validate Noxy release versions' --interface 'default_prompt=Use $updating-noxy-version to update Noxy''s minor version by default, or apply a major or patch bump when requested, and run all required checks.'
+```
+
+Verify `agents/openai.yaml` contains:
+
+```yaml
+interface:
+  display_name: "Update Noxy Version"
+  short_description: "Update and validate Noxy release versions"
+  default_prompt: "Use $updating-noxy-version to update Noxy's minor version by default, or apply a major or patch bump when requested, and run all required checks."
+```
+
+- [ ] **Step 4: Refine the Unreleased changelog entry**
+
+Replace the current updater bullet with:
+
+```markdown
+- Repository-local skill for safe, transactional Noxy version updates by major, minor, patch, or explicit target, with default-minor behavior, dry-run validation, and rollback coverage. `#tooling` @estevaofon
+```
+
+Do not create a dated release heading.
+
+- [ ] **Step 5: Validate structure, size, metadata, and patch**
+
+Run:
+
+```powershell
+python 'C:/Users/estev/.codex/skills/.system/skill-creator/scripts/quick_validate.py' .agents/skills/updating-noxy-version
+(Get-Content -Raw .agents/skills/updating-noxy-version/SKILL.md | Measure-Object -Word).Words
+rg -n 'TBD|TODO|FIXME|placeholder|v1\.6\.0' .agents/skills/updating-noxy-version/SKILL.md .agents/skills/updating-noxy-version/agents/openai.yaml
+git diff --check
+```
+
+Expected: `Skill is valid!`, fewer than 500 words, no scan matches, and no patch errors.
+
+- [ ] **Step 6: Forward-test the updated skill**
+
+Dispatch a different fresh-context agent with the same Step 1 prompt.
+
+Expected:
+
+- “update the Noxy version” previews and applies with the omitted target or `minor`.
+- Patch uses `patch`.
+- Major uses `major`.
+- Explicit `v2.3.4` remains supported.
+- Every path previews before applying, names all four project checks, and performs no commit/tag/push/PR operation.
+
+If guidance changes are required, edit only the minimum wording, rerun the official validator, and repeat the forward-test.
+
+- [ ] **Step 7: Commit the workflow and metadata**
+
+```powershell
+git add -- .agents/skills/updating-noxy-version/SKILL.md .agents/skills/updating-noxy-version/agents/openai.yaml CHANGELOG.md
+git commit -m "docs: generalize version update skill targets"
+```
+
+---
+
+### Task 3: Validate end to end and update the existing PR
+
+**Files:**
+- Test: `.agents/skills/updating-noxy-version/scripts/test_update_version.py`
+- Test: `.agents/skills/updating-noxy-version/SKILL.md`
+- Test: `.agents/skills/updating-noxy-version/agents/openai.yaml`
+- Verify: existing PR `https://github.com/estevaofon/noxy/pull/11`
+
+**Interfaces:**
+- Consumes: the completed updater, skill, and metadata.
+- Produces: fresh local evidence and updated commits on the existing remote PR branch.
+
+- [ ] **Step 1: Run the complete updater and skill checks**
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/test_update_version.py -v
+python -m py_compile .agents/skills/updating-noxy-version/scripts/update_version.py .agents/skills/updating-noxy-version/scripts/test_update_version.py
+python 'C:/Users/estev/.codex/skills/.system/skill-creator/scripts/quick_validate.py' .agents/skills/updating-noxy-version
+git diff --check
+```
+
+Expected: `Ran 17 tests`, `OK`, successful compilation, `Skill is valid!`, and no patch errors.
+
+- [ ] **Step 2: Exercise the default-minor real-repository dry run**
+
+Capture `git status --short`, then run:
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/update_version.py --date 2026-08-09 --dry-run
+```
+
+Expected: exactly five diff headers and a derived target of `1.6.0` from the repository's current `1.5.0`. Compare status before and after; it must be identical.
+
+- [ ] **Step 3: Exercise major and patch calculations without writes**
+
+Run:
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/update_version.py major --date 2026-08-09 --dry-run
+python .agents/skills/updating-noxy-version/scripts/update_version.py patch --date 2026-08-09 --dry-run
+```
+
+Expected: the major diff uses `2.0.0`, the patch diff uses `1.5.1`, both touch exactly five files, and `git status --short` remains unchanged.
+
+- [ ] **Step 4: Run the project verification suite**
+
+```powershell
+go test ./...
+go build ./...
+go vet ./...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Expected: every Go command exits 0 and the integration report contains `Falhou: 0`.
+
+- [ ] **Step 5: Review branch scope**
+
+```powershell
+git status --short
+git diff --check
+git log --oneline origin/develop..HEAD
+```
+
+Expected: a clean worktree, no patch errors, and only intentional feature/spec/changelog commits beyond `origin/develop`.
+
+- [ ] **Step 6: Push the current branch and verify PR #11**
+
+```powershell
+git push
+gh pr view 11 --json url,state,baseRefName,headRefName,title
+```
+
+Expected: push succeeds; PR #11 remains `OPEN`, base `develop`, head `feat/updating-noxy-version-skill`, and no second PR is created.

--- a/docs/superpowers/specs/2026-08-09-updating-noxy-version-bump-kinds-design.md
+++ b/docs/superpowers/specs/2026-08-09-updating-noxy-version-bump-kinds-design.md
@@ -68,4 +68,3 @@ Add RED/GREEN regression coverage for:
 - CLI argument parsing defaults the omitted target to `minor`.
 
 Re-run the complete updater suite, skill validator, real repository dry run, Go tests/build/vet, and the Noxy integration suite before updating the open pull request.
-

--- a/docs/superpowers/specs/2026-08-09-updating-noxy-version-bump-kinds-design.md
+++ b/docs/superpowers/specs/2026-08-09-updating-noxy-version-bump-kinds-design.md
@@ -1,0 +1,71 @@
+# Updating Noxy Version Bump Kinds Design
+
+## Goal
+
+Allow the repository-local `$updating-noxy-version` skill to update Noxy by semantic-version component instead of requiring a concrete version every time. When a user asks only to update or bump the version, default to a minor bump.
+
+## Supported requests
+
+The workflow accepts four target forms:
+
+| Request | Current `1.5.0` becomes |
+|---|---|
+| `major` | `2.0.0` |
+| `minor` | `1.6.0` |
+| `patch` | `1.5.1` |
+| `X.Y.Z` or `vX.Y.Z` | The explicit version |
+
+Natural-language requests such as “update the version” or “bump Noxy” resolve to `minor` unless the user names `major`, `minor`, `patch`, or an explicit semantic version.
+
+## Updater interface
+
+Keep the existing positional interface and extend its accepted values:
+
+```powershell
+python .agents/skills/updating-noxy-version/scripts/update_version.py [major|minor|patch|X.Y.Z|vX.Y.Z] [--date YYYY-MM-DD] [--dry-run] [--root PATH]
+```
+
+The positional target becomes optional and defaults to `minor`. Explicit versions remain backward compatible.
+
+The updater must derive bump targets from the single current version returned by the existing cross-surface consistency validation:
+
+- `major`: increment major; reset minor and patch to zero.
+- `minor`: preserve major; increment minor; reset patch to zero.
+- `patch`: preserve major and minor; increment patch.
+- Explicit version: preserve the current strict SemVer and monotonic-increase behavior.
+
+All derived targets continue through the existing replacement, changelog, dry-run, transactional write, rollback, and recovery logic.
+
+## Skill workflow and metadata
+
+Update `SKILL.md` to resolve the user's request before preview:
+
+1. Use an explicit version when supplied.
+2. Otherwise use a named `major`, `minor`, or `patch` bump.
+3. Default to `minor` when the request does not name a target.
+4. Pass the resolved target directly to the bundled updater for dry-run and apply.
+
+Replace the hardcoded `v1.6.0` UI prompt with a generic prompt that states the default-minor behavior and mentions major and patch overrides.
+
+## Validation and errors
+
+- Accept bump keywords case-insensitively after trimming surrounding whitespace.
+- Reject any other target with an error listing the accepted keywords and explicit SemVer forms.
+- Keep explicit SemVer restricted to ASCII digits.
+- Preserve the rule that explicit target versions must be greater than the current version.
+- A validation error or dry run must leave every release file unchanged.
+
+## Testing
+
+Add RED/GREEN regression coverage for:
+
+- Default omitted target resolves to a minor bump.
+- Named `major`, `minor`, and `patch` calculations.
+- Case-insensitive and whitespace-trimmed bump keywords.
+- Explicit `X.Y.Z` and `vX.Y.Z` compatibility.
+- Invalid target rejection without writes.
+- Derived bumps update exactly the same five surfaces and preserve history/dependencies.
+- CLI argument parsing defaults the omitted target to `minor`.
+
+Re-run the complete updater suite, skill validator, real repository dry run, Go tests/build/vet, and the Noxy integration suite before updating the open pull request.
+


### PR DESCRIPTION
## Summary
- Add the repository-local `$updating-noxy-version` workflow.
- Provide deterministic dry-run, validation, transactional writes, rollback, and recovery artifacts.
- Cover version synchronization and failure paths with 13 Python regression tests.

## Components
- Skill instructions and OpenAI UI metadata.
- Python version updater and unit tests.
- Unreleased changelog entry.

## Related Issues
- None.

## Test Plan
- [x] Implementação
- [x] Testes unitários passando (13/13)
- [x] Testado integrado (157/157 Noxy examples)
- [x] `go test ./...`, `go build ./...`, and `go vet ./...` passed.