### PR TITLE
feat/NoxyDB-v0.2 - Adicionar codificação JSON estrita observável

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@
 
 ### Added
 
+- Observable strict JSON encoding through `json.dumps_result`, with explicit
+  success, payload, and error fields. `#stdlib` @estevaofon
 - Experimental external terminal package backed by a Go plugin.
 - Complete Space Invaders example using the external terminal package.
 - Neo Arcade Space Invaders 2 example with colored terminal sprites, deterministic starfield, smoke validation, and safe interactive terminal cleanup. `#examples` @estevaofon
+
+### Fixed
+
+- Strict JSON encoding now rejects unsupported values, non-finite floats,
+  cycles, typed nil containers, and invalid UTF-8 without lossy fallback.
+  `#vm` @estevaofon
 
 ## [0.1.0] - 2026-08-10
 

--- a/docs/JSON_SUPPORT.md
+++ b/docs/JSON_SUPPORT.md
@@ -119,3 +119,29 @@ print(conf.port) // 8080
 - **Extra Fields:** Fields in the JSON that do not match any Struct field are ignored.
 - **Type Mismatch:** The system attempts to cast compatible types (e.g., float to int if lossless), but fundamentally incompatible types (e.g., string to int) will generally result in the field being skipped or zero-valued.
 - **Nested Structures:** `json_unmarshal` works recursively. If a Struct contains fields that are other Structs, the corresponding nested JSON object will populate that child Struct in-place.
+
+## Strict observable encoding
+
+The json module exposes strict encoding when callers need explicit failure:
+
+```noxy
+use json
+
+let value: map[string, any] = {"name": "Noxy", "active": true}
+let result: json.EncodeResult = json.dumps_result(value)
+if result.success then
+    print(result.data)
+else
+    print(result.error)
+end
+```
+
+json.dumps_result accepts null, bool, int, finite float, string, arrays, and
+recursively string-keyed maps. It rejects bytes, structs, references,
+callables, channels, wait groups, non-string map keys, NaN, infinities,
+unsupported runtime values, and cycles. Reusing an acyclic child in multiple
+branches is valid.
+
+On success, data contains complete JSON and error is empty. On failure, data is
+empty and error is non-empty. The legacy json_dumps function is unchanged and
+retains its permissive compatibility behavior.

--- a/internal/stdlib/json.nx
+++ b/internal/stdlib/json.nx
@@ -1,0 +1,9 @@
+struct EncodeResult
+    success: bool
+    data: string
+    error: string
+end
+
+func dumps_result(value: any) -> EncodeResult
+    return json_dumps_result(value, EncodeResult)
+end

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -22,6 +22,35 @@ func (vm *VM) defineJSONBuiltins() {
 		return value.NewString(string(bytes))
 	})
 
