### PR TITLE
feat/NO-CARD - Adicionar Space Invaders 2 com visual Neo Arcade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Experimental external terminal package backed by a Go plugin.
 - Complete Space Invaders example using the external terminal package.
+- Neo Arcade Space Invaders 2 example with colored terminal sprites, deterministic starfield, smoke validation, and safe interactive terminal cleanup. `#examples` @estevaofon
 
 ## [0.1.0] - 2026-08-10
 

--- a/noxy_examples/run_all_tests.nx
+++ b/noxy_examples/run_all_tests.nx
@@ -36,7 +36,7 @@ func should_ignore(s: string) -> bool
     "simple_server.nx", "web_app.nx", "http_server_basic.nx", "http_server_docs.nx", 
     "form_app.nx", "http_server_sockets.nx", "todo_app2.nx", "todo_app.nx", "cadastro_usuarios.nx", "md2html.nx",
     "watch_file.nx", "stress_test.nx", "division_error.nx", "error_type.nx", "error_arity.nx", "test_let_error.nx", "error_index.nx",
-    "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "space_invaders.nx"]
+    "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "space_invaders.nx", "space_invaders2.nx"]
     if contains(exclusions, s) then
          return true
     end

--- a/noxy_examples/run_all_tests_concurrent.nx
+++ b/noxy_examples/run_all_tests_concurrent.nx
@@ -30,7 +30,7 @@ func should_ignore(s: string) -> bool
     "watch_file.nx", "stress_test.nx", "division_error.nx", "error_type.nx", "error_arity.nx", "test_let_error.nx", "error_index.nx",
     "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "run_all_tests.nx",
     "fibonacci_spinner.nx", "web_server_demo.nx", "test_typed_chan_error.nx", "test_web_server.nx",
-    "langtons_ant.nx", "conway.nx", "conway_random.nx", "brainfuck.nx", "space_invaders.nx"]
+    "langtons_ant.nx", "conway.nx", "conway_random.nx", "brainfuck.nx", "space_invaders.nx", "space_invaders2.nx"]
     
     if contains(exclusions, s) then 
         return true 

--- a/noxy_examples/space_invaders2.nx
+++ b/noxy_examples/space_invaders2.nx
@@ -5,6 +5,7 @@
 
 use sys
 use github_com.estevaofon.noxy_terminal.terminal as terminal
+use strings
 use time
 
 let WIDTH: int = 56
