### PR TITLE
feat/NO-CARD - Adicionar biblioteca terminal externa e Space Invaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Experimental external terminal package backed by a Go plugin.
+- Complete Space Invaders example using the external terminal package.
+
 ## [0.1.0] - 2026-08-10
 
 ### Added

--- a/docs/PACKAGE_MANAGER.md
+++ b/docs/PACKAGE_MANAGER.md
@@ -53,9 +53,13 @@ my_project/
 
 ## Using Packages
 
-Once installed, you can import packages in your Noxy code using their path relative to `noxy_libs` or the project root conform configured.
+Once installed, import packages using the module path. For example, the external terminal package is imported as:
 
-*(Note: Specific import syntax depends on the current Noxy language specification for imports, typically finding files in `noxy_libs` automatically or via relative paths).*
+```noxy
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+```
+
+The current package copy is provisional inside `noxy_libs` and may move to its own repository later.
 
 ## Creating a Package
 

--- a/docs/superpowers/plans/2026-08-10-external-terminal-library.md
+++ b/docs/superpowers/plans/2026-08-10-external-terminal-library.md
@@ -1,0 +1,739 @@
+# External Terminal Library Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an experimental external terminal package under `noxy_libs`, backed by an out-of-process Go plugin, and run the complete Space Invaders example against it without terminal-specific VM or embedded-stdlib code.
+
+**Architecture:** A typed Noxy wrapper lazily loads `noxy-plugin-terminal` through the existing generic plugin system. The plugin reserves stdin/stdout for line-delimited JSON RPC, opens the controlling terminal separately through `/dev/tty` or `CONIN$`, and owns raw-mode lifecycle and key normalization.
+
+**Tech Stack:** Noxy 0.1.0, Go 1.24.0/toolchain 1.24.11, `golang.org/x/term v0.39.0`, line-delimited JSON RPC, PowerShell and POSIX shell build scripts.
+
+## Global Constraints
+
+- Start from `origin/develop` on branch `feat/external-terminal-library`.
+- Keep the complete Space Invaders game and deterministic `--smoke` mode.
+- Preserve `TerminalResult`, `KeyEvent`, `is_terminal`, `open_raw`, `read_key`, and `close`.
+- Import the package as `github_com.estevaofon.noxy_terminal.terminal`.
+- Add no terminal-specific builtin under `internal/vm` and no terminal module under `internal/stdlib`.
+- Do not change the generic plugin protocol.
+- Support one blocking terminal reader; callers stop the reader loop before `close`.
+- Use `/dev/tty` on non-Windows systems and `CONIN$` on Windows.
+- Keep stdin/stdout exclusively for plugin JSON RPC; diagnostics go to stderr.
+- Keep tests boundary-oriented and do not add a VM test that references Space Invaders.
+- The package remains experimental and in-repository; publishing a separate repository is out of scope.
+
+---
+
+### Task 1: Build the external raw-terminal runtime
+
+**Files:**
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/go.mod`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/go.sum`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal_unix.go`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go`
+- Test: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go`
+
+**Interfaces:**
+- Consumes: `golang.org/x/term` for `IsTerminal`, `MakeRaw`, and `Restore`.
+- Produces: `newTerminalRuntime(driver terminalDriver) *terminalRuntime`; methods `isTerminal() bool`, `openRaw() bool`, `readKey() (string, bool)`, `lastError() string`, `close() bool`, and `shutdown()`; pure helper `normalizeKey(rune) string`.
+
+- [ ] **Step 1: Create the nested Go module**
+
+Create `go.mod` exactly as:
+
+~~~go
+module github.com/estevaofon/noxy_terminal
+
+go 1.24.0
+
+toolchain go1.24.11
+
+require golang.org/x/term v0.39.0
+~~~
+
+Run:
+
+~~~powershell
+go mod download golang.org/x/term@v0.39.0
+~~~
+
+from `noxy_libs/github_com/estevaofon/noxy_terminal`.
+
+Expected: `go.sum` is generated and the dependency download exits 0.
+
+- [ ] **Step 2: Write failing lifecycle and normalization tests**
+
+Define test fakes implementing these interfaces:
+
+~~~go
+type terminalDevice interface {
+	io.Reader
+	io.Closer
+	Fd() uintptr
+}
+
+type terminalDriver interface {
+	open() (terminalDevice, error)
+	isTerminal(fd int) bool
+	makeRaw(fd int) (*terminalSnapshot, error)
+	restore(fd int, snapshot *terminalSnapshot) error
+}
+~~~
+
+Add these tests before production code:
+
+~~~go
+func TestRuntimeRejectsNonTerminal(t *testing.T)
+func TestRuntimeOpenReadCloseIsIdempotent(t *testing.T)
+func TestRuntimeReportsRestoreFailure(t *testing.T)
+func TestNormalizeKey(t *testing.T)
+func TestShutdownRestoresAndClosesDevice(t *testing.T)
+~~~
+
+`TestRuntimeOpenReadCloseIsIdempotent` uses input `"A"` and asserts:
+
+- two `openRaw` calls succeed;
+- `makeRaw` is called once;
+- `readKey` returns `"a", true`;
+- two `close` calls succeed;
+- `restore` and device `Close` are each called once.
+
+`TestNormalizeKey` uses this exact table:
+
+~~~go
+tests := []struct {
+	input rune
+	want  string
+}{
+	{'A', "a"},
+	{' ', "space"},
+	{'\r', "enter"},
+	{'\n', "enter"},
+	{'\x03', "ctrl+c"},
+	{'é', "é"},
+	{'\x01', "unknown:0x01"},
+}
+~~~
+
+Run:
+
+~~~powershell
+go test ./... -run 'TestRuntime|TestNormalizeKey' -count=1
+~~~
+
+Expected RED: compilation fails because `terminalRuntime` and `normalizeKey` do not exist.
+
+- [ ] **Step 3: Implement terminal driver and runtime**
+
+In `terminal.go` define:
+
+~~~go
+type terminalSnapshot struct {
+	state *term.State
+}
+
+type xTermDriver struct{}
+
+type terminalRuntime struct {
+	stateMu  sync.Mutex
+	readMu   sync.Mutex
+	driver   terminalDriver
+	device   terminalDevice
+	input    *bufio.Reader
+	saved    *terminalSnapshot
+	raw      bool
+	stopping bool
+	lastErr  string
+}
+~~~
+
+Implement `xTermDriver` as:
+
+~~~go
+func (xTermDriver) open() (terminalDevice, error) {
+	return openTerminalDevice()
+}
+
+func (xTermDriver) isTerminal(fd int) bool {
+	return term.IsTerminal(fd)
+}
+
+func (xTermDriver) makeRaw(fd int) (*terminalSnapshot, error) {
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return &terminalSnapshot{state: state}, nil
+}
+
+func (xTermDriver) restore(fd int, snapshot *terminalSnapshot) error {
+	return term.Restore(fd, snapshot.state)
+}
+~~~
+
+Implement runtime behavior with these exact rules:
+
+- `isTerminal` opens a temporary device, checks `driver.isTerminal`, closes it,
+  and records any open/close error.
+- `openRaw` holds `stateMu`; it rejects `stopping`, returns true when already
+  raw, opens the device, verifies it is a terminal, calls `makeRaw`, and stores
+  device, reader, and snapshot only after success.
+- `readKey` serializes through `readMu`, snapshots the active reader under
+  `stateMu`, reads one rune without holding `stateMu`, normalizes it, and records
+  read failures.
+- `close` restores before closing the device. Restore failure returns false and
+  retains state so a caller may retry.
+- `shutdown` marks `stopping`, attempts restore, closes the device even if
+  restore fails, and clears held resources.
+- A successful operation clears `lastErr`; `lastError` returns it under lock.
+
+Implement `normalizeKey` with the exact table from Step 2 and lowercase only
+ASCII `A` through `Z`.
+
+Create platform files:
+
+~~~go
+//go:build !windows
+
+package main
+
+import "os"
+
+func openTerminalDevice() (terminalDevice, error) {
+	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
+}
+~~~
+
+~~~go
+//go:build windows
+
+package main
+
+import "os"
+
+func openTerminalDevice() (terminalDevice, error) {
+	return os.OpenFile("CONIN$", os.O_RDWR, 0)
+}
+~~~
+
+- [ ] **Step 4: Verify GREEN and format**
+
+Run from the external package directory:
+
+~~~powershell
+gofmt -w terminal.go terminal_unix.go terminal_windows.go terminal_test.go
+go mod tidy
+go test ./... -run 'TestRuntime|TestNormalizeKey|TestShutdown' -count=1
+go test ./...
+~~~
+
+Expected: all external package tests PASS with no warning output.
+
+- [ ] **Step 5: Commit the terminal runtime**
+
+~~~powershell
+git add -- noxy_libs/github_com/estevaofon/noxy_terminal/go.mod noxy_libs/github_com/estevaofon/noxy_terminal/go.sum noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go noxy_libs/github_com/estevaofon/noxy_terminal/terminal_unix.go noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
+git commit -m "feat: add external terminal runtime"
+~~~
+
+---
+
+### Task 2: Add the JSON plugin server and parent-exit cleanup
+
+**Files:**
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/main.go`
+- Test: `noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go`
+- Modify: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go`
+
+**Interfaces:**
+- Consumes: the `terminalRuntime` methods from Task 1.
+- Produces: `pluginRequest`, `pluginResponse`, `pluginServer`, `newPluginServer(runtime, output)`, `serve(input) error`, and `handle(request) pluginResponse`.
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Add these tests:
+
+~~~go
+func TestPluginServerPrimitiveResultsAndLastError(t *testing.T)
+func TestPluginServerRestoresTerminalOnParentEOF(t *testing.T)
+func TestPluginServerRejectsUnknownMethod(t *testing.T)
+~~~
+
+The primitive-results test calls `handle` directly and asserts:
+
+- `is_terminal` returns boolean true;
+- `open_raw` returns boolean true;
+- `read_key` returns string `"a"`;
+- `close` returns boolean true;
+- after a forced read error, `last_error` returns the driver error text.
+
+The EOF test uses a blocking fake device whose `Read` waits until `Close`. Feed
+the server these two JSON lines followed by EOF:
+
+~~~json
+{"method":"open_raw","params":[]}
+{"method":"read_key","params":[]}
+~~~
+
+Assert `restore` and device `Close` are called once and `serve` returns.
+
+Run:
+
+~~~powershell
+go test ./... -run TestPluginServer -count=1
+~~~
+
+Expected RED: compilation fails because `pluginServer` is undefined.
+
+- [ ] **Step 2: Implement request dispatch**
+
+Define:
+
+~~~go
+type pluginRequest struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+}
+
+type pluginResponse struct {
+	Result interface{} `json:"result,omitempty"`
+	Error  string      `json:"error,omitempty"`
+}
+
+type pluginServer struct {
+	runtime *terminalRuntime
+	encoder *json.Encoder
+	writeMu sync.Mutex
+	workers sync.WaitGroup
+}
+~~~
+
+`handle` returns primitive results with this switch:
+
+~~~go
+switch request.Method {
+case "is_terminal":
+	return pluginResponse{Result: server.runtime.isTerminal()}
+case "open_raw":
+	return pluginResponse{Result: server.runtime.openRaw()}
+case "read_key":
+	key, ok := server.runtime.readKey()
+	if !ok {
+		return pluginResponse{Result: nil}
+	}
+	return pluginResponse{Result: key}
+case "last_error":
+	return pluginResponse{Result: server.runtime.lastError()}
+case "close":
+	return pluginResponse{Result: server.runtime.close()}
+default:
+	return pluginResponse{Error: "unknown method: " + request.Method}
+}
+~~~
+
+`write` holds `writeMu` and writes through `json.Encoder`. JSON decode failures
+produce an error response and do not terminate the scanner.
+
+- [ ] **Step 3: Implement EOF-safe serving**
+
+`serve` scans stdin continuously. Handle `read_key` in a tracked worker so the
+scanner can still observe pipe EOF; handle other methods synchronously.
+
+On scanner EOF:
+
+1. call `runtime.shutdown()`;
+2. wait for read workers;
+3. return `scanner.Err()`.
+
+Use a copied byte slice for each scanned line before passing it to a worker.
+Never write diagnostics to the JSON output stream.
+
+`main` constructs `newTerminalRuntime(xTermDriver{})`, defers `shutdown`,
+installs an `os.Interrupt`/`syscall.SIGTERM` handler that calls `shutdown` and
+then `os.Exit(0)`, and serves `os.Stdin` to `os.Stdout`. If `serve` returns an
+error, print it to stderr and exit nonzero; never print diagnostics to stdout.
+
+- [ ] **Step 4: Verify GREEN and build**
+
+Run:
+
+~~~powershell
+gofmt -w main.go server_test.go terminal_test.go
+go test ./... -run TestPluginServer -count=1
+go test ./...
+go build ./...
+~~~
+
+Expected: protocol tests PASS and the plugin builds.
+
+- [ ] **Step 5: Commit the plugin server**
+
+~~~powershell
+git add -- noxy_libs/github_com/estevaofon/noxy_terminal/main.go noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
+git commit -m "feat: add terminal plugin protocol"
+~~~
+
+---
+
+### Task 3: Add the typed Noxy wrapper and build tooling
+
+**Files:**
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/terminal.nx`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/noxy.mod`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/README.md`
+- Create: `noxy_libs/github_com/estevaofon/noxy_terminal/.gitignore`
+
+**Interfaces:**
+- Consumes: generic builtin `sys_load_plugin(name, executable)` and dynamic
+  native `terminal_request(method)`.
+- Produces: typed external module `TerminalResult`, `KeyEvent`,
+  `is_terminal() bool`, `open_raw() TerminalResult`,
+  `read_key() KeyEvent`, and `close() bool`.
+
+- [ ] **Step 1: Create module metadata and build scripts**
+
+Create `noxy.mod`:
+
+~~~text
+module github.com/estevaofon/noxy_terminal
+
+noxy v0.1.0
+~~~
+
+Create `build_plugin.ps1`:
+
+~~~powershell
+$ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot
+try {
+    go build -o noxy-plugin-terminal.exe .
+    Write-Host "Created noxy-plugin-terminal.exe"
+} finally {
+    Pop-Location
+}
+~~~
+
+Create `build_plugin.sh`:
+
+~~~bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+go build -o noxy-plugin-terminal .
+echo "Created noxy-plugin-terminal"
+~~~
+
+Create `.gitignore` exactly as:
+
+~~~gitignore
+/noxy-plugin-terminal
+/noxy-plugin-terminal.exe
+~~~
+
+Mark `build_plugin.sh` executable in Git:
+
+~~~powershell
+git update-index --add --chmod=+x noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh
+~~~
+
+- [ ] **Step 2: Implement the lazy typed wrapper**
+
+Create `terminal.nx` with this API and lazy-load state:
+
+~~~noxy
+let _terminal_loaded: bool = false
+let _terminal_attempted: bool = false
+let _terminal_load_error: string = ""
+
+struct TerminalResult
+    ok: bool
+    error: string
+end
+
+struct KeyEvent
+    ok: bool
+    key: string
+    error: string
+end
+
+func _ensure_terminal_plugin() -> bool
+    if _terminal_loaded then return true end
+    if _terminal_attempted then return false end
+
+    _terminal_attempted = true
+    _terminal_loaded = sys_load_plugin("terminal", "noxy-plugin-terminal")
+    if !_terminal_loaded then
+        _terminal_load_error = "noxy-plugin-terminal was not found or could not be started"
+    end
+    return _terminal_loaded
+end
+
+func _terminal_error() -> string
+    if !_terminal_loaded then return _terminal_load_error end
+    let result: any = terminal_request("last_error")
+    if result == null then return "terminal plugin request failed" end
+    return to_str(result)
+end
+
+func _terminal_bool(method: string) -> bool
+    let result: any = terminal_request(method)
+    return result != null && to_str(result) == "true"
+end
+
+func is_terminal() -> bool
+    if !_ensure_terminal_plugin() then return false end
+    return _terminal_bool("is_terminal")
+end
+
+func open_raw() -> TerminalResult
+    if !_ensure_terminal_plugin() then
+        return TerminalResult(false, _terminal_error())
+    end
+    let ok: bool = _terminal_bool("open_raw")
+    if !ok then return TerminalResult(false, _terminal_error()) end
+    return TerminalResult(true, "")
+end
+
+func read_key() -> KeyEvent
+    if !_ensure_terminal_plugin() then
+        return KeyEvent(false, "", _terminal_error())
+    end
+    let result: any = terminal_request("read_key")
+    if result == null then return KeyEvent(false, "", _terminal_error()) end
+    return KeyEvent(true, to_str(result), "")
+end
+
+func close() -> bool
+    if !_terminal_loaded then return true end
+    return _terminal_bool("close")
+end
+~~~
+
+- [ ] **Step 3: Document package usage**
+
+`README.md` must include:
+
+- experimental status and current in-repository location;
+- build prerequisites: Go 1.24+;
+- PowerShell and POSIX build commands;
+- import path `github_com.estevaofon.noxy_terminal.terminal`;
+- the complete public API signatures;
+- supported key names;
+- one-reader lifecycle rule;
+- explicit `close` guidance;
+- Windows `CONIN$` and Unix `/dev/tty` behavior;
+- Space Invaders build and run commands.
+
+- [ ] **Step 4: Build and compile the wrapper boundary**
+
+Run:
+
+~~~powershell
+./build_plugin.ps1
+go test ./...
+go build ./...
+~~~
+
+from the external package directory.
+
+Expected: the terminal plugin is built, its Go tests pass, and the package
+compiles. The Noxy import and typed-wrapper boundary is exercised with the game
+smoke in Task 4, avoiding a dependency on an unrelated external plugin.
+
+- [ ] **Step 5: Commit wrapper and tooling**
+
+~~~powershell
+git add -- noxy_libs/github_com/estevaofon/noxy_terminal/terminal.nx noxy_libs/github_com/estevaofon/noxy_terminal/noxy.mod noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1 noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh noxy_libs/github_com/estevaofon/noxy_terminal/README.md noxy_libs/github_com/estevaofon/noxy_terminal/.gitignore
+git commit -m "feat: expose external terminal module"
+~~~
+
+---
+
+### Task 4: Port the complete Space Invaders example
+
+**Files:**
+- Create: `noxy_examples/space_invaders.nx`
+- Modify: `noxy_examples/run_all_tests_concurrent.nx`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/PACKAGE_MANAGER.md`
+
+**Interfaces:**
+- Consumes: external module
+  `github_com.estevaofon.noxy_terminal.terminal` from Task 3.
+- Produces: the complete existing Space Invaders example with unchanged game
+  behavior and `--smoke` output `SPACE_INVADERS_SMOKE_OK`.
+
+- [ ] **Step 1: Restore the existing complete game**
+
+Use `e6d68f5:noxy_examples/space_invaders.nx` as the exact source artifact.
+Create the file byte-for-byte from that revision, then replace only:
+
+~~~noxy
+use terminal
+~~~
+
+with:
+
+~~~noxy
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+~~~
+
+Do not change game constants, structs, routines, channels, rendering, controls,
+cleanup, or smoke logic.
+
+- [ ] **Step 2: Keep the interactive game out of the generic runner**
+
+Add `"space_invaders.nx"` to the `exclusions` array in
+`noxy_examples/run_all_tests_concurrent.nx`. Do not add a VM Go test for the
+game.
+
+- [ ] **Step 3: Update root documentation**
+
+Add changelog entries under `Unreleased / Added` for:
+
+- the experimental external terminal package backed by a Go plugin;
+- the complete Space Invaders example using that package.
+
+In `docs/PACKAGE_MANAGER.md`, replace the vague import note with the concrete
+external-module example:
+
+~~~noxy
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+~~~
+
+State that the current package copy is provisional inside `noxy_libs` and may
+move to its own repository later.
+
+Do not add `terminal` to the embedded standard-library list in
+`docs/NOXY_LANGUAGE_SPEC.md`.
+
+- [ ] **Step 4: Verify game compilation and smoke**
+
+From the repository root run:
+
+~~~powershell
+go run cmd/noxy/main.go noxy_examples/space_invaders.nx --smoke
+~~~
+
+Expected exact output:
+
+~~~text
+SPACE_INVADERS_SMOKE_OK
+~~~
+
+Run the plugin build from its package directory, then manually start the game
+when an interactive terminal is available:
+
+~~~powershell
+./build_plugin.ps1
+Set-Location ../../../..
+go run cmd/noxy/main.go noxy_examples/space_invaders.nx
+~~~
+
+Expected manual behavior: A/D move, Space fires, Q or Ctrl+C exits, and the
+cursor and terminal mode are restored.
+
+- [ ] **Step 5: Commit the example and root docs**
+
+~~~powershell
+git add -- noxy_examples/space_invaders.nx noxy_examples/run_all_tests_concurrent.nx CHANGELOG.md docs/PACKAGE_MANAGER.md
+git commit -m "feat: add external terminal space invaders"
+~~~
+
+---
+
+### Task 5: Verify boundaries, cross-platform compilation, and repository regression
+
+**Files:**
+- Verify: `noxy_libs/github_com/estevaofon/noxy_terminal/`
+- Verify: `noxy_examples/space_invaders.nx`
+- Verify: `noxy_examples/run_all_tests_concurrent.nx`
+- Verify: `CHANGELOG.md`
+- Verify: `docs/PACKAGE_MANAGER.md`
+
+**Interfaces:**
+- Consumes: all outputs from Tasks 1–4.
+- Produces: evidence that the package is external, cross-platform files compile,
+  the game smoke passes, and the repository remains green.
+
+- [ ] **Step 1: Verify no terminal implementation entered VM or stdlib**
+
+Run:
+
+~~~powershell
+git diff --name-only origin/develop...HEAD
+rg -n "terminal_(is_terminal|open_raw|read_key|close)|defineTerminalBuiltins|terminalRuntime" internal/vm internal/stdlib
+~~~
+
+Expected: the changed-file list contains no terminal implementation under
+`internal/vm` or `internal/stdlib`, and `rg` finds no newly introduced terminal
+implementation.
+
+- [ ] **Step 2: Verify the external Go module**
+
+From `noxy_libs/github_com/estevaofon/noxy_terminal` run:
+
+~~~powershell
+gofmt -d terminal.go terminal_unix.go terminal_windows.go terminal_test.go main.go server_test.go
+go test ./...
+go build ./...
+$env:GOOS = "linux"
+$env:GOARCH = "amd64"
+go build ./...
+$env:GOOS = "windows"
+$env:GOARCH = "amd64"
+go build ./...
+Remove-Item Env:GOOS
+Remove-Item Env:GOARCH
+~~~
+
+Expected: formatting diff is empty; all tests and native/cross-platform builds
+exit 0.
+
+- [ ] **Step 3: Verify Noxy smoke and internal tests**
+
+From repository root run:
+
+~~~powershell
+go test ./internal/...
+go run cmd/noxy/main.go noxy_examples/space_invaders.nx --smoke
+~~~
+
+Expected: internal packages PASS and smoke prints
+`SPACE_INVADERS_SMOKE_OK`.
+
+- [ ] **Step 4: Run the complete Noxy example runner**
+
+~~~powershell
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+~~~
+
+Expected: zero failures and final line `TODOS TESTES PASSARAM.`.
+
+- [ ] **Step 5: Run repository build and vet**
+
+~~~powershell
+go build ./...
+go vet ./...
+git diff --check
+git status -sb
+~~~
+
+Expected: all commands exit 0 and the branch is clean.
+
+- [ ] **Step 6: Review and publish**
+
+Request code review for the complete range:
+
+~~~powershell
+$externalTerminalBase = git merge-base origin/develop HEAD
+$externalTerminalHead = git rev-parse HEAD
+git diff --stat "$externalTerminalBase..$externalTerminalHead"
+~~~
+
+Resolve Critical and Important findings, re-run affected tests, then push
+`feat/external-terminal-library` and open a separate pull request targeting
+`develop`.

--- a/docs/superpowers/specs/2026-08-10-external-terminal-library-design.md
+++ b/docs/superpowers/specs/2026-08-10-external-terminal-library-design.md
@@ -1,0 +1,216 @@
+# External Terminal Library Design
+
+## Context
+
+Noxy is still evolving, and the terminal API is intended for personal
+experimentation rather than as a stable part of the VM. The existing
+`develop` branch already supports external libraries under `noxy_libs` and
+out-of-process native plugins loaded with `sys_load_plugin`.
+
+This change will keep the complete Space Invaders example while moving all
+terminal-specific native behavior out of `internal/vm` and `internal/stdlib`.
+The first version will live inside this repository at
+`noxy_libs/github_com/estevaofon/noxy_terminal`. It can become a separate
+repository later without changing its public import path or package layout.
+
+## Goals
+
+- Provide raw terminal input as an external Noxy library backed by a Go plugin.
+- Preserve the current typed Noxy API used by Space Invaders.
+- Keep the complete game and its deterministic `--smoke` mode.
+- Support Windows and Unix-like terminals.
+- Require no terminal-specific builtin, embedded stdlib module, or VM lifecycle
+  change.
+- Keep automated coverage focused on the external package and public example.
+
+## Non-Goals
+
+- Publishing `noxy_terminal` as a separate GitHub repository in this change.
+- Changing the generic Noxy plugin protocol.
+- Supporting multiple simultaneous terminal readers.
+- Cancelling an active blocking key read through `close`.
+- Stabilizing the terminal API for backward compatibility.
+- Adding cursor movement, colors, screen clearing, or other ANSI presentation
+  helpers.
+
+## Package Layout
+
+The new package will live at:
+
+~~~text
+noxy_libs/github_com/estevaofon/noxy_terminal/
+├── terminal.nx
+├── noxy.mod
+├── README.md
+├── go.mod
+├── go.sum
+├── main.go
+├── terminal.go
+├── terminal_unix.go
+├── terminal_windows.go
+├── terminal_test.go
+├── build_plugin.sh
+└── build_plugin.ps1
+~~~
+
+Responsibilities:
+
+- `terminal.nx` exposes the typed Noxy API and lazily loads the plugin.
+- `main.go` implements the line-delimited JSON request loop used by the generic
+  Noxy plugin client.
+- `terminal.go` owns raw-mode state, key normalization, error state, and
+  platform-independent operations.
+- `terminal_unix.go` opens `/dev/tty`.
+- `terminal_windows.go` opens `CONIN$`.
+- `terminal_test.go` tests the external runtime through a fake terminal driver.
+- The build scripts produce `noxy-plugin-terminal` in the package directory so
+  the existing recursive `sys_load_plugin` lookup can find it.
+- `README.md` documents build, import, lifecycle, supported keys, and the
+  experimental status.
+
+## Public Noxy API
+
+The external wrapper preserves the API already consumed by the game:
+
+~~~noxy
+struct TerminalResult
+    ok: bool
+    error: string
+end
+
+struct KeyEvent
+    ok: bool
+    key: string
+    error: string
+end
+
+func is_terminal() -> bool
+func open_raw() -> TerminalResult
+func read_key() -> KeyEvent
+func close() -> bool
+~~~
+
+Space Invaders imports it with:
+
+~~~noxy
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+~~~
+
+The wrapper loads `noxy-plugin-terminal` only when a terminal function is first
+called. Consequently, `space_invaders.nx --smoke` does not require a built
+plugin and does not print a plugin warning.
+
+## Plugin Protocol
+
+The generic plugin transport continues to use line-delimited JSON on the
+plugin's stdin and stdout. Those streams are reserved exclusively for RPC and
+must never be used as the interactive terminal.
+
+The plugin exposes these methods:
+
+| Method | Result | Meaning |
+|---|---|---|
+| `is_terminal` | boolean | Whether the controlling terminal can be opened |
+| `open_raw` | boolean | Whether raw mode was opened |
+| `read_key` | string or null | Normalized key, or null on failure |
+| `last_error` | string | Most recent operational failure |
+| `close` | boolean | Whether terminal state was restored |
+
+Operational failures return `false` or `null` and update `last_error`. Unknown
+methods and malformed RPC requests use the plugin protocol's error field.
+
+`terminal.nx` converts these primitive/dynamic responses into
+`TerminalResult` and `KeyEvent`. This keeps plugin serialization independent of
+Noxy struct representation.
+
+## Terminal Access and Lifecycle
+
+The plugin is launched with pipes for RPC, so file descriptor 0 is not the
+interactive console. It opens the controlling terminal separately:
+
+- Unix-like systems: `/dev/tty`.
+- Windows: `CONIN$`.
+
+`golang.org/x/term` performs terminal detection, raw-mode activation, and
+restoration on the opened handle.
+
+The runtime stores the opened file, saved terminal state, raw flag, and last
+error behind a mutex. Open and close are idempotent. A single blocking reader
+is supported. The caller must allow its reader loop to finish before calling
+`close`; this is already how Space Invaders handles `q` and `ctrl+c`.
+
+The RPC scanner must remain able to observe parent-pipe EOF while `read_key` is
+blocked. It dispatches the single in-flight request to a worker and continues
+watching stdin. On EOF it restores and closes the terminal handle. Signal
+handling also attempts restoration before the plugin exits. Explicit
+`terminal.close()` remains the primary cleanup path.
+
+## Key Representation
+
+The external library preserves the current experimental normalization:
+
+- ASCII letters become lowercase.
+- Space becomes `"space"`.
+- CR or LF becomes `"enter"`.
+- Ctrl+C becomes `"ctrl+c"`.
+- Printable Unicode is returned as a one-rune string.
+- Other control runes use `"unknown:0xNN"`.
+- Multi-byte special-key sequences such as arrows are not supported.
+
+## Space Invaders
+
+The complete game from the terminal feature remains at
+`noxy_examples/space_invaders.nx`. Game logic, concurrency, rendering, controls,
+and deterministic smoke behavior remain unchanged. Only the terminal import
+changes to the external package path.
+
+Interactive setup requires building the plugin first. The README and example
+documentation provide both PowerShell and shell commands.
+
+## Error Handling
+
+- Failure to find or start the plugin becomes a failed typed result rather than
+  a VM crash.
+- Terminal detection/open/read/restore failures update `last_error`.
+- `read_key` returns `KeyEvent(false, "", error)` on failure.
+- `close` returns `false` when restoration fails.
+- JSON protocol diagnostics go to stderr, never stdout.
+- Cleanup failure does not replace an existing protocol parse/dispatch error.
+
+## Testing
+
+Coverage remains intentionally small and boundary-oriented:
+
+1. External Go package tests:
+   - reject unavailable/non-terminal handles;
+   - idempotent open/close;
+   - representative key normalization;
+   - restoration on explicit close and parent EOF;
+   - primitive protocol results and `last_error`.
+2. Compile the external Noxy module and the complete Space Invaders example.
+3. Run `space_invaders.nx --smoke` as a separate integration command.
+4. Run `go test ./internal/...` and the existing concurrent Noxy example runner.
+5. Build the plugin on the current platform.
+6. Perform an optional manual interactive game run when a real terminal is
+   available.
+
+No test under `internal/vm` references Space Invaders.
+
+## Documentation
+
+- The package README is the authoritative API and build guide.
+- The root changelog describes the external package and example.
+- The language specification does not list `terminal` as an embedded standard
+  library module.
+- Package-manager documentation may use `noxy_terminal` as an external package
+  example but must state that this in-repository copy is provisional.
+
+## Success Criteria
+
+- The branch is created from the current `origin/develop`.
+- No terminal-specific production code exists under `internal/vm` or
+  `internal/stdlib`.
+- The plugin builds from the external package directory on the current OS.
+- Space Invaders compiles and its smoke mode passes with the external import.
+- Internal Go tests and the concurrent Noxy runner pass.
+- The new branch is pushed and a separate pull request targets `develop`.

--- a/noxy_examples/run_all_tests_concurrent.nx
+++ b/noxy_examples/run_all_tests_concurrent.nx
@@ -30,7 +30,7 @@ func should_ignore(s: string) -> bool
     "watch_file.nx", "stress_test.nx", "division_error.nx", "error_type.nx", "error_arity.nx", "test_let_error.nx", "error_index.nx",
     "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "run_all_tests.nx",
     "fibonacci_spinner.nx", "web_server_demo.nx", "test_typed_chan_error.nx", "test_web_server.nx",
-    "langtons_ant.nx", "conway.nx", "conway_random.nx", "brainfuck.nx"]
+    "langtons_ant.nx", "conway.nx", "conway_random.nx", "brainfuck.nx", "space_invaders.nx"]
     
     if contains(exclusions, s) then 
         return true 

--- a/noxy_examples/space_invaders.nx
+++ b/noxy_examples/space_invaders.nx
@@ -1,0 +1,484 @@
+use sys
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+use time
+
+let WIDTH: int = 40
+let HEIGHT: int = 20
+let INVADER_ROWS: int = 4
+let INVADER_COLS: int = 8
+let FRAME_MS: int = 50
+
+struct Invader
+    x: int
+    y: int
+    alive: bool
+end
+
+struct Projectile
+    x: int
+    y: int
+    active: bool
+end
+
+struct GameState
+    player_x: int
+    lives: int
+    score: int
+    invader_dx: int
+    invader_step_ms: int
+    last_invader_step: int
+    last_enemy_shot: int
+    enemy_column: int
+    invulnerable_until: int
+    status: string
+end
+
+func read_controls(commands: chan string)
+    while true do
+        let event: terminal.KeyEvent = terminal.read_key()
+        if !event.ok then
+            chan_send(commands, "q")
+            return
+        end
+        chan_send(commands, event.key)
+        if event.key == "q" || event.key == "ctrl+c" then
+            return
+        end
+    end
+end
+
+func new_invaders() -> Invader[]
+    let invaders: Invader[] = []
+    let row: int = 0
+    while row < INVADER_ROWS do
+        let column: int = 0
+        while column < INVADER_COLS do
+            append(invaders, Invader(4 + column * 4, 2 + row * 2, true))
+            column = column + 1
+        end
+        row = row + 1
+    end
+    return invaders
+end
+
+func new_enemy_shots() -> Projectile[]
+    let shots: Projectile[] = []
+    let i: int = 0
+    while i < 3 do
+        append(shots, Projectile(0, 0, false))
+        i = i + 1
+    end
+    return shots
+end
+
+func apply_command(state: ref GameState, shot: ref Projectile, command: string)
+    if state.status != "playing" then
+        return
+    end
+
+    if command == "a" then
+        if state.player_x > 1 then
+            state.player_x = state.player_x - 1
+        end
+    elif command == "d" then
+        if state.player_x < WIDTH - 2 then
+            state.player_x = state.player_x + 1
+        end
+    elif command == "space" then
+        if !shot.active then
+            shot.x = state.player_x
+            shot.y = HEIGHT - 3
+            shot.active = true
+        end
+    elif command == "q" || command == "ctrl+c" then
+        state.status = "quit"
+    end
+end
+
+func count_alive(invaders: Invader[]) -> int
+    let alive: int = 0
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive then
+            alive = alive + 1
+        end
+        i = i + 1
+    end
+    return alive
+end
+
+func step_invaders(state: ref GameState, invaders: ref Invader[], now: int)
+    if state.status != "playing" || now - state.last_invader_step < state.invader_step_ms then
+        return
+    end
+
+    let turn: bool = false
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive then
+            let next_x: int = invaders[i].x + state.invader_dx
+            if next_x <= 1 || next_x >= WIDTH - 2 then
+                turn = true
+            end
+        end
+        i = i + 1
+    end
+
+    i = 0
+    if turn then
+        state.invader_dx = 0 - state.invader_dx
+        while i < length(invaders) do
+            if invaders[i].alive then
+                invaders[i].y = invaders[i].y + 1
+            end
+            i = i + 1
+        end
+    else
+        while i < length(invaders) do
+            if invaders[i].alive then
+                invaders[i].x = invaders[i].x + state.invader_dx
+            end
+            i = i + 1
+        end
+    end
+
+    let destroyed: int = INVADER_ROWS * INVADER_COLS - count_alive(invaders)
+    state.invader_step_ms = 500 - destroyed * 25
+    if state.invader_step_ms < 100 then
+        state.invader_step_ms = 100
+    end
+    state.last_invader_step = now
+end
+
+func step_player_shot(state: ref GameState, shot: ref Projectile, invaders: ref Invader[])
+    if state.status != "playing" || !shot.active then
+        return
+    end
+
+    shot.y = shot.y - 1
+    if shot.y <= 0 then
+        shot.active = false
+        return
+    end
+
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive && invaders[i].x == shot.x && invaders[i].y == shot.y then
+            invaders[i].alive = false
+            state.score = state.score + 10
+            shot.active = false
+            return
+        end
+        i = i + 1
+    end
+end
+
+func step_enemy_shots(state: ref GameState, shots: ref Projectile[], now: int)
+    if state.status != "playing" then
+        return
+    end
+
+    let i: int = 0
+    while i < length(shots) do
+        if shots[i].active then
+            shots[i].y = shots[i].y + 1
+            if shots[i].y >= HEIGHT - 2 then
+                if shots[i].x == state.player_x && now >= state.invulnerable_until then
+                    state.lives = state.lives - 1
+                    state.invulnerable_until = now + 750
+                end
+                shots[i].active = false
+            end
+        end
+        i = i + 1
+    end
+end
+
+func spawn_enemy_shot(state: ref GameState, invaders: Invader[], shots: ref Projectile[], now: int)
+    if state.status != "playing" || now - state.last_enemy_shot < 800 then
+        return
+    end
+
+    let slot: int = -1
+    let i: int = 0
+    while i < length(shots) do
+        if !shots[i].active && slot == -1 then
+            slot = i
+        end
+        i = i + 1
+    end
+    if slot == -1 then
+        return
+    end
+
+    let attempt: int = 0
+    while attempt < INVADER_COLS do
+        let column: int = (state.enemy_column + attempt) % INVADER_COLS
+        let shooter: int = -1
+        i = 0
+        while i < length(invaders) do
+            if i % INVADER_COLS == column && invaders[i].alive then
+                if shooter == -1 || invaders[i].y > invaders[shooter].y then
+                    shooter = i
+                end
+            end
+            i = i + 1
+        end
+
+        if shooter != -1 then
+            shots[slot].x = invaders[shooter].x
+            shots[slot].y = invaders[shooter].y + 1
+            shots[slot].active = true
+            state.enemy_column = (column + 1) % INVADER_COLS
+            state.last_enemy_shot = now
+            return
+        end
+        attempt = attempt + 1
+    end
+
+    state.last_enemy_shot = now
+end
+
+func update_status(state: ref GameState, invaders: Invader[])
+    if state.status != "playing" then
+        return
+    end
+    if state.lives <= 0 then
+        state.status = "defeat"
+        return
+    end
+    if count_alive(invaders) == 0 then
+        state.status = "victory"
+        return
+    end
+
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive && invaders[i].y >= HEIGHT - 2 then
+            state.status = "defeat"
+            return
+        end
+        i = i + 1
+    end
+end
+
+func fixed_width_line(text: string) -> string
+    let line: string = text
+    while length(line) < WIDTH do
+        line = line + " "
+    end
+    return line
+end
+
+func build_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_shots: Projectile[]) -> string
+    let cells: string[] = []
+    let i: int = 0
+    while i < WIDTH * HEIGHT do
+        append(cells, " ")
+        i = i + 1
+    end
+
+    let y: int = 0
+    while y < HEIGHT do
+        let x: int = 0
+        while x < WIDTH do
+            if y == 0 || y == HEIGHT - 1 || x == 0 || x == WIDTH - 1 then
+                cells[y * WIDTH + x] = "#"
+            end
+            x = x + 1
+        end
+        y = y + 1
+    end
+
+    i = 0
+    while i < length(invaders) do
+        if invaders[i].alive then
+            cells[invaders[i].y * WIDTH + invaders[i].x] = "W"
+        end
+        i = i + 1
+    end
+    if shot.active then
+        cells[shot.y * WIDTH + shot.x] = "|"
+    end
+    i = 0
+    while i < length(enemy_shots) do
+        if enemy_shots[i].active then
+            cells[enemy_shots[i].y * WIDTH + enemy_shots[i].x] = "!"
+        end
+        i = i + 1
+    end
+    cells[(HEIGHT - 2) * WIDTH + state.player_x] = "A"
+
+    let frame: string = fixed_width_line("Score: " + to_str(state.score) + " Lives: " + to_str(state.lives) + " Status: " + state.status) + "\n"
+    y = 0
+    while y < HEIGHT do
+        let row: string = ""
+        let x: int = 0
+        while x < WIDTH do
+            row = row + cells[y * WIDTH + x]
+            x = x + 1
+        end
+        frame = frame + row + "\n"
+        y = y + 1
+    end
+    frame = frame + fixed_width_line("A/D move  SPACE fire  Q quit")
+    return frame
+end
+
+func smoke_fail(message: string)
+    print("SPACE_INVADERS_SMOKE_FAIL: " + message)
+    sys.exit(1)
+end
+
+func run_smoke()
+    let base: int = time.now_ms()
+    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, base, base - 800, 0, 0, "playing")
+    let invaders: Invader[] = new_invaders()
+    let shot: Projectile = Projectile(0, 0, false)
+    let enemy_shots: Projectile[] = new_enemy_shots()
+
+    apply_command(state, shot, "a")
+    apply_command(state, shot, "d")
+    apply_command(state, shot, "space")
+
+    let frame_number: int = 0
+    while frame_number < 12 do
+        let now: int = base + frame_number * FRAME_MS
+        step_invaders(state, invaders, now)
+        step_player_shot(state, shot, invaders)
+        step_enemy_shots(state, enemy_shots, now)
+        spawn_enemy_shot(state, invaders, enemy_shots, now)
+        update_status(state, invaders)
+        let frame: string = build_frame(state, invaders, shot, enemy_shots)
+
+        if state.player_x < 1 || state.player_x > WIDTH - 2 then
+            smoke_fail("player left playfield")
+        end
+        if state.lives < 0 || state.lives > 3 then
+            smoke_fail("invalid lives")
+        end
+        if shot.active && (shot.y <= 0 || shot.y >= HEIGHT - 1) then
+            smoke_fail("player projectile left playfield")
+        end
+        let active_enemy_shots: int = 0
+        let i: int = 0
+        while i < length(enemy_shots) do
+            if enemy_shots[i].active then
+                active_enemy_shots = active_enemy_shots + 1
+                if enemy_shots[i].y <= 0 || enemy_shots[i].y >= HEIGHT - 1 then
+                    smoke_fail("enemy projectile left playfield")
+                end
+            end
+            i = i + 1
+        end
+        if active_enemy_shots > 3 then
+            smoke_fail("too many enemy projectiles")
+        end
+        if length(frame) != (HEIGHT + 2) * (WIDTH + 1) - 1 then
+            smoke_fail("invalid frame dimensions")
+        end
+        frame_number = frame_number + 1
+    end
+
+    if state.score != 10 then
+        smoke_fail("player projectile did not hit an invader")
+    end
+    if count_alive(invaders) != INVADER_ROWS * INVADER_COLS - 1 then
+        smoke_fail("alive invader count is inconsistent")
+    end
+    print("SPACE_INVADERS_SMOKE_OK")
+end
+
+func run_interactive()
+    if !terminal.is_terminal() then
+        print("Space Invaders requires an interactive terminal on standard input.")
+        return
+    end
+
+    let opened: terminal.TerminalResult = terminal.open_raw()
+    if !opened.ok then
+        print("Unable to open raw terminal mode: " + opened.error)
+        return
+    end
+
+    let started_at: int = time.now_ms()
+    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, started_at, started_at, 0, 0, "playing")
+    let invaders: Invader[] = new_invaders()
+    let shot: Projectile = Projectile(0, 0, false)
+    let enemy_shots: Projectile[] = new_enemy_shots()
+    let commands: chan string = make_chan(16)
+    let escape: string = fmt("%c", 27)
+    spawn(read_controls, commands)
+
+    iprint(escape + "[?25l" + escape + "[2J")
+    while state.status == "playing" do
+        let draining_commands: bool = true
+        while draining_commands do
+            when
+                case command = chan_recv(commands) then
+                    apply_command(state, shot, command)
+                default
+                    draining_commands = false
+            end
+        end
+
+        if state.status == "playing" then
+            let now: int = time.now_ms()
+            step_invaders(state, invaders, now)
+            step_player_shot(state, shot, invaders)
+            step_enemy_shots(state, enemy_shots, now)
+            spawn_enemy_shot(state, invaders, enemy_shots, now)
+            update_status(state, invaders)
+        end
+
+        let frame: string = build_frame(state, invaders, shot, enemy_shots)
+        iprint(escape + "[H" + frame)
+        if state.status == "playing" then
+            time.sleep(FRAME_MS)
+        end
+    end
+
+    if state.status == "victory" || state.status == "defeat" then
+        let waiting_to_exit: bool = true
+        while waiting_to_exit do
+            let command: string = chan_recv(commands)
+            if command == "q" || command == "ctrl+c" then
+                waiting_to_exit = false
+            end
+        end
+    end
+
+    let closed: bool = terminal.close()
+    iprint(escape + "[?25h")
+    print("")
+    if !closed then
+        print("Warning: terminal raw mode could not be restored cleanly.")
+    end
+    if state.status == "victory" then
+        print("Victory! Final score: " + to_str(state.score))
+    elif state.status == "defeat" then
+        print("Defeat. Final score: " + to_str(state.score))
+    else
+        print("Game quit. Final score: " + to_str(state.score))
+    end
+end
+
+func main()
+    let args: string[] = sys.argv()
+    let smoke: bool = false
+    let i: int = 0
+    while i < length(args) do
+        if args[i] == "--smoke" then
+            smoke = true
+        end
+        i = i + 1
+    end
+
+    if smoke then
+        run_smoke()
+        return
+    end
+    run_interactive()
+end
+
+main()

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/.gitignore
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/.gitignore
@@ -1,0 +1,2 @@
+/noxy-plugin-terminal
+/noxy-plugin-terminal.exe

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/README.md
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/README.md
@@ -17,8 +17,10 @@ the following commands:
 ```
 
 The build creates `noxy-plugin-terminal` (`noxy-plugin-terminal.exe` on
-Windows). Keep that binary next to the program that loads this module, or make
-it available on `PATH`.
+Windows). At load time, the generic loader searches `PATH`, the current working
+directory, and recursively below that directory's `noxy_libs` tree. Place the
+binary in one of those locations; it is not resolved relative to the Noxy
+executable.
 
 ## Use
 