+	vm.DefineNative("json_dumps_result", func(args []value.Value) value.Value {
+		if len(args) < 2 {
+			return value.NewNull()
+		}
+		resultType, ok := args[1].Obj.(*value.ObjStruct)
+		if !ok {
+			return value.NewNull()
+		}
+		result := value.NewInstance(resultType).Obj.(*value.ObjInstance)
+		result.Fields["success"] = value.NewBool(false)
+		result.Fields["data"] = value.NewString("")
+		result.Fields["error"] = value.NewString(errJSONUnsupported.Error())
+
+		goValue, err := strictJSONValToGo(args[0])
+		if err != nil {
+			result.Fields["error"] = value.NewString(err.Error())
+			return value.Value{Type: value.VAL_OBJ, Obj: result}
+		}
+		encoded, err := json.Marshal(goValue)
+		if err != nil {
+			result.Fields["error"] = value.NewString(err.Error())
+			return value.Value{Type: value.VAL_OBJ, Obj: result}
+		}
+		result.Fields["success"] = value.NewBool(true)
+		result.Fields["data"] = value.NewString(string(encoded))
+		result.Fields["error"] = value.NewString("")
+		return value.Value{Type: value.VAL_OBJ, Obj: result}
+	})
+
 	// json_parse(str) -> Value
 	vm.DefineNative("json_parse", func(args []value.Value) value.Value {
 		if len(args) < 1 {

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"noxy-vm/internal/value"
 )
@@ -80,6 +81,9 @@ func (vm *VM) defineJSONBuiltins() {
 			return value.NewBool(false)
 		}
 		jsonStr := args[0].String()
+		if !utf8.ValidString(jsonStr) {
+			return value.NewBool(false)
+		}
 		target := args[1]
 
 		var result interface{}

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -72,6 +72,26 @@ func TestStrictJSONValToGoRejectsNonJSONValues(t *testing.T) {
 	}
 }
 
+func TestStrictJSONValToGoRejectsInvalidUTF8Strings(t *testing.T) {
+	invalidValue := value.NewString(string([]byte{0xff}))
+	invalidKey := value.NewMap()
+	invalidKey.Obj.(*value.ObjMap).Data[string([]byte{0xff})] = value.NewBool(true)
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{name: "value", input: invalidValue},
+		{name: "map key", input: invalidKey},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := strictJSONValToGo(tt.input); err == nil {
+				t.Fatal("strict conversion accepted invalid UTF-8")
+			}
+		})
+	}
+}
+
 func TestStrictJSONValToGoRejectsCyclesAndAcceptsSharedChildren(t *testing.T) {
 	arrayCycle := value.NewArray(nil)
 	arrayCycle.Obj.(*value.ObjArray).Elements = []value.Value{arrayCycle}
@@ -185,6 +205,56 @@ func TestJSONDumpsResultBuiltinReportsSuccessAndFailure(t *testing.T) {
 	assertBuiltinValue(t, failureFields["data"], value.NewString(""))
 	if failureFields["error"].String() == "" {
 		t.Fatal("strict encoder returned an empty error")
+	}
+}
+
+func TestJSONDumpsResultBuiltinRejectsInvalidStrictValues(t *testing.T) {
+	machine := New()
+	resultType := value.NewStruct("EncodeResult", []string{"success", "data", "error"})
+	invalidKey := value.NewMap()
+	invalidKey.Obj.(*value.ObjMap).Data[string([]byte{0xff})] = value.NewBool(true)
+	arrayCycle := value.NewArray(nil)
+	arrayCycle.Obj.(*value.ObjArray).Elements = []value.Value{arrayCycle}
+	mapCycle := value.NewMap()
+	mapCycle.Obj.(*value.ObjMap).Data["self"] = mapCycle
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{name: "invalid UTF-8 string", input: value.NewString(string([]byte{0xff}))},
+		{name: "invalid UTF-8 map key", input: invalidKey},
+		{name: "NaN", input: value.NewFloat(math.NaN())},
+		{name: "array cycle", input: arrayCycle},
+		{name: "map cycle", input: mapCycle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failure := callBuiltin(t, machine, "json_dumps_result", tt.input, resultType)
+			fields := failure.Obj.(*value.ObjInstance).Fields
+			assertBuiltinValue(t, fields["success"], value.NewBool(false))
+			assertBuiltinValue(t, fields["data"], value.NewString(""))
+			if fields["error"].String() == "" {
+				t.Fatal("strict encoder returned an empty error")
+			}
+		})
+	}
+}
+
+func TestJSONLoadsBuiltinRejectsInvalidUTF8WithoutMutation(t *testing.T) {
+	machine := New()
+	target := value.NewMap()
+	targetMap := target.Obj.(*value.ObjMap)
+	targetMap.Data["sentinel"] = value.NewString("keep")
+	invalidJSON := value.NewString(string([]byte{'{', '"', 'n', 'a', 'm', 'e', '"', ':', '"', 0xff, '"', '}'}))
+
+	result := callBuiltin(t, machine, "json_loads", invalidJSON, target)
+	assertBuiltinValue(t, result, value.NewBool(false))
+	if len(targetMap.Data) != 1 {
+		t.Fatalf("target mutated after invalid JSON: %#v", targetMap.Data)
+	}
+	assertBuiltinValue(t, targetMap.Data["sentinel"], value.NewString("keep"))
+	if _, exists := targetMap.Data["name"]; exists {
+		t.Fatal("target gained a field from invalid JSON")
 	}
 }
 

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -166,6 +166,28 @@ func TestJSONDumpsBuiltin(t *testing.T) {
 	}
 }
 