@@ -224,6 +225,11 @@ func spawn_enemy_shot(state: ref GameState, invaders: Invader[], shots: ref Proj
         end
 
         if shooter != -1 then
+            if invaders[shooter].y + 1 >= HEIGHT - 1 then
+                state.enemy_column = (column + 1) % INVADER_COLS
+                state.last_enemy_shot = now
+                return
+            end
             shots[slot].x = invaders[shooter].x
             shots[slot].y = invaders[shooter].y + 1
             shots[slot].active = true
@@ -279,10 +285,9 @@ func contains_text(text: string, target: string) -> bool
 end
 
 func cell_color(cell: string) -> string
-    if cell == "╭" || cell == "╬" || cell == "╮" || cell == "╰" || cell == "╩" || cell == "╯" then
-        return "96"
-    end
-    if cell == "▟" || cell == "█" || cell == "▙" then return "92" end
+    if cell == "╭" || cell == "╬" || cell == "╮" then return "95" end
+    if cell == "╰" || cell == "╩" || cell == "╯" then return "93" end
+    if cell == "▟" || cell == "█" || cell == "▙" then return "96" end
     if cell == "│" then return "93" end
     if cell == "▼" then return "91" end
     if cell == "✦" || cell == "·" then return "90" end
@@ -327,7 +332,14 @@ func build_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_
         cells[(HEIGHT - 2) * WIDTH + state.player_x + 1] = "▙"
     end
 
-    let frame: string = color("93", colored) + "SCORE " + to_str(state.score) + "   LIVES " + to_str(state.lives) + "   STATUS " + state.status + color("0", colored) + "\n"
+    let hud_score: string = "SCORE " + to_str(state.score) + "   "
+    let hud_lives: string = "LIVES " + to_str(state.lives) + "   "
+    let hud_status: string = "STATUS " + state.status
+    let hud_padding: string = ""
+    while length(hud_score) + length(hud_lives) + length(hud_status) + length(hud_padding) < WIDTH + 2 do
+        hud_padding = hud_padding + " "
+    end
+    let frame: string = color("93", colored) + hud_score + color("92", colored) + hud_lives + color("93", colored) + hud_status + hud_padding + color("0", colored) + "\n"
     let border: string = "╔"
     i = 0
     while i < WIDTH do
@@ -335,17 +347,17 @@ func build_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_
         i = i + 1
     end
     border = border + "╗"
-    frame = frame + color("95", colored) + border + color("0", colored) + "\n"
+    frame = frame + color("96", colored) + border + color("0", colored) + "\n"
 
     let y: int = 0
     while y < HEIGHT do
-        let row: string = color("95", colored) + "║"
+        let row: string = color("96", colored) + "║"
         let x: int = 0
         while x < WIDTH do
             let cell: string = cells[y * WIDTH + x]
             let code: string = cell_color(cell)
             if code != "" then
-                row = row + color(code, colored) + cell + color("95", colored)
+                row = row + color(code, colored) + cell + color("96", colored)
             else
                 row = row + cell
             end
@@ -355,7 +367,7 @@ func build_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_
         frame = frame + row + "\n"
         y = y + 1
     end
-    frame = frame + color("95", colored) + "╚"
+    frame = frame + color("96", colored) + "╚"
     i = 0
     while i < WIDTH do
         frame = frame + "═"
@@ -369,14 +381,9 @@ func smoke_fail(message: string)
     sys.exit(1)
 end
 
-func run_smoke()
-    let base: int = time.now_ms()
-    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, base, base - 800, 0, 0, "playing")
-    let invaders: Invader[] = new_invaders()
-    let shot: Projectile = Projectile(0, 0, false)
-    let enemy_shots: Projectile[] = new_enemy_shots()
-
+func smoke_assert_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_shots: Projectile[])
     let frame: string = build_frame(state, invaders, shot, enemy_shots, false)
+    let colored_frame: string = build_frame(state, invaders, shot, enemy_shots, true)
     if !contains_text(frame, "SCORE") then smoke_fail("HUD is missing score") end
     if !contains_text(frame, "LIVES") then smoke_fail("HUD is missing lives") end
     if !contains_text(frame, "╔") || !contains_text(frame, "╝") then
@@ -385,6 +392,69 @@ func run_smoke()
     if !contains_text(frame, "╭╬╮") && !contains_text(frame, "╰╩╯") then
         smoke_fail("invader sprite is missing")
     end