@@ -59,9 +61,13 @@ named keys `space`, `enter`, and `ctrl+c`. Other printable characters are
 returned as themselves; unsupported control input is represented as
 `unknown:0xNN`.
 
-Only one reader may call `read_key()` at a time. Call `close()` explicitly
-after opening raw mode, including on every normal game exit, so the terminal
-settings are restored promptly. Calling `close()` before opening is safe.
+Only one reader may call `read_key()` at a time. `read_key()` and plugin RPC
+requests are blocking and serialized, so never call `close()` while a reader
+loop is active. First signal the reader loop to stop, let it return from
+`read_key()`, and wait for that loop to finish; only then call `close()`.
+Call `close()` explicitly after opening raw mode, including on every normal
+game exit, so the terminal settings are restored promptly. Calling `close()`
+before opening is safe.
 
 On Windows the plugin opens `CONIN$`; on Unix-like systems it opens `/dev/tty`.
 This lets interactive terminal input work even when the program's standard

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/README.md
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/README.md
@@ -1,0 +1,86 @@
+# Noxy Terminal
+
+`noxy_terminal` is an experimental native terminal-input module. It currently
+lives in this repository at `noxy_libs/github_com/estevaofon/noxy_terminal`.
+
+## Prerequisites and build
+
+Building the plugin requires Go 1.24 or newer. From this directory, run one of
+the following commands:
+
+```powershell
+.\build_plugin.ps1
+```
+
+```bash
+./build_plugin.sh
+```
+
+The build creates `noxy-plugin-terminal` (`noxy-plugin-terminal.exe` on
+Windows). Keep that binary next to the program that loads this module, or make
+it available on `PATH`.
+
+## Use
+
+Import `github_com.estevaofon.noxy_terminal.terminal`:
+
+```noxy
+use github_com.estevaofon.noxy_terminal.terminal
+
+let opened: terminal.TerminalResult = terminal.open_raw()
+if opened.ok then
+    let event: terminal.KeyEvent = terminal.read_key()
+    terminal.close()
+end
+```
+
+Public API:
+
+```noxy
+struct TerminalResult
+    ok: bool
+    error: string
+end
+
+struct KeyEvent
+    ok: bool
+    key: string
+    error: string
+end
+
+func is_terminal() -> bool
+func open_raw() -> TerminalResult
+func read_key() -> KeyEvent
+func close() -> bool
+```
+
+`read_key()` returns lowercase letters for uppercase alphabetic input and the
+named keys `space`, `enter`, and `ctrl+c`. Other printable characters are
+returned as themselves; unsupported control input is represented as
+`unknown:0xNN`.
+
+Only one reader may call `read_key()` at a time. Call `close()` explicitly
+after opening raw mode, including on every normal game exit, so the terminal
+settings are restored promptly. Calling `close()` before opening is safe.
+
+On Windows the plugin opens `CONIN$`; on Unix-like systems it opens `/dev/tty`.
+This lets interactive terminal input work even when the program's standard
+input is redirected, provided that device is available.
+
+## Space Invaders
+
+Build the Noxy executable and the terminal plugin, then run the example from
+the repository root:
+
+```powershell
+go build -o noxy.exe ./cmd/noxy
+.\noxy_libs\github_com\estevaofon\noxy_terminal\build_plugin.ps1
+$env:PATH = "$(Resolve-Path .\noxy_libs\github_com\estevaofon\noxy_terminal);$env:PATH"
+.\noxy.exe noxy_examples\space_invaders.nx
+```
+
+```bash
+go build -o noxy ./cmd/noxy
+./noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh
+PATH="$(pwd)/noxy_libs/github_com/estevaofon/noxy_terminal:$PATH" ./noxy noxy_examples/space_invaders.nx
+```

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot
 try {
     go build -o noxy-plugin-terminal.exe .
+    if ($LASTEXITCODE -ne 0) {
+        throw "go build failed with exit code $LASTEXITCODE"
+    }
     Write-Host "Created noxy-plugin-terminal.exe"
 } finally {
     Pop-Location

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot
+try {
+    go build -o noxy-plugin-terminal.exe .
+    Write-Host "Created noxy-plugin-terminal.exe"
+} finally {
+    Pop-Location
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+go build -o noxy-plugin-terminal .
+echo "Created noxy-plugin-terminal"

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin_windows_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/build_plugin_windows_test.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildPluginPowerShellStopsAfterGoBuildFailure(t *testing.T) {
+	shimDirectory := t.TempDir()
+	shimPath := filepath.Join(shimDirectory, "go.cmd")
+	shim := "@echo off\r\necho injected go build failure 1>&2\r\nexit /b 37\r\n"
+	if err := os.WriteFile(shimPath, []byte(shim), 0o600); err != nil {
+		t.Fatalf("write go shim: %v", err)
+	}
+
+	scriptPath, err := filepath.Abs("build_plugin.ps1")
+	if err != nil {
+		t.Fatalf("resolve build script: %v", err)
+	}
+	command := exec.Command(
+		"powershell.exe",
+		"-NoLogo",
+		"-NoProfile",
+		"-NonInteractive",
+		"-ExecutionPolicy", "Bypass",
+		"-File", scriptPath,
+	)
+	command.Env = prependPath(os.Environ(), shimDirectory)
+
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("build script exited successfully after go build failure:\n%s", output)
+	}
+	if strings.Contains(string(output), "Created noxy-plugin-terminal.exe") {
+		t.Fatalf("build script printed success after go build failure:\n%s", output)
+	}
+	if !strings.Contains(string(output), "injected go build failure") {
+		t.Fatalf("build script did not execute injected go shim:\n%s", output)
+	}
+}
+
+func prependPath(environment []string, directory string) []string {
+	updated := append([]string(nil), environment...)
+	for index, entry := range updated {
+		key, value, found := strings.Cut(entry, "=")
+		if found && strings.EqualFold(key, "PATH") {
+			updated[index] = key + "=" + directory + string(os.PathListSeparator) + value
+			return updated
+		}
+	}
+	return append(updated, "PATH="+directory)
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/go.mod
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 toolchain go1.24.11
 
-require golang.org/x/term v0.39.0
-
-require golang.org/x/sys v0.40.0 // indirect
+require (
+	golang.org/x/sys v0.40.0
+	golang.org/x/term v0.39.0
+)

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/go.mod
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/go.mod
@@ -1,0 +1,9 @@
+module github.com/estevaofon/noxy_terminal
+
+go 1.24.0
+
+toolchain go1.24.11
+
+require golang.org/x/term v0.39.0
+
+require golang.org/x/sys v0.40.0 // indirect

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/go.sum
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
+golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
@@ -63,6 +63,8 @@ func (server *pluginServer) write(response pluginResponse) error {
 }
 
 func (server *pluginServer) serve(input io.Reader) error {
+	prepareOutputSignals()
+
 	scanner := bufio.NewScanner(input)
 	workerErrors := make(chan error, 1)
 	inputCloser, _ := input.(io.Closer)

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+type pluginRequest struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+}
+
+type pluginResponse struct {
+	Result interface{} `json:"result,omitempty"`
+	Error  string      `json:"error,omitempty"`
+}
+
+type pluginServer struct {
+	runtime *terminalRuntime
+	encoder *json.Encoder
+	writeMu sync.Mutex
+	workers sync.WaitGroup
+}
+
+func newPluginServer(runtime *terminalRuntime, output io.Writer) *pluginServer {
+	return &pluginServer{
+		runtime: runtime,
+		encoder: json.NewEncoder(output),
+	}
+}
+
+func (server *pluginServer) handle(request pluginRequest) pluginResponse {
+	switch request.Method {
+	case "is_terminal":
+		return pluginResponse{Result: server.runtime.isTerminal()}
+	case "open_raw":
+		return pluginResponse{Result: server.runtime.openRaw()}
+	case "read_key":
+		key, ok := server.runtime.readKey()
+		if !ok {
+			return pluginResponse{Result: nil}
+		}
+		return pluginResponse{Result: key}
+	case "last_error":
+		return pluginResponse{Result: server.runtime.lastError()}
+	case "close":
+		return pluginResponse{Result: server.runtime.close()}
+	default:
+		return pluginResponse{Error: "unknown method: " + request.Method}
+	}
+}
+
+func (server *pluginServer) write(response pluginResponse) {
+	server.writeMu.Lock()
+	defer server.writeMu.Unlock()
+	_ = server.encoder.Encode(response)
+}
+
+func (server *pluginServer) serve(input io.Reader) error {
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		line := append([]byte(nil), scanner.Bytes()...)
+		var request pluginRequest
+		if err := json.Unmarshal(line, &request); err != nil {
+			server.write(pluginResponse{Error: err.Error()})
+			continue
+		}
+
+		if request.Method == "read_key" {
+			server.workers.Add(1)
+			go func(request pluginRequest) {
+				defer server.workers.Done()
+				server.write(server.handle(request))
+			}(request)
+			continue
+		}
+
+		server.write(server.handle(request))
+	}
+
+	server.runtime.shutdown()
+	server.workers.Wait()
+	return scanner.Err()
+}
+
+func main() {
+	runtime := newTerminalRuntime(xTermDriver{})
+	defer runtime.shutdown()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	go func() {
+		<-signals
+		runtime.shutdown()
+		os.Exit(0)
+	}()
+
+	server := newPluginServer(runtime, os.Stdout)
+	if err := server.serve(os.Stdin); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/main.go
@@ -56,19 +56,37 @@ func (server *pluginServer) handle(request pluginRequest) pluginResponse {
 	}
 }
 
-func (server *pluginServer) write(response pluginResponse) {
+func (server *pluginServer) write(response pluginResponse) error {
 	server.writeMu.Lock()
 	defer server.writeMu.Unlock()
-	_ = server.encoder.Encode(response)
+	return server.encoder.Encode(response)
 }
 
 func (server *pluginServer) serve(input io.Reader) error {
 	scanner := bufio.NewScanner(input)
+	workerErrors := make(chan error, 1)
+	inputCloser, _ := input.(io.Closer)
+	var closeInput sync.Once
+	reportWorkerError := func(err error) {
+		server.runtime.shutdown()
+		select {
+		case workerErrors <- err:
+		default:
+		}
+		if inputCloser != nil {
+			closeInput.Do(func() { _ = inputCloser.Close() })
+		}
+	}
+
 	for scanner.Scan() {
 		line := append([]byte(nil), scanner.Bytes()...)
 		var request pluginRequest
 		if err := json.Unmarshal(line, &request); err != nil {
-			server.write(pluginResponse{Error: err.Error()})
+			if writeErr := server.write(pluginResponse{Error: err.Error()}); writeErr != nil {
+				server.runtime.shutdown()
+				server.workers.Wait()
+				return writeErr
+			}
 			continue
 		}
 
@@ -76,16 +94,27 @@ func (server *pluginServer) serve(input io.Reader) error {
 			server.workers.Add(1)
 			go func(request pluginRequest) {
 				defer server.workers.Done()
-				server.write(server.handle(request))
+				if err := server.write(server.handle(request)); err != nil {
+					reportWorkerError(err)
+				}
 			}(request)
 			continue
 		}
 
-		server.write(server.handle(request))
+		if err := server.write(server.handle(request)); err != nil {
+			server.runtime.shutdown()
+			server.workers.Wait()
+			return err
+		}
 	}
 
 	server.runtime.shutdown()
 	server.workers.Wait()
+	select {
+	case err := <-workerErrors:
+		return err
+	default:
+	}
 	return scanner.Err()
 }
 

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/noxy.mod
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/noxy.mod
@@ -1,0 +1,3 @@
+module github.com/estevaofon/noxy_terminal
+
+noxy v0.1.0

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPluginServerPrimitiveResultsAndLastError(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("A")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	server := newPluginServer(newTerminalRuntime(driver), io.Discard)
+
+	assertPluginResult(t, server.handle(pluginRequest{Method: "is_terminal"}), true)
+	assertPluginResult(t, server.handle(pluginRequest{Method: "open_raw"}), true)
+	assertPluginResult(t, server.handle(pluginRequest{Method: "read_key"}), "a")
+	assertPluginResult(t, server.handle(pluginRequest{Method: "close"}), true)
+
+	readErr := errors.New("forced read failure")
+	failingDevice := &fakeTerminalDevice{reader: errorReader{err: readErr}}
+	failingDriver := &fakeTerminalDriver{device: failingDevice, terminal: true}
+	failingServer := newPluginServer(newTerminalRuntime(failingDriver), io.Discard)
+	assertPluginResult(t, failingServer.handle(pluginRequest{Method: "open_raw"}), true)
+	assertPluginResult(t, failingServer.handle(pluginRequest{Method: "read_key"}), nil)
+	assertPluginResult(t, failingServer.handle(pluginRequest{Method: "last_error"}), readErr.Error())
+}
+
+func TestPluginServerRestoresTerminalOnParentEOF(t *testing.T) {
+	device := newBlockingTerminalDevice()
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	runtime := newTerminalRuntime(driver)
+	server := newPluginServer(runtime, &bytes.Buffer{})
+	inputReader, inputWriter := io.Pipe()
+	t.Cleanup(func() {
+		_ = inputWriter.Close()
+		_ = inputReader.Close()
+		runtime.shutdown()
+	})
+	serveDone := make(chan error, 1)
+
+	go func() {
+		serveDone <- server.serve(inputReader)
+	}()
+
+	if _, err := io.WriteString(inputWriter, "{\"method\":\"open_raw\",\"params\":[]}\n{\"method\":\"read_key\",\"params\":[]}\n"); err != nil {
+		t.Fatalf("write requests: %v", err)
+	}
+
+	select {
+	case <-device.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("read_key did not start")
+	}
+
+	if err := inputWriter.Close(); err != nil {
+		t.Fatalf("close input: %v", err)
+	}
+
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("serve() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve() did not return after parent EOF")
+	}
+
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if got := device.closeCount(); got != 1 {
+		t.Fatalf("Close calls = %d, want 1", got)
+	}
+}
+
+func TestPluginServerRejectsUnknownMethod(t *testing.T) {
+	server := newPluginServer(newTerminalRuntime(&fakeTerminalDriver{}), io.Discard)
+
+	response := server.handle(pluginRequest{Method: "missing"})
+	if response.Error != "unknown method: missing" {
+		t.Fatalf("error = %q, want %q", response.Error, "unknown method: missing")
+	}
+}
+
+func TestPluginServerWritesJSONResponsesAndContinuesAfterDecodeError(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	var output bytes.Buffer
+	server := newPluginServer(newTerminalRuntime(driver), &output)
+
+	input := strings.NewReader("not json\n{\"method\":\"is_terminal\",\"params\":[]}\n")
+	if err := server.serve(input); err != nil {
+		t.Fatalf("serve() error = %v, want nil", err)
+	}
+
+	decoder := json.NewDecoder(&output)
+	var decodeError pluginResponse
+	if err := decoder.Decode(&decodeError); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if decodeError.Error == "" {
+		t.Fatal("decode error response has no error")
+	}
+
+	var result pluginResponse
+	if err := decoder.Decode(&result); err != nil {
+		t.Fatalf("decode result response: %v", err)
+	}
+	assertPluginResult(t, result, true)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func assertPluginResult(t *testing.T, response pluginResponse, want interface{}) {
+	t.Helper()
+	if response.Error != "" {
+		t.Fatalf("unexpected response error: %s", response.Error)
+	}
+	if response.Result != want {
+		t.Fatalf("result = %#v, want %#v", response.Result, want)
+	}
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -113,12 +114,88 @@ func TestPluginServerWritesJSONResponsesAndContinuesAfterDecodeError(t *testing.
 	assertPluginResult(t, result, true)
 }
 
+func TestPluginServerReturnsWorkerWriteErrorAndShutsDown(t *testing.T) {
+	writeErr := errors.New("RPC output failed")
+	output := &failAfterWriter{remainingWrites: 1, err: writeErr}
+	device := &fakeTerminalDevice{reader: strings.NewReader("A")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	runtime := newTerminalRuntime(driver)
+	server := newPluginServer(runtime, output)
+	inputReader, inputWriter := io.Pipe()
+	t.Cleanup(func() {
+		_ = inputWriter.Close()
+		_ = inputReader.Close()
+		runtime.shutdown()
+	})
+	serveDone := make(chan error, 1)
+
+	go func() {
+		serveDone <- server.serve(inputReader)
+	}()
+
+	if _, err := io.WriteString(inputWriter, "{\"method\":\"open_raw\",\"params\":[]}\n{\"method\":\"read_key\",\"params\":[]}\n"); err != nil {
+		t.Fatalf("write requests: %v", err)
+	}
+
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, writeErr) {
+			t.Fatalf("serve() error = %v, want %v", err, writeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve() did not return after worker response write failed")
+	}
+
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if device.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", device.closeCalls)
+	}
+}
+
+func TestPluginServerReturnsSynchronousWriteErrorAndShutsDown(t *testing.T) {
+	writeErr := errors.New("RPC output failed")
+	output := &failAfterWriter{err: writeErr}
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	runtime := newTerminalRuntime(driver)
+	server := newPluginServer(runtime, output)
+
+	err := server.serve(strings.NewReader("{\"method\":\"open_raw\",\"params\":[]}\n"))
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("serve() error = %v, want %v", err, writeErr)
+	}
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if device.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", device.closeCalls)
+	}
+}
+
 type errorReader struct {
 	err error
 }
 
 func (r errorReader) Read([]byte) (int, error) {
 	return 0, r.err
+}
+
+type failAfterWriter struct {
+	mu              sync.Mutex
+	remainingWrites int
+	err             error
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.remainingWrites == 0 {
+		return 0, w.err
+	}
+	w.remainingWrites--
+	return len(p), nil
 }
 
 func assertPluginResult(t *testing.T, response pluginResponse, want interface{}) {

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_other.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package main
+
+func prepareOutputSignals() {}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_unix.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package main
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+func prepareOutputSignals() {
+	signal.Ignore(syscall.SIGPIPE)
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_unix_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/sigpipe_unix_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+const (
+	sigpipeHelper       = "NOXY_TERMINAL_SIGPIPE_HELPER"
+	sigpipeHelperMarker = "NOXY_TERMINAL_SIGPIPE_MARKER"
+)
+
+func TestPluginServerClosedStdoutReturnsEPIPEAfterCleanup(t *testing.T) {
+	if os.Getenv(sigpipeHelper) == "1" {
+		runSIGPIPEHelper(t)
+		return
+	}
+
+	marker := filepath.Join(t.TempDir(), "cleanup-complete")
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	if err := readEnd.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	defer writeEnd.Close()
+
+	command := exec.Command(os.Args[0], "-test.run=^TestPluginServerClosedStdoutReturnsEPIPEAfterCleanup$")
+	command.Env = append(os.Environ(),
+		sigpipeHelper+"=1",
+		sigpipeHelperMarker+"="+marker,
+	)
+	command.Stdout = writeEnd
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+
+	if err := command.Run(); err != nil {
+		t.Fatalf("SIGPIPE helper exited before cleanup: %v\n%s", err, stderr.Bytes())
+	}
+	contents, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read cleanup marker: %v", err)
+	}
+	if string(contents) != "restored-and-closed" {
+		t.Fatalf("cleanup marker = %q, want %q", contents, "restored-and-closed")
+	}
+}
+
+func runSIGPIPEHelper(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	server := newPluginServer(newTerminalRuntime(driver), os.Stdout)
+
+	err := server.serve(strings.NewReader("{\"method\":\"open_raw\",\"params\":[]}\n"))
+	if !errors.Is(err, syscall.EPIPE) {
+		t.Fatalf("serve() error = %v, want EPIPE", err)
+	}
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if device.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", device.closeCalls)
+	}
+	if err := os.WriteFile(os.Getenv(sigpipeHelperMarker), []byte("restored-and-closed"), 0o600); err != nil {
+		t.Fatalf("write cleanup marker: %v", err)
+	}
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+type terminalDevice interface {
+	io.Reader
+	io.Closer
+	Fd() uintptr
+}
+
+type terminalDriver interface {
+	open() (terminalDevice, error)
+	isTerminal(fd int) bool
+	makeRaw(fd int) (*terminalSnapshot, error)
+	restore(fd int, snapshot *terminalSnapshot) error
+}
+
+type terminalSnapshot struct {
+	state *term.State
+}
+
+type xTermDriver struct{}
+
+type terminalRuntime struct {
+	stateMu  sync.Mutex
+	readMu   sync.Mutex
+	driver   terminalDriver
+	device   terminalDevice
+	input    *bufio.Reader
+	saved    *terminalSnapshot
+	raw      bool
+	stopping bool
+	lastErr  string
+}
+
+func (xTermDriver) open() (terminalDevice, error) {
+	return openTerminalDevice()
+}
+
+func (xTermDriver) isTerminal(fd int) bool {
+	return term.IsTerminal(fd)
+}
+
+func (xTermDriver) makeRaw(fd int) (*terminalSnapshot, error) {
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return &terminalSnapshot{state: state}, nil
+}
+
+func (xTermDriver) restore(fd int, snapshot *terminalSnapshot) error {
+	return term.Restore(fd, snapshot.state)
+}
+
+func newTerminalRuntime(driver terminalDriver) *terminalRuntime {
+	return &terminalRuntime{driver: driver}
+}
+
+func (r *terminalRuntime) isTerminal() bool {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+
+	device, err := r.driver.open()
+	if err != nil {
+		r.lastErr = err.Error()
+		return false
+	}
+
+	isTerminal := r.driver.isTerminal(int(device.Fd()))
+	if err := device.Close(); err != nil {
+		r.lastErr = err.Error()
+		return false
+	}
+
+	r.lastErr = ""
+	return isTerminal
+}
+
+func (r *terminalRuntime) openRaw() bool {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+
+	if r.stopping {
+		r.lastErr = "terminal runtime is shutting down"
+		return false
+	}
+	if r.raw {
+		r.lastErr = ""
+		return true
+	}
+
+	device, err := r.driver.open()
+	if err != nil {
+		r.lastErr = err.Error()
+		return false
+	}
+
+	if !r.driver.isTerminal(int(device.Fd())) {
+		if err := device.Close(); err != nil {
+			r.lastErr = err.Error()
+			return false
+		}
+		r.lastErr = "terminal device is not a terminal"
+		return false
+	}
+
+	snapshot, err := r.driver.makeRaw(int(device.Fd()))
+	if err != nil {
+		if closeErr := device.Close(); closeErr != nil {
+			r.lastErr = closeErr.Error()
+			return false
+		}
+		r.lastErr = err.Error()
+		return false
+	}
+
+	r.device = device
+	r.input = bufio.NewReader(device)
+	r.saved = snapshot
+	r.raw = true
+	r.lastErr = ""
+	return true
+}
+
+func (r *terminalRuntime) readKey() (string, bool) {
+	r.readMu.Lock()
+	defer r.readMu.Unlock()
+
+	r.stateMu.Lock()
+	input := r.input
+	r.stateMu.Unlock()
+
+	if input == nil {
+		r.recordError(fmt.Errorf("terminal is not open"))
+		return "", false
+	}
+
+	key, _, err := input.ReadRune()
+	if err != nil {
+		r.recordError(err)
+		return "", false
+	}
+
+	r.clearError()
+	return normalizeKey(key), true
+}
+
+func (r *terminalRuntime) lastError() string {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	return r.lastErr
+}
+
+func (r *terminalRuntime) close() bool {
+	r.readMu.Lock()
+	defer r.readMu.Unlock()
+
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+
+	if !r.raw {
+		r.lastErr = ""
+		return true
+	}
+
+	if err := r.driver.restore(int(r.device.Fd()), r.saved); err != nil {
+		r.lastErr = err.Error()
+		return false
+	}
+
+	if err := r.device.Close(); err != nil {
+		r.clearResources()
+		r.lastErr = err.Error()
+		return false
+	}
+
+	r.clearResources()
+	r.lastErr = ""
+	return true
+}
+
+func (r *terminalRuntime) shutdown() {
+	r.stateMu.Lock()
+	r.stopping = true
+	r.stateMu.Unlock()
+
+	r.readMu.Lock()
+	defer r.readMu.Unlock()
+
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+
+	if r.device == nil {
+		r.lastErr = ""
+		return
+	}
+
+	var operationErr error
+	if r.raw {
+		operationErr = r.driver.restore(int(r.device.Fd()), r.saved)
+	}
+	if err := r.device.Close(); err != nil && operationErr == nil {
+		operationErr = err
+	}
+	r.clearResources()
+	if operationErr != nil {
+		r.lastErr = operationErr.Error()
+		return
+	}
+	r.lastErr = ""
+}
+
+func (r *terminalRuntime) recordError(err error) {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.lastErr = err.Error()
+}
+
+func (r *terminalRuntime) clearError() {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.lastErr = ""
+}
+
+func (r *terminalRuntime) clearResources() {
+	r.device = nil
+	r.input = nil
+	r.saved = nil
+	r.raw = false
+}
+
+func normalizeKey(key rune) string {
+	switch key {
+	case ' ':
+		return "space"
+	case '\r', '\n':
+		return "enter"
+	case '\x03':
+		return "ctrl+c"
+	}
+	if key >= 'A' && key <= 'Z' {
+		return string(key + ('a' - 'A'))
+	}
+	if key < 0x20 || key == 0x7f {
+		return fmt.Sprintf("unknown:0x%02x", key)
+	}
+	return string(key)
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.go
@@ -189,14 +189,9 @@ func (r *terminalRuntime) close() bool {
 
 func (r *terminalRuntime) shutdown() {
 	r.stateMu.Lock()
-	r.stopping = true
-	r.stateMu.Unlock()
-
-	r.readMu.Lock()
-	defer r.readMu.Unlock()
-
-	r.stateMu.Lock()
 	defer r.stateMu.Unlock()
+
+	r.stopping = true
 
 	if r.device == nil {
 		r.lastErr = ""

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.nx
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal.nx
@@ -1,0 +1,66 @@
+let _terminal_loaded: bool = false
+let _terminal_attempted: bool = false
+let _terminal_load_error: string = ""
+
+struct TerminalResult
+    ok: bool
+    error: string
+end
+
+struct KeyEvent
+    ok: bool
+    key: string
+    error: string
+end
+
+func _ensure_terminal_plugin() -> bool
+    if _terminal_loaded then return true end
+    if _terminal_attempted then return false end
+
+    _terminal_attempted = true
+    _terminal_loaded = sys_load_plugin("terminal", "noxy-plugin-terminal")
+    if !_terminal_loaded then
+        _terminal_load_error = "noxy-plugin-terminal was not found or could not be started"
+    end
+    return _terminal_loaded
+end
+
+func _terminal_error() -> string
+    if !_terminal_loaded then return _terminal_load_error end
+    let result: any = terminal_request("last_error")
+    if result == null then return "terminal plugin request failed" end
+    return to_str(result)
+end
+
+func _terminal_bool(method: string) -> bool
+    let result: any = terminal_request(method)
+    return result != null && to_str(result) == "true"
+end
+
+func is_terminal() -> bool
+    if !_ensure_terminal_plugin() then return false end
+    return _terminal_bool("is_terminal")
+end
+
+func open_raw() -> TerminalResult
+    if !_ensure_terminal_plugin() then
+        return TerminalResult(false, _terminal_error())
+    end
+    let ok: bool = _terminal_bool("open_raw")
+    if !ok then return TerminalResult(false, _terminal_error()) end
+    return TerminalResult(true, "")
+end
+
+func read_key() -> KeyEvent
+    if !_ensure_terminal_plugin() then
+        return KeyEvent(false, "", _terminal_error())
+    end
+    let result: any = terminal_request("read_key")
+    if result == null then return KeyEvent(false, "", _terminal_error()) end
+    return KeyEvent(true, to_str(result), "")
+end
+
+func close() -> bool
+    if !_terminal_loaded then return true end
+    return _terminal_bool("close")
+end

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type fakeTerminalDevice struct {
+	reader     io.Reader
+	fd         uintptr
+	closeErr   error
+	closeCalls int
+}
+
+func (d *fakeTerminalDevice) Read(p []byte) (int, error) {
+	return d.reader.Read(p)
+}
+
+func (d *fakeTerminalDevice) Close() error {
+	d.closeCalls++
+	return d.closeErr
+}
+
+func (d *fakeTerminalDevice) Fd() uintptr {
+	return d.fd
+}
+
+type fakeTerminalDriver struct {
+	device       terminalDevice
+	openErr      error
+	terminal     bool
+	makeRawErr   error
+	restoreErr   error
+	openCalls    int
+	makeRawCalls int
+	restoreCalls int
+}
+
+func (d *fakeTerminalDriver) open() (terminalDevice, error) {
+	d.openCalls++
+	return d.device, d.openErr
+}
+
+func (d *fakeTerminalDriver) isTerminal(int) bool {
+	return d.terminal
+}
+
+func (d *fakeTerminalDriver) makeRaw(int) (*terminalSnapshot, error) {
+	d.makeRawCalls++
+	if d.makeRawErr != nil {
+		return nil, d.makeRawErr
+	}
+	return &terminalSnapshot{}, nil
+}
+
+func (d *fakeTerminalDriver) restore(int, *terminalSnapshot) error {
+	d.restoreCalls++
+	return d.restoreErr
+}
+
+func TestRuntimeRejectsNonTerminal(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{device: device}
+	runtime := newTerminalRuntime(driver)
+
+	if runtime.isTerminal() {
+		t.Fatal("isTerminal() = true, want false")
+	}
+	if runtime.openRaw() {
+		t.Fatal("openRaw() = true, want false")
+	}
+	if device.closeCalls != 2 {
+		t.Fatalf("Close calls = %d, want 2", device.closeCalls)
+	}
+}
+
+func TestRuntimeOpenReadCloseIsIdempotent(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("A")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	runtime := newTerminalRuntime(driver)
+
+	if !runtime.openRaw() {
+		t.Fatalf("first openRaw() = false: %s", runtime.lastError())
+	}
+	if !runtime.openRaw() {
+		t.Fatalf("second openRaw() = false: %s", runtime.lastError())
+	}
+	if driver.makeRawCalls != 1 {
+		t.Fatalf("makeRaw calls = %d, want 1", driver.makeRawCalls)
+	}
+
+	key, ok := runtime.readKey()
+	if !ok || key != "a" {
+		t.Fatalf("readKey() = %q, %t; want %q, true", key, ok, "a")
+	}
+
+	if !runtime.close() {
+		t.Fatalf("first close() = false: %s", runtime.lastError())
+	}
+	if !runtime.close() {
+		t.Fatalf("second close() = false: %s", runtime.lastError())
+	}
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if device.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", device.closeCalls)
+	}
+}
+
+func TestRuntimeReportsRestoreFailure(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{
+		device:     device,
+		terminal:   true,
+		restoreErr: errors.New("restore failed"),
+	}
+	runtime := newTerminalRuntime(driver)
+
+	if !runtime.openRaw() {
+		t.Fatalf("openRaw() = false: %s", runtime.lastError())
+	}
+	if runtime.close() {
+		t.Fatal("close() = true, want false")
+	}
+	if got := runtime.lastError(); got != "restore failed" {
+		t.Fatalf("lastError() = %q, want %q", got, "restore failed")
+	}
+	if device.closeCalls != 0 {
+		t.Fatalf("Close calls = %d, want 0", device.closeCalls)
+	}
+}
+
+func TestNormalizeKey(t *testing.T) {
+	tests := []struct {
+		input rune
+		want  string
+	}{
+		{'A', "a"},
+		{' ', "space"},
+		{'\r', "enter"},
+		{'\n', "enter"},
+		{'\x03', "ctrl+c"},
+		{'é', "é"},
+		{'\x01', "unknown:0x01"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.want, func(t *testing.T) {
+			if got := normalizeKey(test.input); got != test.want {
+				t.Fatalf("normalizeKey(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestShutdownRestoresAndClosesDevice(t *testing.T) {
+	device := &fakeTerminalDevice{reader: strings.NewReader("")}
+	driver := &fakeTerminalDriver{device: device, terminal: true}
+	runtime := newTerminalRuntime(driver)
+
+	if !runtime.openRaw() {
+		t.Fatalf("openRaw() = false: %s", runtime.lastError())
+	}
+	runtime.shutdown()
+
+	if driver.restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", driver.restoreCalls)
+	}
+	if device.closeCalls != 1 {
+		t.Fatalf("Close calls = %d, want 1", device.closeCalls)
+	}
+	if runtime.openRaw() {
+		t.Fatal("openRaw() after shutdown = true, want false")
+	}
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -12,6 +13,47 @@ type fakeTerminalDevice struct {
 	fd         uintptr
 	closeErr   error
 	closeCalls int
+}
+
+type blockingTerminalDevice struct {
+	fd          uintptr
+	readStarted chan struct{}
+	closed      chan struct{}
+	startOnce   sync.Once
+	closeOnce   sync.Once
+	mu          sync.Mutex
+	closeCalls  int
+}
+
+func newBlockingTerminalDevice() *blockingTerminalDevice {
+	return &blockingTerminalDevice{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (d *blockingTerminalDevice) Read([]byte) (int, error) {
+	d.startOnce.Do(func() { close(d.readStarted) })
+	<-d.closed
+	return 0, io.EOF
+}
+
+func (d *blockingTerminalDevice) Close() error {
+	d.mu.Lock()
+	d.closeCalls++
+	d.mu.Unlock()
+	d.closeOnce.Do(func() { close(d.closed) })
+	return nil
+}
+
+func (d *blockingTerminalDevice) Fd() uintptr {
+	return d.fd
+}
+
+func (d *blockingTerminalDevice) closeCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closeCalls
 }
 
 func (d *fakeTerminalDevice) Read(p []byte) (int, error) {

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_unix.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func openTerminalDevice() (terminalDevice, error) {
+	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go
@@ -2,8 +2,167 @@
 
 package main
 
-import "os"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+
+	"golang.org/x/sys/windows"
+)
+
+var cancelSynchronousIOProc = windows.NewLazySystemDLL("kernel32.dll").NewProc("CancelSynchronousIo")
+
+type windowsTerminalRead struct {
+	thread   windows.Handle
+	done     chan struct{}
+	handleMu sync.Mutex
+}
+
+type windowsTerminalDevice struct {
+	file *os.File
+
+	readMu sync.Mutex
+	state  sync.Mutex
+	active *windowsTerminalRead
+	closed bool
+
+	closeOnce sync.Once
+	closeDone chan struct{}
+	closeErr  error
+}
 
 func openTerminalDevice() (terminalDevice, error) {
-	return os.OpenFile("CONIN$", os.O_RDWR, 0)
+	file, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsTerminalDevice{
+		file:      file,
+		closeDone: make(chan struct{}),
+	}, nil
+}
+
+func (d *windowsTerminalDevice) Read(buffer []byte) (int, error) {
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+
+	d.readMu.Lock()
+	defer d.readMu.Unlock()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	thread, err := duplicateCurrentThread()
+	if err != nil {
+		return 0, fmt.Errorf("duplicate console reader thread: %w", err)
+	}
+
+	operation := &windowsTerminalRead{
+		thread: thread,
+		done:   make(chan struct{}),
+	}
+
+	d.state.Lock()
+	if d.closed {
+		d.state.Unlock()
+		_ = windows.CloseHandle(thread)
+		return 0, os.ErrClosed
+	}
+	d.active = operation
+	d.state.Unlock()
+
+	n, readErr := d.file.Read(buffer)
+
+	d.state.Lock()
+	if d.active == operation {
+		d.active = nil
+	}
+	d.state.Unlock()
+	operation.handleMu.Lock()
+	if err := windows.CloseHandle(thread); err != nil {
+		readErr = errors.Join(readErr, fmt.Errorf("close console reader thread: %w", err))
+	}
+	close(operation.done)
+	operation.handleMu.Unlock()
+	return n, readErr
+}
+
+func (d *windowsTerminalDevice) Close() error {
+	d.closeOnce.Do(func() {
+		d.closeErr = d.close()
+		close(d.closeDone)
+	})
+	<-d.closeDone
+	return d.closeErr
+}
+
+func (d *windowsTerminalDevice) close() error {
+	d.state.Lock()
+	d.closed = true
+	operation := d.active
+	d.state.Unlock()
+
+	if operation != nil {
+		if err := cancelTerminalRead(operation); err != nil {
+			return err
+		}
+	}
+	return d.file.Close()
+}
+
+func (d *windowsTerminalDevice) Fd() uintptr {
+	return d.file.Fd()
+}
+
+func duplicateCurrentThread() (windows.Handle, error) {
+	process := windows.CurrentProcess()
+	var thread windows.Handle
+	err := windows.DuplicateHandle(
+		process,
+		windows.CurrentThread(),
+		process,
+		&thread,
+		0,
+		false,
+		windows.DUPLICATE_SAME_ACCESS,
+	)
+	return thread, err
+}
+
+func cancelTerminalRead(operation *windowsTerminalRead) error {
+	for {
+		operation.handleMu.Lock()
+		select {
+		case <-operation.done:
+			operation.handleMu.Unlock()
+			return nil
+		default:
+		}
+
+		err := cancelSynchronousIO(operation.thread)
+		operation.handleMu.Unlock()
+		if err == nil {
+			<-operation.done
+			return nil
+		}
+		if !errors.Is(err, windows.ERROR_NOT_FOUND) {
+			return fmt.Errorf("cancel console read: %w", err)
+		}
+
+		// The reader publishes its real thread handle immediately before
+		// entering ReadConsoleW. If cancellation wins that small race, let the
+		// reader enter the syscall and try again.
+		runtime.Gosched()
+	}
+}
+
+func cancelSynchronousIO(thread windows.Handle) error {
+	result, _, callErr := cancelSynchronousIOProc.Call(uintptr(thread))
+	if result != 0 {
+		return nil
+	}
+	return callErr
 }

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func openTerminalDevice() (terminalDevice, error) {
+	return os.OpenFile("CONIN$", os.O_RDWR, 0)
+}

--- a/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows_test.go
+++ b/noxy_libs/github_com/estevaofon/noxy_terminal/terminal_windows_test.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsConsoleReadHelper = "NOXY_TERMINAL_WINDOWS_CONSOLE_READ_HELPER"
+
+func TestWindowsTerminalDeviceCloseUnblocksRead(t *testing.T) {
+	if os.Getenv(windowsConsoleReadHelper) == "1" {
+		runWindowsConsoleReadHelper(t)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestWindowsTerminalDeviceCloseUnblocksRead$")
+	command.Env = append(os.Environ(), windowsConsoleReadHelper+"=1")
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_CONSOLE,
+		HideWindow:    true,
+	}
+
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("console read helper did not terminate after device close: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("console read helper failed: %v\n%s", err, output)
+	}
+}
+
+func runWindowsConsoleReadHelper(t *testing.T) {
+	device, err := openTerminalDevice()
+	if err != nil {
+		t.Fatalf("open CONIN$: %v", err)
+	}
+	windowsDevice, ok := device.(*windowsTerminalDevice)
+	if !ok {
+		t.Fatalf("terminal device type = %T, want *windowsTerminalDevice", device)
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		var buffer [4]byte
+		_, err := device.Read(buffer[:])
+		readDone <- err
+	}()
+
+	waitForWindowsTerminalRead(t, windowsDevice)
+	select {
+	case err := <-readDone:
+		t.Fatalf("CONIN$ read returned before Close: %v", err)
+	default:
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- device.Close()
+	}()
+
+	select {
+	case err := <-readDone:
+		if err == nil {
+			t.Fatal("cancelled CONIN$ read returned without an error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked CONIN$ read was not released by Close")
+	}
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("close CONIN$: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after the CONIN$ read ended")
+	}
+}
+
+func waitForWindowsTerminalRead(t *testing.T, device *windowsTerminalDevice) {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		device.state.Lock()
+		active := device.active != nil
+		device.state.Unlock()
+		if active {
+			return
+		}
+
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("CONIN$ read did not become active")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adiciona `noxy_terminal` como biblioteca externa experimental em `noxy_libs`, sem builtin específico na VM ou módulo embutido na stdlib.
- Mantém o exemplo completo de Space Invaders usando o import externo e o smoke determinístico.
- Implementa cleanup robusto para EOF/sinais, cancelamento de leitura `CONIN$` no Windows e tratamento de `SIGPIPE` no Unix.

## Components
- Plugin Go externo com protocolo JSON, raw mode e suporte Windows/Unix.
- Wrapper Noxy tipado com carregamento lazy, scripts de build e documentação.
- Space Invaders completo, exclusão do runner interativo e documentação raiz.
- Testes de lifecycle, protocolo, falhas de escrita, console Windows e build PowerShell.

## Related Issues
- No related issue.

## Test Plan
- [x] Implementação
- [x] Testes unitários passando (`go test ./...` e `go test -race ./...` no módulo externo)
- [x] Testado integrado (`go test ./internal/...`, smoke e runner Noxy 157/157)
- [x] Build e vet (`go build ./...`, `go vet ./...`, cross-build Windows/Linux)
- [x] Teste interativo do Space Invaders confirmado