+func TestJSONDumpsResultBuiltinReportsSuccessAndFailure(t *testing.T) {
+	machine := New()
+	resultType := value.NewStruct("EncodeResult", []string{"success", "data", "error"})
+	valid := value.NewMap()
+	valid.Obj.(*value.ObjMap).Data["name"] = value.NewString("Noxy")
+	success := callBuiltin(t, machine, "json_dumps_result", valid, resultType)
+	successFields := success.Obj.(*value.ObjInstance).Fields
+	assertBuiltinValue(t, successFields["success"], value.NewBool(true))
+	assertBuiltinValue(t, successFields["data"], value.NewString("{\"name\":\"Noxy\"}"))
+	assertBuiltinValue(t, successFields["error"], value.NewString(""))
+
+	invalid := value.NewMap()
+	invalid.Obj.(*value.ObjMap).Data["raw"] = value.NewBytes("abc")
+	failure := callBuiltin(t, machine, "json_dumps_result", invalid, resultType)
+	failureFields := failure.Obj.(*value.ObjInstance).Fields
+	assertBuiltinValue(t, failureFields["success"], value.NewBool(false))
+	assertBuiltinValue(t, failureFields["data"], value.NewString(""))
+	if failureFields["error"].String() == "" {
+		t.Fatal("strict encoder returned an empty error")
+	}
+}
+
 func TestJSONParseBuiltin(t *testing.T) {
 	machine := New()
 	scalarTests := []struct {

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -101,6 +101,25 @@ func TestStrictJSONValToGoRejectsCyclesAndAcceptsSharedChildren(t *testing.T) {
 	}
 }
 
+func TestStrictJSONValToGoRejectsTypedNilContainers(t *testing.T) {
+	var nilArray *value.ObjArray
+	var nilMap *value.ObjMap
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{"typed nil array", value.Value{Type: value.VAL_OBJ, Obj: nilArray}},
+		{"typed nil map", value.Value{Type: value.VAL_OBJ, Obj: nilMap}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := strictJSONValToGo(tt.input); err == nil {
+				t.Fatal("strict conversion accepted a typed nil container")
+			}
+		})
+	}
+}
+
 func requireBuiltinMap(t *testing.T, got value.Value) *value.ObjMap {
 	t.Helper()
 	if got.Type != value.VAL_OBJ {

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -2,11 +2,104 @@ package vm
 
 import (
 	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 
 	"noxy-vm/internal/value"
 )
+
+func TestStrictJSONValToGoAcceptsJSONDomain(t *testing.T) {
+	nested := value.NewMap()
+	nested.Obj.(*value.ObjMap).Data["city"] = value.NewString("Cuiabá")
+	document := value.NewMap()
+	document.Obj.(*value.ObjMap).Data["empty"] = value.NewString("")
+	document.Obj.(*value.ObjMap).Data["int"] = value.NewInt(30)
+	document.Obj.(*value.ObjMap).Data["minimum"] = value.NewInt(-9223372036854775807 - 1)
+	document.Obj.(*value.ObjMap).Data["maximum"] = value.NewInt(9223372036854775807)
+	document.Obj.(*value.ObjMap).Data["float"] = value.NewFloat(1.25)
+	document.Obj.(*value.ObjMap).Data["active"] = value.NewBool(true)
+	document.Obj.(*value.ObjMap).Data["nothing"] = value.NewNull()
+	document.Obj.(*value.ObjMap).Data["items"] = value.NewArray(
+		[]value.Value{value.NewString("Noxy"), value.NewInt(2), nested},
+	)
+
+	got, err := strictJSONValToGo(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]interface{}{
+		"empty": "", "int": int64(30),
+		"minimum": int64(-9223372036854775807 - 1),
+		"maximum": int64(9223372036854775807),
+		"float":   1.25, "active": true,
+		"nothing": nil,
+		"items":   []interface{}{"Noxy", int64(2), map[string]interface{}{"city": "Cuiabá"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("strict conversion = %#v, want %#v", got, want)
+	}
+}
+
+func TestStrictJSONValToGoRejectsNonJSONValues(t *testing.T) {
+	definition := value.NewStruct("Point", []string{"x"})
+	instance := value.NewInstance(definition.Obj.(*value.ObjStruct))
+	badKeyMap := value.NewMap()
+	badKeyMap.Obj.(*value.ObjMap).Data[int64(7)] = value.NewString("seven")
+	tests := []struct {
+		name  string
+		input value.Value
+	}{
+		{"bytes", value.NewBytes("raw")},
+		{"struct definition", definition},
+		{"struct instance", instance},
+		{"function", value.NewFunction("noop", 0, 0, nil, nil, nil)},
+		{"native", value.NewNative("noop", func([]value.Value) value.Value { return value.NewNull() })},
+		{"channel", value.NewChannel(1)},
+		{"wait group", value.NewWaitGroup()},
+		{"reference", value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{}}},
+		{"non-string key", badKeyMap},
+		{"nan", value.NewFloat(math.NaN())},
+		{"positive infinity", value.NewFloat(math.Inf(1))},
+		{"negative infinity", value.NewFloat(math.Inf(-1))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := strictJSONValToGo(tt.input); err == nil {
+				t.Fatal("strict conversion accepted a non-JSON value")
+			}
+		})
+	}
+}
+
+func TestStrictJSONValToGoRejectsCyclesAndAcceptsSharedChildren(t *testing.T) {
+	arrayCycle := value.NewArray(nil)
+	arrayCycle.Obj.(*value.ObjArray).Elements = []value.Value{arrayCycle}
+	if _, err := strictJSONValToGo(arrayCycle); err == nil {
+		t.Fatal("array cycle was accepted")
+	}
+
+	mapCycle := value.NewMap()
+	mapCycle.Obj.(*value.ObjMap).Data["self"] = mapCycle
+	if _, err := strictJSONValToGo(mapCycle); err == nil {
+		t.Fatal("map cycle was accepted")
+	}
+
+	left := value.NewMap()
+	right := value.NewArray(nil)
+	left.Obj.(*value.ObjMap).Data["right"] = right
+	right.Obj.(*value.ObjArray).Elements = []value.Value{left}
+	if _, err := strictJSONValToGo(left); err == nil {
+		t.Fatal("indirect cycle was accepted")
+	}
+
+	child := value.NewMap()
+	child.Obj.(*value.ObjMap).Data["value"] = value.NewInt(1)
+	root := value.NewArray([]value.Value{child, child})
+	if _, err := strictJSONValToGo(root); err != nil {
+		t.Fatalf("shared acyclic child rejected: %v", err)
+	}
+}
 
 func requireBuiltinMap(t *testing.T, got value.Value) *value.ObjMap {
 	t.Helper()

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -19,7 +19,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"hex_decode", "hex_encode", "input", "io_close", "io_close_result", "io_exists",
 		"io_mkdir", "io_open", "io_read", "io_read_bytes", "io_read_lines",
 		"io_remove", "io_stat", "io_write", "io_write_result", "iprint", "json_dumps",
-		"json_loads", "json_parse", "keys", "length", "make_chan",
+		"json_dumps_result", "json_loads", "json_parse", "keys", "length", "make_chan",
 		"make_wg", "net_accept", "net_close", "net_connect", "net_listen",
 		"net_recv", "net_select", "net_send", "net_setblocking", "ord",
 		"pop", "print", "slice", "spawn", "sqlite_bind_float",

--- a/internal/vm/json_strict.go
+++ b/internal/vm/json_strict.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"errors"
 	"math"
+	"unicode/utf8"
 
 	"noxy-vm/internal/value"
 )
@@ -11,6 +12,7 @@ var (
 	errJSONUnsupported = errors.New("value is not JSON-compatible")
 	errJSONNonFinite   = errors.New("non-finite float is not valid JSON")
 	errJSONCycle       = errors.New("cyclic value is not valid JSON")
+	errJSONInvalidUTF8 = errors.New("invalid UTF-8 is not valid JSON")
 )
 
 type strictJSONTraversal struct {
@@ -42,6 +44,9 @@ func (t *strictJSONTraversal) convert(input value.Value) (interface{}, error) {
 	case value.VAL_OBJ:
 		switch object := input.Obj.(type) {
 		case string:
+			if !utf8.ValidString(object) {
+				return nil, errJSONInvalidUTF8
+			}
 			return object, nil
 		case *value.ObjArray:
 			if object == nil {
@@ -89,6 +94,9 @@ func (t *strictJSONTraversal) convertMap(mapping *value.ObjMap) (map[string]inte
 		stringKey, ok := key.(string)
 		if !ok {
 			return nil, errJSONUnsupported
+		}
+		if !utf8.ValidString(stringKey) {
+			return nil, errJSONInvalidUTF8
 		}
 		convertedValue, err := t.convert(item)
 		if err != nil {

--- a/internal/vm/json_strict.go
+++ b/internal/vm/json_strict.go
@@ -44,8 +44,14 @@ func (t *strictJSONTraversal) convert(input value.Value) (interface{}, error) {
 		case string:
 			return object, nil
 		case *value.ObjArray:
+			if object == nil {
+				return nil, errJSONUnsupported
+			}
 			return t.convertArray(object)
 		case *value.ObjMap:
+			if object == nil {
+				return nil, errJSONUnsupported
+			}
 			return t.convertMap(object)
 		default:
 			return nil, errJSONUnsupported

--- a/internal/vm/json_strict.go
+++ b/internal/vm/json_strict.go
@@ -1,0 +1,94 @@
+package vm
+
+import (
+	"errors"
+	"math"
+
+	"noxy-vm/internal/value"
+)
+
+var (
+	errJSONUnsupported = errors.New("value is not JSON-compatible")
+	errJSONNonFinite   = errors.New("non-finite float is not valid JSON")
+	errJSONCycle       = errors.New("cyclic value is not valid JSON")
+)
+
+type strictJSONTraversal struct {
+	arrays map[*value.ObjArray]bool
+	maps   map[*value.ObjMap]bool
+}
+
+func strictJSONValToGo(input value.Value) (interface{}, error) {
+	traversal := strictJSONTraversal{
+		arrays: make(map[*value.ObjArray]bool),
+		maps:   make(map[*value.ObjMap]bool),
+	}
+	return traversal.convert(input)
+}
+
+func (t *strictJSONTraversal) convert(input value.Value) (interface{}, error) {
+	switch input.Type {
+	case value.VAL_NULL:
+		return nil, nil
+	case value.VAL_BOOL:
+		return input.AsBool, nil
+	case value.VAL_INT:
+		return input.AsInt, nil
+	case value.VAL_FLOAT:
+		if math.IsNaN(input.AsFloat) || math.IsInf(input.AsFloat, 0) {
+			return nil, errJSONNonFinite
+		}
+		return input.AsFloat, nil
+	case value.VAL_OBJ:
+		switch object := input.Obj.(type) {
+		case string:
+			return object, nil
+		case *value.ObjArray:
+			return t.convertArray(object)
+		case *value.ObjMap:
+			return t.convertMap(object)
+		default:
+			return nil, errJSONUnsupported
+		}
+	default:
+		return nil, errJSONUnsupported
+	}
+}
+
+func (t *strictJSONTraversal) convertArray(array *value.ObjArray) ([]interface{}, error) {
+	if t.arrays[array] {
+		return nil, errJSONCycle
+	}
+	t.arrays[array] = true
+	defer delete(t.arrays, array)
+	converted := make([]interface{}, len(array.Elements))
+	for index, element := range array.Elements {
+		item, err := t.convert(element)
+		if err != nil {
+			return nil, err
+		}
+		converted[index] = item
+	}
+	return converted, nil
+}
+
+func (t *strictJSONTraversal) convertMap(mapping *value.ObjMap) (map[string]interface{}, error) {
+	if t.maps[mapping] {
+		return nil, errJSONCycle
+	}
+	t.maps[mapping] = true
+	defer delete(t.maps, mapping)
+	converted := make(map[string]interface{}, len(mapping.Data))
+	for key, item := range mapping.Data {
+		stringKey, ok := key.(string)
+		if !ok {
+			return nil, errJSONUnsupported
+		}
+		convertedValue, err := t.convert(item)
+		if err != nil {
+			return nil, err
+		}
+		converted[stringKey] = convertedValue
+	}
+	return converted, nil
+}

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -30,6 +30,17 @@ test_report(written.success && written.bytes_written == 2 && written.error == ""
 	testExpectedObject(t, true, got)
 }
 
+func TestJSONModuleExposesStrictObservableEncoding(t *testing.T) {
+	source := "\nuse json\n" +
+		"let values: any[] = [1, true, null]\n" +
+		"let document: map[string, any] = {\"name\": \"Noxy\", \"values\": values}\n" +
+		"let encoded: json.EncodeResult = json.dumps_result(document)\n" +
+		"let invalid: map[string, any] = {\"raw\": b\"abc\"}\n" +
+		"let rejected: json.EncodeResult = json.dumps_result(invalid)\n" +
+		"test_report(encoded.success && encoded.data != \"\" && encoded.error == \"\" && !rejected.success && rejected.data == \"\" && rejected.error != \"\")"
+	testExpectedObject(t, true, runTypedFunctionProgram(t, source))
+}
+
 func runWithTypedTestNative(t *testing.T, input string, sig value.NativeSignature, called *bool) error {
 	t.Helper()
 	l := lexer.New(input)


### PR DESCRIPTION
## Summary
- Adiciona conversão estrita e recursiva do domínio JSON na VM.
- Expõe `json.dumps_result` com sucesso e erro observáveis, sem alterar o `json_dumps` legado.
- Rejeita valores não representáveis, NaN, infinitos, ciclos, containers nil e UTF-8 inválido.

## Components
- VM e builtins JSON.
- Módulo `json` da stdlib.
- Testes de conversão, contratos nativos e integração da linguagem.
- Documentação e CHANGELOG.

## Related Issues
- Nenhum card associado.

## Test Plan
- [x] Implementação
- [x] Testes unitários passando (`go test ./...`)
- [x] Testado integrado (157/157 testes Noxy)