+    if cell_color("▟") != "96" then smoke_fail("player sprite is not cyan") end
+    if cell_color("╭") != "95" then smoke_fail("upper invader sprite is not magenta") end
+    if cell_color("╰") != "93" then smoke_fail("lower invader sprite is not yellow") end
+    if !contains_text(colored_frame, color("96", true) + "╔") then
+        smoke_fail("arcade border is not cyan")
+    end
+    if !contains_text(colored_frame, color("92", true) + "LIVES 3") then
+        smoke_fail("HUD lives segment is not green")
+    end
+
+    let frame_lines: strings.SplitResult = strings.split(frame, "\n")
+    if frame_lines.count != HEIGHT + 3 then smoke_fail("frame has invalid line count") end
+    let line_index: int = 0
+    while line_index < frame_lines.count do
+        if length(frame_lines.parts[line_index]) != WIDTH + 2 then
+            smoke_fail("frame line has invalid visual width")
+        end
+        line_index = line_index + 1
+    end
+    if contains_text(frame, fmt("%c", 27)) then
+        smoke_fail("plain frame contains ANSI escape codes")
+    end
+end
+
+func smoke_assert_boundaries(base: int)
+    let boundary_state: GameState = GameState(2, 3, 0, 1, 500, base, base, 0, 0, "playing")
+    let boundary_shot: Projectile = Projectile(0, 0, false)
+    let boundary_step: int = 0
+    while boundary_step < WIDTH * 2 do
+        apply_command(boundary_state, boundary_shot, "a")
+        boundary_step = boundary_step + 1
+    end
+    if boundary_state.player_x != 2 then smoke_fail("player crossed left boundary") end
+    boundary_step = 0
+    while boundary_step < WIDTH * 2 do
+        apply_command(boundary_state, boundary_shot, "d")
+        boundary_step = boundary_step + 1
+    end
+    if boundary_state.player_x != WIDTH - 3 then smoke_fail("player crossed right boundary") end
+
+    let low_invaders: Invader[] = new_invaders()
+    let low_index: int = 0
+    while low_index < length(low_invaders) do
+        low_invaders[low_index].alive = false
+        low_index = low_index + 1
+    end
+    low_invaders[0].alive = true
+    low_invaders[0].y = HEIGHT - 2
+    let spawn_state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, base, base - 800, 0, 0, "playing")
+    let spawn_shots: Projectile[] = new_enemy_shots()
+    spawn_enemy_shot(spawn_state, low_invaders, spawn_shots, base)
+    if spawn_shots[0].active then smoke_fail("enemy projectile spawned outside playfield") end
+end
+
+func run_smoke()
+    let base: int = time.now_ms()
+    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, base, base - 800, 0, 0, "playing")
+    let invaders: Invader[] = new_invaders()
+    let shot: Projectile = Projectile(0, 0, false)
+    let enemy_shots: Projectile[] = new_enemy_shots()
+
+    smoke_assert_frame(state, invaders, shot, enemy_shots)
+    smoke_assert_boundaries(base)
 
     apply_command(state, shot, "a")
     apply_command(state, shot, "d")
@@ -424,13 +494,13 @@ func run_smoke()
         end
         frame_number = frame_number + 1
     end
-
     if state.score != 10 then
         smoke_fail("player projectile did not hit an invader")
     end
     if count_alive(invaders) != INVADER_ROWS * INVADER_COLS - 1 then
         smoke_fail("alive invader count is inconsistent")
     end
+    if state.status != "playing" then smoke_fail("smoke simulation left playing status") end
     print("SPACE_INVADERS2_SMOKE_OK")
 end
 

--- a/noxy_examples/space_invaders2.nx
+++ b/noxy_examples/space_invaders2.nx
@@ -1,0 +1,313 @@
+// Este exemplo requer a biblioteca noxy_terminal.
+// Instale com: noxy --get github.com/estevaofon/noxy_terminal
+// Depois, siga as instruções do README da biblioteca: também é necessário
+// executar o script build_plugin.ps1 (Windows) ou build_plugin.sh (Unix).
+
+use sys
+use github_com.estevaofon.noxy_terminal.terminal as terminal
+use time
+
+let WIDTH: int = 56
+let HEIGHT: int = 22
+let INVADER_ROWS: int = 4
+let INVADER_COLS: int = 8
+let FRAME_MS: int = 50
+
+struct Invader
+    x: int
+    y: int
+    alive: bool
+end
+
+struct Projectile
+    x: int
+    y: int
+    active: bool
+end
+
+struct GameState
+    player_x: int
+    lives: int
+    score: int
+    invader_dx: int
+    invader_step_ms: int
+    last_invader_step: int
+    last_enemy_shot: int
+    enemy_column: int
+    invulnerable_until: int
+    status: string
+end
+
+func new_invaders() -> Invader[]
+    let invaders: Invader[] = []
+    let row: int = 0
+    while row < INVADER_ROWS do
+        let column: int = 0
+        while column < INVADER_COLS do
+            append(invaders, Invader(8 + column * 5, 3 + row * 2, true))
+            column = column + 1
+        end
+        row = row + 1
+    end
+    return invaders
+end
+
+func new_enemy_shots() -> Projectile[]
+    let shots: Projectile[] = []
+    let i: int = 0
+    while i < 3 do
+        append(shots, Projectile(0, 0, false))
+        i = i + 1
+    end
+    return shots
+end
+
+func apply_command(state: ref GameState, shot: ref Projectile, command: string)
+    if state.status != "playing" then
+        return
+    end
+    if command == "a" && state.player_x > 2 then
+        state.player_x = state.player_x - 1
+    elif command == "d" && state.player_x < WIDTH - 3 then
+        state.player_x = state.player_x + 1
+    elif command == "space" && !shot.active then
+        shot.x = state.player_x
+        shot.y = HEIGHT - 4
+        shot.active = true
+    elif command == "q" || command == "ctrl+c" then
+        state.status = "quit"
+    end
+end
+
+func count_alive(invaders: Invader[]) -> int
+    let alive: int = 0
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive then
+            alive = alive + 1
+        end
+        i = i + 1
+    end
+    return alive
+end
+
+func step_invaders(state: ref GameState, invaders: ref Invader[], now: int)
+    if state.status != "playing" || now - state.last_invader_step < state.invader_step_ms then
+        return
+    end
+
+    let turn: bool = false
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive then
+            let next_x: int = invaders[i].x + state.invader_dx
+            if next_x <= 1 || next_x >= WIDTH - 2 then
+                turn = true
+            end
+        end
+        i = i + 1
+    end
+
+    i = 0
+    if turn then
+        state.invader_dx = 0 - state.invader_dx
+        while i < length(invaders) do
+            if invaders[i].alive then
+                invaders[i].y = invaders[i].y + 1
+            end
+            i = i + 1
+        end
+    else
+        while i < length(invaders) do
+            if invaders[i].alive then
+                invaders[i].x = invaders[i].x + state.invader_dx
+            end
+            i = i + 1
+        end
+    end
+
+    let destroyed: int = INVADER_ROWS * INVADER_COLS - count_alive(invaders)
+    state.invader_step_ms = 500 - destroyed * 25
+    if state.invader_step_ms < 100 then
+        state.invader_step_ms = 100
+    end
+    state.last_invader_step = now
+end
+
+func step_player_shot(state: ref GameState, shot: ref Projectile, invaders: ref Invader[])
+    if state.status != "playing" || !shot.active then
+        return
+    end
+
+    shot.y = shot.y - 1
+    if shot.y <= 0 then
+        shot.active = false
+        return
+    end
+
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive && invaders[i].x == shot.x && invaders[i].y == shot.y then
+            invaders[i].alive = false
+            state.score = state.score + 10
+            shot.active = false
+            return
+        end
+        i = i + 1
+    end
+end
+
+func step_enemy_shots(state: ref GameState, shots: ref Projectile[], now: int)
+    if state.status != "playing" then
+        return
+    end
+
+    let i: int = 0
+    while i < length(shots) do
+        if shots[i].active then
+            shots[i].y = shots[i].y + 1
+            if shots[i].y >= HEIGHT - 2 then
+                if shots[i].x == state.player_x && now >= state.invulnerable_until then
+                    state.lives = state.lives - 1
+                    state.invulnerable_until = now + 750
+                end
+                shots[i].active = false
+            end
+        end
+        i = i + 1
+    end
+end
+
+func spawn_enemy_shot(state: ref GameState, invaders: Invader[], shots: ref Projectile[], now: int)
+    if state.status != "playing" || now - state.last_enemy_shot < 800 then
+        return
+    end
+
+    let slot: int = -1
+    let i: int = 0
+    while i < length(shots) do
+        if !shots[i].active && slot == -1 then
+            slot = i
+        end
+        i = i + 1
+    end
+    if slot == -1 then
+        return
+    end
+
+    let attempt: int = 0
+    while attempt < INVADER_COLS do
+        let column: int = (state.enemy_column + attempt) % INVADER_COLS
+        let shooter: int = -1
+        i = 0
+        while i < length(invaders) do
+            if i % INVADER_COLS == column && invaders[i].alive then
+                if shooter == -1 || invaders[i].y > invaders[shooter].y then
+                    shooter = i
+                end
+            end
+            i = i + 1
+        end
+
+        if shooter != -1 then
+            shots[slot].x = invaders[shooter].x
+            shots[slot].y = invaders[shooter].y + 1
+            shots[slot].active = true
+            state.enemy_column = (column + 1) % INVADER_COLS
+            state.last_enemy_shot = now
+            return
+        end
+        attempt = attempt + 1
+    end
+
+    state.last_enemy_shot = now
+end
+
+func update_status(state: ref GameState, invaders: Invader[])
+    if state.status != "playing" then
+        return
+    end
+    if state.lives <= 0 then
+        state.status = "defeat"
+        return
+    end
+    if count_alive(invaders) == 0 then
+        state.status = "victory"
+        return
+    end
+
+    let i: int = 0
+    while i < length(invaders) do
+        if invaders[i].alive && invaders[i].y >= HEIGHT - 2 then
+            state.status = "defeat"
+            return
+        end
+        i = i + 1
+    end
+end
+
+func smoke_fail(message: string)
+    print("SPACE_INVADERS2_SMOKE_FAIL: " + message)
+    sys.exit(1)
+end
+
+func run_smoke()
+    let base: int = time.now_ms()
+    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, base, base - 800, 0, 0, "playing")
+    let invaders: Invader[] = new_invaders()
+    let shot: Projectile = Projectile(0, 0, false)
+    let enemy_shots: Projectile[] = new_enemy_shots()
+
+    apply_command(state, shot, "a")
+    apply_command(state, shot, "d")
+    apply_command(state, shot, "space")
+
+    let frame_number: int = 0
+    while frame_number < 12 do
+        let now: int = base + frame_number * FRAME_MS
+        step_invaders(state, invaders, now)
+        step_player_shot(state, shot, invaders)
+        step_enemy_shots(state, enemy_shots, now)
+        spawn_enemy_shot(state, invaders, enemy_shots, now)
+        update_status(state, invaders)
+
+        if state.player_x < 2 || state.player_x > WIDTH - 3 then
+            smoke_fail("player left playfield")
+        end
+        if state.lives < 0 || state.lives > 3 then
+            smoke_fail("invalid lives")
+        end
+        if shot.active && (shot.y <= 0 || shot.y >= HEIGHT - 1) then
+            smoke_fail("player projectile left playfield")
+        end
+        let active_enemy_shots: int = 0
+        let i: int = 0
+        while i < length(enemy_shots) do
+            if enemy_shots[i].active then
+                active_enemy_shots = active_enemy_shots + 1
+                if enemy_shots[i].y <= 0 || enemy_shots[i].y >= HEIGHT - 1 then
+                    smoke_fail("enemy projectile left playfield")
+                end
+            end
+            i = i + 1
+        end
+        if active_enemy_shots > 3 then
+            smoke_fail("too many enemy projectiles")
+        end
+        frame_number = frame_number + 1
+    end
+
+    if state.score != 10 then
+        smoke_fail("player projectile did not hit an invader")
+    end
+    if count_alive(invaders) != INVADER_ROWS * INVADER_COLS - 1 then
+        smoke_fail("alive invader count is inconsistent")
+    end
+    print("SPACE_INVADERS2_SMOKE_OK")
+end
+
+func main()
+    run_smoke()
+end
+
+main()

--- a/noxy_examples/space_invaders2.nx
+++ b/noxy_examples/space_invaders2.nx
@@ -246,6 +246,110 @@ func update_status(state: ref GameState, invaders: Invader[])
     end
 end
 
+func color(code: string, enabled: bool) -> string
+    if !enabled then
+        return ""
+    end
+    return fmt("%c", 27) + "[" + code + "m"
+end
+
+func star_at(x: int, y: int) -> string
+    let seed: int = (x * 17 + y * 31) % 47
+    if seed == 0 then return "✦" end
+    if seed == 7 || seed == 19 then return "·" end
+    return " "
+end
+
+func contains_text(text: string, target: string) -> bool
+    return strings_contains(text, target)
+end
+
+func cell_color(cell: string) -> string
+    if cell == "╭" || cell == "╬" || cell == "╮" || cell == "╰" || cell == "╩" || cell == "╯" then
+        return "96"
+    end
+    if cell == "▟" || cell == "█" || cell == "▙" then return "92" end
+    if cell == "│" then return "93" end
+    if cell == "▼" then return "91" end
+    if cell == "✦" || cell == "·" then return "90" end
+    return ""
+end
+
+func build_frame(state: GameState, invaders: Invader[], shot: Projectile, enemy_shots: Projectile[], colored: bool) -> string
+    let cells: string[] = []
+    let i: int = 0
+    while i < WIDTH * HEIGHT do
+        append(cells, star_at(i % WIDTH, i / WIDTH))
+        i = i + 1
+    end
+
+    i = 0
+    while i < length(invaders) do
+        if invaders[i].alive && invaders[i].x > 0 && invaders[i].x < WIDTH - 1 && invaders[i].y > 0 && invaders[i].y < HEIGHT - 1 then
+            let sprite: string[] = ["╭", "╬", "╮"]
+            if (invaders[i].y / 2) % 2 == 0 then
+                sprite = ["╰", "╩", "╯"]
+            end
+            cells[invaders[i].y * WIDTH + invaders[i].x - 1] = sprite[0]
+            cells[invaders[i].y * WIDTH + invaders[i].x] = sprite[1]
+            cells[invaders[i].y * WIDTH + invaders[i].x + 1] = sprite[2]
+        end
+        i = i + 1
+    end
+
+    if shot.active && shot.x >= 0 && shot.x < WIDTH && shot.y >= 0 && shot.y < HEIGHT then
+        cells[shot.y * WIDTH + shot.x] = "│"
+    end
+    i = 0
+    while i < length(enemy_shots) do
+        if enemy_shots[i].active && enemy_shots[i].x >= 0 && enemy_shots[i].x < WIDTH && enemy_shots[i].y >= 0 && enemy_shots[i].y < HEIGHT then
+            cells[enemy_shots[i].y * WIDTH + enemy_shots[i].x] = "▼"
+        end
+        i = i + 1
+    end
+    if state.player_x > 0 && state.player_x < WIDTH - 1 then
+        cells[(HEIGHT - 2) * WIDTH + state.player_x - 1] = "▟"
+        cells[(HEIGHT - 2) * WIDTH + state.player_x] = "█"
+        cells[(HEIGHT - 2) * WIDTH + state.player_x + 1] = "▙"
+    end
+
+    let frame: string = color("93", colored) + "SCORE " + to_str(state.score) + "   LIVES " + to_str(state.lives) + "   STATUS " + state.status + color("0", colored) + "\n"
+    let border: string = "╔"
+    i = 0
+    while i < WIDTH do
+        border = border + "═"
+        i = i + 1
+    end
+    border = border + "╗"
+    frame = frame + color("95", colored) + border + color("0", colored) + "\n"
+
+    let y: int = 0
+    while y < HEIGHT do
+        let row: string = color("95", colored) + "║"
+        let x: int = 0
+        while x < WIDTH do
+            let cell: string = cells[y * WIDTH + x]
+            let code: string = cell_color(cell)
+            if code != "" then
+                row = row + color(code, colored) + cell + color("95", colored)
+            else
+                row = row + cell
+            end
+            x = x + 1
+        end
+        row = row + "║" + color("0", colored)
+        frame = frame + row + "\n"
+        y = y + 1
+    end
+    frame = frame + color("95", colored) + "╚"
+    i = 0
+    while i < WIDTH do
+        frame = frame + "═"
+        i = i + 1
+    end
+    return frame + "╝" + color("0", colored)
+end
+
 func smoke_fail(message: string)
     print("SPACE_INVADERS2_SMOKE_FAIL: " + message)
     sys.exit(1)
@@ -257,6 +361,16 @@ func run_smoke()
     let invaders: Invader[] = new_invaders()
     let shot: Projectile = Projectile(0, 0, false)
     let enemy_shots: Projectile[] = new_enemy_shots()
+
+    let frame: string = build_frame(state, invaders, shot, enemy_shots, false)
+    if !contains_text(frame, "SCORE") then smoke_fail("HUD is missing score") end
+    if !contains_text(frame, "LIVES") then smoke_fail("HUD is missing lives") end
+    if !contains_text(frame, "╔") || !contains_text(frame, "╝") then
+        smoke_fail("arcade border is incomplete")
+    end
+    if !contains_text(frame, "╭╬╮") && !contains_text(frame, "╰╩╯") then
+        smoke_fail("invader sprite is missing")
+    end
 
     apply_command(state, shot, "a")
     apply_command(state, shot, "d")

--- a/noxy_examples/space_invaders2.nx
+++ b/noxy_examples/space_invaders2.nx
@@ -38,6 +38,20 @@ struct GameState
     status: string
 end
 
+func read_controls(commands: chan string)
+    while true do
+        let event: terminal.KeyEvent = terminal.read_key()
+        if !event.ok then
+            chan_send(commands, "q")
+            return
+        end
+        chan_send(commands, event.key)
+        if event.key == "q" || event.key == "ctrl+c" then
+            return
+        end
+    end
+end
+
 func new_invaders() -> Invader[]
     let invaders: Invader[] = []
     let row: int = 0
@@ -420,8 +434,82 @@ func run_smoke()
     print("SPACE_INVADERS2_SMOKE_OK")
 end
 
+func run_interactive()
+    if !terminal.is_terminal() then
+        print("Space Invaders 2 requires an interactive terminal on standard input.")
+        return
+    end
+
+    let opened: terminal.TerminalResult = terminal.open_raw()
+    if !opened.ok then
+        print("Unable to open raw terminal mode: " + opened.error)
+        return
+    end
+
+    let started_at: int = time.now_ms()
+    let state: GameState = GameState(WIDTH / 2, 3, 0, 1, 500, started_at, started_at, 0, 0, "playing")
+    let invaders: Invader[] = new_invaders()
+    let shot: Projectile = Projectile(0, 0, false)
+    let enemy_shots: Projectile[] = new_enemy_shots()
+    let commands: chan string = make_chan(16)
+    let escape: string = fmt("%c", 27)
+    spawn(read_controls, commands)
+
+    iprint(escape + "[?1049h" + escape + "[?25l" + escape + "[2J")
+    while state.status == "playing" do
+        let draining_commands: bool = true
+        while draining_commands do
+            when
+                case command = chan_recv(commands) then
+                    apply_command(state, shot, command)
+                default
+                    draining_commands = false
+            end
+        end
+
+        if state.status == "playing" then
+            let now: int = time.now_ms()
+            step_invaders(state, invaders, now)
+            step_player_shot(state, shot, invaders)
+            step_enemy_shots(state, enemy_shots, now)
+            spawn_enemy_shot(state, invaders, enemy_shots, now)
+            update_status(state, invaders)
+        end
+
+        let frame: string = build_frame(state, invaders, shot, enemy_shots, true)
+        iprint(escape + "[H" + frame)
+        if state.status == "playing" then
+            time.sleep(FRAME_MS)
+        end
+    end
+
+    if state.status == "victory" || state.status == "defeat" then
+        let waiting_to_exit: bool = true
+        while waiting_to_exit do
+            let command: string = chan_recv(commands)
+            if command == "q" || command == "ctrl+c" then
+                waiting_to_exit = false
+            end
+        end
+    end
+
+    iprint(escape + "[0m" + escape + "[?25h" + escape + "[?1049l")
+    let closed: bool = terminal.close()
+    print("")
+    if !closed then
+        print("Warning: terminal raw mode could not be restored cleanly.")
+    end
+end
+
 func main()
-    run_smoke()
+    let args: string[] = sys.argv()
+    let smoke: bool = false
+    let i: int = 0
+    while i < length(args) do
+        if args[i] == "--smoke" then smoke = true end
+        i = i + 1
+    end
+    if smoke then run_smoke() else run_interactive() end
 end
 
 main()


### PR DESCRIPTION
## Summary
- Adiciona space_invaders2.nx com visual Neo Arcade colorido no terminal.
- Mantém a mecânica do exemplo original com sprites de três colunas, estrelas, HUD e moldura.
- Reforça o smoke test e restaura o terminal com segurança ao encerrar.

## Components
- Novo exemplo interativo 
oxy_examples/space_invaders2.nx.
- Exclusões nos runners sequencial e concorrente.
- Entrada em CHANGELOG.md.

## Related Issues
- N/A

## Test Plan
- [x] Implementação
- [x] Testes unitários passando (go test ./...)
- [x] Testado integrado (smoke OK e runner concorrente 157/157)