### PR TITLE
feat/runtime-context-foundation - Add concurrency-safe runtime foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,18 @@
 
 ### Fixed
 
+- Stateful native calls now receive the actively executing VM instead of a VM captured during builtin registration.
+- File, network, SQLite database, and SQLite statement handles now have shared ownership and synchronized lifecycle state across VMs sharing one runtime.
+- Concurrent requests for the same module now share one successful initialization, with coordinated failure retry and import-cycle detection.
+- Global bindings, module exports, maps, registries, and per-resource mutable state no longer expose the migrated concurrent Go-map crash paths.
 - Strict JSON encoding now rejects unsupported values, non-finite floats,
   cycles, typed nil containers, and invalid UTF-8 without lossy fallback.
   `#vm` @estevaofon
+
+### Follow-up
+
+- Corrected `net_select` polling semantics remain follow-up work; this foundation only moves the existing buffered state into shared synchronized resources.
+- Supervised `spawn` and task values remain follow-up work; this foundation does not change current public spawn behavior.
 
 ## [0.1.0] - 2026-08-10
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -107,6 +107,12 @@ Consequently, replacing or directly mutating the top-level copy does not affect 
 
 Parameters declared with `ref` skip the shallow copy and access the caller's original value directly.
 
+#### Concurrency and composite values
+
+Shared routines use synchronized global bindings, module state, maps, and runtime handle registries. An individual binding lookup/update or map operation is safe from the Go runtime's concurrent-map crash, but synchronization is not recursive and does not make a read-modify-write sequence atomic. Arrays, structs, and nested composite values may still share mutable identity because parameter copying remains shallow. Concurrent compound operations or nested composite mutation require coordination through channels or another explicit single-owner protocol.
+
+This runtime foundation does not change any public Noxy syntax, builtin signature, result shape, or shallow-copy rule.
+
 #### Arrays (Dynamic and Fixed)
 
 **1. Dynamic Arrays (Recommended)**

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -8,6 +8,18 @@ Noxy provides first-class support for concurrency through **Noxy Routines** and 
 2.  **Channels**: Typed conduits that allow Noxy routines to communicate with each other and synchronize their execution.
 3.  **Shared State**: While channels are preferred, Noxy routines share the same global variables and module state, allowing for shared-memory patterns (though message passing is recommended).
 
+### Runtime sharing guarantees
+
+Routines whose VMs share one runtime state see the same global bindings, module cache, and open file, network, SQLite database, and SQLite statement handles. A stateful builtin always uses the VM that is actively executing the call, so a handle created in one shared VM can be used from another.
+
+Individual global-binding and map operations are synchronized and do not crash the Go runtime when used concurrently. Concurrent module requests share one successful initialization, and individual resource registries and resource state are also synchronized.
+
+These guarantees do not make a sequence of operations atomic. For example, `counter = counter + 1` is still a separate read and write. Likewise, arrays, structs, and composite values nested inside a map or global binding are not recursively synchronized. Coordinate compound operations and mutation of nested composite values with channels (or another explicit single-owner protocol).
+
+Function arguments preserve Noxy's shallow-copy rules: the outer array, map, or struct is copied for an ordinary parameter, while nested composites remain shared. The synchronized runtime foundation does not turn that shallow copy into a deep copy.
+
+This foundation changes no public Noxy syntax, builtin signature, or result shape. Corrected `net_select` semantics and supervised `spawn`/task behavior are separate follow-up work.
+
 ---
 
 ## Spawning Routines

--- a/docs/superpowers/plans/2026-08-13-runtime-context-foundation.md
+++ b/docs/superpowers/plans/2026-08-13-runtime-context-foundation.md
@@ -1,0 +1,1622 @@
+# Runtime Context Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace VM-capturing natives, raw global/module maps, and split resource ownership with a concurrency-safe runtime foundation that preserves existing Noxy programs and legacy Go native APIs.
+
+**Architecture:** Native values carry either the legacy handler or a contextual handler invoked with the active VM. `value.GlobalEnvironment` and synchronized `ObjMap` storage provide stable global identity and live module exports, while `SharedState` owns coordinated module loading and per-resource registries. Registry locks protect lookup only; each resource entry owns operation and close synchronization.
+
+**Tech Stack:** Go 1.24.0, toolchain Go 1.24.11, Noxy bytecode VM, Go `sync` primitives, `go test -race`.
+
+## Global Constraints
+
+- Do not change Noxy syntax or any existing Noxy builtin signature in this subproject.
+- Preserve the Go signatures of `value.NewNative`, `value.NewNativeWithSignature`, `VM.DefineNative`, and `VM.DefineNativeWithSignature`.
+- Keep current `net_select`, blocking socket, builtin result, and detached `spawn` semantics; only move ownership and synchronization.
+- Do not implement cross-VM value validation, supervised tasks, `defer`, signals, substring changes, or HTTP changes here.
+- Use test-first red-green-refactor for every behavior.
+- Never hold an environment, module-cache, or registry lock while executing Noxy/native code or blocking I/O.
+- Individual map operations are synchronized; compound Noxy operations are not made atomic.
+- Keep the worktree's unrelated user changes untouched.
+
+---
+
+## Planned File Structure
+
+### New files
+
+- `internal/value/native.go` — dual native ABI and invocation.
+- `internal/value/native_test.go` — native ABI compatibility and invalid-state tests.
+- `internal/value/map.go` — synchronized map storage and `ObjMap` API.
+- `internal/value/map_test.go` — map operation and race tests.
+- `internal/value/environment.go` — hierarchical `GlobalEnvironment`.
+- `internal/value/environment_test.go` — resolution, shadowing, owner, and live-export tests.
+- `internal/vm/module_cache.go` — single-flight module cache and dependency graph.
+- `internal/vm/module_cache_test.go` — concurrent load and cross-flight cycle tests.
+- `internal/vm/resources.go` — handle registries and resource entry types.
+- `internal/vm/resources_test.go` — registry/lifecycle tests.
+- `internal/vm/runtime_context_test.go` — active-VM dispatch and initialization tests.
+
+### Modified files
+
+- `internal/value/value.go` — use environments, new map/native types, and global-reference owners.
+- `internal/plugin/plugin.go` — consume map snapshots.
+- `internal/compiler/compiler.go` — construct unbound functions with environment metadata.
+- `internal/vm/vm.go` — new shared state, root environment, initialization, and native registration.
+- `internal/vm/calls.go` — invoke natives contextually and copy synchronized maps.
+- `internal/vm/call_validation.go` — callable validation through `ObjNative.IsCallable`.
+- `internal/vm/executor.go` — environment-based opcodes, map API, imports, and copy-out execution.
+- `internal/vm/references.go` — environment owners and synchronized map references.
+- `internal/vm/modules.go` — resolve sources, use live environments, and call module cache.
+- `internal/vm/runtime_type_validation.go` — inspect map snapshots.
+- `internal/vm/json_population.go` — snapshot/replace map population.
+- `internal/vm/json_strict.go` — snapshot map serialization.
+- `internal/vm/builtins_collections.go` — synchronized maps and contextual reference operations.
+- `internal/vm/builtins_json.go` — synchronized maps and contextual `json_loads`.
+- `internal/vm/builtins_io.go` — shared file resources.
+- `internal/vm/builtins_net.go` — shared synchronized listener/socket resources.
+- `internal/vm/builtins_sqlite.go` — shared database/statement resources.
+- `internal/vm/builtins_concurrency.go` — active VM context without changing spawn semantics.
+- `internal/vm/builtins_sys.go` — active VM for dynamic plugin registration.
+- `internal/vm/builtins.go` — one-time builtin initialization.
+- `internal/vm/vm_test_helpers_test.go` — invoke builtin through active VM.
+- Every `internal/vm/*_test.go` returned by `rg -l '\.Data\b|\.Globals\b|openFiles|NetListeners|NetConns|DbHandles|StmtHandles|StmtParams' internal/vm -g '*_test.go'` — replace direct fields with supported APIs in the task that removes each field.
+- `internal/vm/architecture_test.go` — enforce the new boundaries.
+- `docs/CONCURRENCY.md`, `docs/NOXY_LANGUAGE_SPEC.md`, `CHANGELOG.md` — document guarantees and compatibility.
+
+---
+
+### Task 1: Add the dual native ABI and active-context invocation
+
+**Files:**
+- Create: `internal/value/native.go`
+- Create: `internal/value/native_test.go`
+- Create: `internal/vm/runtime_context_test.go`
+- Modify: `internal/value/value.go`
+- Modify: `internal/vm/calls.go`
+- Modify: `internal/vm/call_validation.go`
+- Modify: `internal/vm/runtime_type_validation.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/vm_test_helpers_test.go`
+- Modify: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Produces: `value.NativeContext`, `value.ContextualNativeFunc`, `(*ObjNative).Invoke`, `(*ObjNative).IsCallable`, contextual constructors, and contextual VM registration methods.
+- Preserves: all existing legacy native constructors and registration methods.
+
+- [ ] **Step 1: Write failing value-level ABI tests**
+
+```go
+package value
+
+import (
+	"errors"
+	"testing"
+)
+
+type testNativeContext struct{}
+
+func (*testNativeContext) IsNativeContext() {}
+
+func TestObjNativeInvokeSupportsLegacyAndContextualHandlers(t *testing.T) {
+	ctx := &testNativeContext{}
+	legacy := NewNative("legacy", func(args []Value) Value { return args[0] })
+	got, err := legacy.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(7)})
+	if err != nil || got.AsInt != 7 {
+		t.Fatalf("legacy invoke=(%v, %v), want (7, nil)", got, err)
+	}
+
+	contextual := NewContextualNative("contextual", func(actual NativeContext, args []Value) (Value, error) {
+		if actual != ctx {
+			return NewNull(), errors.New("wrong context")
+		}
+		return args[0], nil
+	})
+	got, err = contextual.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(9)})
+	if err != nil || got.AsInt != 9 {
+		t.Fatalf("contextual invoke=(%v, %v), want (9, nil)", got, err)
+	}
+}
+
+func TestObjNativeInvokeRejectsInvalidHandlerConfigurations(t *testing.T) {
+	ctx := &testNativeContext{}
+	tests := []*ObjNative{
+		{Name: "missing"},
+		{Name: "both", Fn: func([]Value) Value { return NewNull() }, Contextual: func(NativeContext, []Value) (Value, error) { return NewNull(), nil }},
+	}
+	for _, native := range tests {
+		if native.IsCallable() {
+			t.Fatalf("%s unexpectedly callable", native.Name)
+		}
+		if _, err := native.Invoke(ctx, nil); err == nil {
+			t.Fatalf("%s invoke succeeded", native.Name)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `go test ./internal/value -run 'TestObjNativeInvoke' -v`
+Expected: build failure because contextual native types and `Invoke` do not exist.
+
+- [ ] **Step 3: Implement the dual ABI**
+
+Move the native definitions from `value.go` to `native.go` and implement:
+
+```go
+package value
+
+import "fmt"
+
+type NativeContext interface {
+	IsNativeContext()
+}
+
+type NativeFunc func(args []Value) Value
+type ContextualNativeFunc func(context NativeContext, args []Value) (Value, error)
+
+type ObjNative struct {
+	Name       string
+	Fn         NativeFunc
+	Contextual ContextualNativeFunc
+	Signature  *NativeSignature
+}
+
+func (native *ObjNative) IsCallable() bool {
+	return native != nil && (native.Fn == nil) != (native.Contextual == nil)
+}
+
+func (native *ObjNative) Invoke(context NativeContext, args []Value) (Value, error) {
+	if native == nil {
+		return NewNull(), fmt.Errorf("invalid native function")
+	}
+	if !native.IsCallable() {
+		return NewNull(), fmt.Errorf("native '%s' must define exactly one handler", native.Name)
+	}
+	if native.Contextual != nil {
+		if context == nil {
+			return NewNull(), fmt.Errorf("native '%s' requires a runtime context", native.Name)
+		}
+		return native.Contextual(context, args)
+	}
+	return native.Fn(args), nil
+}
+
+func NewNative(name string, fn NativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Fn: fn}}
+}
+
+func NewNativeWithSignature(name string, signature NativeSignature, fn NativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Fn: fn, Signature: &signature}}
+}
+
+func NewContextualNative(name string, fn ContextualNativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Contextual: fn}}
+}
+
+func NewContextualNativeWithSignature(name string, signature NativeSignature, fn ContextualNativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Contextual: fn, Signature: &signature}}
+}
+```
+
+- [ ] **Step 4: Route VM calls through `Invoke`**
+
+Add to `VM`:
+
+```go
+func (*VM) IsNativeContext() {}
+
+func nativeVM(context value.NativeContext) (*VM, error) {
+	machine, ok := context.(*VM)
+	if !ok || machine == nil {
+		return nil, fmt.Errorf("invalid VM native context")
+	}
+	return machine, nil
+}
+```
+
+Add `DefineContextualNative` and `DefineContextualNativeWithSignature` beside the legacy methods. In `callValue`, keep existing signature validation and argument-copy preparation, then replace direct invocation with:
+
+```go
+result, err := native.Invoke(vm, args)
+if err != nil {
+	return false, vm.runtimeError(c, ip, "%s", err)
+}
+vm.stackTop -= argCount + 1
+vm.push(result)
+return true, nil
+```
+
+Change every callable check from `native.Fn != nil` to `native.IsCallable()`.
+
+- [ ] **Step 5: Make test helpers invoke with the selected VM**
+
+```go
+func callBuiltin(t *testing.T, machine *VM, name string, args ...value.Value) value.Value {
+	t.Helper()
+	result, err := requireBuiltin(t, machine, name).Invoke(machine, args)
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	return result
+}
+```
+
+Apply the same `Invoke(machine, args)` rule in bounded helpers.
+
+- [ ] **Step 6: Add and run an active-VM regression test**
+
+```go
+func TestContextualNativeReceivesCallingVM(t *testing.T) {
+	parent := NewWithConfig(VMConfig{RootPath: "parent"})
+	child := NewWithShared(parent.shared, VMConfig{RootPath: "child"})
+	parent.DefineContextualNative("active_root", func(context value.NativeContext, _ []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		return value.NewString(machine.Config.RootPath), nil
+	})
+	assertBuiltinValue(t, callBuiltin(t, child, "active_root"), value.NewString("child"))
+}
+```
+
+Run: `go test ./internal/value ./internal/vm -run 'TestObjNativeInvoke|TestContextualNativeReceivesCallingVM' -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add internal/value/native.go internal/value/native_test.go internal/value/value.go internal/vm/calls.go internal/vm/call_validation.go internal/vm/runtime_type_validation.go internal/vm/vm.go internal/vm/vm_test_helpers_test.go internal/vm/builtins_net_test.go internal/vm/runtime_context_test.go
+git commit -m "refactor(vm): add contextual native invocation"
+```
+
+---
+
+### Task 2: Add synchronized `ObjMap` storage without breaking the build
+
+**Files:**
+- Create: `internal/value/map.go`
+- Create: `internal/value/map_test.go`
+- Modify: `internal/value/value.go`
+
+**Interfaces:**
+- Produces: `ObjMap.Get`, `Set`, `Delete`, `Len`, `Snapshot`, and `Replace`.
+- Temporary compatibility: keep `Data` as an alias only until Task 3 migrates every caller.
+
+- [ ] **Step 1: Write failing synchronized-map tests**
+
+```go
+func TestObjMapOperationsUseSnapshots(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	mapping.Set("answer", NewInt(42))
+	if got, ok := mapping.Get("answer"); !ok || got.AsInt != 42 {
+		t.Fatalf("answer=(%v,%t)", got, ok)
+	}
+	snapshot := mapping.Snapshot()
+	snapshot["answer"] = NewInt(0)
+	got, _ := mapping.Get("answer")
+	if got.AsInt != 42 {
+		t.Fatal("snapshot mutated live map")
+	}
+	if !mapping.Delete("answer") || mapping.Len() != 0 {
+		t.Fatal("delete did not remove key")
+	}
+}
+
+func TestObjMapConcurrentSetAndSnapshot(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		workers.Add(2)
+		go func(id int) {
+			defer workers.Done()
+			<-start
+			for n := 0; n < 100; n++ {
+				mapping.Set(int64(id*100+n), NewInt(int64(n)))
+			}
+		}(i)
+		go func() {
+			defer workers.Done()
+			<-start
+			for n := 0; n < 100; n++ {
+				_ = mapping.Snapshot()
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/value -run 'TestObjMap' -v`
+Expected: build failure because the methods do not exist.
+
+- [ ] **Step 3: Implement `bindingStore` and the map methods**
+
+```go
+type bindingStore struct {
+	mu     sync.RWMutex
+	values map[interface{}]Value
+}
+
+func newBindingStore(values map[interface{}]Value) *bindingStore {
+	if values == nil {
+		values = make(map[interface{}]Value)
+	}
+	return &bindingStore{values: values}
+}
+
+func (store *bindingStore) get(key interface{}) (Value, bool) {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	result, ok := store.values[key]
+	return result, ok
+}
+
+func (store *bindingStore) set(key interface{}, item Value) {
+	store.mu.Lock()
+	store.values[key] = item
+	store.mu.Unlock()
+}
+
+func (store *bindingStore) defineIfAbsent(key interface{}, item Value) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, exists := store.values[key]; exists {
+		return false
+	}
+	store.values[key] = item
+	return true
+}
+
+func (store *bindingStore) delete(key interface{}) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, exists := store.values[key]; !exists {
+		return false
+	}
+	delete(store.values, key)
+	return true
+}
+
+func (store *bindingStore) snapshot() map[interface{}]Value {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	result := make(map[interface{}]Value, len(store.values))
+	for key, item := range store.values {
+		result[key] = item
+	}
+	return result
+}
+
+func (store *bindingStore) replace(values map[interface{}]Value) {
+	store.mu.Lock()
+	store.values = make(map[interface{}]Value, len(values))
+	for key, item := range values {
+		store.values[key] = item
+	}
+	store.mu.Unlock()
+}
+
+type ObjMap struct {
+	Data        map[interface{}]Value // removed in Task 3
+	store       *bindingStore
+	storeOnce   sync.Once
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
+}
+
+func (mapping *ObjMap) ensureStore() *bindingStore {
+	mapping.storeOnce.Do(func() { mapping.store = newBindingStore(mapping.Data) })
+	return mapping.store
+}
+
+func (mapping *ObjMap) Get(key interface{}) (Value, bool) { return mapping.ensureStore().get(key) }
+func (mapping *ObjMap) Set(key interface{}, item Value) { mapping.ensureStore().set(key, item) }
+func (mapping *ObjMap) Delete(key interface{}) bool { return mapping.ensureStore().delete(key) }
+func (mapping *ObjMap) Len() int { return len(mapping.Snapshot()) }
+func (mapping *ObjMap) Snapshot() map[interface{}]Value { return mapping.ensureStore().snapshot() }
+func (mapping *ObjMap) Replace(values map[interface{}]Value) { mapping.ensureStore().replace(values) }
+```
+
+Constructors must initialize `Data` and `store` with the same initial map during this compatibility task.
+
+- [ ] **Step 4: Verify GREEN under the race detector**
+
+Run: `go test -race ./internal/value -run 'TestObjMap' -v`
+Expected: PASS with no race report.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/value/map.go internal/value/map_test.go internal/value/value.go
+git commit -m "refactor(value): add synchronized map storage"
+```
+
+---
+
+### Task 3: Migrate all runtime map access and remove `ObjMap.Data`
+
+**Files:**
+- Modify: `internal/value/map.go`
+- Modify: `internal/value/value.go`
+- Modify: `internal/plugin/plugin.go`
+- Modify: `internal/vm/builtins_collections.go`
+- Modify: `internal/vm/builtins_json.go`
+- Modify: `internal/vm/builtins_net.go`
+- Modify: `internal/vm/calls.go`
+- Modify: `internal/vm/executor.go`
+- Modify: `internal/vm/json_population.go`
+- Modify: `internal/vm/json_strict.go`
+- Modify: `internal/vm/references.go`
+- Modify: `internal/vm/runtime_type_validation.go`
+- Modify: every test file returned by `rg -l '\.Data\b' internal/vm -g '*_test.go'`.
+
+**Interfaces:**
+- Consumes: synchronized `ObjMap` API from Task 2.
+- Produces: no mutable raw map field anywhere in `ObjMap` consumers.
+
+- [ ] **Step 1: Add an architectural test that currently fails**
+
+Add to `architecture_test.go`:
+
+```go
+func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") || file == "architecture_test.go" {
+			continue
+		}
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(source, []byte(".Data")) {
+			t.Errorf("%s accesses ObjMap.Data directly", file)
+		}
+	}
+}
+```
+
+Run: `go test ./internal/vm -run TestRuntimeDoesNotAccessObjMapDataDirectly -v`
+Expected: FAIL listing current direct-access files.
+
+- [ ] **Step 2: Apply the exact production-code mapping**
+
+Use these replacements in every production occurrence:
+
+| Old operation | New operation |
+|---|---|
+| `mapping.Data[key]` read | `mapping.Get(key)` |
+| `mapping.Data[key] = item` | `mapping.Set(key, item)` |
+| `delete(mapping.Data, key)` | `mapping.Delete(key)` |
+| `len(mapping.Data)` | `mapping.Len()` |
+| `for key, item := range mapping.Data` | `for key, item := range mapping.Snapshot()` |
+| replace whole `mapping.Data` | `mapping.Replace(newValues)` |
+| shallow-copy `mapping.Data` | use `mapping.Snapshot()` |
+
+For absent indexed reads, preserve `null` behavior:
+
+```go
+item, exists := mapping.Get(key)
+if !exists {
+	item = value.NewNull()
+}
+```
+
+For map references, return a setter that calls `mapping.Set(key, updated)`. For JSON population, build a new map from `Snapshot`, validate it completely, and call `Replace` only after validation succeeds.
+
+- [ ] **Step 3: Migrate tests to supported helpers**
+
+Add test-only helpers:
+
+```go
+func setTestMap(mapping *value.ObjMap, key interface{}, item value.Value) {
+	mapping.Set(key, item)
+}
+
+func requireTestMapValue(t *testing.T, mapping *value.ObjMap, key interface{}) value.Value {
+	t.Helper()
+	item, ok := mapping.Get(key)
+	if !ok {
+		t.Fatalf("map is missing key %v", key)
+	}
+	return item
+}
+```
+
+Replace test mutation, lookup, iteration, and length with `Set`, `Get`, `Snapshot`, and `Len`.
+
+- [ ] **Step 4: Remove compatibility storage**
+
+Change `ObjMap` to:
+
+```go
+type ObjMap struct {
+	store       *bindingStore
+	storeOnce   sync.Once
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
+}
+```
+
+Make `ensureStore` preserve an injected live store:
+
+```go
+func (mapping *ObjMap) ensureStore() *bindingStore {
+	mapping.storeOnce.Do(func() {
+		if mapping.store == nil {
+			mapping.store = newBindingStore(nil)
+		}
+	})
+	return mapping.store
+}
+```
+
+`NewMap` creates `&ObjMap{store: newBindingStore(nil)}` and calls `ensureStore()` before returning. `NewMapWithData` creates an empty map, converts the input keys, calls `Replace`, and returns it. `String` and `Format` iterate over `Snapshot()`.
+
+- [ ] **Step 5: Verify no direct field remains**
+
+Run: `rg -n '\.Data\b' internal -g '*.go'`
+Expected: no matches.
+
+Run: `go test -race ./internal/value ./internal/plugin ./internal/vm`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/value internal/plugin internal/vm
+git commit -m "refactor(value): encapsulate synchronized maps"
+```
+
+---
+
+### Task 4: Add hierarchical `GlobalEnvironment`
+
+**Files:**
+- Create: `internal/value/environment.go`
+- Create: `internal/value/environment_test.go`
+- Modify: `internal/value/map.go`
+
+**Interfaces:**
+- Produces: environment resolution, ownership, snapshots, replacement, and live export maps.
+
+- [ ] **Step 1: Write failing environment tests**
+
+```go
+func TestGlobalEnvironmentResolvesAndShadowsParent(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	root.SetLocal("value", NewInt(1))
+	child := NewGlobalEnvironment(root)
+	if got, _ := child.Resolve("value"); got.AsInt != 1 {
+		t.Fatalf("inherited value=%v", got)
+	}
+	owner, ok := child.ResolveOwner("value")
+	if !ok || owner != root {
+		t.Fatal("wrong inherited owner")
+	}
+	child.SetLocal("value", NewInt(2))
+	owner, _ = child.ResolveOwner("value")
+	if owner != child {
+		t.Fatal("shadow did not become local")
+	}
+}
+
+func TestGlobalEnvironmentExportsAreLiveAndLocalOnly(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	root.SetLocal("builtin", NewInt(1))
+	module := NewGlobalEnvironment(root)
+	module.SetLocal("answer", NewInt(41))
+	exports := module.ExportMap().Obj.(*ObjMap)
+	module.SetLocal("answer", NewInt(42))
+	if got, _ := exports.Get("answer"); got.AsInt != 42 {
+		t.Fatalf("live export=%v", got)
+	}
+	if _, inherited := exports.Get("builtin"); inherited {
+		t.Fatal("exports leaked parent binding")
+	}
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/value -run TestGlobalEnvironment -v`
+Expected: build failure because `GlobalEnvironment` does not exist.
+
+- [ ] **Step 3: Implement the environment**
+
+```go
+type GlobalEnvironment struct {
+	local  *bindingStore
+	parent *GlobalEnvironment
+}
+
+func NewGlobalEnvironment(parent *GlobalEnvironment) *GlobalEnvironment {
+	return &GlobalEnvironment{local: newBindingStore(nil), parent: parent}
+}
+
+func NewGlobalEnvironmentFrom(values map[string]Value, parent *GlobalEnvironment) *GlobalEnvironment {
+	environment := NewGlobalEnvironment(parent)
+	for name, item := range values {
+		environment.SetLocal(name, item)
+	}
+	return environment
+}
+
+func (environment *GlobalEnvironment) GetLocal(name string) (Value, bool) {
+	if environment == nil {
+		return Value{}, false
+	}
+	return environment.local.get(name)
+}
+
+func (environment *GlobalEnvironment) Resolve(name string) (Value, bool) {
+	for current := environment; current != nil; current = current.parent {
+		if item, ok := current.GetLocal(name); ok {
+			return item, true
+		}
+	}
+	return Value{}, false
+}
+
+func (environment *GlobalEnvironment) SetLocal(name string, item Value) {
+	environment.local.set(name, item)
+}
+
+func (environment *GlobalEnvironment) DefineLocalIfAbsent(name string, item Value) bool {
+	return environment.local.defineIfAbsent(name, item)
+}
+
+func (environment *GlobalEnvironment) ResolveOwner(name string) (*GlobalEnvironment, bool) {
+	for current := environment; current != nil; current = current.parent {
+		if _, ok := current.GetLocal(name); ok {
+			return current, true
+		}
+	}
+	return nil, false
+}
+
+func (environment *GlobalEnvironment) LocalSnapshot() map[string]Value {
+	result := make(map[string]Value)
+	for key, item := range environment.local.snapshot() {
+		if name, ok := key.(string); ok {
+			result[name] = item
+		}
+	}
+	return result
+}
+
+func (environment *GlobalEnvironment) ReplaceLocal(values map[string]Value) {
+	replacement := make(map[interface{}]Value, len(values))
+	for name, item := range values {
+		replacement[name] = item
+	}
+	environment.local.replace(replacement)
+}
+
+func (environment *GlobalEnvironment) ExportMap() Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjMap{store: environment.local}}
+}
+```
+
+- [ ] **Step 4: Run environment and map races**
+
+Run: `go test -race ./internal/value -run 'TestGlobalEnvironment|TestObjMap' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/value/environment.go internal/value/environment_test.go internal/value/map.go
+git commit -m "feat(value): add synchronized global environments"
+```
+
+---
+
+### Task 5: Migrate VM execution, closures, globals, references, and map adapters
+
+**Files:**
+- Modify: `internal/value/value.go`
+- Modify: `internal/compiler/compiler.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/executor.go`
+- Modify: `internal/vm/calls.go`
+- Modify: `internal/vm/references.go`
+- Modify: `internal/vm/builtins_concurrency.go`
+- Modify: `internal/vm/modules.go`
+- Modify: `internal/vm/reference_ownership_test.go`
+- Modify: `internal/vm/native_signatures_test.go`
+- Modify: `internal/vm/module_exports_test.go`
+- Modify: `internal/vm/architecture_test.go`
+
+**Interfaces:**
+- Consumes: `GlobalEnvironment`.
+- Produces: environment-based frames/closures/functions/refs, `InterpretWithEnvironment`, and copy-in/copy-out `InterpretWithGlobals`.
+
+- [ ] **Step 1: Write failing execution tests**
+
+Add tests for an explicitly empty map and owner identity:
+
+```go
+func TestInterpretWithGlobalsUsesNonNilEmptyEnvironment(t *testing.T) {
+	code := compileVMSource(t, "let answer: int = 42")
+	globals := map[string]value.Value{}
+	if err := New().InterpretWithGlobals(code, globals); err != nil {
+		t.Fatal(err)
+	}
+	if got := globals["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("answer=%v", got)
+	}
+}
+
+func TestModuleGlobalReferenceRetainsResolvedEnvironment(t *testing.T) {
+	root := value.NewGlobalEnvironment(nil)
+	root.SetLocal("root", value.NewInt(1))
+	module := value.NewGlobalEnvironment(root)
+	module.SetLocal("module", value.NewInt(2))
+	machine := New()
+	machine.shared.Root = root
+	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "module", GlobalOwner: module}
+	if err := machine.storeGlobalReferenceValue(ref, value.NewInt(3)); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := module.GetLocal("module")
+	if got.AsInt != 3 {
+		t.Fatalf("module value=%v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestInterpretWithGlobalsUsesNonNilEmptyEnvironment|TestModuleGlobalReferenceRetainsResolvedEnvironment' -v`
+Expected: build failure because VM objects still use raw maps.
+
+- [ ] **Step 3: Change value and frame ownership types**
+
+Use these exact fields:
+
+```go
+type ObjFunction struct {
+	Name string
+	Arity int
+	UpvalueCount int
+	Params []ParamInfo
+	Chunk interface{}
+	Environment *GlobalEnvironment
+	RuntimeType *RuntimeTypeInfo
+}
+
+type ObjClosure struct {
+	Function *ObjFunction
+	Upvalues []*ObjUpvalue
+	Environment *GlobalEnvironment
+}
+
+type ObjRef struct {
+	// existing metadata
+	GlobalOwner *GlobalEnvironment
+	// existing non-global target fields
+}
+
+type CallFrame struct {
+	Closure *value.ObjClosure
+	IP int
+	Slots int
+	Environment *value.GlobalEnvironment
+}
+```
+
+Change `NewFunction`'s final argument from `map[string]Value` to `*GlobalEnvironment`, then update its compiler, executor, module, malformed-value-test, and closure call sites reported by `rg -n 'NewFunction\(' internal -g '*.go'` to pass either the current environment or `nil` for unbound compiler constants.
+
+- [ ] **Step 4: Add root and interpretation entry points**
+
+`SharedState` gains `Root *value.GlobalEnvironment`. Implement:
+
+```go
+func (vm *VM) Interpret(c *chunk.Chunk) error {
+	return vm.InterpretWithEnvironment(c, vm.shared.Root)
+}
+
+func (vm *VM) InterpretWithGlobals(c *chunk.Chunk, globals map[string]value.Value) (err error) {
+	if globals == nil {
+		return vm.InterpretWithEnvironment(c, vm.shared.Root)
+	}
+	environment := value.NewGlobalEnvironmentFrom(globals, vm.shared.Root)
+	defer func() {
+		for name := range globals {
+			delete(globals, name)
+		}
+		for name, item := range environment.LocalSnapshot() {
+			globals[name] = item
+		}
+	}()
+	return vm.InterpretWithEnvironment(c, environment)
+}
+
+func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.GlobalEnvironment) error {
+	if environment == nil {
+		return fmt.Errorf("interpret requires a global environment")
+	}
+	scriptFunction := &value.ObjFunction{Name: "script", Arity: 0, Chunk: c, Environment: environment}
+	scriptClosure := &value.ObjClosure{Function: scriptFunction, Upvalues: []*value.ObjUpvalue{}, Environment: environment}
+	vm.stackTop = 0
+	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: scriptClosure})
+	frame := &CallFrame{Closure: scriptClosure, IP: 0, Slots: 1, Environment: environment}
+	vm.frames[0] = frame
+	vm.frameCount = 1
+	vm.currentFrame = frame
+	return vm.run(1)
+}
+```
+
+`GetGlobal`, `SetGlobal`, and native definition delegate to `shared.Root`; definition uses `DefineLocalIfAbsent`.
+
+- [ ] **Step 5: Migrate global and closure opcodes**
+
+Implement the opcode rules exactly:
+
+```go
+// OP_GET_GLOBAL
+item, ok := frame.Environment.Resolve(name)
+
+// OP_SET_GLOBAL
+frame.Environment.SetLocal(name, vm.peek(0))
+
+// OP_REF_GLOBAL
+owner, ok := frame.Environment.ResolveOwner(name)
+vm.push(value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{
+	RefType: value.REF_GLOBAL,
+	Name: name,
+	GlobalOwner: owner,
+}})
+```
+
+Bind function constants and closures to `frame.Environment`. Construct call frames from `closure.Environment`. Change global reference storage to `GlobalOwner.GetLocal`/`SetLocal`.
+
+- [ ] **Step 6: Use live module environments before adding cache coordination**
+
+In every embedded/file module path:
+
+```go
+moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
+moduleFunction.Environment = moduleEnvironment
+moduleClosure.Environment = moduleEnvironment
+vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: moduleClosure})
+if ok, err := vm.callValue(vm.peek(0), 0, nil, 0); !ok { return value.NewNull(), err }
+startFrameCount := vm.frameCount
+if err := vm.run(startFrameCount); err != nil { return value.NewNull(), err }
+vm.pop()
+return moduleEnvironment.ExportMap(), nil
+```
+
+Directory modules use a standalone child environment, insert child exports with `SetLocal`, and return `ExportMap`.
+
+- [ ] **Step 7: Add architectural assertions and verify**
+
+Update architecture tests to reject `Globals map` and `GlobalOwner *map`. Run:
+
+```powershell
+rg -n '\.Globals\b|Globals:|GlobalOwner \*map' internal/value internal/vm -g '*.go'
+go test -race ./internal/value ./internal/vm
+```
+
+Expected: `rg` finds no obsolete ownership fields; tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add internal/value/value.go internal/compiler/compiler.go internal/vm
+git commit -m "refactor(vm): use synchronized global environments"
+```
+
+---
+
+### Task 6: Coordinate module loading and detect concurrent cycles
+
+**Files:**
+- Create: `internal/vm/module_cache.go`
+- Create: `internal/vm/module_cache_test.go`
+- Modify: `internal/vm/modules.go`
+- Modify: `internal/vm/executor.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/module_exports_test.go`
+
+**Interfaces:**
+- Produces: canonical `moduleKey`, `moduleCache.Do`, per-VM load stack, successful-result caching, failure retry, and dependency-cycle errors.
+
+- [ ] **Step 1: Write deterministic failing cache tests**
+
+Test one initializer with channels:
+
+```go
+func TestModuleCacheInitializesKeyOnce(t *testing.T) {
+	cache := newModuleCache()
+	key := moduleKey{Root: "root", Name: "module"}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	load := func() (value.Value, error) {
+		if calls.Add(1) == 1 {
+			close(entered)
+		}
+		<-release
+		return value.NewInt(42), nil
+	}
+	results := make(chan value.Value, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			got, err := cache.Do(key, nil, load)
+			if err != nil { t.Error(err); return }
+			results <- got
+		}()
+	}
+	<-entered
+	close(release)
+	<-results
+	<-results
+	if calls.Load() != 1 { t.Fatalf("loads=%d", calls.Load()) }
+}
+```
+
+Add a cross-flight graph test that establishes `A -> B`, then attempts `B -> A`, and requires an error containing `A -> B -> A` without waiting.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run TestModuleCache -v`
+Expected: build failure because the cache does not exist.
+
+- [ ] **Step 3: Implement cache state and graph**
+
+Use these types:
+
+```go
+type moduleKey struct { Root, Name string }
+type moduleEntry struct {
+	done chan struct{}
+	result value.Value
+	err error
+}
+type moduleCache struct {
+	mu sync.Mutex
+	entries map[moduleKey]*moduleEntry
+	dependencies map[moduleKey]map[moduleKey]struct{}
+}
+```
+
+`Do(key, parent, load)` must:
+
+1. return ready cached results immediately;
+2. install `loading` for the first caller;
+3. add `parent -> key` before waiting or loading;
+4. run DFS from `key` to `parent` before adding the edge and return a formatted cycle if reachable;
+5. wait on `entry.done` outside the lock;
+6. run `load` outside the lock for the owner;
+7. publish result/error, close `done`, and remove failed entries;
+8. remove the dependency edge on every return path.
+
+- [ ] **Step 4: Split module resolution from cached initialization**
+
+Refactor `modules.go` into:
+
+```go
+func (vm *VM) resolveModule(name string) (resolvedModule, error)
+func (vm *VM) loadResolvedModule(source resolvedModule) (value.Value, error)
+func (vm *VM) loadModule(name string) (value.Value, error)
+```
+
+`resolvedModule` contains canonical identity, kind (embedded/file/directory), and path/content. The cache key includes canonical `RootPath`, current `NOXY_PATH`, and resolved module name. `loadModule` passes the top of the per-VM module-load stack as parent, pushes the owner key only while executing `loadResolvedModule`, and pops it with `defer`.
+
+Change `OP_IMPORT` to call only `loadModule`; remove separate `GetModule`/`SetModule` calls.
+
+- [ ] **Step 5: Add integration tests for concurrent import and direct cycles**
+
+Create `counter.nx` under `t.TempDir()` with `test_module_init()`. Compile `use counter` once, create two VMs with the same `SharedState` and root, and register:
+
+```go
+var initializations atomic.Int32
+parent.DefineNative("test_module_init", func([]value.Value) value.Value {
+	initializations.Add(1)
+	return value.NewNull()
+})
+```
+
+Run the compiled import simultaneously in both VMs behind a start channel, collect two errors, and assert both nil and `initializations.Load() == 1`.
+
+For direct cycles, write `a.nx` containing `use b` and `b.nx` containing `use a`; interpret `use a` and assert the error contains `a -> b -> a`. The lower-level cache test from Step 1 remains the deterministic cross-flight `A/B` cycle test.
+
+Run: `go test -race ./internal/vm -run 'TestModuleCache|TestConcurrentModule|Test.*ImportCycle' -v`
+Expected: PASS with no deadlock or race.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/module_cache.go internal/vm/module_cache_test.go internal/vm/modules.go internal/vm/executor.go internal/vm/vm.go internal/vm/module_exports_test.go
+git commit -m "fix(vm): coordinate concurrent module loading"
+```
+
+---
+
+### Task 7: Introduce shared handle registries and resource entries
+
+**Files:**
+- Create: `internal/vm/resources.go`
+- Create: `internal/vm/resources_test.go`
+- Modify: `internal/vm/vm.go`
+
+**Interfaces:**
+- Produces: `handleRegistry[T]`, `FileResource`, `ListenerResource`, `SocketResource`, `DatabaseResource`, and `StatementResource`.
+
+- [ ] **Step 1: Write failing registry lifecycle tests**
+
+```go
+func TestHandleRegistryUsesMonotonicNonReusableHandles(t *testing.T) {
+	registry := newHandleRegistry[string]()
+	first := registry.add("first")
+	if _, ok := registry.remove(first); !ok { t.Fatal("remove failed") }
+	second := registry.add("second")
+	if second <= first { t.Fatalf("handles %d then %d", first, second) }
+	if _, ok := registry.get(first); ok { t.Fatal("removed handle resolved") }
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run TestHandleRegistry -v`
+Expected: build failure.
+
+- [ ] **Step 3: Implement registry and resource types**
+
+```go
+type handleRegistry[T any] struct {
+	mu sync.RWMutex
+	next int
+	items map[int]T
+}
+
+func newHandleRegistry[T any]() *handleRegistry[T] {
+	return &handleRegistry[T]{next: 1, items: make(map[int]T)}
+}
+
+func (registry *handleRegistry[T]) add(item T) int {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	handle := registry.next
+	registry.next++
+	registry.items[handle] = item
+	return handle
+}
+
+func (registry *handleRegistry[T]) get(handle int) (T, bool) {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	item, ok := registry.items[handle]
+	return item, ok
+}
+
+func (registry *handleRegistry[T]) remove(handle int) (T, bool) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	item, ok := registry.items[handle]
+	if ok { delete(registry.items, handle) }
+	return item, ok
+}
+```
+
+Define these entries:
+
+```go
+type FileResource struct {
+	stateMu sync.Mutex
+	operationMu sync.Mutex
+	file *os.File
+	closed bool
+}
+
+type ListenerResource struct {
+	stateMu sync.Mutex
+	acceptMu sync.Mutex
+	listener net.Listener
+	bufferedAccept net.Conn
+	closed bool
+}
+
+type SocketResource struct {
+	stateMu sync.Mutex
+	readMu sync.Mutex
+	writeMu sync.Mutex
+	connection net.Conn
+	bufferedRead []byte
+	closed bool
+}
+
+type DatabaseResource struct {
+	stateMu sync.Mutex
+	database *sql.DB
+	closed bool
+}
+
+type StatementResource struct {
+	mu sync.Mutex
+	statement *sql.Stmt
+	parameters map[int]interface{}
+	closed bool
+}
+```
+
+- [ ] **Step 4: Replace `SharedState` resource fields**
+
+```go
+type SharedState struct {
+	Root *value.GlobalEnvironment
+	Modules *moduleCache
+	Files *handleRegistry[*FileResource]
+	Listeners *handleRegistry[*ListenerResource]
+	Sockets *handleRegistry[*SocketResource]
+	Databases *handleRegistry[*DatabaseResource]
+	Statements *handleRegistry[*StatementResource]
+	initOnce sync.Once
+}
+```
+
+At this checkpoint, add the new registry fields alongside the old file/network/SQLite fields. Do not redirect existing builtins yet. Task 8 removes only `openFiles`/`nextFD`; Task 9 removes only old network fields; Task 10 removes only old SQLite fields. This keeps each commit buildable without an adapter that has two owners for the same resource.
+
+- [ ] **Step 5: Run and commit**
+
+Run: `go test -race ./internal/vm -run TestHandleRegistry -v`
+Expected: PASS.
+
+```powershell
+git add internal/vm/resources.go internal/vm/resources_test.go internal/vm/vm.go
+git commit -m "refactor(vm): add shared resource registries"
+```
+
+---
+
+### Task 8: Move file handles into shared contextual resources
+
+**Files:**
+- Modify: `internal/vm/builtins_io.go`
+- Modify: `internal/vm/builtins_io_test.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/resources.go`
+
+**Interfaces:**
+- Consumes: active contextual native and `SharedState.Files`.
+- Produces: cross-VM file handle visibility and synchronized close/operation lifecycle.
+
+- [ ] **Step 1: Write the failing cross-VM test**
+
+```go
+func TestFileHandleIsUsableAcrossSharedVMs(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	path := filepath.Join(t.TempDir(), "shared.txt")
+	fileType := testFileDefinition()
+	handle := callBuiltin(t, parent, "io_open", value.NewString(path), value.NewString("w"), fileType)
+	callBuiltin(t, child, "io_write", handle, value.NewString("shared"))
+	callBuiltin(t, child, "io_close", handle)
+	contents, err := os.ReadFile(path)
+	if err != nil || string(contents) != "shared" {
+		t.Fatalf("contents=%q err=%v", contents, err)
+	}
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run TestFileHandleIsUsableAcrossSharedVMs -v`
+Expected: FAIL because the child resolves the native captured by the parent but file state is VM-local.
+
+- [ ] **Step 3: Add file resource operations**
+
+Add:
+
+```go
+func (resource *FileResource) use(operation func(*os.File) value.Value) (value.Value, bool) {
+	resource.operationMu.Lock()
+	defer resource.operationMu.Unlock()
+	resource.stateMu.Lock()
+	if resource.closed || resource.file == nil {
+		resource.stateMu.Unlock()
+		return value.NewNull(), false
+	}
+	file := resource.file
+	resource.stateMu.Unlock()
+	return operation(file), true
+}
+
+func (resource *FileResource) close() error {
+	resource.stateMu.Lock()
+	if resource.closed || resource.file == nil {
+		resource.stateMu.Unlock()
+		return os.ErrClosed
+	}
+	resource.closed = true
+	file := resource.file
+	resource.stateMu.Unlock()
+	return file.Close()
+}
+```
+
+Builtin handlers obtain the resource with `machine.shared.Files.get(handle)` before calling `use`; close obtains it with `remove` before calling `close`. Registry locks are therefore released before `Read`, `Write`, `Stat`, or `Close`.
+
+Close must remove the handle first, set `closed`, and call `file.Close()` without waiting for `operationMu`.
+
+- [ ] **Step 4: Convert stateful IO natives**
+
+Register `io_open`, both close variants, both write variants, both read variants, and `io_read_lines` with `DefineContextualNative`. Start each handler with:
+
+```go
+machine, err := nativeVM(context)
+if err != nil { return value.NewNull(), err }
+```
+
+Return `(existingResult, nil)` for all existing operational outcomes. Leave path-only pure functions legacy. Remove `VM.openFiles` and `VM.nextFD`.
+
+- [ ] **Step 5: Update cleanup and add a close/read lifecycle test**
+
+Add `handleRegistry.snapshot()` for test cleanup. Replace each `machine.openFiles` cleanup/assertion with `machine.shared.Files.snapshot()` or `get`.
+
+Add this deterministic underlying-close test:
+
+```go
+func TestFileCloseInterruptsBlockedReadWithoutRegistryDeadlock(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil { t.Fatal(err) }
+	defer writer.Close()
+	machine := New()
+	resource := &FileResource{file: reader}
+	handle := machine.shared.Files.add(resource)
+	done := make(chan error, 1)
+	go func() {
+		resource.operationMu.Lock()
+		defer resource.operationMu.Unlock()
+		buffer := make([]byte, 1)
+		_, readErr := resource.file.Read(buffer)
+		done <- readErr
+	}()
+	removed, ok := machine.shared.Files.remove(handle)
+	if !ok { t.Fatal("file handle disappeared") }
+	removed.stateMu.Lock()
+	removed.closed = true
+	removed.stateMu.Unlock()
+	if err := removed.file.Close(); err != nil { t.Fatal(err) }
+	select {
+	case readErr := <-done:
+		if readErr == nil { t.Fatal("blocked read succeeded after close") }
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("close did not interrupt blocked read")
+	}
+}
+```
+
+Run: `go test -race ./internal/vm -run 'TestIO|TestFileHandle' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/builtins_io.go internal/vm/builtins_io_test.go internal/vm/resources.go internal/vm/vm.go
+git commit -m "fix(io): share file resources across VMs"
+```
+
+---
+
+### Task 9: Move network state and select buffers into synchronized resources
+
+**Files:**
+- Modify: `internal/vm/builtins_net.go`
+- Modify: `internal/vm/builtins_net_test.go`
+- Modify: `internal/vm/resources.go`
+- Modify: `internal/vm/vm.go`
+
+**Interfaces:**
+- Consumes: listener/socket registries and contextual native ABI.
+- Produces: shared per-listener accepted-connection buffer and per-socket read buffer.
+- Preserves: current sequential, read-only, consuming `net_select` behavior until the network subproject.
+
+- [ ] **Step 1: Write failing cross-VM buffer and concurrent-select tests**
+
+Use the existing `TestNetworkBuiltinsLoopbackLifecycle` setup through accept, then create `child := NewWithShared(machine.shared, machine.Config)`. Send `"x"` from the client, call `net_select` on the server socket through `machine`, and call `net_recv(server, 1)` through `child`; assert `ok=true`, `count=1`, and `data=b"x"`.
+
+Add a second test with the same accepted server socket:
+
+```go
+start := make(chan struct{})
+done := make(chan value.Value, 2)
+for _, current := range []*VM{machine, child} {
+	current := current
+	go func() {
+		<-start
+		done <- callBuiltinWithinBound(t, current, "net_select",
+			value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5))
+	}()
+}
+close(start)
+for i := 0; i < 2; i++ {
+	select {
+	case <-done:
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("concurrent net_select did not complete")
+	}
+}
+```
+
+Send one byte before releasing `start`. The readiness counts may differ because readiness remains advisory; the assertions are bounded completion, valid `SelectResult`, and no race/panic.
+
+- [ ] **Step 2: Verify RED under `-race`**
+
+Run: `go test -race ./internal/vm -run 'TestNetSelectBufferIsSharedAcrossVMs|TestConcurrentNetSelect' -v`
+Expected: race report or incorrect cross-VM receive with the current local buffers.
+
+- [ ] **Step 3: Convert listener and socket registration**
+
+`net_listen` stores `*ListenerResource`; `net_connect` and successful accept store `*SocketResource`. Every handler resolves the active VM context and uses its `SharedState` registries.
+
+Use this lock protocol:
+
+- accept/select-listener: `acceptMu`, then briefly `stateMu`, never registry lock;
+- recv/select-connection: `readMu`, then briefly `stateMu`;
+- send: `writeMu`, then briefly `stateMu`;
+- close: registry removal, mark closed under `stateMu`, close underlying object without read/write/accept lock.
+
+The current peeked byte is stored in `SocketResource.bufferedRead`; the accepted connection is stored in `ListenerResource.bufferedAccept`.
+
+- [ ] **Step 4: Preserve socket result shapes**
+
+Continue returning the existing socket and `NetResult` maps and existing error strings. Do not change timeout coercion, write/error sets, or `setblocking` behavior in this task.
+
+Remove `NetListeners`, `NetConns`, `NetLock`, `NextNetID`, `netBufferedData`, and `netBufferedConns` from old locations.
+
+- [ ] **Step 5: Verify targeted and full network tests**
+
+Run: `go test -race ./internal/vm -run 'TestNetwork|TestNetSelect|TestConcurrentNetSelect' -v`
+Expected: PASS without race reports.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/builtins_net.go internal/vm/builtins_net_test.go internal/vm/resources.go internal/vm/vm.go
+git commit -m "fix(net): synchronize shared socket state"
+```
+
+---
+
+### Task 10: Move SQLite handles and statement parameters into resources
+
+**Files:**
+- Modify: `internal/vm/builtins_sqlite.go`
+- Modify: `internal/vm/builtins_sqlite_test.go`
+- Modify: `internal/vm/resources.go`
+- Modify: `internal/vm/vm.go`
+
+**Interfaces:**
+- Produces: shared database/statement resources and per-statement parameter synchronization.
+
+- [ ] **Step 1: Write failing cross-VM SQLite tests**
+
+Use `newSQLiteTestDefinitions()` and `sqliteTemplate()`. Open `filepath.Join(t.TempDir(), "shared.sqlite")` with `parent`, create `entries(id INTEGER, name TEXT)` with `sqlite_exec`, and prepare `INSERT INTO entries VALUES (?, ?)` with `parent`. Bind index 1 through `parent` and index 2 through `child := NewWithShared(parent.shared, parent.Config)`, execute through `child`, then query through `parent` and assert one row containing `1, "shared"`.
+
+For the parameter race, prepare one statement and release 16 goroutines through `start := make(chan struct{})`; even goroutines repeatedly call `sqlite_bind_int(statement, 1, i)` and odd goroutines repeatedly call `sqlite_bind_text(statement, 2, to_str(i))`, each 100 times. Wait with `sync.WaitGroup`; the assertion is completion and no `-race` report. Reset and finalize the statement after the workers finish.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test -race ./internal/vm -run 'TestSQLiteHandlesAreSharedAcrossVMs|TestSQLiteStatementParametersConcurrent' -v`
+Expected: race report for statement parameters or failure caused by old coarse state.
+
+- [ ] **Step 3: Convert database natives**
+
+Register all SQLite builtins contextually. `sqlite_open` adds `DatabaseResource`; database operations resolve it without holding registry locks. `sqlite_close` removes, marks closed, and closes outside the registry lock.
+
+- [ ] **Step 4: Convert statement natives**
+
+`sqlite_prepare` creates `StatementResource{statement: stmt, parameters: make(map[int]interface{})}`. Bind and reset serialize through the statement mutex. `sqlite_step_exec` locks the statement, copies parameters in ascending index order, clears the parameter map, unlocks, and then calls the underlying statement with that immutable slice. Finalize removes the entry, locks it, marks it closed, detaches the statement pointer, unlocks, and closes the detached statement. A bind/step that obtained the entry before finalize rechecks `closed` while holding the statement mutex and becomes the existing invalid/no-op result if closed.
+
+Remove `DbHandles`, `StmtHandles`, `StmtParams`, counters, and `DbLock`.
+
+- [ ] **Step 5: Verify**
+
+Run: `go test -race ./internal/vm -run 'TestSQLite' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/builtins_sqlite.go internal/vm/builtins_sqlite_test.go internal/vm/resources.go internal/vm/vm.go
+git commit -m "fix(sqlite): synchronize shared database resources"
+```
+
+---
+
+### Task 11: Convert remaining VM-dependent natives and initialize builtins once
+
+**Files:**
+- Modify: `internal/vm/builtins.go`
+- Modify: `internal/vm/builtins_collections.go`
+- Modify: `internal/vm/builtins_concurrency.go`
+- Modify: `internal/vm/builtins_json.go`
+- Modify: `internal/vm/builtins_sys.go`
+- Modify: `internal/vm/builtins_registry_test.go`
+- Modify: `internal/vm/builtins_concurrency_test.go`
+- Modify: `internal/vm/native_signatures_test.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/runtime_context_test.go`
+
+**Interfaces:**
+- Produces: no standard native that captures a bootstrap VM while accessing VM state; one-time shared builtin registration.
+- Preserves: current detached spawn execution behavior, including its existing argument/global semantics for the later spawn subproject.
+
+- [ ] **Step 1: Write failing one-time initialization tests**
+
+```go
+func TestSharedVMsReuseBuiltinValuesButInvokeActiveContext(t *testing.T) {
+	parent := NewWithConfig(VMConfig{RootPath: "parent"})
+	child := NewWithShared(parent.shared, VMConfig{RootPath: "child"})
+	parentSpawn, _ := parent.GetGlobal("spawn")
+	childSpawn, _ := child.GetGlobal("spawn")
+	if parentSpawn.Obj != childSpawn.Obj {
+		t.Fatal("shared VM registered a second spawn native")
+	}
+}
+```
+
+Add this classification test, which fails until each listed builtin is contextual:
+
+```go
+func TestStatefulBuiltinsUseContextualHandlers(t *testing.T) {
+	machine := New()
+	for _, name := range []string{
+		"spawn", "delete", "append", "pop", "json_loads", "sys_load_plugin",
+		"io_open", "net_listen", "sqlite_open",
+	} {
+		native := requireBuiltin(t, machine, name)
+		if native.Contextual == nil || native.Fn != nil || !native.IsCallable() {
+			t.Errorf("%s is not exclusively contextual", name)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestSharedVMsReuseBuiltinValues|TestContextualCollection|TestContextualJSON' -v`
+Expected: FAIL because builtins are still registered per VM or capture bootstrap state.
+
+- [ ] **Step 3: Convert VM-dependent handlers**
+
+Use contextual handlers for:
+
+- `spawn`;
+- `delete`, `append`, and `pop`;
+- `json_loads`;
+- `sys_load_plugin`.
+
+Each obtains `machine := nativeVM(context)` and uses that machine for reference resolution, child VM creation, current-frame metadata, or dynamic registration. Plugin request closures remain legacy because they capture only the synchronized `PluginClient`.
+
+Do not change spawn argument copying or its selection of the function environment in this task.
+
+- [ ] **Step 4: Add one-time shared initialization**
+
+Implement:
+
+```go
+func (shared *SharedState) initializeState() {
+	shared.stateOnce.Do(func() {
+		shared.Root = value.NewGlobalEnvironment(nil)
+		shared.Modules = newModuleCache()
+		shared.Files = newHandleRegistry[*FileResource]()
+		shared.Listeners = newHandleRegistry[*ListenerResource]()
+		shared.Sockets = newHandleRegistry[*SocketResource]()
+		shared.Databases = newHandleRegistry[*DatabaseResource]()
+		shared.Statements = newHandleRegistry[*StatementResource]()
+	})
+}
+```
+
+`SharedState` also owns `builtinsOnce sync.Once`. `NewWithShared` calls `shared.initializeState()`, constructs the executor-local `VM`, and then calls `shared.builtinsOnce.Do(vm.defineBuiltins)`. Every handler that reads VM state must already be contextual at this point; legacy handlers registered during this call may capture only immutable package data or an explicitly concurrency-safe external client. Therefore, the stored builtin values do not retain the bootstrap VM for runtime state access.
+
+- [ ] **Step 5: Verify registry identity and behavior**
+
+Run: `go test -race ./internal/vm -run 'TestSharedVMsReuseBuiltinValues|TestSpawn|Test.*JSON|Test.*Collection' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/builtins.go internal/vm/builtins_collections.go internal/vm/builtins_concurrency.go internal/vm/builtins_json.go internal/vm/builtins_sys.go internal/vm/builtins_registry_test.go internal/vm/builtins_concurrency_test.go internal/vm/native_signatures_test.go internal/vm/vm.go internal/vm/runtime_context_test.go
+git commit -m "refactor(vm): bind stateful natives to active context"
+```
+
+---
+
+### Task 12: Enforce architecture, document guarantees, and run full verification
+
+**Files:**
+- Modify: `internal/vm/architecture_test.go`
+- Modify: `docs/CONCURRENCY.md`
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: permanent regression guards and user-facing concurrency documentation.
+
+- [ ] **Step 1: Strengthen architectural tests**
+
+Assert source structure contains:
+
+- contextual invocation through `Invoke`;
+- `GlobalEnvironment` on frames, functions, closures, and global references;
+- resource registries only in `SharedState`;
+- module cache in its own file.
+
+Assert source structure excludes:
+
+```text
+ObjMap.Data
+Globals map[string]value.Value
+GlobalOwner *map[string]value.Value
+openFiles on VM
+netBufferedData on VM
+netBufferedConns on VM
+DbHandles/StmtHandles/StmtParams raw maps
+native.Fn(args) direct calls
+```
+
+- [ ] **Step 2: Document exact guarantees and limitations**
+
+In `docs/CONCURRENCY.md`, document that shared VMs share globals, module cache, and handles; individual binding/map operations avoid Go map crashes; compound operations and nested composite mutation still require channels.
+
+In `docs/NOXY_LANGUAGE_SPEC.md`, retain shallow-copy semantics and add the memory-model note beside composite values. State that no public Noxy API changed in this foundation.
+
+In `CHANGELOG.md`, record fixes for active native context, cross-VM handle ownership, module single initialization, and concurrent map crashes. Explicitly state that `net_select` semantics and supervised spawn remain follow-up work.
+
+- [ ] **Step 3: Run formatting and focused verification**
+
+Run:
+
+```powershell
+gofmt -w internal/value internal/plugin internal/vm internal/compiler
+go test -race ./internal/value ./internal/plugin ./internal/vm
+```
+
+Expected: PASS with no race reports.
+
+- [ ] **Step 4: Run the repository-required verification**
+
+Run each command independently:
+
+```powershell
+go test ./internal/...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+go build ./...
+go vet ./...
+```
+
+Expected: every command exits 0; the Noxy concurrent runner reports no unexpected failures.
+
+- [ ] **Step 5: Confirm architectural scans are empty**
+
+```powershell
+rg -n '\.Data\b|Globals map\[string\]|GlobalOwner \*map|openFiles|netBuffered(Data|Conns)|DbHandles|StmtHandles|StmtParams|\.Fn\(args\)' internal -g '*.go'
+```
+
+Expected: no production-code matches; any allowed compatibility assertion in tests must be explicit and narrowly scoped.
+
+- [ ] **Step 6: Review the diff against the specification**
+
+Read `docs/superpowers/specs/2026-08-13-runtime-context-foundation-design.md` section by section and confirm every goal and non-goal. Verify no public Noxy signature changed and no follow-up feature leaked into this implementation.
+
+- [ ] **Step 7: Commit final guards and documentation**
+
+```powershell
+git add internal/vm/architecture_test.go docs/CONCURRENCY.md docs/NOXY_LANGUAGE_SPEC.md CHANGELOG.md
+git commit -m "docs: describe concurrency-safe runtime foundation"
+```

--- a/docs/superpowers/specs/2026-08-13-runtime-context-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-13-runtime-context-foundation-design.md
@@ -1,7 +1,7 @@
 # Runtime Context Foundation Design
 
-**Date:** 2026-08-13  
-**Status:** Approved design, awaiting written-spec review  
+**Date:** 2026-08-13
+**Status:** Approved design, awaiting written-spec review
 **Scope:** First subproject in the NoxyDB-driven runtime improvements
 
 ## 1. Purpose

--- a/docs/superpowers/specs/2026-08-13-runtime-context-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-13-runtime-context-foundation-design.md
@@ -1,0 +1,506 @@
+# Runtime Context Foundation Design
+
+**Date:** 2026-08-13  
+**Status:** Approved design, awaiting written-spec review  
+**Scope:** First subproject in the NoxyDB-driven runtime improvements
+
+## 1. Purpose
+
+This subproject establishes the concurrency-safe runtime foundation required by
+the later fixes for `spawn`, network polling, supervised tasks, `defer`, signals,
+strings, and the HTTP server.
+
+The immediate defects are architectural:
+
+- native functions stored in shared globals capture the first `VM` that
+  registered them;
+- files remain local to a VM while sockets and SQLite handles are only partly
+  shared;
+- network look-ahead buffers remain local to a VM even though connections are
+  shared;
+- module and frame globals are raw Go maps;
+- concurrent module loads can initialize the same module more than once.
+
+This design removes those inconsistencies without changing Noxy source syntax
+or the public behavior of existing builtins.
+
+## 2. Goals
+
+1. Invoke stateful natives with the VM that is actually executing the call.
+2. Preserve source compatibility for the existing Go native APIs.
+3. Replace raw global maps with synchronized, identity-stable environments.
+4. Give module exports a synchronized live view of their module environment.
+5. Coordinate concurrent module loading and detect import cycles.
+6. Make files, sockets, listeners, databases, and statements safely reachable
+   from every VM sharing the same `SharedState`.
+7. Eliminate concurrent Go map access in the migrated tables and stores.
+8. Preserve all existing Noxy builtin signatures and observable success/error
+   result shapes.
+
+## 3. Non-goals
+
+This subproject does not implement:
+
+- corrected `spawn` argument, closure, or module-environment semantics;
+- the recursive cross-VM value-transfer policy;
+- a new network poller or new `net_select` semantics;
+- socket nonblocking mode or read/write timeouts;
+- supervised `Task` values;
+- unwind, `defer`, or exception handling;
+- signal subscriptions;
+- string substring corrections;
+- the incremental strict HTTP server.
+
+The existing `net_select` buffering behavior is retained temporarily, but its
+buffers move into synchronized shared resources so that polling and receiving
+through different VMs use the same state.
+
+## 4. Native ABI
+
+### 4.1 Dual handler model
+
+The existing native ABI remains unchanged:
+
+```go
+type NativeFunc func([]Value) Value
+```
+
+A contextual ABI is added:
+
+```go
+type NativeContext interface {
+	IsNativeContext()
+}
+
+type ContextualNativeFunc func(NativeContext, []Value) (Value, error)
+```
+
+`VM` implements `NativeContext`. The interface is deliberately opaque; it is a
+type-safe carrier for the active runtime, not a growing abstraction of VM
+operations. Builtin handlers implemented in package `vm` validate and convert
+the context to `*VM`.
+
+`ObjNative` holds exactly one handler:
+
+```go
+type ObjNative struct {
+	Name       string
+	Fn         NativeFunc
+	Contextual ContextualNativeFunc
+	Signature  *NativeSignature
+}
+```
+
+All native invocation goes through:
+
+```go
+func (native *ObjNative) Invoke(
+	context NativeContext,
+	args []Value,
+) (Value, error)
+```
+
+`Invoke` has these rules:
+
+- only `Fn` is set: call it and return `(result, nil)`;
+- only `Contextual` is set: require a non-nil valid context and call it;
+- neither or both are set: return an ordinary invocation error;
+- never panic because the handler or context is absent or malformed.
+
+Runtime callability checks use an `IsCallable`-style predicate rather than
+testing `native.Fn != nil`.
+
+### 4.2 Constructors and registration
+
+The following existing APIs retain their signatures and behavior:
+
+```go
+value.NewNative(...)
+value.NewNativeWithSignature(...)
+vm.DefineNative(...)
+vm.DefineNativeWithSignature(...)
+```
+
+The following APIs are added:
+
+```go
+value.NewContextualNative(...)
+value.NewContextualNativeWithSignature(...)
+vm.DefineContextualNative(...)
+vm.DefineContextualNativeWithSignature(...)
+```
+
+Legacy extension code remains source-compatible. Go binaries are rebuilt as
+usual after the internal package changes. Existing RPC-based Noxy plugins keep
+their public protocol unchanged.
+
+Pure natives may remain legacy handlers. Natives that access VM or shared
+runtime state become contextual. A legacy plugin closure that captures only its
+own concurrency-safe client may remain legacy; it must not capture a VM.
+
+### 4.3 Registration lifecycle
+
+`SharedState` owns an initialization `sync.Once`. Both `New()` and
+`NewWithShared()` ensure that the root environment, registries, module cache,
+and standard builtins are initialized exactly once.
+
+Builtin handler values do not capture the VM used during initialization.
+`NewWithShared()` then initializes only per-executor state such as stack,
+frames, and configuration.
+
+Dynamic `DefineNative` operations use an atomic define-if-absent operation on
+the root environment. The first definition retains the name, preserving the
+current behavior while avoiding check-then-set races.
+
+## 5. Synchronized values and global environments
+
+### 5.1 Shared binding store
+
+Package `value` contains a private synchronized store:
+
+```go
+type bindingStore struct {
+	mu     sync.RWMutex
+	values map[interface{}]Value
+}
+```
+
+It provides individual `Get`, `Set`, `DefineIfAbsent`, `Delete`, `Len`, and
+`Snapshot` operations. Locks are held only while accessing the map. Returned
+`Value` objects are not recursively locked or copied by the store.
+
+`ObjMap` uses this store and exposes methods instead of a mutable `Data` field.
+All VM, JSON, collection, reference, and test code migrates to those methods.
+This prevents internal code from bypassing the store mutex.
+
+Individual map operations become safe against Go's concurrent-map crash. A
+multi-operation transaction remains non-atomic and requires program-level
+coordination.
+
+### 5.2 Global environment
+
+`GlobalEnvironment` contains a local `bindingStore` and an immutable optional
+parent pointer. It provides:
+
+```go
+GetLocal(name string) (Value, bool)
+Resolve(name string) (Value, bool)
+SetLocal(name string, value Value)
+DefineLocalIfAbsent(name string, value Value) bool
+ResolveOwner(name string) (*GlobalEnvironment, bool)
+LocalSnapshot() map[string]Value
+```
+
+Lookup locks one environment at a time and releases the lock before walking to
+the parent. No environment lock remains held while Noxy or native code runs.
+
+Every `CallFrame`, `ObjFunction`, and `ObjClosure` stores a non-nil
+`*GlobalEnvironment`. `ObjRef` global references store the owner environment
+and binding name instead of `*map[string]Value`.
+
+The environment rules are:
+
+- the root environment contains builtins and script globals;
+- a module environment has the root environment as its parent;
+- reads resolve local bindings before parent bindings;
+- assignments always write to the current frame's local environment;
+- a module assignment to an inherited name creates or updates a local binding;
+- a global reference uses `ResolveOwner` and retains that exact environment;
+- module exports include local bindings only, never inherited builtins.
+
+Accordingly:
+
+- `OP_GET_GLOBAL` calls `Resolve`;
+- `OP_SET_GLOBAL` calls `SetLocal`;
+- `OP_REF_GLOBAL` calls `ResolveOwner`;
+- wildcard and selected imports write with `SetLocal`.
+
+When a function constant is materialized, the resulting function and closure
+are bound to the current frame environment. Calls use the environment retained
+by the closure.
+
+### 5.3 Live module exports
+
+The module export object and its `GlobalEnvironment` local bindings share the
+same `bindingStore` and therefore the same identity and mutex:
+
+```text
+module GlobalEnvironment.local -> bindingStore <- module export object
+```
+
+Consequences:
+
+- `module.member` sees later assignments made by module functions;
+- module functions see writes performed through the module export object;
+- there is no snapshot staleness or duplicate mutex for the same bindings;
+- wildcard import takes a local snapshot, releases its source lock, and only
+  then writes to the target environment.
+
+The mutable `ObjMap.Data` field is an internal compatibility break accepted by
+this design. The source-compatibility guarantee covers the native construction
+and registration APIs, not direct mutation of internal value fields.
+
+### 5.4 `InterpretWithGlobals`
+
+`InterpretWithGlobals(chunk, globals)` keeps its Go signature but uses
+copy-in/copy-out semantics:
+
+1. If `globals` is non-nil, copy its bindings into a new child environment of
+   the root, even when the map is empty.
+2. Execute the script in that environment.
+3. Take a synchronized local snapshot on every return path, including runtime
+   error.
+4. Replace the caller map contents with that snapshot before returning.
+
+The caller must not mutate its map concurrently with the method call. Spawned
+work that outlives the call continues to use the internal environment; its
+later writes are not reflected into the caller map.
+
+`nil` remains the explicit request to execute directly in the root environment.
+A new `InterpretWithEnvironment` entry point supports callers that require a
+persistent synchronized environment rather than a synchronous map adapter.
+
+## 6. Concurrent module loading
+
+### 6.1 Cache identity and states
+
+The module cache key contains the canonical module root and resolved module
+name so VMs with different `RootPath` configurations cannot collide merely
+because they share a `SharedState`.
+
+Each entry has one of these states:
+
+```text
+loading -> ready
+        -> failed
+```
+
+A loading entry owns a completion channel. Cache locks protect entry and
+dependency-graph bookkeeping only; parsing, compilation, module execution, and
+waiting occur without the cache lock.
+
+### 6.2 Single initialization
+
+For a missing key, the first caller installs `loading` and initializes the
+module. Other callers obtain the same entry and wait on its completion channel.
+The module export object is published as `ready` only after parsing,
+compilation, and execution succeed.
+
+On failure, the entry records the error and closes its completion channel so
+all callers already attached to that attempt observe the same error. The cache
+then removes that failed entry; a later request may begin a new attempt.
+
+Partially initialized environments and exports are never published.
+
+### 6.3 Cycle detection
+
+Cycle detection covers both ordinary recursion and cycles split across
+concurrent loading attempts.
+
+Each active module load records directed dependency edges. Before a loading
+module waits for another loading module, the coordinator adds the proposed edge
+and checks whether it closes a cycle. If it would, no wait occurs and the
+runtime returns an import error containing the complete module chain.
+
+Dependency edges are removed when their load attempt completes. This avoids the
+cross-flight deadlock in which one goroutine loads `A -> B` while another loads
+`B -> A`.
+
+## 7. Shared resources
+
+### 7.1 Registry rules
+
+`SharedState` owns separate registries for:
+
+- files;
+- listeners and connections;
+- databases;
+- statements.
+
+Each registry has its own mutex and monotonic handle counter. Handles are not
+reused during the lifetime of a `SharedState`.
+
+A registry lock is used only to locate, insert, or remove an entry. It is never
+held during resource I/O, environment access, module execution, native code, or
+while another registry is locked.
+
+### 7.2 Resource entries
+
+Entries own their lifecycle and operation synchronization:
+
+```text
+FileResource
+  state mutex, operation mutex, file, closed
+
+ListenerResource
+  state mutex, accept mutex, listener, buffered accepted connection, closed
+
+SocketResource
+  state mutex, read mutex, write mutex, connection, buffered read data, closed
+
+DatabaseResource
+  state mutex, database, closed
+
+StatementResource
+  mutex, statement, pending parameters, closed
+```
+
+The temporary accept and read buffers used by the current `net_select` move
+into their corresponding listener or socket entry. A poll in one VM and an
+accept or receive in another therefore observe the same buffered state.
+
+SQLite statement parameters move into `StatementResource` and are protected by
+the statement mutex. Database and statement handles no longer rely on one
+coarse database lock during operations.
+
+### 7.3 Operation and close protocol
+
+An operation:
+
+1. obtains the entry pointer under the registry lock;
+2. releases the registry lock;
+3. checks and operates through the entry's locks;
+4. never reacquires a registry lock while holding an operation lock.
+
+Close:
+
+1. atomically removes the handle from its registry;
+2. marks the entry closed under its state lock;
+3. closes the underlying resource outside the registry lock;
+4. does not wait for a read or accept operation mutex before closing.
+
+Closing the underlying resource is allowed to interrupt pending operations.
+An operation that already holds the entry may finish or receive the underlying
+close error. A new operation observes an invalid handle. Repeated close calls
+retain each builtin's current public result behavior.
+
+Explicit builtin close remains the resource-lifetime mechanism. A VM does not
+automatically close shared resources when its own interpretation ends, because
+another VM may still use them.
+
+## 8. Invocation and error flow
+
+Native calls follow this sequence:
+
+```text
+OP_CALL
+  -> validate arity, type contract, and reference modes
+  -> shallow-copy ordinary parameters
+  -> ObjNative.Invoke(active VM, prepared arguments)
+  -> convert invocation error to runtimeError with source location
+  -> replace callee and arguments with the result
+```
+
+Expected operational failures such as a missing file or invalid socket retain
+their current Noxy result representation. The `error` result of a contextual
+handler is reserved for invocation failures that terminate the current Noxy
+execution.
+
+The foundation introduces ordinary VM errors, rather than panics, for:
+
+- a native with zero or two handlers;
+- absent or incompatible `NativeContext`;
+- a global reference without a valid owner environment;
+- an inconsistent module-cache entry;
+- an import cycle, including its dependency chain.
+
+Existing builtin-specific invalid/closed-handle results remain compatible.
+Unexpected Go panics continue to identify internal implementation defects and
+are not silently translated into operational results.
+
+## 9. Concurrency guarantees and limits
+
+This foundation guarantees:
+
+- synchronized access to global bindings, module exports, generic map storage,
+  resource registries, per-resource mutable state, and module-cache metadata;
+- no Go concurrent-map panic from the migrated storage;
+- consistent resource visibility between VMs sharing a `SharedState`;
+- exactly one successful initialization for a concurrently requested module
+  cache key;
+- no cache-lock retention while arbitrary Noxy or native code executes.
+
+It does not make compound language operations atomic. For example:
+
+```noxy
+counter = counter + 1
+```
+
+is still a read followed by a write. Concurrent mutation of arrays, structs,
+or a sequence of map operations still requires channels or another explicit
+coordination mechanism. Synchronizing a global binding does not recursively
+synchronize the object stored in that binding.
+
+## 10. Migration strategy
+
+The implementation proceeds in this order, with tests remaining buildable at
+each step and the whole subproject delivered as one consistent unit:
+
+1. Add the contextual ABI, constructors, `Invoke`, and legacy adapters.
+2. Route every native call and callability check through the new abstraction.
+3. Add synchronized map storage and `GlobalEnvironment`.
+4. Migrate frames, functions, closures, globals, references, and imports.
+5. Make module exports a live view and add coordinated module loading.
+6. Add shared resource entries and migrate file, network, and SQLite state.
+7. Convert every state-dependent builtin to a contextual handler.
+8. Remove obsolete local state, raw-map access, and direct handler calls.
+9. Update architecture, concurrency, compatibility, and language documentation.
+
+Although intermediate commits may introduce adapters, no stage is considered
+complete while contextual dispatch and shared resource ownership disagree.
+
+## 11. Testing strategy
+
+All production behavior is introduced test-first. Each regression test must be
+observed failing for the intended reason before its implementation is added.
+Concurrent tests use channels and barriers instead of timing sleeps.
+
+Required coverage includes:
+
+- legacy native invocation;
+- contextual native invocation with the active VM;
+- invalid zero-handler and dual-handler natives;
+- two shared VMs invoking the same native without context capture;
+- local-before-parent global resolution;
+- local assignment shadowing an inherited binding;
+- global references retaining their owner environment;
+- non-nil empty `InterpretWithGlobals` maps and copy-out on success and error;
+- live module exports after a module function updates a binding;
+- wildcard imports excluding inherited bindings;
+- one initialization under concurrent imports;
+- direct and cross-flight import cycles with the complete chain;
+- cross-VM file-handle use;
+- cross-VM visibility of network buffers;
+- concurrent close without panic or raw-map access;
+- synchronized SQLite statement parameters;
+- preservation of existing native Go API call sites;
+- preservation of existing Noxy builtin signatures and result shapes.
+
+Architecture tests prevent reintroduction of:
+
+- mutable raw `ObjMap` storage access;
+- global `map` fields in frames, functions, closures, or references;
+- VM-local file or network-buffer registries;
+- direct invocation of `ObjNative.Fn`;
+- registry locks held during blocking I/O or Noxy execution.
+
+## 12. Acceptance criteria
+
+The implementation is accepted only after fresh successful runs of:
+
+```powershell
+go test ./internal/...
+go test -race ./internal/vm
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+go build ./...
+go vet ./...
+```
+
+In addition:
+
+- no existing Noxy program requires a source change;
+- the existing Go native constructors and VM registration methods compile
+  unchanged;
+- the race-enabled tests cover the new concurrent paths;
+- the later `spawn` and network projects can build on these abstractions without
+  moving ownership again.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -189,7 +189,7 @@ func ValueToInterface(v value.Value) interface{} {
 			return arr
 		case *value.ObjMap:
 			m := make(map[string]interface{})
-			for k, val := range o.Data {
+			for k, val := range o.Snapshot() {
 				if keyStr, ok := k.(string); ok {
 					m[keyStr] = ValueToInterface(val)
 				} else {

--- a/internal/value/environment.go
+++ b/internal/value/environment.go
@@ -1,0 +1,73 @@
+package value
+
+type GlobalEnvironment struct {
+	local  *bindingStore
+	parent *GlobalEnvironment
+}
+
+func NewGlobalEnvironment(parent *GlobalEnvironment) *GlobalEnvironment {
+	return &GlobalEnvironment{local: newBindingStore(nil), parent: parent}
+}
+
+func NewGlobalEnvironmentFrom(values map[string]Value, parent *GlobalEnvironment) *GlobalEnvironment {
+	environment := NewGlobalEnvironment(parent)
+	for name, item := range values {
+		environment.SetLocal(name, item)
+	}
+	return environment
+}
+
+func (environment *GlobalEnvironment) GetLocal(name string) (Value, bool) {
+	if environment == nil {
+		return Value{}, false
+	}
+	return environment.local.get(name)
+}
+
+func (environment *GlobalEnvironment) Resolve(name string) (Value, bool) {
+	for current := environment; current != nil; current = current.parent {
+		if item, ok := current.GetLocal(name); ok {
+			return item, true
+		}
+	}
+	return Value{}, false
+}
+
+func (environment *GlobalEnvironment) SetLocal(name string, item Value) {
+	environment.local.set(name, item)
+}
+
+func (environment *GlobalEnvironment) DefineLocalIfAbsent(name string, item Value) bool {
+	return environment.local.defineIfAbsent(name, item)
+}
+
+func (environment *GlobalEnvironment) ResolveOwner(name string) (*GlobalEnvironment, bool) {
+	for current := environment; current != nil; current = current.parent {
+		if _, ok := current.GetLocal(name); ok {
+			return current, true
+		}
+	}
+	return nil, false
+}
+
+func (environment *GlobalEnvironment) LocalSnapshot() map[string]Value {
+	result := make(map[string]Value)
+	for key, item := range environment.local.snapshot() {
+		if name, ok := key.(string); ok {
+			result[name] = item
+		}
+	}
+	return result
+}
+
+func (environment *GlobalEnvironment) ReplaceLocal(values map[string]Value) {
+	replacement := make(map[interface{}]Value, len(values))
+	for name, item := range values {
+		replacement[name] = item
+	}
+	environment.local.replace(replacement)
+}
+
+func (environment *GlobalEnvironment) ExportMap() Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjMap{store: environment.local}}
+}

--- a/internal/value/environment_test.go
+++ b/internal/value/environment_test.go
@@ -1,0 +1,79 @@
+package value
+
+import "testing"
+
+func TestGlobalEnvironmentResolvesAndShadowsParent(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	root.SetLocal("value", NewInt(1))
+	child := NewGlobalEnvironment(root)
+	if got, _ := child.Resolve("value"); got.AsInt != 1 {
+		t.Fatalf("inherited value=%v", got)
+	}
+	owner, ok := child.ResolveOwner("value")
+	if !ok || owner != root {
+		t.Fatal("wrong inherited owner")
+	}
+	child.SetLocal("value", NewInt(2))
+	owner, _ = child.ResolveOwner("value")
+	if owner != child {
+		t.Fatal("shadow did not become local")
+	}
+}
+
+func TestGlobalEnvironmentExportsAreLiveAndLocalOnly(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	root.SetLocal("builtin", NewInt(1))
+	module := NewGlobalEnvironment(root)
+	module.SetLocal("answer", NewInt(41))
+	exports := module.ExportMap().Obj.(*ObjMap)
+	module.SetLocal("answer", NewInt(42))
+	if got, _ := exports.Get("answer"); got.AsInt != 42 {
+		t.Fatalf("live export=%v", got)
+	}
+	if _, inherited := exports.Get("builtin"); inherited {
+		t.Fatal("exports leaked parent binding")
+	}
+}
+
+func TestGlobalEnvironmentLocalOperationsAndSnapshots(t *testing.T) {
+	environment := NewGlobalEnvironmentFrom(map[string]Value{
+		"seed": NewInt(1),
+	}, nil)
+
+	if got, found := environment.GetLocal("seed"); !found || got.AsInt != 1 {
+		t.Fatalf("seed=(%v,%t)", got, found)
+	}
+	if environment.DefineLocalIfAbsent("seed", NewInt(2)) {
+		t.Fatal("existing local binding was redefined")
+	}
+	if !environment.DefineLocalIfAbsent("new", NewInt(3)) {
+		t.Fatal("missing local binding was not defined")
+	}
+
+	snapshot := environment.LocalSnapshot()
+	snapshot["seed"] = NewInt(0)
+	if got, _ := environment.GetLocal("seed"); got.AsInt != 1 {
+		t.Fatal("local snapshot mutated environment")
+	}
+
+	environment.ReplaceLocal(map[string]Value{"replacement": NewInt(4)})
+	if _, found := environment.GetLocal("seed"); found {
+		t.Fatal("replace retained old local binding")
+	}
+	if got, found := environment.GetLocal("replacement"); !found || got.AsInt != 4 {
+		t.Fatalf("replacement=(%v,%t)", got, found)
+	}
+}
+
+func TestGlobalEnvironmentNilDoesNotResolve(t *testing.T) {
+	var environment *GlobalEnvironment
+	if _, found := environment.GetLocal("missing"); found {
+		t.Fatal("nil environment resolved a local binding")
+	}
+	if _, found := environment.Resolve("missing"); found {
+		t.Fatal("nil environment resolved a binding")
+	}
+	if owner, found := environment.ResolveOwner("missing"); found || owner != nil {
+		t.Fatalf("nil resolve owner=(%v,%t)", owner, found)
+	}
+}

--- a/internal/value/map.go
+++ b/internal/value/map.go
@@ -1,0 +1,106 @@
+package value
+
+import "sync"
+
+type bindingStore struct {
+	mu     sync.RWMutex
+	values map[interface{}]Value
+}
+
+func newBindingStore(values map[interface{}]Value) *bindingStore {
+	if values == nil {
+		values = make(map[interface{}]Value)
+	}
+	return &bindingStore{values: values}
+}
+
+func (store *bindingStore) get(key interface{}) (Value, bool) {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	result, ok := store.values[key]
+	return result, ok
+}
+
+func (store *bindingStore) set(key interface{}, item Value) {
+	store.mu.Lock()
+	store.values[key] = item
+	store.mu.Unlock()
+}
+
+func (store *bindingStore) defineIfAbsent(key interface{}, item Value) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, exists := store.values[key]; exists {
+		return false
+	}
+	store.values[key] = item
+	return true
+}
+
+func (store *bindingStore) delete(key interface{}) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, exists := store.values[key]; !exists {
+		return false
+	}
+	delete(store.values, key)
+	return true
+}
+
+func (store *bindingStore) snapshot() map[interface{}]Value {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	result := make(map[interface{}]Value, len(store.values))
+	for key, item := range store.values {
+		result[key] = item
+	}
+	return result
+}
+
+func (store *bindingStore) replace(values map[interface{}]Value) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	replacement := make(map[interface{}]Value, len(values))
+	for key, item := range values {
+		replacement[key] = item
+	}
+	for key := range store.values {
+		delete(store.values, key)
+	}
+	for key, item := range replacement {
+		store.values[key] = item
+	}
+}
+
+func (mapping *ObjMap) ensureStore() *bindingStore {
+	mapping.storeOnce.Do(func() {
+		mapping.store = newBindingStore(mapping.Data)
+		mapping.Data = mapping.store.values
+	})
+	return mapping.store
+}
+
+func (mapping *ObjMap) Get(key interface{}) (Value, bool) {
+	return mapping.ensureStore().get(key)
+}
+
+func (mapping *ObjMap) Set(key interface{}, item Value) {
+	mapping.ensureStore().set(key, item)
+}
+
+func (mapping *ObjMap) Delete(key interface{}) bool {
+	return mapping.ensureStore().delete(key)
+}
+
+func (mapping *ObjMap) Len() int {
+	return len(mapping.Snapshot())
+}
+
+func (mapping *ObjMap) Snapshot() map[interface{}]Value {
+	return mapping.ensureStore().snapshot()
+}
+
+func (mapping *ObjMap) Replace(values map[interface{}]Value) {
+	mapping.ensureStore().replace(values)
+}

--- a/internal/value/map.go
+++ b/internal/value/map.go
@@ -75,8 +75,9 @@ func (store *bindingStore) replace(values map[interface{}]Value) {
 
 func (mapping *ObjMap) ensureStore() *bindingStore {
 	mapping.storeOnce.Do(func() {
-		mapping.store = newBindingStore(mapping.Data)
-		mapping.Data = mapping.store.values
+		if mapping.store == nil {
+			mapping.store = newBindingStore(nil)
+		}
 	})
 	return mapping.store
 }

--- a/internal/value/map_test.go
+++ b/internal/value/map_test.go
@@ -1,0 +1,78 @@
+package value
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestObjMapOperationsUseSnapshots(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	mapping.Set("answer", NewInt(42))
+	if got, ok := mapping.Get("answer"); !ok || got.AsInt != 42 {
+		t.Fatalf("answer=(%v,%t)", got, ok)
+	}
+
+	snapshot := mapping.Snapshot()
+	snapshot["answer"] = NewInt(0)
+	got, _ := mapping.Get("answer")
+	if got.AsInt != 42 {
+		t.Fatal("snapshot mutated live map")
+	}
+
+	if !mapping.Delete("answer") || mapping.Len() != 0 {
+		t.Fatal("delete did not remove key")
+	}
+}
+
+func TestObjMapReplaceKeepsDataAliasCurrent(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	data := mapping.Data
+	mapping.Set("old", NewInt(1))
+	mapping.Replace(map[interface{}]Value{"new": NewInt(2)})
+
+	if mapping.Data == nil || len(data) != 1 {
+		t.Fatal("replace did not preserve the legacy data map")
+	}
+	if _, found := data["old"]; found {
+		t.Fatal("replace did not clear legacy data")
+	}
+	if got, found := data["new"]; !found || got.AsInt != 2 {
+		t.Fatalf("legacy data new=(%v,%t)", got, found)
+	}
+}
+
+func TestObjMapReplaceAcceptsItsDataAlias(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	mapping.Set("answer", NewInt(42))
+
+	mapping.Replace(mapping.Data)
+
+	if got, found := mapping.Get("answer"); !found || got.AsInt != 42 {
+		t.Fatalf("answer=(%v,%t)", got, found)
+	}
+}
+
+func TestObjMapConcurrentSetAndSnapshot(t *testing.T) {
+	mapping := NewMap().Obj.(*ObjMap)
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		workers.Add(2)
+		go func(id int) {
+			defer workers.Done()
+			<-start
+			for n := 0; n < 100; n++ {
+				mapping.Set(int64(id*100+n), NewInt(int64(n)))
+			}
+		}(i)
+		go func() {
+			defer workers.Done()
+			<-start
+			for n := 0; n < 100; n++ {
+				_ = mapping.Snapshot()
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+}

--- a/internal/value/map_test.go
+++ b/internal/value/map_test.go
@@ -5,6 +5,38 @@ import (
 	"testing"
 )
 
+func TestObjMapZeroValueSupportsPublicOperations(t *testing.T) {
+	mapping := &ObjMap{}
+	if _, found := mapping.Get("missing"); found {
+		t.Fatal("zero-value map unexpectedly contains missing key")
+	}
+
+	mapping.Set("answer", NewInt(42))
+	snapshot := mapping.Snapshot()
+	if got, found := snapshot["answer"]; !found || got.AsInt != 42 {
+		t.Fatalf("snapshot answer=(%v,%t)", got, found)
+	}
+	if got := mapping.String(); got != "{answer: 42}" {
+		t.Fatalf("String()=%q", got)
+	}
+}
+
+func TestObjMapPreservesInjectedBindingStore(t *testing.T) {
+	injected := newBindingStore(map[interface{}]Value{"seed": NewInt(7)})
+	mapping := &ObjMap{store: injected}
+
+	if got := mapping.ensureStore(); got != injected {
+		t.Fatal("ensureStore replaced injected store")
+	}
+	if got, found := mapping.Get("seed"); !found || got.AsInt != 7 {
+		t.Fatalf("seed=(%v,%t)", got, found)
+	}
+	mapping.Set("added", NewInt(9))
+	if got, found := injected.get("added"); !found || got.AsInt != 9 {
+		t.Fatalf("injected added=(%v,%t)", got, found)
+	}
+}
+
 func TestObjMapOperationsUseSnapshots(t *testing.T) {
 	mapping := NewMap().Obj.(*ObjMap)
 	mapping.Set("answer", NewInt(42))

--- a/internal/value/map_test.go
+++ b/internal/value/map_test.go
@@ -24,28 +24,27 @@ func TestObjMapOperationsUseSnapshots(t *testing.T) {
 	}
 }
 
-func TestObjMapReplaceKeepsDataAliasCurrent(t *testing.T) {
+func TestObjMapReplaceReplacesLiveValues(t *testing.T) {
 	mapping := NewMap().Obj.(*ObjMap)
-	data := mapping.Data
 	mapping.Set("old", NewInt(1))
 	mapping.Replace(map[interface{}]Value{"new": NewInt(2)})
 
-	if mapping.Data == nil || len(data) != 1 {
-		t.Fatal("replace did not preserve the legacy data map")
+	if mapping.Len() != 1 {
+		t.Fatal("replace did not replace values")
 	}
-	if _, found := data["old"]; found {
-		t.Fatal("replace did not clear legacy data")
+	if _, found := mapping.Get("old"); found {
+		t.Fatal("replace did not clear old value")
 	}
-	if got, found := data["new"]; !found || got.AsInt != 2 {
-		t.Fatalf("legacy data new=(%v,%t)", got, found)
+	if got, found := mapping.Get("new"); !found || got.AsInt != 2 {
+		t.Fatalf("new=(%v,%t)", got, found)
 	}
 }
 
-func TestObjMapReplaceAcceptsItsDataAlias(t *testing.T) {
+func TestObjMapReplaceAcceptsSnapshot(t *testing.T) {
 	mapping := NewMap().Obj.(*ObjMap)
 	mapping.Set("answer", NewInt(42))
 
-	mapping.Replace(mapping.Data)
+	mapping.Replace(mapping.Snapshot())
 
 	if got, found := mapping.Get("answer"); !found || got.AsInt != 42 {
 		t.Fatalf("answer=(%v,%t)", got, found)

--- a/internal/value/native.go
+++ b/internal/value/native.go
@@ -1,0 +1,53 @@
+package value
+
+import "fmt"
+
+type NativeContext interface {
+	IsNativeContext()
+}
+
+type NativeFunc func(args []Value) Value
+type ContextualNativeFunc func(context NativeContext, args []Value) (Value, error)
+
+type ObjNative struct {
+	Name       string
+	Fn         NativeFunc
+	Contextual ContextualNativeFunc
+	Signature  *NativeSignature
+}
+
+func (native *ObjNative) IsCallable() bool {
+	return native != nil && (native.Fn == nil) != (native.Contextual == nil)
+}
+
+func (native *ObjNative) Invoke(context NativeContext, args []Value) (Value, error) {
+	if native == nil {
+		return NewNull(), fmt.Errorf("invalid native function")
+	}
+	if !native.IsCallable() {
+		return NewNull(), fmt.Errorf("native '%s' must define exactly one handler", native.Name)
+	}
+	if native.Contextual != nil {
+		if context == nil {
+			return NewNull(), fmt.Errorf("native '%s' requires a runtime context", native.Name)
+		}
+		return native.Contextual(context, args)
+	}
+	return native.Fn(args), nil
+}
+
+func NewNative(name string, fn NativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Fn: fn}}
+}
+
+func NewNativeWithSignature(name string, signature NativeSignature, fn NativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Fn: fn, Signature: &signature}}
+}
+
+func NewContextualNative(name string, fn ContextualNativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Contextual: fn}}
+}
+
+func NewContextualNativeWithSignature(name string, signature NativeSignature, fn ContextualNativeFunc) Value {
+	return Value{Type: VAL_NATIVE, Obj: &ObjNative{Name: name, Contextual: fn, Signature: &signature}}
+}

--- a/internal/value/native_test.go
+++ b/internal/value/native_test.go
@@ -1,0 +1,46 @@
+package value
+
+import (
+	"errors"
+	"testing"
+)
+
+type testNativeContext struct{}
+
+func (*testNativeContext) IsNativeContext() {}
+
+func TestObjNativeInvokeSupportsLegacyAndContextualHandlers(t *testing.T) {
+	ctx := &testNativeContext{}
+	legacy := NewNative("legacy", func(args []Value) Value { return args[0] })
+	got, err := legacy.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(7)})
+	if err != nil || got.AsInt != 7 {
+		t.Fatalf("legacy invoke=(%v, %v), want (7, nil)", got, err)
+	}
+
+	contextual := NewContextualNative("contextual", func(actual NativeContext, args []Value) (Value, error) {
+		if actual != ctx {
+			return NewNull(), errors.New("wrong context")
+		}
+		return args[0], nil
+	})
+	got, err = contextual.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(9)})
+	if err != nil || got.AsInt != 9 {
+		t.Fatalf("contextual invoke=(%v, %v), want (9, nil)", got, err)
+	}
+}
+
+func TestObjNativeInvokeRejectsInvalidHandlerConfigurations(t *testing.T) {
+	ctx := &testNativeContext{}
+	tests := []*ObjNative{
+		{Name: "missing"},
+		{Name: "both", Fn: func([]Value) Value { return NewNull() }, Contextual: func(NativeContext, []Value) (Value, error) { return NewNull(), nil }},
+	}
+	for _, native := range tests {
+		if native.IsCallable() {
+			t.Fatalf("%s unexpectedly callable", native.Name)
+		}
+		if _, err := native.Invoke(ctx, nil); err == nil {
+			t.Fatalf("%s invoke succeeded", native.Name)
+		}
+	}
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -137,7 +137,7 @@ type ObjFunction struct {
 	UpvalueCount int // Added for Closures
 	Params       []ParamInfo
 	Chunk        interface{}
-	Globals      map[string]Value // Module/Context globals
+	Environment  *GlobalEnvironment
 	RuntimeType  *RuntimeTypeInfo
 }
 
@@ -148,9 +148,9 @@ type ObjUpvalue struct {
 }
 
 type ObjClosure struct {
-	Function *ObjFunction
-	Upvalues []*ObjUpvalue
-	Globals  map[string]Value // Context globals
+	Function    *ObjFunction
+	Upvalues    []*ObjUpvalue
+	Environment *GlobalEnvironment
 }
 
 func (oc *ObjClosure) String() string {
@@ -329,7 +329,7 @@ type ObjRef struct {
 	JSONDynamic atomic.Bool // Declared any target: JSON may replace its concrete runtime type.
 	TargetType  atomic.Pointer[RuntimeTypeInfo]
 	Name        string // For Global or Property Name
-	GlobalOwner *map[string]Value
+	GlobalOwner *GlobalEnvironment
 	Ptr         *Value      // For Local (unsafe if escapes)
 	Upvalue     *ObjUpvalue // For Local (safe, captured)
 	Container   Value       // For Property/Index (Object, Array, Map)
@@ -479,17 +479,17 @@ func NewInstance(def *ObjStruct) Value {
 	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
 }
 
-func NewFunction(name string, arity int, upvalueCount int, params []ParamInfo, chunk interface{}, globals map[string]Value) Value {
+func NewFunction(name string, arity int, upvalueCount int, params []ParamInfo, chunk interface{}, environment *GlobalEnvironment) Value {
 	return Value{
 		Type: VAL_FUNCTION,
-		Obj:  &ObjFunction{Name: name, Arity: arity, UpvalueCount: upvalueCount, Params: params, Chunk: chunk, Globals: globals},
+		Obj:  &ObjFunction{Name: name, Arity: arity, UpvalueCount: upvalueCount, Params: params, Chunk: chunk, Environment: environment},
 	}
 }
 
 func NewClosure(fn *ObjFunction) Value {
 	return Value{
 		Type: VAL_FUNCTION, // Reuse VAL_FUNCTION to mean "Callable" (VM will assume ObjClosure or handle translation?)
-		Obj:  &ObjClosure{Function: fn, Upvalues: make([]*ObjUpvalue, fn.UpvalueCount)},
+		Obj:  &ObjClosure{Function: fn, Upvalues: make([]*ObjUpvalue, fn.UpvalueCount), Environment: fn.Environment},
 	}
 }
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -201,6 +201,8 @@ func (oa *ObjArray) Format(f fmt.State, verb rune) {
 
 type ObjMap struct {
 	Data        map[interface{}]Value
+	store       *bindingStore
+	storeOnce   sync.Once
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
 }
 
@@ -454,7 +456,8 @@ func NewArray(elements []Value) Value {
 }
 
 func NewMap() Value {
-	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: make(map[interface{}]Value)}}
+	data := make(map[interface{}]Value)
+	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: data, store: newBindingStore(data)}}
 }
 
 func NewMapWithData(data map[string]Value) Value {
@@ -462,7 +465,7 @@ func NewMapWithData(data map[string]Value) Value {
 	for k, v := range data {
 		m[k] = v
 	}
-	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: m}}
+	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: m, store: newBindingStore(m)}}
 }
 
 func NewStruct(name string, fields []string) Value {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -200,7 +200,6 @@ func (oa *ObjArray) Format(f fmt.State, verb rune) {
 }
 
 type ObjMap struct {
-	Data        map[interface{}]Value
 	store       *bindingStore
 	storeOnce   sync.Once
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
@@ -209,9 +208,10 @@ type ObjMap struct {
 func (om *ObjMap) String() string {
 	s := "{"
 	i := 0
-	for k, v := range om.Data {
+	values := om.Snapshot()
+	for k, v := range values {
 		s += fmt.Sprintf("%v: %s", k, v.String())
-		if i < len(om.Data)-1 {
+		if i < len(values)-1 {
 			s += ", "
 		}
 		i++
@@ -456,16 +456,19 @@ func NewArray(elements []Value) Value {
 }
 
 func NewMap() Value {
-	data := make(map[interface{}]Value)
-	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: data, store: newBindingStore(data)}}
+	mapping := &ObjMap{store: newBindingStore(nil)}
+	mapping.ensureStore()
+	return Value{Type: VAL_OBJ, Obj: mapping}
 }
 
 func NewMapWithData(data map[string]Value) Value {
-	m := make(map[interface{}]Value)
+	values := make(map[interface{}]Value, len(data))
 	for k, v := range data {
-		m[k] = v
+		values[k] = v
 	}
-	return Value{Type: VAL_OBJ, Obj: &ObjMap{Data: m, store: newBindingStore(m)}}
+	mapping := NewMap()
+	mapping.Obj.(*ObjMap).Replace(values)
+	return mapping
 }
 
 func NewStruct(name string, fields []string) Value {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -161,14 +161,6 @@ func (oc *ObjClosure) Format(f fmt.State, verb rune) {
 	fmt.Fprint(f, oc.String())
 }
 
-type NativeFunc func(args []Value) Value
-
-type ObjNative struct {
-	Name      string
-	Fn        NativeFunc
-	Signature *NativeSignature
-}
-
 type ObjArray struct {
 	Elements    []Value
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
@@ -492,20 +484,6 @@ func NewClosure(fn *ObjFunction) Value {
 	return Value{
 		Type: VAL_FUNCTION, // Reuse VAL_FUNCTION to mean "Callable" (VM will assume ObjClosure or handle translation?)
 		Obj:  &ObjClosure{Function: fn, Upvalues: make([]*ObjUpvalue, fn.UpvalueCount)},
-	}
-}
-
-func NewNative(name string, fn NativeFunc) Value {
-	return Value{
-		Type: VAL_NATIVE,
-		Obj:  &ObjNative{Name: name, Fn: fn, Signature: nil},
-	}
-}
-
-func NewNativeWithSignature(name string, signature NativeSignature, fn NativeFunc) Value {
-	return Value{
-		Type: VAL_NATIVE,
-		Obj:  &ObjNative{Name: name, Fn: fn, Signature: &signature},
 	}
 }
 

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -183,6 +184,7 @@ func TestRuntimeOwnershipDoesNotUseRawGlobalMaps(t *testing.T) {
 }
 
 func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {
+	directDataSelector := regexp.MustCompile(`\.Data\b`)
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatal(err)
@@ -195,8 +197,26 @@ func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if bytes.Contains(source, []byte(".Dat"+"a")) {
+		if directDataSelector.Match(source) {
 			t.Errorf("%s accesses ObjMap.Dat"+"a directly", file)
+		}
+	}
+}
+
+func TestDirectDataSelectorPatternUsesWordBoundary(t *testing.T) {
+	pattern := regexp.MustCompile(`\.Data\b`)
+	tests := []struct {
+		source string
+		match  bool
+	}{
+		{source: "mapping.Data", match: true},
+		{source: "mapping.Data[key]", match: true},
+		{source: "shared.Databases", match: false},
+		{source: "item.Dataset", match: false},
+	}
+	for _, test := range tests {
+		if got := pattern.MatchString(test.source); got != test.match {
+			t.Errorf("pattern match for %q = %t, want %t", test.source, got, test.match)
 		}
 	}
 }

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -6,8 +6,25 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"noxy-vm/internal/value"
 )
+
+func setTestMap(mapping *value.ObjMap, key interface{}, item value.Value) {
+	mapping.Set(key, item)
+}
+
+func requireTestMapValue(t *testing.T, mapping *value.ObjMap, key interface{}) value.Value {
+	t.Helper()
+	item, ok := mapping.Get(key)
+	if !ok {
+		t.Fatalf("map is missing key %v", key)
+	}
+	return item
+}
 
 func requireSourceFunctions(t *testing.T, filename string, names ...string) {
 	t.Helper()
@@ -115,4 +132,23 @@ func TestExecutorSourceLayout(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") || file == "architecture_test.go" {
+			continue
+		}
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(source, []byte(".Dat"+"a")) {
+			t.Errorf("%s accesses ObjMap.Dat"+"a directly", file)
+		}
+	}
 }

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -183,40 +183,327 @@ func TestRuntimeOwnershipDoesNotUseRawGlobalMaps(t *testing.T) {
 	}
 }
 
-func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {
-	directDataSelector := regexp.MustCompile(`\.Data\b`)
-	files, err := filepath.Glob("*.go")
+func productionGoFiles(t *testing.T) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir("..", func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, file := range files {
-		if strings.HasSuffix(file, "_test.go") || file == "architecture_test.go" {
+	return files
+}
+
+func expressionText(t *testing.T, expression ast.Expr) string {
+	t.Helper()
+	var text strings.Builder
+	if err := printer.Fprint(&text, token.NewFileSet(), expression); err != nil {
+		t.Fatal(err)
+	}
+	return text.String()
+}
+
+func sourceStructFields(t *testing.T, filename, structName string) map[string]string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+	fields := make(map[string]string)
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok {
 			continue
 		}
-		source, err := os.ReadFile(file)
+		for _, specification := range general.Specs {
+			typeSpec, ok := specification.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != structName {
+				continue
+			}
+			structure, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				t.Fatalf("%s.%s is not a struct", filename, structName)
+			}
+			for _, field := range structure.Fields.List {
+				for _, name := range field.Names {
+					fields[name.Name] = expressionText(t, field.Type)
+				}
+			}
+		}
+	}
+	if len(fields) == 0 {
+		t.Fatalf("%s does not declare struct %s", filename, structName)
+	}
+	return fields
+}
+
+func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte) []string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filename, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+	found := make(map[string]bool)
+	for _, declaration := range file.Decls {
+		if general, ok := declaration.(*ast.GenDecl); ok {
+			for _, specification := range general.Specs {
+				typeSpec, ok := specification.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				structure, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range structure.Fields.List {
+					_, rawMap := field.Type.(*ast.MapType)
+					pointer, pointerType := field.Type.(*ast.StarExpr)
+					rawMapPointer := false
+					if pointerType {
+						_, rawMapPointer = pointer.X.(*ast.MapType)
+					}
+					for _, name := range field.Names {
+						switch {
+						case typeSpec.Name.Name == "VM" && name.Name == "openFiles":
+							found["VM.openFiles field"] = true
+						case typeSpec.Name.Name == "VM" && name.Name == "netBufferedData":
+							found["VM.netBufferedData field"] = true
+						case typeSpec.Name.Name == "VM" && name.Name == "netBufferedConns":
+							found["VM.netBufferedConns field"] = true
+						case name.Name == "Globals" && rawMap:
+							found["Globals raw map field"] = true
+						case name.Name == "GlobalOwner" && pointerType && rawMapPointer:
+							found["GlobalOwner raw map pointer field"] = true
+						case name.Name == "DbHandles" && rawMap:
+							found["DbHandles raw map field"] = true
+						case name.Name == "StmtHandles" && rawMap:
+							found["StmtHandles raw map field"] = true
+						case name.Name == "StmtParams" && rawMap:
+							found["StmtParams raw map field"] = true
+						}
+					}
+				}
+			}
+		}
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		allowedLegacyDispatch := function.Name.Name == "Invoke" && function.Recv != nil && expressionText(t, function.Recv.List[0].Type) == "*ObjNative"
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.SelectorExpr:
+				if typed.Sel.Name == "Data" {
+					found["ObjMap.Data selector"] = true
+				}
+			case *ast.CallExpr:
+				selector, ok := typed.Fun.(*ast.SelectorExpr)
+				if ok && selector.Sel.Name == "Fn" && !allowedLegacyDispatch {
+					found["direct native.Fn invocation"] = true
+				}
+			}
+			return true
+		})
+	}
+	order := []string{
+		"ObjMap.Data selector",
+		"VM.openFiles field",
+		"VM.netBufferedData field",
+		"VM.netBufferedConns field",
+		"direct native.Fn invocation",
+		"Globals raw map field",
+		"GlobalOwner raw map pointer field",
+		"DbHandles raw map field",
+		"StmtHandles raw map field",
+		"StmtParams raw map field",
+	}
+	var matches []string
+	for _, issue := range order {
+		if found[issue] {
+			matches = append(matches, issue)
+		}
+	}
+	return matches
+}
+
+func TestRuntimeFoundationExcludesObsoleteProductionStructures(t *testing.T) {
+	for _, filename := range productionGoFiles(t) {
+		source, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if directDataSelector.Match(source) {
-			t.Errorf("%s accesses ObjMap.Dat"+"a directly", file)
+		for _, issue := range runtimeForbiddenSourceMatches(t, filename, source) {
+			t.Errorf("%s: %s", filename, issue)
 		}
 	}
 }
 
-func TestDirectDataSelectorPatternUsesWordBoundary(t *testing.T) {
-	pattern := regexp.MustCompile(`\.Data\b`)
+func TestRuntimeFoundationRequiresContextAndEnvironmentOwnership(t *testing.T) {
+	callFrame := sourceStructFields(t, "vm.go", "CallFrame")
+	if got := callFrame["Environment"]; got != "*value.GlobalEnvironment" {
+		t.Errorf("CallFrame.Environment=%q", got)
+	}
+	for _, structName := range []string{"ObjFunction", "ObjClosure"} {
+		fields := sourceStructFields(t, filepath.Join("..", "value", "value.go"), structName)
+		if got := fields["Environment"]; got != "*GlobalEnvironment" {
+			t.Errorf("%s.Environment=%q", structName, got)
+		}
+	}
+	reference := sourceStructFields(t, filepath.Join("..", "value", "value.go"), "ObjRef")
+	if got := reference["GlobalOwner"]; got != "*GlobalEnvironment" {
+		t.Errorf("ObjRef.GlobalOwner=%q", got)
+	}
+
+	calls, err := os.ReadFile("calls.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := parser.ParseFile(token.NewFileSet(), "calls.go", calls, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundInvoke := false
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		receiver, receiverOK := selector.X.(*ast.Ident)
+		activeContext, contextOK := call.Args[0].(*ast.Ident)
+		if receiverOK && contextOK && selector.Sel.Name == "Invoke" && receiver.Name == "native" && activeContext.Name == "vm" {
+			foundInvoke = true
+		}
+		return true
+	})
+	if !foundInvoke {
+		t.Error("calls.go does not dispatch natives through Invoke")
+	}
+}
+
+func TestResourceRegistriesAndModuleCacheHaveSharedOwners(t *testing.T) {
+	shared := sourceStructFields(t, "vm.go", "SharedState")
+	wantRegistries := map[string]string{
+		"Files":      "*handleRegistry[*FileResource]",
+		"Listeners":  "*handleRegistry[*ListenerResource]",
+		"Sockets":    "*handleRegistry[*SocketResource]",
+		"Databases":  "*handleRegistry[*DatabaseResource]",
+		"Statements": "*handleRegistry[*StatementResource]",
+	}
+	for name, want := range wantRegistries {
+		if got := shared[name]; got != want {
+			t.Errorf("SharedState.%s=%q want %q", name, got, want)
+		}
+	}
+	if got := shared["Modules"]; got != "*moduleCache" {
+		t.Errorf("SharedState.Modules=%q", got)
+	}
+
+	for _, filename := range productionGoFiles(t) {
+		if filepath.Dir(filename) != "." && filepath.Clean(filepath.Dir(filename)) != filepath.Clean("../vm") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, declaration := range file.Decls {
+			general, ok := declaration.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, specification := range general.Specs {
+				typeSpec, ok := specification.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if typeSpec.Name.Name == "moduleCache" && filepath.Base(filename) != "module_cache.go" {
+					t.Errorf("moduleCache declared outside module_cache.go: %s", filename)
+				}
+				structure, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range structure.Fields.List {
+					if strings.Contains(expressionText(t, field.Type), "handleRegistry[") && typeSpec.Name.Name != "SharedState" {
+						t.Errorf("resource registry declared on %s in %s", typeSpec.Name.Name, filename)
+					}
+				}
+			}
+		}
+	}
+	requireSourceFunctions(t, "module_cache.go", "newModuleCache")
+}
+
+func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {
 	tests := []struct {
-		source string
-		match  bool
+		name     string
+		filename string
+		source   string
+		want     []string
 	}{
-		{source: "mapping.Data", match: true},
-		{source: "mapping.Data[key]", match: true},
-		{source: "shared.Databases", match: false},
-		{source: "item.Dataset", match: false},
+		{
+			name:     "forbidden selectors and VM fields",
+			filename: "runtime.go",
+			source: `package vm
+				type VM struct {
+					openFiles map[int]int
+					netBufferedData map[int][]byte
+					netBufferedConns map[int]int
+				}
+				func use(mapping *holder, native *callable, args []int) {
+					_ = mapping.Data
+					_ = native.Fn(args)
+				}`,
+			want: []string{"ObjMap.Data selector", "VM.openFiles field", "VM.netBufferedData field", "VM.netBufferedConns field", "direct native.Fn invocation"},
+		},
+		{
+			name:     "forbidden raw ownership fields",
+			filename: "ownership.go",
+			source: `package vm
+				type owner struct {
+					Globals map[string]int
+					GlobalOwner *map[string]int
+					DbHandles map[int]int
+					StmtHandles map[int]int
+					StmtParams map[int]map[int]int
+				}`,
+			want: []string{"Globals raw map field", "GlobalOwner raw map pointer field", "DbHandles raw map field", "StmtHandles raw map field", "StmtParams raw map field"},
+		},
+		{
+			name:     "comments strings and longer names are allowed",
+			filename: "allowed.go",
+			source: `package vm
+				var assertion = "openFiles netBufferedData DbHandles native.Fn(args) .Data"
+				// Globals map[string]int; GlobalOwner *map[string]int
+				type SharedState struct { Databases int }
+				func use(item *holder) { _ = item.Dataset }`,
+		},
+		{
+			name:     "legacy dispatch is allowed only inside Invoke",
+			filename: "native.go",
+			source: `package value
+				type ObjNative struct { Fn func([]int) int }
+				func (native *ObjNative) Invoke(args []int) int { return native.Fn(args) }`,
+		},
 	}
 	for _, test := range tests {
-		if got := pattern.MatchString(test.source); got != test.match {
-			t.Errorf("pattern match for %q = %t, want %t", test.source, got, test.match)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			got := runtimeForbiddenSourceMatches(t, test.filename, []byte(test.source))
+			if strings.Join(got, "|") != strings.Join(test.want, "|") {
+				t.Fatalf("matches=%v want=%v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -245,6 +245,85 @@ func sourceStructFields(t *testing.T, filename, structName string) map[string]st
 	return fields
 }
 
+func runtimeTargetTypeName(expression ast.Expr, aliases map[string]string) string {
+	var name string
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		name = typed.Name
+	case *ast.SelectorExpr:
+		name = typed.Sel.Name
+	case *ast.StarExpr:
+		return runtimeTargetTypeName(typed.X, aliases)
+	case *ast.ParenExpr:
+		return runtimeTargetTypeName(typed.X, aliases)
+	}
+	for name != "" {
+		if name == "ObjMap" || name == "ObjNative" {
+			return name
+		}
+		next, ok := aliases[name]
+		if !ok || next == name {
+			break
+		}
+		name = next
+	}
+	return ""
+}
+
+func runtimeValueTargetType(expression ast.Expr, variables, aliases map[string]string) string {
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		return variables[typed.Name]
+	case *ast.ParenExpr:
+		return runtimeValueTargetType(typed.X, variables, aliases)
+	case *ast.UnaryExpr:
+		return runtimeValueTargetType(typed.X, variables, aliases)
+	case *ast.TypeAssertExpr:
+		return runtimeTargetTypeName(typed.Type, aliases)
+	case *ast.CallExpr:
+		return runtimeTargetTypeName(typed.Fun, aliases)
+	}
+	return ""
+}
+
+func recordRuntimeVariableField(field *ast.Field, variables, aliases map[string]string) {
+	target := runtimeTargetTypeName(field.Type, aliases)
+	if target == "" {
+		return
+	}
+	for _, name := range field.Names {
+		variables[name.Name] = target
+	}
+}
+
+func recordRuntimeVariableSpec(specification *ast.ValueSpec, variables, aliases map[string]string) {
+	target := runtimeTargetTypeName(specification.Type, aliases)
+	for index, name := range specification.Names {
+		actual := target
+		if actual == "" && index < len(specification.Values) {
+			actual = runtimeValueTargetType(specification.Values[index], variables, aliases)
+		}
+		if actual != "" {
+			variables[name.Name] = actual
+		}
+	}
+}
+
+func recordRuntimeAssignment(assignment *ast.AssignStmt, variables, aliases map[string]string) {
+	if len(assignment.Lhs) != len(assignment.Rhs) {
+		return
+	}
+	for index, left := range assignment.Lhs {
+		name, ok := left.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if target := runtimeValueTargetType(assignment.Rhs[index], variables, aliases); target != "" {
+			variables[name.Name] = target
+		}
+	}
+}
+
 func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte) []string {
 	t.Helper()
 	file, err := parser.ParseFile(token.NewFileSet(), filename, source, 0)
@@ -252,6 +331,34 @@ func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte)
 		t.Fatalf("parse %s: %v", filename, err)
 	}
 	found := make(map[string]bool)
+	aliases := make(map[string]string)
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, specification := range general.Specs {
+			typeSpec, ok := specification.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if target := runtimeTargetTypeName(typeSpec.Type, aliases); target != "" {
+				aliases[typeSpec.Name.Name] = target
+			}
+		}
+	}
+	globalVariables := make(map[string]string)
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.VAR {
+			continue
+		}
+		for _, specification := range general.Specs {
+			if valueSpec, ok := specification.(*ast.ValueSpec); ok {
+				recordRuntimeVariableSpec(valueSpec, globalVariables, aliases)
+			}
+		}
+	}
 	for _, declaration := range file.Decls {
 		if general, ok := declaration.(*ast.GenDecl); ok {
 			for _, specification := range general.Specs {
@@ -298,15 +405,40 @@ func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte)
 			continue
 		}
 		allowedLegacyDispatch := function.Name.Name == "Invoke" && function.Recv != nil && expressionText(t, function.Recv.List[0].Type) == "*ObjNative"
+		variables := make(map[string]string, len(globalVariables))
+		for name, target := range globalVariables {
+			variables[name] = target
+		}
+		if function.Recv != nil {
+			for _, field := range function.Recv.List {
+				recordRuntimeVariableField(field, variables, aliases)
+			}
+		}
+		if function.Type.Params != nil {
+			for _, field := range function.Type.Params.List {
+				recordRuntimeVariableField(field, variables, aliases)
+			}
+		}
 		ast.Inspect(function.Body, func(node ast.Node) bool {
 			switch typed := node.(type) {
+			case *ast.AssignStmt:
+				recordRuntimeAssignment(typed, variables, aliases)
+			case *ast.DeclStmt:
+				general, ok := typed.Decl.(*ast.GenDecl)
+				if ok && general.Tok == token.VAR {
+					for _, specification := range general.Specs {
+						if valueSpec, ok := specification.(*ast.ValueSpec); ok {
+							recordRuntimeVariableSpec(valueSpec, variables, aliases)
+						}
+					}
+				}
 			case *ast.SelectorExpr:
-				if typed.Sel.Name == "Data" {
+				if typed.Sel.Name == "Data" && runtimeValueTargetType(typed.X, variables, aliases) == "ObjMap" {
 					found["ObjMap.Data selector"] = true
 				}
 			case *ast.CallExpr:
 				selector, ok := typed.Fun.(*ast.SelectorExpr)
-				if ok && selector.Sel.Name == "Fn" && !allowedLegacyDispatch {
+				if ok && selector.Sel.Name == "Fn" && !allowedLegacyDispatch && runtimeValueTargetType(selector.X, variables, aliases) == "ObjNative" {
 					found["direct native.Fn invocation"] = true
 				}
 			}
@@ -457,14 +589,20 @@ func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {
 			name:     "forbidden selectors and VM fields",
 			filename: "runtime.go",
 			source: `package vm
+				type ObjMap struct { Data map[string]int }
+				type ObjNative struct { Fn func([]int) int }
+				type MapAlias = ObjMap
+				type NativeAlias = ObjNative
 				type VM struct {
 					openFiles map[int]int
 					netBufferedData map[int][]byte
 					netBufferedConns map[int]int
 				}
-				func use(mapping *holder, native *callable, args []int) {
-					_ = mapping.Data
-					_ = native.Fn(args)
+				func use(mapping *MapAlias, native *NativeAlias, args []int) {
+					mappingAlias := mapping
+					nativeAlias := native
+					_ = mappingAlias.Data
+					_ = nativeAlias.Fn(args)
 				}`,
 			want: []string{"ObjMap.Data selector", "VM.openFiles field", "VM.netBufferedData field", "VM.netBufferedConns field", "direct native.Fn invocation"},
 		},
@@ -482,13 +620,21 @@ func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {
 			want: []string{"Globals raw map field", "GlobalOwner raw map pointer field", "DbHandles raw map field", "StmtHandles raw map field", "StmtParams raw map field"},
 		},
 		{
-			name:     "comments strings and longer names are allowed",
+			name:     "unrelated fields comments strings and longer names are allowed",
 			filename: "allowed.go",
 			source: `package vm
 				var assertion = "openFiles netBufferedData DbHandles native.Fn(args) .Data"
 				// Globals map[string]int; GlobalOwner *map[string]int
+				type holder struct { Data int }
+				type callable struct { Fn func([]int) int }
 				type SharedState struct { Databases int }
-				func use(item *holder) { _ = item.Dataset }`,
+				func use(item *holder, function *callable, args []int) {
+					itemAlias := item
+					functionAlias := function
+					_ = itemAlias.Data
+					_ = item.Dataset
+					_ = functionAlias.Fn(args)
+				}`,
 		},
 		{
 			name:     "legacy dispatch is allowed only inside Invoke",

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -85,16 +85,20 @@ func TestExecutorSourceLayout(t *testing.T) {
 			t.Fatalf("parse vm.go: %v", err)
 		}
 		allowed := map[string]bool{
-			"runtimeError":              true,
-			"New":                       true,
-			"NewWithConfig":             true,
-			"NewWithShared":             true,
-			"DefineNative":              true,
-			"DefineNativeWithSignature": true,
-			"SetGlobal":                 true,
-			"GetGlobal":                 true,
-			"SetModule":                 true,
-			"GetModule":                 true,
+			"runtimeError":                        true,
+			"IsNativeContext":                     true,
+			"nativeVM":                            true,
+			"New":                                 true,
+			"NewWithConfig":                       true,
+			"NewWithShared":                       true,
+			"DefineNative":                        true,
+			"DefineNativeWithSignature":           true,
+			"DefineContextualNative":              true,
+			"DefineContextualNativeWithSignature": true,
+			"SetGlobal":                           true,
+			"GetGlobal":                           true,
+			"SetModule":                           true,
+			"GetModule":                           true,
 		}
 		found := make(map[string]bool)
 		for _, declaration := range file.Decls {

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -404,7 +404,13 @@ func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte)
 		if !ok || function.Body == nil {
 			continue
 		}
-		allowedLegacyDispatch := function.Name.Name == "Invoke" && function.Recv != nil && expressionText(t, function.Recv.List[0].Type) == "*ObjNative"
+		legacyDispatchReceiver := ""
+		if function.Name.Name == "Invoke" && function.Recv != nil && len(function.Recv.List) == 1 {
+			receiver := function.Recv.List[0]
+			if len(receiver.Names) == 1 && expressionText(t, receiver.Type) == "*ObjNative" {
+				legacyDispatchReceiver = receiver.Names[0].Name
+			}
+		}
 		variables := make(map[string]string, len(globalVariables))
 		for name, target := range globalVariables {
 			variables[name] = target
@@ -438,6 +444,11 @@ func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte)
 				}
 			case *ast.CallExpr:
 				selector, ok := typed.Fun.(*ast.SelectorExpr)
+				allowedLegacyDispatch := false
+				if ok && legacyDispatchReceiver != "" {
+					receiver, isIdentifier := selector.X.(*ast.Ident)
+					allowedLegacyDispatch = isIdentifier && receiver.Name == legacyDispatchReceiver
+				}
 				if ok && selector.Sel.Name == "Fn" && !allowedLegacyDispatch && runtimeValueTargetType(selector.X, variables, aliases) == "ObjNative" {
 					found["direct native.Fn invocation"] = true
 				}
@@ -642,6 +653,18 @@ func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {
 			source: `package value
 				type ObjNative struct { Fn func([]int) int }
 				func (native *ObjNative) Invoke(args []int) int { return native.Fn(args) }`,
+		},
+		{
+			name:     "legacy dispatch rejects receiver aliases inside Invoke",
+			filename: "native.go",
+			source: `package value
+				type ObjNative struct { Fn func([]int) int }
+				func (native *ObjNative) Invoke(args []int) int {
+					other := native
+					_ = native.Fn(args)
+					return other.Fn(args)
+				}`,
+			want: []string{"direct native.Fn invocation"},
 		},
 	}
 	for _, test := range tests {

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -81,7 +81,7 @@ func TestModuleSourceLayout(t *testing.T) {
 
 func TestExecutorSourceLayout(t *testing.T) {
 	t.Run("executor declarations", func(t *testing.T) {
-		requireSourceFunctions(t, "executor.go", "Interpret", "InterpretWithGlobals", "run")
+		requireSourceFunctions(t, "executor.go", "Interpret", "InterpretWithGlobals", "InterpretWithEnvironment", "run")
 	})
 
 	t.Run("vm.go boundary", func(t *testing.T) {
@@ -132,6 +132,54 @@ func TestExecutorSourceLayout(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRuntimeOwnershipDoesNotUseRawGlobalMaps(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	valueFiles, err := filepath.Glob(filepath.Join("..", "value", "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files = append(files, valueFiles...)
+
+	for _, filename := range files {
+		if strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", filename, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.SelectorExpr:
+				if typed.Sel.Name == "Globals" {
+					t.Errorf("%s accesses obsolete Globals ownership", filename)
+				}
+			case *ast.KeyValueExpr:
+				if key, ok := typed.Key.(*ast.Ident); ok && key.Name == "Globals" {
+					t.Errorf("%s initializes obsolete Globals ownership", filename)
+				}
+			case *ast.Field:
+				for _, name := range typed.Names {
+					if name.Name == "Globals" {
+						t.Errorf("%s declares obsolete Globals ownership", filename)
+					}
+					if name.Name == "GlobalOwner" {
+						if pointer, ok := typed.Type.(*ast.StarExpr); ok {
+							if _, rawMap := pointer.X.(*ast.MapType); rawMap {
+								t.Errorf("%s declares GlobalOwner as a map pointer", filename)
+							}
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
 }
 
 func TestRuntimeDoesNotAccessObjMapDataDirectly(t *testing.T) {

--- a/internal/vm/builtins.go
+++ b/internal/vm/builtins.go
@@ -1,5 +1,19 @@
 package vm
 
+import "noxy-vm/internal/value"
+
+func (shared *SharedState) initializeState() {
+	shared.stateOnce.Do(func() {
+		shared.Root = value.NewGlobalEnvironment(nil)
+		shared.Modules = newModuleCache()
+		shared.Files = newHandleRegistry[*FileResource]()
+		shared.Listeners = newSequencedHandleRegistry[*ListenerResource](1, 2)
+		shared.Sockets = newSequencedHandleRegistry[*SocketResource](2, 2)
+		shared.Databases = newHandleRegistry[*DatabaseResource]()
+		shared.Statements = newHandleRegistry[*StatementResource]()
+	})
+}
+
 func (vm *VM) defineBuiltins() {
 	vm.defineCoreBuiltins()
 	vm.defineConcurrencyBuiltins()

--- a/internal/vm/builtins_collections.go
+++ b/internal/vm/builtins_collections.go
@@ -25,7 +25,7 @@ func (vm *VM) defineCollectionBuiltins() {
 				return value.NewInt(int64(len(arr.Elements)))
 			}
 			if mp, ok := arg.Obj.(*value.ObjMap); ok {
-				return value.NewInt(int64(len(mp.Data)))
+				return value.NewInt(int64(mp.Len()))
 			}
 		}
 		return value.NewInt(0)
@@ -38,8 +38,9 @@ func (vm *VM) defineCollectionBuiltins() {
 		mapVal := args[0]
 		if mapVal.Type == value.VAL_OBJ {
 			if m, ok := mapVal.Obj.(*value.ObjMap); ok {
-				keys := make([]value.Value, 0, len(m.Data))
-				for k := range m.Data {
+				values := m.Snapshot()
+				keys := make([]value.Value, 0, len(values))
+				for k := range values {
 					if kInt, ok := k.(int64); ok {
 						keys = append(keys, value.NewInt(kInt))
 					} else if kStr, ok := k.(string); ok {
@@ -80,7 +81,7 @@ func (vm *VM) defineCollectionBuiltins() {
 					}
 				}
 				if key != nil {
-					delete(m.Data, key)
+					m.Delete(key)
 				}
 			}
 		}
@@ -231,7 +232,7 @@ func (vm *VM) defineCollectionBuiltins() {
 				} else {
 					return value.NewBool(false)
 				}
-				_, ok := mapObj.Data[key]
+				_, ok := mapObj.Get(key)
 				return value.NewBool(ok)
 			}
 		}

--- a/internal/vm/builtins_collections.go
+++ b/internal/vm/builtins_collections.go
@@ -61,13 +61,17 @@ func (vm *VM) defineCollectionBuiltins() {
 		},
 		ReturnType: "void",
 	}
-	vm.DefineNativeWithSignature("delete", deleteSignature, func(args []value.Value) value.Value {
-		if len(args) != 2 {
-			return value.NewNull()
+	vm.DefineContextualNativeWithSignature("delete", deleteSignature, func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, contextErr := nativeVM(context)
+		if contextErr != nil {
+			return value.NewNull(), contextErr
 		}
-		mapVal, err := vm.resolveReferenceValue(args[0])
+		if len(args) != 2 {
+			return value.NewNull(), nil
+		}
+		mapVal, err := machine.resolveReferenceValue(args[0])
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		keyVal := args[1]
 		if mapVal.Type == value.VAL_OBJ {
@@ -85,7 +89,7 @@ func (vm *VM) defineCollectionBuiltins() {
 				}
 			}
 		}
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
 	appendSignature := value.NativeSignature{
 		Arity: 2,
@@ -94,25 +98,29 @@ func (vm *VM) defineCollectionBuiltins() {
 		},
 		ReturnType: "void",
 	}
-	vm.DefineNativeWithSignature("append", appendSignature, func(args []value.Value) value.Value {
+	vm.DefineContextualNativeWithSignature("append", appendSignature, func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, contextErr := nativeVM(context)
+		if contextErr != nil {
+			return value.NewNull(), contextErr
+		}
 		if len(args) != 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		targetRef, _ := args[0].Obj.(*value.ObjRef)
-		arrVal, err := vm.resolveReferenceValue(args[0])
+		arrVal, err := machine.resolveReferenceValue(args[0])
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		item := args[1]
-		if !vm.appendItemCompatible(targetRef, item) {
-			return value.NewNull()
+		if !machine.appendItemCompatible(targetRef, item) {
+			return value.NewNull(), nil
 		}
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
 				arr.Elements = append(arr.Elements, item)
 			}
 		}
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
 	popSignature := value.NativeSignature{
 		Arity: 1,
@@ -121,25 +129,29 @@ func (vm *VM) defineCollectionBuiltins() {
 		},
 		ReturnType: "any",
 	}
-	vm.DefineNativeWithSignature("pop", popSignature, func(args []value.Value) value.Value {
-		if len(args) != 1 {
-			return value.NewNull()
+	vm.DefineContextualNativeWithSignature("pop", popSignature, func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, contextErr := nativeVM(context)
+		if contextErr != nil {
+			return value.NewNull(), contextErr
 		}
-		arrVal, err := vm.resolveReferenceValue(args[0])
+		if len(args) != 1 {
+			return value.NewNull(), nil
+		}
+		arrVal, err := machine.resolveReferenceValue(args[0])
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
 				if len(arr.Elements) == 0 {
-					return value.NewNull()
+					return value.NewNull(), nil
 				}
 				val := arr.Elements[len(arr.Elements)-1]
 				arr.Elements = arr.Elements[:len(arr.Elements)-1]
-				return val
+				return val, nil
 			}
 		}
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
 	vm.DefineNative("slice", func(args []value.Value) value.Value {
 		if len(args) < 3 {

--- a/internal/vm/builtins_collections_test.go
+++ b/internal/vm/builtins_collections_test.go
@@ -41,9 +41,9 @@ func TestLengthAndKeysBuiltins(t *testing.T) {
 	machine := New()
 	mapValue := value.NewMap()
 	mapObject := mapValue.Obj.(*value.ObjMap)
-	mapObject.Data["name"] = value.NewString("Noxy")
-	mapObject.Data[int64(7)] = value.NewBool(true)
-	mapObject.Data[false] = value.NewInt(99)
+	setTestMap(mapObject, "name", value.NewString("Noxy"))
+	setTestMap(mapObject, int64(7), value.NewBool(true))
+	setTestMap(mapObject, false, value.NewInt(99))
 
 	lengthTests := []struct {
 		name string
@@ -98,25 +98,25 @@ func TestMutatingCollectionBuiltinsUseReferencedTarget(t *testing.T) {
 
 	storedMap := value.NewMap()
 	mapObject := storedMap.Obj.(*value.ObjMap)
-	mapObject.Data["remove"] = value.NewInt(1)
-	mapObject.Data["keep"] = value.NewInt(2)
-	mapObject.Data[int64(3)] = value.NewString("three")
+	setTestMap(mapObject, "remove", value.NewInt(1))
+	setTestMap(mapObject, "keep", value.NewInt(2))
+	setTestMap(mapObject, int64(3), value.NewString("three"))
 	mapRef := pointerReference(&storedMap)
 	assertBuiltinValue(t, callBuiltin(t, machine, "delete", mapRef, value.NewString("remove")), value.NewNull())
-	if _, exists := storedMap.Obj.(*value.ObjMap).Data["remove"]; exists {
+	if _, exists := storedMap.Obj.(*value.ObjMap).Get("remove"); exists {
 		t.Fatal("delete did not mutate the referenced map")
 	}
 	assertBuiltinValue(t, callBuiltin(t, machine, "delete", mapRef, value.NewInt(3)), value.NewNull())
-	if _, exists := storedMap.Obj.(*value.ObjMap).Data[int64(3)]; exists {
+	if _, exists := storedMap.Obj.(*value.ObjMap).Get(int64(3)); exists {
 		t.Fatal("delete did not remove an integer key")
 	}
 	assertBuiltinValue(t, callBuiltin(t, machine, "delete", mapRef, value.NewBool(true)), value.NewNull())
-	if _, exists := storedMap.Obj.(*value.ObjMap).Data["keep"]; !exists {
+	if _, exists := storedMap.Obj.(*value.ObjMap).Get("keep"); !exists {
 		t.Fatal("delete with an unsupported key changed the map")
 	}
 	plainMap := value.NewMapWithData(map[string]value.Value{"still": value.NewInt(1)})
 	assertBuiltinValue(t, callBuiltin(t, machine, "delete", plainMap, value.NewString("still")), value.NewNull())
-	if _, exists := plainMap.Obj.(*value.ObjMap).Data["still"]; !exists {
+	if _, exists := plainMap.Obj.(*value.ObjMap).Get("still"); !exists {
 		t.Fatal("delete mutated a non-reference argument")
 	}
 
@@ -196,8 +196,8 @@ func TestCollectionMembershipBuiltins(t *testing.T) {
 
 	mapValue := value.NewMap()
 	mapObject := mapValue.Obj.(*value.ObjMap)
-	mapObject.Data["one"] = value.NewInt(1)
-	mapObject.Data[int64(2)] = value.NewString("two")
+	setTestMap(mapObject, "one", value.NewInt(1))
+	setTestMap(mapObject, int64(2), value.NewString("two"))
 	hasKeyTests := []struct {
 		name string
 		args []value.Value

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -30,7 +30,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		if cl, ok := fnVal.Obj.(*value.ObjClosure); ok {
 			closure = cl
 		} else if fn, ok := fnVal.Obj.(*value.ObjFunction); ok {
-			closure = &value.ObjClosure{Function: fn, Upvalues: []*value.ObjUpvalue{}}
+			closure = &value.ObjClosure{Function: fn, Upvalues: []*value.ObjUpvalue{}, Environment: fn.Environment}
 		} else {
 			fmt.Println("Runtime Error: spawn expects a function or closure")
 			return value.NewNull()
@@ -54,14 +54,11 @@ func (vm *VM) defineConcurrencyBuiltins() {
 
 		// Create Frame
 		frame := &CallFrame{
-			Closure: closure,
-			IP:      0,
-			Slots:   0,
-			Globals: nil,
+			Closure:     closure,
+			IP:          0,
+			Slots:       0,
+			Environment: closure.Environment,
 		}
-
-		// Inherit globals from the function/closure.
-		frame.Globals = fnObj.Globals
 
 		threadVM.frames[0] = frame
 		threadVM.frameCount = 1

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -9,21 +9,25 @@ import (
 
 func (vm *VM) defineConcurrencyBuiltins() {
 	// Concurrency Primitives
-	vm.DefineNative("spawn", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("spawn", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 1 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		fnVal := args[0]
 		if fnVal.Type != value.VAL_FUNCTION {
 			// Only script functions are supported in spawn.
 			fmt.Println("Runtime Error: spawn expects a function")
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		threadArgs := args[1:]
 
 		// Create new VM thread sharing state
-		threadVM := NewWithShared(vm.shared, vm.Config)
+		threadVM := NewWithShared(machine.shared, machine.Config)
 
 		// Setup execution
 		var closure *value.ObjClosure
@@ -33,7 +37,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 			closure = &value.ObjClosure{Function: fn, Upvalues: []*value.ObjUpvalue{}, Environment: fn.Environment}
 		} else {
 			fmt.Println("Runtime Error: spawn expects a function or closure")
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		fnObj := closure.Function
@@ -41,7 +45,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		// Check arity
 		if len(threadArgs) != fnObj.Arity {
 			fmt.Printf("Runtime Error: spawn expected %d args, got %d\n", fnObj.Arity, len(threadArgs))
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		// Push Function (Stack slot 0)
@@ -77,7 +81,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 			}
 		}()
 
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
 
 	vm.DefineNative("make_chan", func(args []value.Value) value.Value {

--- a/internal/vm/builtins_concurrency_test.go
+++ b/internal/vm/builtins_concurrency_test.go
@@ -109,3 +109,41 @@ test_report(to_int(received))
 	}
 	assertBuiltinValue(t, captured, value.NewInt(42))
 }
+
+func TestSpawnUsesCallingVMConfig(t *testing.T) {
+	parent := NewWithConfig(VMConfig{RootPath: "parent"})
+	child := NewWithShared(parent.shared, VMConfig{RootPath: "child"})
+	parent.DefineContextualNative("active_root", func(context value.NativeContext, _ []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		return value.NewString(machine.Config.RootPath), nil
+	})
+	captured := value.NewNull()
+	parent.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	code := compileVMSource(t, `
+func worker(channel: any)
+    chan_send(channel, active_root())
+end
+let channel: any = make_chan(0)
+spawn(worker, channel)
+test_report(chan_recv(channel))
+`)
+	completed := make(chan error, 1)
+	go func() { completed <- child.Interpret(code) }()
+	select {
+	case err := <-completed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("spawn did not complete")
+	}
+	assertBuiltinValue(t, captured, value.NewString("child"))
+}

--- a/internal/vm/builtins_io.go
+++ b/internal/vm/builtins_io.go
@@ -43,10 +43,12 @@ func (vm *VM) defineIOBuiltins() {
 		}
 
 		inst := value.NewInstance(structDef).Obj.(*value.ObjInstance)
+		machine.shared.fileMetaMu.Lock()
 		inst.Fields["fd"] = value.NewInt(fd)
 		inst.Fields["path"] = value.NewString(path)
 		inst.Fields["mode"] = value.NewString(mode)
 		inst.Fields["open"] = value.NewBool(isOpen)
+		machine.shared.fileMetaMu.Unlock()
 		return value.Value{Type: value.VAL_OBJ, Obj: inst}, nil
 	})
 
@@ -63,10 +65,10 @@ func (vm *VM) defineIOBuiltins() {
 			return value.NewNull(), nil
 		}
 
-		resource, exists := machine.shared.Files.remove(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.remove(fileHandle(machine.shared, inst))
 		if exists {
 			_ = resource.close()
-			inst.Fields["open"] = value.NewBool(false)
+			markFileClosed(machine.shared, inst)
 		}
 		return value.NewNull(), nil
 	})
@@ -91,13 +93,13 @@ func (vm *VM) defineIOBuiltins() {
 		result := value.NewInstance(resultStruct).Obj.(*value.ObjInstance)
 		result.Fields["success"] = value.NewBool(false)
 		result.Fields["error"] = value.NewString("File not open")
-		resource, exists := machine.shared.Files.remove(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.remove(fileHandle(machine.shared, inst))
 		if !exists {
 			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
 
 		closeErr := resource.close()
-		inst.Fields["open"] = value.NewBool(false)
+		markFileClosed(machine.shared, inst)
 		if closeErr != nil {
 			result.Fields["error"] = value.NewString(closeErr.Error())
 			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
@@ -119,7 +121,7 @@ func (vm *VM) defineIOBuiltins() {
 		if !ok {
 			return value.NewNull(), nil
 		}
-		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
 			return value.NewNull(), nil
 		}
@@ -155,7 +157,7 @@ func (vm *VM) defineIOBuiltins() {
 		result.Fields["success"] = value.NewBool(false)
 		result.Fields["bytes_written"] = value.NewInt(0)
 		result.Fields["error"] = value.NewString("File not open")
-		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
 			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
@@ -201,7 +203,7 @@ func (vm *VM) defineIOBuiltins() {
 		}
 
 		result := newIOReadResult(resultStruct, false, value.NewString(""), "File not open")
-		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
 			return result, nil
 		}
@@ -233,7 +235,7 @@ func (vm *VM) defineIOBuiltins() {
 		}
 
 		result := newIOReadResult(resultStruct, false, value.NewBytes(""), "File not open")
-		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
 			return result, nil
 		}
@@ -279,7 +281,7 @@ func (vm *VM) defineIOBuiltins() {
 		}
 
 		result := newIOLinesResult(resultStruct, false, nil, "File not open")
-		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
 			return result, nil
 		}
@@ -335,6 +337,19 @@ func (vm *VM) defineIOBuiltins() {
 		text, _ := reader.ReadString('\n')
 		return value.NewString(strings.TrimRight(text, "\r\n"))
 	})
+}
+
+func fileHandle(shared *SharedState, instance *value.ObjInstance) int {
+	shared.fileMetaMu.RLock()
+	handle := int(instance.Fields["fd"].AsInt)
+	shared.fileMetaMu.RUnlock()
+	return handle
+}
+
+func markFileClosed(shared *SharedState, instance *value.ObjInstance) {
+	shared.fileMetaMu.Lock()
+	instance.Fields["open"] = value.NewBool(false)
+	shared.fileMetaMu.Unlock()
 }
 
 func readFileContents(file *os.File) ([]byte, bool, string) {

--- a/internal/vm/builtins_io.go
+++ b/internal/vm/builtins_io.go
@@ -10,17 +10,20 @@ import (
 )
 
 func (vm *VM) defineIOBuiltins() {
-	vm.DefineNative("io_open", func(args []value.Value) value.Value {
-		// args: path, mode, FileStructDef
+	vm.DefineContextualNative("io_open", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 3 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		path := args[0].String()
 		mode := args[1].String()
 
 		structDef, ok := args[2].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		flag := os.O_RDONLY
@@ -32,16 +35,11 @@ func (vm *VM) defineIOBuiltins() {
 			flag = os.O_RDWR | os.O_CREATE
 		}
 
-		f, err := os.OpenFile(path, flag, 0644)
-		isOpen := true
-		var fd int64 = 0
-
-		if err != nil {
-			isOpen = false
-		} else {
-			fd = vm.nextFD
-			vm.nextFD++
-			vm.openFiles[fd] = f
+		file, openErr := os.OpenFile(path, flag, 0644)
+		isOpen := openErr == nil
+		var fd int64
+		if isOpen {
+			fd = int64(machine.shared.Files.add(&FileResource{file: file}))
 		}
 
 		inst := value.NewInstance(structDef).Obj.(*value.ObjInstance)
@@ -49,291 +47,257 @@ func (vm *VM) defineIOBuiltins() {
 		inst.Fields["path"] = value.NewString(path)
 		inst.Fields["mode"] = value.NewString(mode)
 		inst.Fields["open"] = value.NewBool(isOpen)
-
-		return value.Value{Type: value.VAL_OBJ, Obj: inst}
+		return value.Value{Type: value.VAL_OBJ, Obj: inst}, nil
 	})
-	vm.DefineNative("io_close", func(args []value.Value) value.Value {
+
+	vm.DefineContextualNative("io_close", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 1 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
-		fd := inst.Fields["fd"].AsInt
-		if f, exists := vm.openFiles[fd]; exists {
-			f.Close()
-			delete(vm.openFiles, fd)
+		resource, exists := machine.shared.Files.remove(int(inst.Fields["fd"].AsInt))
+		if exists {
+			_ = resource.close()
 			inst.Fields["open"] = value.NewBool(false)
 		}
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
-	vm.DefineNative("io_close_result", func(args []value.Value) value.Value {
+
+	vm.DefineContextualNative("io_close_result", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		resultStruct, ok := args[1].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		result := value.NewInstance(resultStruct).Obj.(*value.ObjInstance)
 		result.Fields["success"] = value.NewBool(false)
 		result.Fields["error"] = value.NewString("File not open")
-
-		fd := inst.Fields["fd"].AsInt
-		f, exists := vm.openFiles[fd]
+		resource, exists := machine.shared.Files.remove(int(inst.Fields["fd"].AsInt))
 		if !exists {
-			return value.Value{Type: value.VAL_OBJ, Obj: result}
+			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
 
-		err := f.Close()
-		delete(vm.openFiles, fd)
+		closeErr := resource.close()
 		inst.Fields["open"] = value.NewBool(false)
-		if err != nil {
-			result.Fields["error"] = value.NewString(err.Error())
-			return value.Value{Type: value.VAL_OBJ, Obj: result}
+		if closeErr != nil {
+			result.Fields["error"] = value.NewString(closeErr.Error())
+			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
-
 		result.Fields["success"] = value.NewBool(true)
 		result.Fields["error"] = value.NewString("")
-		return value.Value{Type: value.VAL_OBJ, Obj: result}
+		return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 	})
-	vm.DefineNative("io_write", func(args []value.Value) value.Value {
-		if len(args) < 2 {
-			return value.NewNull()
-		}
-		inst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
 
-		fd := inst.Fields["fd"].AsInt
-		if f, exists := vm.openFiles[fd]; exists {
-			if args[1].Type == value.VAL_BYTES {
-				// Bytes are stored as string in Obj, but treat as raw bytes
-				data := args[1].Obj.(string)
-				f.Write([]byte(data))
-			} else {
-				content := args[1].String()
-				f.WriteString(content)
-			}
+	vm.DefineContextualNative("io_write", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
 		}
-		return value.NewNull()
-	})
-	vm.DefineNative("io_write_result", func(args []value.Value) value.Value {
-		if len(args) < 3 {
-			return value.NewNull()
+		if len(args) < 2 {
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
+			return value.NewNull(), nil
+		}
+		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		if !exists {
+			return value.NewNull(), nil
+		}
+		resource.use(func(file *os.File) value.Value {
+			if args[1].Type == value.VAL_BYTES {
+				_, _ = file.Write([]byte(args[1].Obj.(string)))
+			} else {
+				_, _ = file.WriteString(args[1].String())
+			}
 			return value.NewNull()
+		})
+		return value.NewNull(), nil
+	})
+
+	vm.DefineContextualNative("io_write_result", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 3 {
+			return value.NewNull(), nil
+		}
+		inst, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
 		}
 		resultStruct, ok := args[2].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
 		result := value.NewInstance(resultStruct).Obj.(*value.ObjInstance)
 		result.Fields["success"] = value.NewBool(false)
 		result.Fields["bytes_written"] = value.NewInt(0)
 		result.Fields["error"] = value.NewString("File not open")
-
-		fd := inst.Fields["fd"].AsInt
-		f, exists := vm.openFiles[fd]
+		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
 		if !exists {
-			return value.Value{Type: value.VAL_OBJ, Obj: result}
+			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
 
-		var written int
-		var err error
-		if args[1].Type == value.VAL_BYTES {
-			written, err = f.Write([]byte(args[1].Obj.(string)))
-		} else {
-			written, err = f.WriteString(args[1].String())
+		operationResult, used := resource.use(func(file *os.File) value.Value {
+			var written int
+			var writeErr error
+			if args[1].Type == value.VAL_BYTES {
+				written, writeErr = file.Write([]byte(args[1].Obj.(string)))
+			} else {
+				written, writeErr = file.WriteString(args[1].String())
+			}
+			result.Fields["bytes_written"] = value.NewInt(int64(written))
+			if writeErr != nil {
+				result.Fields["error"] = value.NewString(writeErr.Error())
+				return value.Value{Type: value.VAL_OBJ, Obj: result}
+			}
+			result.Fields["success"] = value.NewBool(true)
+			result.Fields["error"] = value.NewString("")
+			return value.Value{Type: value.VAL_OBJ, Obj: result}
+		})
+		if !used {
+			return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
 		}
-		result.Fields["bytes_written"] = value.NewInt(int64(written))
+		return operationResult, nil
+	})
+
+	vm.DefineContextualNative("io_read", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
 		if err != nil {
-			result.Fields["error"] = value.NewString(err.Error())
-			return value.Value{Type: value.VAL_OBJ, Obj: result}
+			return value.NewNull(), err
 		}
-
-		result.Fields["success"] = value.NewBool(true)
-		result.Fields["error"] = value.NewString("")
-		return value.Value{Type: value.VAL_OBJ, Obj: result}
-	})
-	vm.DefineNative("io_read", func(args []value.Value) value.Value {
-		// args: fileInst, IOResultStructDef
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		resStruct, ok := args[1].Obj.(*value.ObjStruct) // IOResult
+		resultStruct, ok := args[1].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
-		fd := inst.Fields["fd"].AsInt
-		var contentStr string
-		var errorStr string
-		var isOk bool = false
-
-		if f, exists := vm.openFiles[fd]; exists {
-			// Read all
-			stat, _ := f.Stat()
-			if stat.Size() > 0 {
-				buf := make([]byte, stat.Size())
-				f.Seek(0, 0)
-				n, err := f.Read(buf)
-				if err == nil || (err != nil && n > 0) { // simple read
-					contentStr = string(buf[:n])
-					isOk = true
-				} else {
-					errorStr = err.Error()
-				}
-			} else {
-				isOk = true // empty file
-			}
-		} else {
-			errorStr = "File not open"
+		result := newIOReadResult(resultStruct, false, value.NewString(""), "File not open")
+		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		if !exists {
+			return result, nil
 		}
-
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(isOk)
-		resInst.Fields["data"] = value.NewString(contentStr)
-		resInst.Fields["error"] = value.NewString(errorStr)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		operationResult, used := resource.use(func(file *os.File) value.Value {
+			content, ok, errorText := readFileContents(file)
+			return newIOReadResult(resultStruct, ok, value.NewString(string(content)), errorText)
+		})
+		if !used {
+			return result, nil
+		}
+		return operationResult, nil
 	})
 
-	vm.DefineNative("io_read_bytes", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("io_read_bytes", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		resStruct, ok := args[1].Obj.(*value.ObjStruct)
+		resultStruct, ok := args[1].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
-		fd := inst.Fields["fd"].AsInt
-		var contentBytes []byte
-		var errorStr string
-		var isOk bool = false
-
-		if f, exists := vm.openFiles[fd]; exists {
-			// Read all
-			stat, _ := f.Stat()
-			if stat.Size() > 0 {
-				buf := make([]byte, stat.Size())
-				f.Seek(0, 0)
-				n, err := f.Read(buf)
-				if err == nil || (err != nil && n > 0) {
-					contentBytes = buf[:n]
-					isOk = true
-				} else {
-					errorStr = err.Error()
-				}
-			} else {
-				contentBytes = []byte{}
-				isOk = true
-			}
-		} else {
-			errorStr = "File not open"
+		result := newIOReadResult(resultStruct, false, value.NewBytes(""), "File not open")
+		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		if !exists {
+			return result, nil
 		}
-
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(isOk)
-		resInst.Fields["data"] = value.NewBytes(string(contentBytes))
-		resInst.Fields["error"] = value.NewString(errorStr)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		operationResult, used := resource.use(func(file *os.File) value.Value {
+			content, ok, errorText := readFileContents(file)
+			return newIOReadResult(resultStruct, ok, value.NewBytes(string(content)), errorText)
+		})
+		if !used {
+			return result, nil
+		}
+		return operationResult, nil
 	})
+
 	vm.DefineNative("io_exists", func(args []value.Value) value.Value {
 		if len(args) < 1 {
 			return value.NewBool(false)
 		}
-		path := args[0].String()
-		_, err := os.Stat(path)
+		_, err := os.Stat(args[0].String())
 		return value.NewBool(err == nil)
 	})
 	vm.DefineNative("io_remove", func(args []value.Value) value.Value {
 		if len(args) < 1 {
 			return value.NewBool(false)
 		}
-		path := args[0].String()
-		err := os.Remove(path)
-		return value.NewBool(err == nil)
+		return value.NewBool(os.Remove(args[0].String()) == nil)
 	})
-	vm.DefineNative("io_read_lines", func(args []value.Value) value.Value {
-		// args: fileInst, IOLinesResultStructDef
+
+	vm.DefineContextualNative("io_read_lines", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		inst, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		resStruct, ok := args[1].Obj.(*value.ObjStruct) // IOLinesResult
+		resultStruct, ok := args[1].Obj.(*value.ObjStruct)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
-		fd := inst.Fields["fd"].AsInt
-		var lines []string
-		var errorStr string
-		var isOk bool = false
-
-		if f, exists := vm.openFiles[fd]; exists {
-			// Read all
-			stat, _ := f.Stat()
-			var contentStr string
-			if stat.Size() > 0 {
-				f.Seek(0, 0)
-				buf := make([]byte, stat.Size())
-				n, err := f.Read(buf)
-				if err == nil || (err != nil && n > 0) {
-					contentStr = string(buf[:n])
-					isOk = true
-				} else {
-					errorStr = err.Error()
-				}
-			} else {
-				isOk = true
+		result := newIOLinesResult(resultStruct, false, nil, "File not open")
+		resource, exists := machine.shared.Files.get(int(inst.Fields["fd"].AsInt))
+		if !exists {
+			return result, nil
+		}
+		operationResult, used := resource.use(func(file *os.File) value.Value {
+			content, ok, errorText := readFileContents(file)
+			var lines []string
+			if ok {
+				normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+				lines = strings.Split(normalized, "\n")
 			}
-
-			if isOk {
-				// Split by newlines, handling \r\n and \n
-				// Naive split
-				contentStr = strings.ReplaceAll(contentStr, "\r\n", "\n")
-				lines = strings.Split(contentStr, "\n")
-				// Retain behavior of strings.Split where trailing newline results in an empty string.
-			}
-		} else {
-			errorStr = "File not open"
+			return newIOLinesResult(resultStruct, ok, lines, errorText)
+		})
+		if !used {
+			return result, nil
 		}
-
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(isOk)
-
-		linesVal := make([]value.Value, len(lines))
-		for i, line := range lines {
-			linesVal[i] = value.NewString(line)
-		}
-		resInst.Fields["data"] = value.NewArray(linesVal)
-
-		resInst.Fields["error"] = value.NewString(errorStr)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		return operationResult, nil
 	})
+
 	vm.DefineNative("io_stat", func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewNull()
@@ -343,41 +307,65 @@ func (vm *VM) defineIOBuiltins() {
 		if !ok {
 			return value.NewNull()
 		}
-
 		info, err := os.Stat(path)
-		exists := (err == nil)
-		size := int64(0)
+		exists := err == nil
+		var size int64
 		isDir := false
 		if exists {
 			size = info.Size()
 			isDir = info.IsDir()
 		}
-
 		inst := value.NewInstance(structDef).Obj.(*value.ObjInstance)
 		inst.Fields["exists"] = value.NewBool(exists)
 		inst.Fields["size"] = value.NewInt(size)
 		inst.Fields["is_dir"] = value.NewBool(isDir)
-
 		return value.Value{Type: value.VAL_OBJ, Obj: inst}
 	})
 	vm.DefineNative("io_mkdir", func(args []value.Value) value.Value {
 		if len(args) < 1 {
 			return value.NewBool(false)
 		}
-		path := args[0].String()
-		err := os.MkdirAll(path, 0755)
-		return value.NewBool(err == nil)
+		return value.NewBool(os.MkdirAll(args[0].String(), 0755) == nil)
 	})
-	// Input
 	vm.DefineNative("input", func(args []value.Value) value.Value {
-		// args[0]: prompt (optional)
 		if len(args) > 0 {
 			fmt.Print(args[0].String())
 		}
 		reader := bufio.NewReader(os.Stdin)
 		text, _ := reader.ReadString('\n')
-		// Trim newline (windows \r\n and unix \n)
-		text = strings.TrimRight(text, "\r\n")
-		return value.NewString(text)
+		return value.NewString(strings.TrimRight(text, "\r\n"))
 	})
+}
+
+func readFileContents(file *os.File) ([]byte, bool, string) {
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, false, err.Error()
+	}
+	if stat.Size() == 0 {
+		return []byte{}, true, ""
+	}
+	buffer := make([]byte, stat.Size())
+	_, _ = file.Seek(0, 0)
+	n, readErr := file.Read(buffer)
+	if readErr == nil || n > 0 {
+		return buffer[:n], true, ""
+	}
+	return nil, false, readErr.Error()
+}
+
+func newIOReadResult(definition *value.ObjStruct, ok bool, data value.Value, errorText string) value.Value {
+	result := value.NewInstance(definition).Obj.(*value.ObjInstance)
+	result.Fields["ok"] = value.NewBool(ok)
+	result.Fields["data"] = data
+	result.Fields["error"] = value.NewString(errorText)
+	return value.Value{Type: value.VAL_OBJ, Obj: result}
+}
+
+func newIOLinesResult(definition *value.ObjStruct, ok bool, lines []string, errorText string) value.Value {
+	values := make([]value.Value, len(lines))
+	for index, line := range lines {
+		values[index] = value.NewString(line)
+	}
+	return newIOReadResult(definition, ok, value.NewArray(values), errorText)
 }

--- a/internal/vm/builtins_io_test.go
+++ b/internal/vm/builtins_io_test.go
@@ -58,6 +58,36 @@ func TestFileHandleIsUsableAcrossSharedVMs(t *testing.T) {
 	}
 }
 
+func TestIOHandleMetadataIsSafeAcrossSharedVMs(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	path := filepath.Join(t.TempDir(), "metadata-race.txt")
+	fileType := testFileDefinition()
+	handle := callBuiltin(t, parent, "io_open", value.NewString(path), value.NewString("w"), fileType)
+	defer callBuiltin(t, parent, "io_close", handle)
+
+	writeNative := requireBuiltin(t, child, "io_write")
+	closeNative := requireBuiltin(t, parent, "io_close")
+	start := make(chan struct{})
+	done := make(chan error, 2)
+	go func() {
+		<-start
+		_, err := writeNative.Invoke(child, []value.Value{handle, value.NewString("")})
+		done <- err
+	}()
+	go func() {
+		<-start
+		_, err := closeNative.Invoke(parent, []value.Value{handle})
+		done <- err
+	}()
+	close(start)
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestFileCloseInterruptsBlockedReadWithoutRegistryDeadlock(t *testing.T) {
 	reader, writer, err := os.Pipe()
 	if err != nil {
@@ -67,26 +97,44 @@ func TestFileCloseInterruptsBlockedReadWithoutRegistryDeadlock(t *testing.T) {
 	machine := New()
 	resource := &FileResource{file: reader}
 	handle := machine.shared.Files.add(resource)
-	done := make(chan error, 1)
+	fileType := testFileDefinition()
+	handleValue := value.NewInstance(fileType.Obj.(*value.ObjStruct))
+	instance := handleValue.Obj.(*value.ObjInstance)
+	instance.Fields["fd"] = value.NewInt(int64(handle))
+	instance.Fields["open"] = value.NewBool(true)
+	closeNative := requireBuiltin(t, machine, "io_close")
+	readStarted := make(chan struct{})
+	readDone := make(chan error, 1)
 	go func() {
 		resource.operationMu.Lock()
 		defer resource.operationMu.Unlock()
+		close(readStarted)
 		buffer := make([]byte, 1)
 		_, readErr := resource.file.Read(buffer)
-		done <- readErr
+		readDone <- readErr
 	}()
-	removed, ok := machine.shared.Files.remove(handle)
-	if !ok {
-		t.Fatal("file handle disappeared")
-	}
-	removed.stateMu.Lock()
-	removed.closed = true
-	removed.stateMu.Unlock()
-	if err := removed.file.Close(); err != nil {
-		t.Fatal(err)
-	}
+	<-readStarted
+
+	closeDone := make(chan error, 1)
+	go func() {
+		_, closeErr := closeNative.Invoke(machine, []value.Value{handleValue})
+		closeDone <- closeErr
+	}()
 	select {
-	case readErr := <-done:
+	case closeErr := <-closeDone:
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("close waited for the active file operation")
+	}
+	if _, ok := machine.shared.Files.get(handle); ok {
+		t.Fatal("closed file handle remains in shared resources")
+	}
+	assertBuiltinValue(t, instance.Fields["open"], value.NewBool(false))
+
+	select {
+	case readErr := <-readDone:
 		if readErr == nil {
 			t.Fatal("blocked read succeeded after close")
 		}

--- a/internal/vm/builtins_io_test.go
+++ b/internal/vm/builtins_io_test.go
@@ -1,8 +1,10 @@
 package vm
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"noxy-vm/internal/value"
 )
@@ -26,14 +28,76 @@ func testIOCloseResultDefinition() value.Value {
 	return value.NewStruct("IOCloseResult", []string{"success", "error"})
 }
 
+func cleanupFileResources(t *testing.T, machine *VM) {
+	t.Helper()
+	t.Cleanup(func() {
+		for handle := range machine.shared.Files.snapshot() {
+			if resource, ok := machine.shared.Files.remove(handle); ok {
+				_ = resource.close()
+			}
+		}
+	})
+}
+
+func TestFileHandleIsUsableAcrossSharedVMs(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	path := filepath.Join(t.TempDir(), "shared.txt")
+	fileType := testFileDefinition()
+	handle := callBuiltin(t, parent, "io_open", value.NewString(path), value.NewString("w"), fileType)
+	defer callBuiltin(t, parent, "io_close", handle)
+	fd := int(requireBuiltinInstance(t, handle, fileType).Fields["fd"].AsInt)
+	if _, ok := parent.shared.Files.get(fd); !ok {
+		t.Fatalf("file handle %d was not published to shared resources", fd)
+	}
+	callBuiltin(t, child, "io_write", handle, value.NewString("shared"))
+	callBuiltin(t, child, "io_close", handle)
+	contents, err := os.ReadFile(path)
+	if err != nil || string(contents) != "shared" {
+		t.Fatalf("contents=%q err=%v", contents, err)
+	}
+}
+
+func TestFileCloseInterruptsBlockedReadWithoutRegistryDeadlock(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	machine := New()
+	resource := &FileResource{file: reader}
+	handle := machine.shared.Files.add(resource)
+	done := make(chan error, 1)
+	go func() {
+		resource.operationMu.Lock()
+		defer resource.operationMu.Unlock()
+		buffer := make([]byte, 1)
+		_, readErr := resource.file.Read(buffer)
+		done <- readErr
+	}()
+	removed, ok := machine.shared.Files.remove(handle)
+	if !ok {
+		t.Fatal("file handle disappeared")
+	}
+	removed.stateMu.Lock()
+	removed.closed = true
+	removed.stateMu.Unlock()
+	if err := removed.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case readErr := <-done:
+		if readErr == nil {
+			t.Fatal("blocked read succeeded after close")
+		}
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("close did not interrupt blocked read")
+	}
+}
+
 func TestIOWriteResultReportsSuccessAndFailure(t *testing.T) {
 	machine := New()
-	defer func() {
-		for descriptor, file := range machine.openFiles {
-			_ = file.Close()
-			delete(machine.openFiles, descriptor)
-		}
-	}()
+	cleanupFileResources(t, machine)
 
 	path := filepath.Join(t.TempDir(), "observable-write.txt")
 	fileDefinition := testFileDefinition()
@@ -47,8 +111,12 @@ func TestIOWriteResultReportsSuccessAndFailure(t *testing.T) {
 	assertBuiltinValue(t, success.Fields["bytes_written"], value.NewInt(int64(len([]byte(contents)))))
 	assertBuiltinValue(t, success.Fields["error"], value.NewString(""))
 
-	fd := handle.Fields["fd"].AsInt
-	if err := machine.openFiles[fd].Close(); err != nil {
+	fd := int(handle.Fields["fd"].AsInt)
+	resource, ok := machine.shared.Files.get(fd)
+	if !ok {
+		t.Fatalf("open file descriptor %d is absent from shared resources", fd)
+	}
+	if err := resource.file.Close(); err != nil {
 		t.Fatalf("close underlying file: %v", err)
 	}
 
@@ -62,12 +130,7 @@ func TestIOWriteResultReportsSuccessAndFailure(t *testing.T) {
 
 func TestIOCloseResultReportsSuccessAndFailure(t *testing.T) {
 	machine := New()
-	defer func() {
-		for descriptor, file := range machine.openFiles {
-			_ = file.Close()
-			delete(machine.openFiles, descriptor)
-		}
-	}()
+	cleanupFileResources(t, machine)
 
 	path := filepath.Join(t.TempDir(), "observable-close.txt")
 	fileDefinition := testFileDefinition()
@@ -88,8 +151,12 @@ func TestIOCloseResultReportsSuccessAndFailure(t *testing.T) {
 
 	failedHandleValue := callBuiltin(t, machine, "io_open", value.NewString(path), value.NewString("a"), fileDefinition)
 	failedHandle := requireBuiltinInstance(t, failedHandleValue, fileDefinition)
-	failedFD := failedHandle.Fields["fd"].AsInt
-	if err := machine.openFiles[failedFD].Close(); err != nil {
+	failedFD := int(failedHandle.Fields["fd"].AsInt)
+	failedResource, ok := machine.shared.Files.get(failedFD)
+	if !ok {
+		t.Fatalf("open file descriptor %d is absent from shared resources", failedFD)
+	}
+	if err := failedResource.file.Close(); err != nil {
 		t.Fatalf("close underlying file: %v", err)
 	}
 	underlyingFailure := requireBuiltinInstance(t, callBuiltin(t, machine, "io_close_result", failedHandleValue, resultDefinition), resultDefinition)
@@ -98,19 +165,14 @@ func TestIOCloseResultReportsSuccessAndFailure(t *testing.T) {
 		t.Fatal("underlying close failure returned an empty error")
 	}
 	assertBuiltinValue(t, failedHandle.Fields["open"], value.NewBool(false))
-	if _, ok := machine.openFiles[failedFD]; ok {
-		t.Fatalf("failed close descriptor %d remains in VM state", failedFD)
+	if _, ok := machine.shared.Files.get(failedFD); ok {
+		t.Fatalf("failed close descriptor %d remains in shared resources", failedFD)
 	}
 }
 
 func TestIOBuiltinsUseTemporaryFilesAndInvalidateHandles(t *testing.T) {
 	machine := New()
-	defer func() {
-		for descriptor, file := range machine.openFiles {
-			_ = file.Close()
-			delete(machine.openFiles, descriptor)
-		}
-	}()
+	cleanupFileResources(t, machine)
 	temporaryRoot := t.TempDir()
 	directory := filepath.Join(temporaryRoot, "nested", "data")
 	path := filepath.Join(directory, "sample.txt")
@@ -123,15 +185,15 @@ func TestIOBuiltinsUseTemporaryFilesAndInvalidateHandles(t *testing.T) {
 	writeHandleValue := callBuiltin(t, machine, "io_open", value.NewString(path), value.NewString("w"), fileDefinition)
 	writeHandle := requireBuiltinInstance(t, writeHandleValue, fileDefinition)
 	assertBuiltinValue(t, writeHandle.Fields["open"], value.NewBool(true))
-	writeFD := writeHandle.Fields["fd"].AsInt
-	if _, ok := machine.openFiles[writeFD]; !ok {
-		t.Fatalf("open file descriptor %d is absent from VM state", writeFD)
+	writeFD := int(writeHandle.Fields["fd"].AsInt)
+	if _, ok := machine.shared.Files.get(writeFD); !ok {
+		t.Fatalf("open file descriptor %d is absent from shared resources", writeFD)
 	}
 	assertBuiltinValue(t, callBuiltin(t, machine, "io_write", writeHandleValue, value.NewBytes(contents)), value.NewNull())
 	assertBuiltinValue(t, callBuiltin(t, machine, "io_close", writeHandleValue), value.NewNull())
 	assertBuiltinValue(t, writeHandle.Fields["open"], value.NewBool(false))
-	if _, ok := machine.openFiles[writeFD]; ok {
-		t.Fatalf("closed file descriptor %d remains in VM state", writeFD)
+	if _, ok := machine.shared.Files.get(writeFD); ok {
+		t.Fatalf("closed file descriptor %d remains in shared resources", writeFD)
 	}
 
 	readHandleValue := callBuiltin(t, machine, "io_open", value.NewString(path), value.NewString("r"), fileDefinition)

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -128,7 +128,7 @@ func jsonValToGo(v value.Value) interface{} {
 			return arr
 		case *value.ObjMap:
 			m := make(map[string]interface{})
-			for k, val := range o.Data {
+			for k, val := range o.Snapshot() {
 				keyStr := fmt.Sprintf("%v", k)
 				m[keyStr] = jsonValToGo(val)
 			}

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -76,13 +76,17 @@ func (vm *VM) defineJSONBuiltins() {
 		},
 		ReturnType: "bool",
 	}
-	vm.DefineNativeWithSignature("json_loads", jsonLoadsSignature, func(args []value.Value) value.Value {
+	vm.DefineContextualNativeWithSignature("json_loads", jsonLoadsSignature, func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, contextErr := nativeVM(context)
+		if contextErr != nil {
+			return value.NewNull(), contextErr
+		}
 		if len(args) < 2 {
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 		jsonStr := args[0].String()
 		if !utf8.ValidString(jsonStr) {
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 		target := args[1]
 
@@ -90,18 +94,18 @@ func (vm *VM) defineJSONBuiltins() {
 		decoder := json.NewDecoder(strings.NewReader(jsonStr))
 		decoder.UseNumber()
 		if err := decoder.Decode(&result); err != nil {
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 		var trailing interface{}
 		if err := decoder.Decode(&trailing); err != io.EOF {
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 
 		// Try to populate target
-		if populateTarget(vm, target, result) {
-			return value.NewBool(true)
+		if populateTarget(machine, target, result) {
+			return value.NewBool(true), nil
 		}
-		return value.NewBool(false)
+		return value.NewBool(false), nil
 	})
 }
 

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestStrictJSONValToGoAcceptsJSONDomain(t *testing.T) {
 	nested := value.NewMap()
-	nested.Obj.(*value.ObjMap).Data["city"] = value.NewString("Cuiabá")
+	setTestMap(nested.Obj.(*value.ObjMap), "city", value.NewString("Cuiabá"))
 	document := value.NewMap()
-	document.Obj.(*value.ObjMap).Data["empty"] = value.NewString("")
-	document.Obj.(*value.ObjMap).Data["int"] = value.NewInt(30)
-	document.Obj.(*value.ObjMap).Data["minimum"] = value.NewInt(-9223372036854775807 - 1)
-	document.Obj.(*value.ObjMap).Data["maximum"] = value.NewInt(9223372036854775807)
-	document.Obj.(*value.ObjMap).Data["float"] = value.NewFloat(1.25)
-	document.Obj.(*value.ObjMap).Data["active"] = value.NewBool(true)
-	document.Obj.(*value.ObjMap).Data["nothing"] = value.NewNull()
-	document.Obj.(*value.ObjMap).Data["items"] = value.NewArray(
+	setTestMap(document.Obj.(*value.ObjMap), "empty", value.NewString(""))
+	setTestMap(document.Obj.(*value.ObjMap), "int", value.NewInt(30))
+	setTestMap(document.Obj.(*value.ObjMap), "minimum", value.NewInt(-9223372036854775807-1))
+	setTestMap(document.Obj.(*value.ObjMap), "maximum", value.NewInt(9223372036854775807))
+	setTestMap(document.Obj.(*value.ObjMap), "float", value.NewFloat(1.25))
+	setTestMap(document.Obj.(*value.ObjMap), "active", value.NewBool(true))
+	setTestMap(document.Obj.(*value.ObjMap), "nothing", value.NewNull())
+	setTestMap(document.Obj.(*value.ObjMap), "items", value.NewArray(
 		[]value.Value{value.NewString("Noxy"), value.NewInt(2), nested},
-	)
+	))
 
 	got, err := strictJSONValToGo(document)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestStrictJSONValToGoRejectsNonJSONValues(t *testing.T) {
 	definition := value.NewStruct("Point", []string{"x"})
 	instance := value.NewInstance(definition.Obj.(*value.ObjStruct))
 	badKeyMap := value.NewMap()
-	badKeyMap.Obj.(*value.ObjMap).Data[int64(7)] = value.NewString("seven")
+	setTestMap(badKeyMap.Obj.(*value.ObjMap), int64(7), value.NewString("seven"))
 	tests := []struct {
 		name  string
 		input value.Value
@@ -75,7 +75,7 @@ func TestStrictJSONValToGoRejectsNonJSONValues(t *testing.T) {
 func TestStrictJSONValToGoRejectsInvalidUTF8Strings(t *testing.T) {
 	invalidValue := value.NewString(string([]byte{0xff}))
 	invalidKey := value.NewMap()
-	invalidKey.Obj.(*value.ObjMap).Data[string([]byte{0xff})] = value.NewBool(true)
+	setTestMap(invalidKey.Obj.(*value.ObjMap), string([]byte{0xff}), value.NewBool(true))
 	tests := []struct {
 		name  string
 		input value.Value
@@ -100,21 +100,21 @@ func TestStrictJSONValToGoRejectsCyclesAndAcceptsSharedChildren(t *testing.T) {
 	}
 
 	mapCycle := value.NewMap()
-	mapCycle.Obj.(*value.ObjMap).Data["self"] = mapCycle
+	setTestMap(mapCycle.Obj.(*value.ObjMap), "self", mapCycle)
 	if _, err := strictJSONValToGo(mapCycle); err == nil {
 		t.Fatal("map cycle was accepted")
 	}
 
 	left := value.NewMap()
 	right := value.NewArray(nil)
-	left.Obj.(*value.ObjMap).Data["right"] = right
+	setTestMap(left.Obj.(*value.ObjMap), "right", right)
 	right.Obj.(*value.ObjArray).Elements = []value.Value{left}
 	if _, err := strictJSONValToGo(left); err == nil {
 		t.Fatal("indirect cycle was accepted")
 	}
 
 	child := value.NewMap()
-	child.Obj.(*value.ObjMap).Data["value"] = value.NewInt(1)
+	setTestMap(child.Obj.(*value.ObjMap), "value", value.NewInt(1))
 	root := value.NewArray([]value.Value{child, child})
 	if _, err := strictJSONValToGo(root); err != nil {
 		t.Fatalf("shared acyclic child rejected: %v", err)
@@ -155,8 +155,8 @@ func requireBuiltinMap(t *testing.T, got value.Value) *value.ObjMap {
 func TestJSONDumpsBuiltin(t *testing.T) {
 	machine := New()
 	mapValue := value.NewMap()
-	mapValue.Obj.(*value.ObjMap).Data["name"] = value.NewString("Noxy")
-	mapValue.Obj.(*value.ObjMap).Data[int64(7)] = value.NewBool(true)
+	setTestMap(mapValue.Obj.(*value.ObjMap), "name", value.NewString("Noxy"))
+	setTestMap(mapValue.Obj.(*value.ObjMap), int64(7), value.NewBool(true))
 	definition := value.NewStruct("Point", []string{"x", "label"})
 	instance := value.NewInstance(definition.Obj.(*value.ObjStruct))
 	instance.Obj.(*value.ObjInstance).Fields["x"] = value.NewInt(3)
@@ -190,7 +190,7 @@ func TestJSONDumpsResultBuiltinReportsSuccessAndFailure(t *testing.T) {
 	machine := New()
 	resultType := value.NewStruct("EncodeResult", []string{"success", "data", "error"})
 	valid := value.NewMap()
-	valid.Obj.(*value.ObjMap).Data["name"] = value.NewString("Noxy")
+	setTestMap(valid.Obj.(*value.ObjMap), "name", value.NewString("Noxy"))
 	success := callBuiltin(t, machine, "json_dumps_result", valid, resultType)
 	successFields := success.Obj.(*value.ObjInstance).Fields
 	assertBuiltinValue(t, successFields["success"], value.NewBool(true))
@@ -198,7 +198,7 @@ func TestJSONDumpsResultBuiltinReportsSuccessAndFailure(t *testing.T) {
 	assertBuiltinValue(t, successFields["error"], value.NewString(""))
 
 	invalid := value.NewMap()
-	invalid.Obj.(*value.ObjMap).Data["raw"] = value.NewBytes("abc")
+	setTestMap(invalid.Obj.(*value.ObjMap), "raw", value.NewBytes("abc"))
 	failure := callBuiltin(t, machine, "json_dumps_result", invalid, resultType)
 	failureFields := failure.Obj.(*value.ObjInstance).Fields
 	assertBuiltinValue(t, failureFields["success"], value.NewBool(false))
@@ -212,11 +212,11 @@ func TestJSONDumpsResultBuiltinRejectsInvalidStrictValues(t *testing.T) {
 	machine := New()
 	resultType := value.NewStruct("EncodeResult", []string{"success", "data", "error"})
 	invalidKey := value.NewMap()
-	invalidKey.Obj.(*value.ObjMap).Data[string([]byte{0xff})] = value.NewBool(true)
+	setTestMap(invalidKey.Obj.(*value.ObjMap), string([]byte{0xff}), value.NewBool(true))
 	arrayCycle := value.NewArray(nil)
 	arrayCycle.Obj.(*value.ObjArray).Elements = []value.Value{arrayCycle}
 	mapCycle := value.NewMap()
-	mapCycle.Obj.(*value.ObjMap).Data["self"] = mapCycle
+	setTestMap(mapCycle.Obj.(*value.ObjMap), "self", mapCycle)
 	tests := []struct {
 		name  string
 		input value.Value
@@ -244,16 +244,16 @@ func TestJSONLoadsBuiltinRejectsInvalidUTF8WithoutMutation(t *testing.T) {
 	machine := New()
 	target := value.NewMap()
 	targetMap := target.Obj.(*value.ObjMap)
-	targetMap.Data["sentinel"] = value.NewString("keep")
+	setTestMap(targetMap, "sentinel", value.NewString("keep"))
 	invalidJSON := value.NewString(string([]byte{'{', '"', 'n', 'a', 'm', 'e', '"', ':', '"', 0xff, '"', '}'}))
 
 	result := callBuiltin(t, machine, "json_loads", invalidJSON, target)
 	assertBuiltinValue(t, result, value.NewBool(false))
-	if len(targetMap.Data) != 1 {
-		t.Fatalf("target mutated after invalid JSON: %#v", targetMap.Data)
+	if targetMap.Len() != 1 {
+		t.Fatalf("target mutated after invalid JSON: %#v", targetMap.Snapshot())
 	}
-	assertBuiltinValue(t, targetMap.Data["sentinel"], value.NewString("keep"))
-	if _, exists := targetMap.Data["name"]; exists {
+	assertBuiltinValue(t, requireTestMapValue(t, targetMap, "sentinel"), value.NewString("keep"))
+	if _, exists := targetMap.Get("name"); exists {
 		t.Fatal("target gained a field from invalid JSON")
 	}
 }
@@ -290,15 +290,15 @@ func TestJSONParseBuiltin(t *testing.T) {
 	assertBuiltinValue(t, parsedArray.Elements[3], value.NewNull())
 
 	parsedMap := requireBuiltinMap(t, callBuiltin(t, machine, "json_parse", value.NewString(`{"a":1,"nested":{"ok":true}}`)))
-	assertBuiltinValue(t, parsedMap.Data["a"], value.NewInt(1))
-	nested := requireBuiltinMap(t, parsedMap.Data["nested"])
-	assertBuiltinValue(t, nested.Data["ok"], value.NewBool(true))
+	assertBuiltinValue(t, requireTestMapValue(t, parsedMap, "a"), value.NewInt(1))
+	nested := requireBuiltinMap(t, requireTestMapValue(t, parsedMap, "nested"))
+	assertBuiltinValue(t, requireTestMapValue(t, nested, "ok"), value.NewBool(true))
 }
 
 func TestJSONValToGo(t *testing.T) {
 	mapValue := value.NewMap()
-	mapValue.Obj.(*value.ObjMap).Data["name"] = value.NewString("Noxy")
-	mapValue.Obj.(*value.ObjMap).Data[int64(7)] = value.NewBool(true)
+	setTestMap(mapValue.Obj.(*value.ObjMap), "name", value.NewString("Noxy"))
+	setTestMap(mapValue.Obj.(*value.ObjMap), int64(7), value.NewBool(true))
 	definition := value.NewStruct("Point", []string{"x"})
 	instance := value.NewInstance(definition.Obj.(*value.ObjStruct))
 	instance.Obj.(*value.ObjInstance).Fields["x"] = value.NewInt(3)
@@ -356,8 +356,8 @@ func TestGoValToNoxy(t *testing.T) {
 	assertBuiltinValue(t, array.Elements[2], value.NewNull())
 
 	mapping := requireBuiltinMap(t, goValToNoxy(map[string]interface{}{"answer": float64(42), "ok": true}))
-	assertBuiltinValue(t, mapping.Data["answer"], value.NewInt(42))
-	assertBuiltinValue(t, mapping.Data["ok"], value.NewBool(true))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "answer"), value.NewInt(42))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "ok"), value.NewBool(true))
 }
 
 func TestJSONReplacementCompatible(t *testing.T) {

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -9,433 +9,417 @@ import (
 	"noxy-vm/internal/value"
 )
 
-func (vm *VM) defineNetworkBuiltins() {
-	// Net Native Functions
-	vm.DefineNative("net_listen", func(args []value.Value) value.Value {
-		if len(args) < 2 {
-			return value.NewNull()
-		}
-		host := args[0].String()
-		port := int(args[1].AsInt)
-		addr := fmt.Sprintf("%s:%d", host, port)
-
-		listener, err := net.Listen("tcp", addr)
-		if err != nil {
-			// Return Socket with open=false
-			socketFields := map[string]value.Value{
-				"fd":   value.NewInt(-1),
-				"addr": value.NewString(host),
-				"port": value.NewInt(int64(port)),
-				"open": value.NewBool(false),
-			}
-			return value.NewMapWithData(socketFields)
-		}
-
-		vm.shared.NetLock.Lock()
-		id := vm.shared.NextNetID
-		vm.shared.NextNetID++
-		vm.shared.NetListeners[id] = listener
-		vm.shared.NetLock.Unlock()
-
-		socketFields := map[string]value.Value{
-			"fd":   value.NewInt(int64(id)),
-			"addr": value.NewString(host),
-			"port": value.NewInt(int64(port)),
-			"open": value.NewBool(true),
-		}
-		return value.NewMapWithData(socketFields)
+func socketValue(fd int, address string, port int, open bool) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"fd":   value.NewInt(int64(fd)),
+		"addr": value.NewString(address),
+		"port": value.NewInt(int64(port)),
+		"open": value.NewBool(open),
 	})
+}
 
-	vm.DefineNative("net_accept", func(args []value.Value) value.Value {
-		if len(args) < 1 {
-			return value.NewNull()
-		}
-		sockMap, ok := args[0].Obj.(*value.ObjMap)
-		if !ok {
-			return value.NewNull()
-		}
-		fdVal, exists := sockMap.Get("fd")
-		if !exists {
-			return value.NewNull()
-		}
-		fd := int(fdVal.AsInt)
+func netResult(ok bool, data string, count int, message string) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":    value.NewBool(ok),
+		"data":  value.NewBytes(data),
+		"count": value.NewInt(int64(count)),
+		"error": value.NewString(message),
+	})
+}
 
-		vm.shared.NetLock.Lock()
-		listener, ok := vm.shared.NetListeners[fd]
-		vm.shared.NetLock.Unlock()
-
-		if !ok {
-			socketFields := map[string]value.Value{
-				"fd":   value.NewInt(-1),
-				"addr": value.NewString(""),
-				"port": value.NewInt(0),
-				"open": value.NewBool(false),
-			}
-			return value.NewMapWithData(socketFields)
-		}
-
-		// Check buffered connection from select
-		var conn net.Conn
-		var err error
-
-		if bufferedConn, ok := vm.netBufferedConns[fd]; ok {
-			conn = bufferedConn
-			delete(vm.netBufferedConns, fd)
+func selectResult(readyRead []value.Value) value.Value {
+	read := make([]value.Value, 64)
+	for index := range read {
+		if index < len(readyRead) {
+			read[index] = readyRead[index]
 		} else {
-			// Accept blocks. Lock is released above.
-			conn, err = listener.Accept()
+			read[index] = value.NewNull()
 		}
-
-		if err != nil {
-			socketFields := map[string]value.Value{
-				"fd":   value.NewInt(-1),
-				"addr": value.NewString(""),
-				"port": value.NewInt(0),
-				"open": value.NewBool(false),
-			}
-			return value.NewMapWithData(socketFields)
-		}
-
-		vm.shared.NetLock.Lock()
-		id := vm.shared.NextNetID
-		vm.shared.NextNetID++
-		vm.shared.NetConns[id] = conn
-		vm.shared.NetLock.Unlock()
-
-		remoteAddr := conn.RemoteAddr().String()
-		socketFields := map[string]value.Value{
-			"fd":   value.NewInt(int64(id)),
-			"addr": value.NewString(remoteAddr),
-			"port": value.NewInt(0),
-			"open": value.NewBool(true),
-		}
-		return value.NewMapWithData(socketFields)
+	}
+	empty := make([]value.Value, 64)
+	for index := range empty {
+		empty[index] = value.NewNull()
+	}
+	return value.NewMapWithData(map[string]value.Value{
+		"read":        value.NewArray(read),
+		"read_count":  value.NewInt(int64(len(readyRead))),
+		"write":       value.NewArray(empty),
+		"write_count": value.NewInt(0),
+		"error":       value.NewArray(empty),
+		"error_count": value.NewInt(0),
 	})
+}
 
-	vm.DefineNative("net_connect", func(args []value.Value) value.Value {
+func acceptConnection(resource *ListenerResource) (net.Conn, error) {
+	resource.acceptMu.Lock()
+	defer resource.acceptMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener == nil {
+		resource.stateMu.Unlock()
+		return nil, net.ErrClosed
+	}
+	if resource.bufferedAccept != nil {
+		connection := resource.bufferedAccept
+		resource.bufferedAccept = nil
+		resource.stateMu.Unlock()
+		return connection, nil
+	}
+	listener := resource.listener
+	resource.stateMu.Unlock()
+	return listener.Accept()
+}
+
+func receiveSocket(resource *SocketResource, size int) value.Value {
+	resource.readMu.Lock()
+	defer resource.readMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return netResult(false, "", 0, "invalid socket")
+	}
+	connection := resource.connection
+	buffered := resource.bufferedRead
+	resource.bufferedRead = nil
+	resource.stateMu.Unlock()
+
+	buffer := make([]byte, size)
+	read := 0
+	if len(buffered) != 0 {
+		copy(buffer, buffered)
+		read = len(buffered)
+	}
+	if read < size {
+		additional, readErr := connection.Read(buffer[read:])
+		if additional > 0 {
+			read += additional
+		}
+		if readErr != nil && read == 0 && additional == 0 {
+			if readErr == io.EOF {
+				return netResult(true, "", 0, "")
+			}
+			return netResult(false, "", 0, readErr.Error())
+		}
+	}
+	return netResult(true, string(buffer[:read]), read, "")
+}
+
+func sendSocket(resource *SocketResource, data string) value.Value {
+	resource.writeMu.Lock()
+	defer resource.writeMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return netResult(false, "", 0, "invalid socket")
+	}
+	connection := resource.connection
+	resource.stateMu.Unlock()
+
+	written, writeErr := connection.Write([]byte(data))
+	if writeErr != nil {
+		return netResult(false, "", 0, writeErr.Error())
+	}
+	return netResult(true, "", written, "")
+}
+
+func selectListener(resource *ListenerResource, timeout time.Duration) bool {
+	resource.acceptMu.Lock()
+	defer resource.acceptMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener == nil {
+		resource.stateMu.Unlock()
+		return false
+	}
+	if resource.bufferedAccept != nil {
+		resource.stateMu.Unlock()
+		return true
+	}
+	listener := resource.listener
+	resource.stateMu.Unlock()
+
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		return false
+	}
+	_ = tcpListener.SetDeadline(time.Now().Add(timeout))
+	connection, acceptErr := listener.Accept()
+	_ = tcpListener.SetDeadline(time.Time{})
+	if acceptErr != nil {
+		return false
+	}
+
+	resource.stateMu.Lock()
+	if resource.closed {
+		resource.stateMu.Unlock()
+		_ = connection.Close()
+		return false
+	}
+	resource.bufferedAccept = connection
+	resource.stateMu.Unlock()
+	return true
+}
+
+func selectSocket(resource *SocketResource, timeout time.Duration) bool {
+	resource.readMu.Lock()
+	defer resource.readMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return false
+	}
+	if len(resource.bufferedRead) != 0 {
+		resource.stateMu.Unlock()
+		return true
+	}
+	connection := resource.connection
+	resource.stateMu.Unlock()
+
+	_ = connection.SetReadDeadline(time.Now().Add(timeout))
+	buffer := make([]byte, 1)
+	read, readErr := connection.Read(buffer)
+	_ = connection.SetReadDeadline(time.Time{})
+	if readErr != nil || read == 0 {
+		return false
+	}
+
+	resource.stateMu.Lock()
+	if resource.closed {
+		resource.stateMu.Unlock()
+		return false
+	}
+	resource.bufferedRead = buffer[:read]
+	resource.stateMu.Unlock()
+	return true
+}
+
+func closeListener(resource *ListenerResource) {
+	resource.stateMu.Lock()
+	if resource.closed {
+		resource.stateMu.Unlock()
+		return
+	}
+	resource.closed = true
+	listener := resource.listener
+	buffered := resource.bufferedAccept
+	resource.bufferedAccept = nil
+	resource.stateMu.Unlock()
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if buffered != nil {
+		_ = buffered.Close()
+	}
+}
+
+func closeSocket(resource *SocketResource) {
+	resource.stateMu.Lock()
+	if resource.closed {
+		resource.stateMu.Unlock()
+		return
+	}
+	resource.closed = true
+	connection := resource.connection
+	resource.bufferedRead = nil
+	resource.stateMu.Unlock()
+	if connection != nil {
+		_ = connection.Close()
+	}
+}
+
+func (vm *VM) defineNetworkBuiltins() {
+	vm.DefineContextualNative("net_listen", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 		host := args[0].String()
 		port := int(args[1].AsInt)
-		addr := fmt.Sprintf("%s:%d", host, port)
+		listener, listenErr := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+		if listenErr != nil {
+			return socketValue(-1, host, port, false), nil
+		}
+		handle := machine.shared.Listeners.add(&ListenerResource{listener: listener})
+		return socketValue(handle, host, port, true), nil
+	})
 
-		conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	vm.DefineContextualNative("net_accept", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
 		if err != nil {
-			socketFields := map[string]value.Value{
-				"fd":   value.NewInt(-1),
-				"addr": value.NewString(host),
-				"port": value.NewInt(int64(port)),
-				"open": value.NewBool(false),
-			}
-			return value.NewMapWithData(socketFields)
+			return value.NewNull(), err
 		}
-
-		vm.shared.NetLock.Lock()
-		id := vm.shared.NextNetID
-		vm.shared.NextNetID++
-		vm.shared.NetConns[id] = conn
-		vm.shared.NetLock.Unlock()
-
-		socketFields := map[string]value.Value{
-			"fd":   value.NewInt(int64(id)),
-			"addr": value.NewString(host),
-			"port": value.NewInt(int64(port)),
-			"open": value.NewBool(true),
+		if len(args) < 1 {
+			return value.NewNull(), nil
 		}
-		return value.NewMapWithData(socketFields)
+		socket, ok := args[0].Obj.(*value.ObjMap)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		fdValue, exists := socket.Get("fd")
+		if !exists {
+			return value.NewNull(), nil
+		}
+		resource, exists := machine.shared.Listeners.get(int(fdValue.AsInt))
+		if !exists {
+			return socketValue(-1, "", 0, false), nil
+		}
+		connection, acceptErr := acceptConnection(resource)
+		if acceptErr != nil {
+			return socketValue(-1, "", 0, false), nil
+		}
+		handle := machine.shared.Sockets.add(&SocketResource{connection: connection})
+		return socketValue(handle, connection.RemoteAddr().String(), 0, true), nil
 	})
 
-	vm.DefineNative("net_recv", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("net_connect", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 2 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		sockMap, ok := args[0].Obj.(*value.ObjMap)
-		if !ok {
-			return value.NewNull()
+		host := args[0].String()
+		port := int(args[1].AsInt)
+		connection, connectErr := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 5*time.Second)
+		if connectErr != nil {
+			return socketValue(-1, host, port, false), nil
 		}
-		fdVal, _ := sockMap.Get("fd")
-		fd := int(fdVal.AsInt)
-		size := int(args[1].AsInt)
-
-		vm.shared.NetLock.Lock()
-		conn, ok := vm.shared.NetConns[fd]
-		vm.shared.NetLock.Unlock()
-
-		if !ok {
-			resultFields := map[string]value.Value{
-				"ok":    value.NewBool(false),
-				"data":  value.NewBytes(""),
-				"count": value.NewInt(0),
-				"error": value.NewString("invalid socket"),
-			}
-			return value.NewMapWithData(resultFields)
-		}
-
-		var n int
-		buf := make([]byte, size)
-
-		// Check buffered data from select
-		if buffered, ok := vm.netBufferedData[fd]; ok {
-			// Copy buffered data
-			copy(buf, buffered)
-			n = len(buffered)
-			delete(vm.netBufferedData, fd)
-		}
-
-		// Try to read more if space available
-		if n < size {
-			// Blocking read (no deadline)
-			n2, err2 := conn.Read(buf[n:])
-			if n2 > 0 {
-				n += n2
-			}
-
-			// Ignore timeout errors if we have at least some data
-			if err2 != nil {
-				if n == 0 {
-					// Only return error if we really got nothing
-					if err2 != nil && n2 == 0 {
-						if err2 == io.EOF {
-							// Return ok=true, count=0 for EOF
-							resultFields := map[string]value.Value{
-								"ok":    value.NewBool(true),
-								"data":  value.NewBytes(""),
-								"count": value.NewInt(0),
-								"error": value.NewString(""),
-							}
-							return value.NewMapWithData(resultFields)
-						}
-						resultFields := map[string]value.Value{
-							"ok":    value.NewBool(false),
-							"data":  value.NewBytes(""),
-							"count": value.NewInt(0),
-							"error": value.NewString(err2.Error()),
-						}
-						return value.NewMapWithData(resultFields)
-					}
-				}
-			}
-		}
-
-		resultFields := map[string]value.Value{
-			"ok":    value.NewBool(true),
-			"data":  value.NewBytes(string(buf[:n])),
-			"count": value.NewInt(int64(n)),
-			"error": value.NewString(""),
-		}
-		return value.NewMapWithData(resultFields)
+		handle := machine.shared.Sockets.add(&SocketResource{connection: connection})
+		return socketValue(handle, host, port, true), nil
 	})
 
-	vm.DefineNative("net_send", func(args []value.Value) value.Value {
-		if len(args) < 2 {
-			return value.NewNull()
+	vm.DefineContextualNative("net_recv", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
 		}
-		sockMap, ok := args[0].Obj.(*value.ObjMap)
+		if len(args) < 2 {
+			return value.NewNull(), nil
+		}
+		socket, ok := args[0].Obj.(*value.ObjMap)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		fdValue, _ := socket.Get("fd")
+		resource, exists := machine.shared.Sockets.get(int(fdValue.AsInt))
+		if !exists {
+			return netResult(false, "", 0, "invalid socket"), nil
+		}
+		return receiveSocket(resource, int(args[1].AsInt)), nil
+	})
+
+	vm.DefineContextualNative("net_send", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 2 {
+			return value.NewNull(), nil
+		}
+		socket, ok := args[0].Obj.(*value.ObjMap)
 		if !ok {
 			fmt.Printf("DEBUG: net_send args[0] not map: %T %v\n", args[0].Obj, args[0].Obj)
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		fdVal, _ := sockMap.Get("fd")
-		fd := int(fdVal.AsInt)
-		var data string
+		fdValue, _ := socket.Get("fd")
+		data := args[1].String()
 		if args[1].Type == value.VAL_BYTES {
 			data = args[1].Obj.(string)
-		} else {
-			data = args[1].String()
 		}
-
-		vm.shared.NetLock.Lock()
-		conn, ok := vm.shared.NetConns[fd]
-		vm.shared.NetLock.Unlock()
-
-		if !ok {
-			resultFields := map[string]value.Value{
-				"ok":    value.NewBool(false),
-				"data":  value.NewBytes(""),
-				"count": value.NewInt(0),
-				"error": value.NewString("invalid socket"),
-			}
-			return value.NewMapWithData(resultFields)
+		resource, exists := machine.shared.Sockets.get(int(fdValue.AsInt))
+		if !exists {
+			return netResult(false, "", 0, "invalid socket"), nil
 		}
-
-		n, err := conn.Write([]byte(data))
-		if err != nil {
-			resultFields := map[string]value.Value{
-				"ok":    value.NewBool(false),
-				"data":  value.NewBytes(""),
-				"count": value.NewInt(0),
-				"error": value.NewString(err.Error()),
-			}
-			return value.NewMapWithData(resultFields)
-		}
-
-		resultFields := map[string]value.Value{
-			"ok":    value.NewBool(true),
-			"data":  value.NewBytes(""),
-			"count": value.NewInt(int64(n)),
-			"error": value.NewString(""),
-		}
-		return value.NewMapWithData(resultFields)
+		return sendSocket(resource, data), nil
 	})
 
-	vm.DefineNative("net_close", func(args []value.Value) value.Value {
-		if len(args) < 1 {
-			return value.NewNull()
+	vm.DefineContextualNative("net_close", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
 		}
-
-		var fd int
-		// Check if arg is int (new style) or map (old style compatibility if needed, but we changed net.nx)
+		if len(args) < 1 {
+			return value.NewNull(), nil
+		}
+		fd := 0
 		if args[0].Type == value.VAL_INT {
 			fd = int(args[0].AsInt)
 		} else if args[0].Type == value.VAL_OBJ {
-			// Fallback for old calls? Or just error.
-			if sockMap, ok := args[0].Obj.(*value.ObjMap); ok {
-				if fdVal, found := sockMap.Get("fd"); found {
-					fd = int(fdVal.AsInt)
+			if socket, ok := args[0].Obj.(*value.ObjMap); ok {
+				if fdValue, found := socket.Get("fd"); found {
+					fd = int(fdValue.AsInt)
 				}
 			}
 		} else {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-
-		vm.shared.NetLock.Lock()
-		defer vm.shared.NetLock.Unlock()
-
-		// Try closing as listener
-		if listener, ok := vm.shared.NetListeners[fd]; ok {
-			listener.Close()
-			delete(vm.shared.NetListeners, fd)
-			return value.NewNull()
+		if resource, exists := machine.shared.Listeners.remove(fd); exists {
+			closeListener(resource)
+			return value.NewNull(), nil
 		}
-
-		// Try closing as connection
-		if conn, ok := vm.shared.NetConns[fd]; ok {
-			conn.Close()
-			delete(vm.shared.NetConns, fd)
+		if resource, exists := machine.shared.Sockets.remove(fd); exists {
+			closeSocket(resource)
 		}
-
-		return value.NewNull()
+		return value.NewNull(), nil
 	})
 
-	vm.DefineNative("net_setblocking", func(args []value.Value) value.Value {
-		// For TCP in Go, blocking is handled at a different level
-		// This is a no-op for now, as Go handles timeouts via SetDeadline
-		return value.NewNull()
+	vm.DefineContextualNative("net_setblocking", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		if _, err := nativeVM(context); err != nil {
+			return value.NewNull(), err
+		}
+		return value.NewNull(), nil
 	})
 
-	vm.DefineNative("net_select", func(args []value.Value) value.Value {
-		// args: read, write (ignored), err (ignored), timeout
+	vm.DefineContextualNative("net_select", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 4 {
-			return value.NewNull() // Or error map
+			return value.NewNull(), nil
 		}
-
-		timeoutMs := int(args[3].AsInt)
-		// Minimum 1ms to allow polling
-		if timeoutMs < 1 {
-			timeoutMs = 1
+		timeoutMilliseconds := int(args[3].AsInt)
+		if timeoutMilliseconds < 1 {
+			timeoutMilliseconds = 1
 		}
-
-		// Prepare Result Data
+		timeout := time.Millisecond * time.Duration(timeoutMilliseconds)
 		readyRead := make([]value.Value, 0)
-
-		// Parse Read Set
-		readArrVal := args[0]
-		if readArrVal.Type == value.VAL_OBJ {
-			if arr, ok := readArrVal.Obj.(*value.ObjArray); ok {
-				for _, el := range arr.Elements {
-					if el.Type == value.VAL_OBJ { // Check if socket (Map or Instance)
-						// Extract FD
-						var fd int64 = -1
-
-						if m, ok := el.Obj.(*value.ObjMap); ok {
-							if f, ok := m.Get("fd"); ok {
-								fd = f.AsInt
-							}
-						} else if inst, ok := el.Obj.(*value.ObjInstance); ok {
-							if f, ok := inst.Fields["fd"]; ok {
-								fd = f.AsInt
-							}
-						}
-
-						if fd != -1 {
-							isReady := false
-							id := int(fd)
-
-							// 1. Check buffers first
-							if _, ok := vm.netBufferedConns[id]; ok {
-								isReady = true
-							} else if _, ok := vm.netBufferedData[id]; ok {
-								isReady = true
-							} else {
-								// 2. Poll
-								vm.shared.NetLock.Lock()
-								l, isListener := vm.shared.NetListeners[id]
-								c, isConn := vm.shared.NetConns[id]
-								vm.shared.NetLock.Unlock()
-
-								if isListener {
-									if tcpL, ok := l.(*net.TCPListener); ok {
-										tcpL.SetDeadline(time.Now().Add(time.Millisecond * time.Duration(timeoutMs)))
-										conn, err := l.Accept()
-										if err == nil {
-											isReady = true
-											vm.netBufferedConns[id] = conn
-										}
-										// Reset deadline?
-										tcpL.SetDeadline(time.Time{})
-									}
-								} else if isConn {
-									conn := c
-									conn.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(timeoutMs)))
-									buf := make([]byte, 1) // Peek 1 byte
-									n, err := conn.Read(buf)
-									if err == nil && n > 0 {
-										isReady = true
-										// Buffer the data
-										vm.netBufferedData[id] = buf[:n]
-									}
-									// Reset deadline
-									conn.SetReadDeadline(time.Time{})
-								}
-							}
-
-							if isReady {
-								readyRead = append(readyRead, el)
-							}
-						}
+		if array, ok := args[0].Obj.(*value.ObjArray); args[0].Type == value.VAL_OBJ && ok {
+			for _, candidate := range array.Elements {
+				if candidate.Type != value.VAL_OBJ {
+					continue
+				}
+				handle := int64(-1)
+				if socket, ok := candidate.Obj.(*value.ObjMap); ok {
+					if fdValue, exists := socket.Get("fd"); exists {
+						handle = fdValue.AsInt
 					}
+				} else if instance, ok := candidate.Obj.(*value.ObjInstance); ok {
+					if fdValue, exists := instance.Fields["fd"]; exists {
+						handle = fdValue.AsInt
+					}
+				}
+				if handle == -1 {
+					continue
+				}
+				ready := false
+				if listener, exists := machine.shared.Listeners.get(int(handle)); exists {
+					ready = selectListener(listener, timeout)
+				} else if socket, exists := machine.shared.Sockets.get(int(handle)); exists {
+					ready = selectSocket(socket, timeout)
+				}
+				if ready {
+					readyRead = append(readyRead, candidate)
 				}
 			}
 		}
-
-		// Construct SelectResult Map
-		// struct SelectResult { read: Socket[64], read_count: int, ... }
-
-		// Fill read array up to 64
-		resReadArr := make([]value.Value, 64)
-		for i := 0; i < 64; i++ {
-			if i < len(readyRead) {
-				resReadArr[i] = readyRead[i]
-			} else {
-				resReadArr[i] = value.NewNull()
-			}
-		}
-
-		// Empties for others
-		emptyArr := make([]value.Value, 64)
-		for i := 0; i < 64; i++ {
-			emptyArr[i] = value.NewNull()
-		}
-
-		resFields := map[string]value.Value{
-			"read":        value.NewArray(resReadArr),
-			"read_count":  value.NewInt(int64(len(readyRead))),
-			"write":       value.NewArray(emptyArr),
-			"write_count": value.NewInt(0),
-			"error":       value.NewArray(emptyArr),
-			"error_count": value.NewInt(0),
-		}
-		return value.NewMapWithData(resFields)
+		return selectResult(readyRead), nil
 	})
 }

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -54,7 +54,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if !ok {
 			return value.NewNull()
 		}
-		fdVal, exists := sockMap.Data["fd"]
+		fdVal, exists := sockMap.Get("fd")
 		if !exists {
 			return value.NewNull()
 		}
@@ -154,7 +154,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if !ok {
 			return value.NewNull()
 		}
-		fdVal, _ := sockMap.Data["fd"]
+		fdVal, _ := sockMap.Get("fd")
 		fd := int(fdVal.AsInt)
 		size := int(args[1].AsInt)
 
@@ -236,7 +236,7 @@ func (vm *VM) defineNetworkBuiltins() {
 			fmt.Printf("DEBUG: net_send args[0] not map: %T %v\n", args[0].Obj, args[0].Obj)
 			return value.NewNull()
 		}
-		fdVal, _ := sockMap.Data["fd"]
+		fdVal, _ := sockMap.Get("fd")
 		fd := int(fdVal.AsInt)
 		var data string
 		if args[1].Type == value.VAL_BYTES {
@@ -291,7 +291,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		} else if args[0].Type == value.VAL_OBJ {
 			// Fallback for old calls? Or just error.
 			if sockMap, ok := args[0].Obj.(*value.ObjMap); ok {
-				if fdVal, found := sockMap.Data["fd"]; found {
+				if fdVal, found := sockMap.Get("fd"); found {
 					fd = int(fdVal.AsInt)
 				}
 			}
@@ -349,7 +349,7 @@ func (vm *VM) defineNetworkBuiltins() {
 						var fd int64 = -1
 
 						if m, ok := el.Obj.(*value.ObjMap); ok {
-							if f, ok := m.Data["fd"]; ok {
+							if f, ok := m.Get("fd"); ok {
 								fd = f.AsInt
 							}
 						} else if inst, ok := el.Obj.(*value.ObjInstance); ok {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -38,28 +38,123 @@ func builtinMapField(t *testing.T, object value.Value, field string) value.Value
 	return requireTestMapValue(t, mapped, field)
 }
 
+func setupAcceptedLoopback(t *testing.T, machine *VM) (value.Value, value.Value, value.Value) {
+	t.Helper()
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
+	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
+	if !exists {
+		t.Fatalf("listener descriptor %d is not registered", listenerFD)
+	}
+	listenerResource.stateMu.Lock()
+	registeredListener := listenerResource.listener
+	listenerResource.stateMu.Unlock()
+	tcpAddress, ok := registeredListener.Addr().(*net.TCPAddr)
+	if !ok || tcpAddress.Port == 0 {
+		t.Fatalf("listener address = %#v, want OS-assigned TCP port", registeredListener.Addr())
+	}
+
+	client := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("127.0.0.1"), value.NewInt(int64(tcpAddress.Port)))
+	assertBuiltinValue(t, builtinMapField(t, client, "open"), value.NewBool(true))
+	listenerReady := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{listener}), value.NewArray(nil), value.NewArray(nil), value.NewInt(250))
+	assertBuiltinValue(t, builtinMapField(t, listenerReady, "read_count"), value.NewInt(1))
+	server := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	assertBuiltinValue(t, builtinMapField(t, server, "open"), value.NewBool(true))
+
+	t.Cleanup(func() {
+		callBuiltinWithinBound(t, machine, "net_close", client)
+		callBuiltinWithinBound(t, machine, "net_close", server)
+		callBuiltinWithinBound(t, machine, "net_close", value.NewInt(int64(listenerFD)))
+	})
+	return listener, client, server
+}
+
+func requireValidSelectResult(t *testing.T, result value.Value) {
+	t.Helper()
+	mapping := requireBuiltinMap(t, result)
+	for _, field := range []string{"read", "write", "error"} {
+		item := requireTestMapValue(t, mapping, field)
+		if _, ok := item.Obj.(*value.ObjArray); item.Type != value.VAL_OBJ || !ok {
+			t.Fatalf("select %s=%v, want array", field, item)
+		}
+	}
+	for _, field := range []string{"read_count", "write_count", "error_count"} {
+		item := requireTestMapValue(t, mapping, field)
+		if item.Type != value.VAL_INT {
+			t.Fatalf("select %s=%v, want int", field, item)
+		}
+	}
+}
+
+func TestNetSelectBufferIsSharedAcrossVMs(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	child := NewWithShared(machine.shared, machine.Config)
+
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
+	selected := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(250))
+	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
+	received := callBuiltinWithinBound(t, child, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("x"))
+}
+
+func TestConcurrentNetSelect(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	child := NewWithShared(machine.shared, machine.Config)
+
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
+	start := make(chan struct{})
+	done := make(chan value.Value, 2)
+	for _, current := range []*VM{machine, child} {
+		current := current
+		go func() {
+			<-start
+			done <- callBuiltinWithinBound(t, current, "net_select",
+				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5))
+		}()
+	}
+	close(start)
+	for i := 0; i < 2; i++ {
+		select {
+		case result := <-done:
+			requireValidSelectResult(t, result)
+		case <-time.After(statefulBuiltinTimeout):
+			t.Fatal("concurrent net_select did not complete")
+		}
+	}
+}
+
 func TestNetworkBuiltinsLoopbackLifecycle(t *testing.T) {
 	machine := New()
 	defer func() {
-		machine.shared.NetLock.Lock()
-		defer machine.shared.NetLock.Unlock()
-		for _, listener := range machine.shared.NetListeners {
-			_ = listener.Close()
+		for handle, listener := range machine.shared.Listeners.snapshot() {
+			machine.shared.Listeners.remove(handle)
+			closeListener(listener)
 		}
-		for _, connection := range machine.shared.NetConns {
-			_ = connection.Close()
+		for handle, socket := range machine.shared.Sockets.snapshot() {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(socket)
 		}
 	}()
 
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
 	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
 	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
-	machine.shared.NetLock.Lock()
-	registeredListener := machine.shared.NetListeners[listenerFD]
-	machine.shared.NetLock.Unlock()
-	if registeredListener == nil {
+	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
+	if !exists {
 		t.Fatalf("listener descriptor %d is not registered", listenerFD)
 	}
+	listenerResource.stateMu.Lock()
+	registeredListener := listenerResource.listener
+	listenerResource.stateMu.Unlock()
 	tcpAddress, ok := registeredListener.Addr().(*net.TCPAddr)
 	if !ok || tcpAddress.Port == 0 {
 		t.Fatalf("listener address = %#v, want OS-assigned TCP port", registeredListener.Addr())
@@ -100,10 +195,8 @@ func TestNetworkBuiltinsLoopbackLifecycle(t *testing.T) {
 	assertBuiltinValue(t, callBuiltinWithinBound(t, machine, "net_close", client), value.NewNull())
 	assertBuiltinValue(t, callBuiltinWithinBound(t, machine, "net_close", server), value.NewNull())
 	assertBuiltinValue(t, callBuiltinWithinBound(t, machine, "net_close", value.NewInt(int64(listenerFD))), value.NewNull())
-	machine.shared.NetLock.Lock()
-	listenerCount := len(machine.shared.NetListeners)
-	connectionCount := len(machine.shared.NetConns)
-	machine.shared.NetLock.Unlock()
+	listenerCount := len(machine.shared.Listeners.snapshot())
+	connectionCount := len(machine.shared.Sockets.snapshot())
 	if listenerCount != 0 || connectionCount != 0 {
 		t.Fatalf("network state after close: %d listeners, %d connections", listenerCount, connectionCount)
 	}

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -35,11 +35,7 @@ func callBuiltinWithinBound(t *testing.T, machine *VM, name string, args ...valu
 func builtinMapField(t *testing.T, object value.Value, field string) value.Value {
 	t.Helper()
 	mapped := requireBuiltinMap(t, object)
-	got, ok := mapped.Data[field]
-	if !ok {
-		t.Fatalf("map does not contain field %q", field)
-	}
-	return got
+	return requireTestMapValue(t, mapped, field)
 }
 
 func TestNetworkBuiltinsLoopbackLifecycle(t *testing.T) {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"net"
 	"testing"
+	"time"
 
 	"noxy-vm/internal/value"
 )
@@ -10,11 +11,25 @@ import (
 func callBuiltinWithinBound(t *testing.T, machine *VM, name string, args ...value.Value) value.Value {
 	t.Helper()
 	native := requireBuiltin(t, machine, name)
-	result := make(chan value.Value, 1)
+	type invocationResult struct {
+		value value.Value
+		err   error
+	}
+	result := make(chan invocationResult, 1)
 	go func() {
-		result <- native.Fn(args)
+		value, err := native.Invoke(machine, args)
+		result <- invocationResult{value: value, err: err}
 	}()
-	return awaitBuiltinResult(t, result, name)
+	select {
+	case invocation := <-result:
+		if invocation.err != nil {
+			t.Fatalf("%s: %v", name, invocation.err)
+		}
+		return invocation.value
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatalf("%s did not complete within %s", name, statefulBuiltinTimeout)
+		return value.NewNull()
+	}
 }
 
 func builtinMapField(t *testing.T, object value.Value, field string) value.Value {

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -111,3 +111,34 @@ func TestBuiltinNativeSignatures(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulBuiltinsUseContextualHandlers(t *testing.T) {
+	machine := New()
+	for _, name := range []string{
+		"spawn", "delete", "append", "pop", "json_loads", "sys_load_plugin",
+		"io_open", "net_listen", "sqlite_open",
+	} {
+		native := requireBuiltin(t, machine, name)
+		if native.Contextual == nil || native.Fn != nil || !native.IsCallable() {
+			t.Errorf("%s is not exclusively contextual", name)
+		}
+	}
+}
+
+func TestContextualCollectionHandlersInvokeThroughCallingVM(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	target := value.NewArray([]value.Value{value.NewInt(1)})
+	ref := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &target}}
+	assertBuiltinValue(t, callBuiltin(t, child, "append", ref, value.NewInt(2)), value.NewNull())
+	assertBuiltinValue(t, callBuiltin(t, child, "pop", ref), value.NewInt(2))
+}
+
+func TestContextualJSONLoadsInvokesThroughCallingVM(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	target := value.NewMap()
+	ref := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &target}}
+	assertBuiltinValue(t, callBuiltin(t, child, "json_loads", value.NewString(`{"answer":42}`), ref), value.NewBool(true))
+	assertBuiltinValue(t, requireTestMapValue(t, target.Obj.(*value.ObjMap), "answer"), value.NewInt(42))
+}

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -46,14 +46,13 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"wg_add", "wg_done", "wg_wait",
 	}
 
-	machine.shared.GlobalsLock.RLock()
-	actual := make([]string, 0, len(machine.shared.Globals))
-	for name, global := range machine.shared.Globals {
+	globals := machine.shared.Root.LocalSnapshot()
+	actual := make([]string, 0, len(globals))
+	for name, global := range globals {
 		if global.Type == value.VAL_NATIVE {
 			actual = append(actual, name)
 		}
 	}
-	machine.shared.GlobalsLock.RUnlock()
 	sort.Strings(actual)
 
 	if !reflect.DeepEqual(actual, expected) {

--- a/internal/vm/builtins_sqlite.go
+++ b/internal/vm/builtins_sqlite.go
@@ -10,473 +10,444 @@ import (
 )
 
 func (vm *VM) defineSQLiteBuiltins() {
-	// SQLite Native Functions
-	vm.DefineNative("sqlite_open", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("sqlite_open", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) != 2 {
-			return value.NewNull()
-		} // path, wrapper struct
-		path := args[0].String()
+			return value.NewNull(), nil
+		}
 		structInst, ok := args[1].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		structDef := structInst.Struct
 
-		db, err := sql.Open("sqlite", path)
-		openVal := true
+		database, openErr := sql.Open("sqlite", args[0].String())
+		open := openErr == nil
+		if open {
+			open = database.Ping() == nil
+		}
+		handle := machine.shared.Databases.add(&DatabaseResource{
+			database: database,
+			closed:   database == nil,
+		})
+
+		instance := value.NewInstance(structInst.Struct).Obj.(*value.ObjInstance)
+		instance.Fields["handle"] = value.NewInt(int64(handle))
+		instance.Fields["open"] = value.NewBool(open)
+		return value.Value{Type: value.VAL_OBJ, Obj: instance}, nil
+	})
+
+	vm.DefineContextualNative("sqlite_close", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
 		if err != nil {
-			openVal = false
-		} else {
-			if err = db.Ping(); err != nil {
-				openVal = false
-			}
+			return value.NewNull(), err
 		}
-
-		vm.shared.DbLock.Lock()
-		id := vm.shared.NextDbID
-		vm.shared.NextDbID++
-		vm.shared.DbHandles[id] = db
-		vm.shared.DbLock.Unlock()
-
-		inst := value.NewInstance(structDef).Obj.(*value.ObjInstance)
-		inst.Fields["handle"] = value.NewInt(int64(id))
-		inst.Fields["open"] = value.NewBool(openVal)
-
-		return value.Value{Type: value.VAL_OBJ, Obj: inst}
-	})
-
-	vm.DefineNative("sqlite_close", func(args []value.Value) value.Value {
 		if len(args) != 1 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		dbInst, ok := args[0].Obj.(*value.ObjInstance)
+		databaseInstance, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
 
-		handle := int(dbInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		defer vm.shared.DbLock.Unlock()
-
-		if db, ok := vm.shared.DbHandles[handle]; ok {
-			db.Close()
-			delete(vm.shared.DbHandles, handle)
-			dbInst.Fields["open"] = value.NewBool(false)
-		}
-		return value.NewNull()
-	})
-
-	vm.DefineNative("sqlite_exec", func(args []value.Value) value.Value {
-		if len(args) < 3 {
-			return value.NewNull()
-		}
-		dbInst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		sqlStr := args[1].String()
-
-		resTmplInst, ok := args[2].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		resStruct := resTmplInst.Struct
-
-		handle := int(dbInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		db, ok := vm.shared.DbHandles[handle]
-		vm.shared.DbLock.Unlock() // Unlock for Exec
-
-		if ok {
-			result, err := db.Exec(sqlStr)
-			resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-			if err != nil {
-				resInst.Fields["ok"] = value.NewBool(false)
-				resInst.Fields["error"] = value.NewString(err.Error())
-				resInst.Fields["rows_affected"] = value.NewInt(0)
-				resInst.Fields["last_insert_id"] = value.NewInt(0)
-			} else {
-				rowsAffected, _ := result.RowsAffected()
-				lastId, _ := result.LastInsertId()
-				resInst.Fields["ok"] = value.NewBool(true)
-				resInst.Fields["error"] = value.NewString("")
-				resInst.Fields["rows_affected"] = value.NewInt(rowsAffected)
-				resInst.Fields["last_insert_id"] = value.NewInt(lastId)
+		resource, exists := machine.shared.Databases.remove(int(databaseInstance.Fields["handle"].AsInt))
+		if exists {
+			resource.stateMu.Lock()
+			database := resource.database
+			resource.closed = true
+			resource.stateMu.Unlock()
+			if database != nil {
+				_ = database.Close()
 			}
-			return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+			databaseInstance.Fields["open"] = value.NewBool(false)
 		}
-		// Invalid handle
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(false)
-		resInst.Fields["error"] = value.NewString("invalid database handle")
-		resInst.Fields["rows_affected"] = value.NewInt(0)
-		resInst.Fields["last_insert_id"] = value.NewInt(0)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		return value.NewNull(), nil
 	})
 
-	vm.DefineNative("sqlite_exec_params", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("sqlite_exec", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 3 {
+			return value.NewNull(), nil
+		}
+		databaseInstance, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		resultTemplate, ok := args[2].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+
+		database, valid := sqliteDatabase(machine, databaseInstance)
+		if !valid {
+			return sqliteExecError(resultTemplate.Struct, "invalid database handle"), nil
+		}
+		result, execErr := database.Exec(args[1].String())
+		return sqliteExecResult(resultTemplate.Struct, result, execErr), nil
+	})
+
+	vm.DefineContextualNative("sqlite_exec_params", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 4 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		dbInst, ok := args[0].Obj.(*value.ObjInstance)
+		databaseInstance, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		sqlStr := args[1].String()
-		paramsArray, ok := args[2].Obj.(*value.ObjArray)
+		parameters, ok := args[2].Obj.(*value.ObjArray)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-
-		resTmplInst, ok := args[3].Obj.(*value.ObjInstance)
+		resultTemplate, ok := args[3].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		resStruct := resTmplInst.Struct
 
-		handle := int(dbInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		db, ok := vm.shared.DbHandles[handle]
-		vm.shared.DbLock.Unlock()
-
-		if ok {
-			// Convert params
-			queryArgs := make([]interface{}, len(paramsArray.Elements))
-			for i, val := range paramsArray.Elements {
-				switch val.Type {
-				case value.VAL_INT:
-					queryArgs[i] = val.AsInt
-				case value.VAL_FLOAT:
-					queryArgs[i] = val.AsFloat
-				case value.VAL_BOOL:
-					queryArgs[i] = val.AsBool
-				case value.VAL_NULL:
-					queryArgs[i] = nil
-				case value.VAL_OBJ:
-					if b, ok := val.Obj.(string); ok {
-						queryArgs[i] = b
-					} else {
-						queryArgs[i] = val.String()
-					}
-				default:
-					queryArgs[i] = val.String()
-				}
-			}
-
-			result, err := db.Exec(sqlStr, queryArgs...)
-			resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-			if err != nil {
-				resInst.Fields["ok"] = value.NewBool(false)
-				resInst.Fields["error"] = value.NewString(err.Error())
-				resInst.Fields["rows_affected"] = value.NewInt(0)
-				resInst.Fields["last_insert_id"] = value.NewInt(0)
-			} else {
-				rowsAffected, _ := result.RowsAffected()
-				lastId, _ := result.LastInsertId()
-				resInst.Fields["ok"] = value.NewBool(true)
-				resInst.Fields["error"] = value.NewString("")
-				resInst.Fields["rows_affected"] = value.NewInt(rowsAffected)
-				resInst.Fields["last_insert_id"] = value.NewInt(lastId)
-			}
-			return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		database, valid := sqliteDatabase(machine, databaseInstance)
+		if !valid {
+			return sqliteExecError(resultTemplate.Struct, "invalid database handle"), nil
 		}
-		// Invalid handle
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(false)
-		resInst.Fields["error"] = value.NewString("invalid database handle")
-		resInst.Fields["rows_affected"] = value.NewInt(0)
-		resInst.Fields["last_insert_id"] = value.NewInt(0)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
+		queryArguments := make([]interface{}, len(parameters.Elements))
+		for index, parameter := range parameters.Elements {
+			queryArguments[index] = sqliteParameter(parameter)
+		}
+		result, execErr := database.Exec(args[1].String(), queryArguments...)
+		return sqliteExecResult(resultTemplate.Struct, result, execErr), nil
 	})
 
-	vm.DefineNative("sqlite_prepare", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("sqlite_prepare", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 3 {
-			return value.NewNull()
-		} // db, sql, stmt wrapper
-		dbInst, ok := args[0].Obj.(*value.ObjInstance)
+			return value.NewNull(), nil
+		}
+		databaseInstance, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		sqlStr := args[1].String()
-		stmtInst, ok := args[2].Obj.(*value.ObjInstance)
+		statementTemplate, ok := args[2].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		stmtStructDef := stmtInst.Struct
 
-		handle := int(dbInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		db, ok := vm.shared.DbHandles[handle]
-		vm.shared.DbLock.Unlock()
-
-		if ok {
-			stmt, err := db.Prepare(sqlStr)
-			if err == nil {
-				vm.shared.DbLock.Lock()
-				id := vm.shared.NextStmtID
-				vm.shared.NextStmtID++
-				vm.shared.StmtHandles[id] = stmt
-				vm.shared.StmtParams[id] = make(map[int]interface{})
-				vm.shared.DbLock.Unlock()
-
-				inst := value.NewInstance(stmtStructDef).Obj.(*value.ObjInstance)
-				inst.Fields["handle"] = value.NewInt(int64(id))
-				return value.Value{Type: value.VAL_OBJ, Obj: inst}
-			}
+		database, valid := sqliteDatabase(machine, databaseInstance)
+		if !valid {
+			return value.NewNull(), nil
 		}
-		return value.NewNull()
+		statement, prepareErr := database.Prepare(args[1].String())
+		if prepareErr != nil {
+			return value.NewNull(), nil
+		}
+		handle := machine.shared.Statements.add(&StatementResource{
+			statement:  statement,
+			parameters: make(map[int]interface{}),
+		})
+		instance := value.NewInstance(statementTemplate.Struct).Obj.(*value.ObjInstance)
+		instance.Fields["handle"] = value.NewInt(int64(handle))
+		return value.Value{Type: value.VAL_OBJ, Obj: instance}, nil
 	})
 
-	bindFunc := func(args []value.Value, val interface{}) value.Value {
+	vm.DefineContextualNative("sqlite_bind_text", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if len(args) < 3 {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		stmtInst, ok := args[0].Obj.(*value.ObjInstance)
+		return bindSQLiteParameter(machine, args, args[2].String()), nil
+	})
+	vm.DefineContextualNative("sqlite_bind_float", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 3 {
+			return value.NewNull(), nil
+		}
+		return bindSQLiteParameter(machine, args, args[2].AsFloat), nil
+	})
+	vm.DefineContextualNative("sqlite_bind_int", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 3 {
+			return value.NewNull(), nil
+		}
+		return bindSQLiteParameter(machine, args, args[2].AsInt), nil
+	})
+
+	vm.DefineContextualNative("sqlite_step_exec", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 2 {
+			return value.NewNull(), nil
+		}
+		statementInstance, ok := args[0].Obj.(*value.ObjInstance)
 		if !ok {
-			return value.NewNull()
+			return value.NewNull(), nil
 		}
-		idx := int(args[1].AsInt)
+		resultTemplate, ok := args[1].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
 
-		handle := int(stmtInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		defer vm.shared.DbLock.Unlock()
-
-		if _, ok := vm.shared.StmtHandles[handle]; ok {
-			if vm.shared.StmtParams[handle] == nil {
-				vm.shared.StmtParams[handle] = make(map[int]interface{})
+		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		if !exists {
+			return sqliteExecError(resultTemplate.Struct, "invalid statement handle"), nil
+		}
+		resource.mu.Lock()
+		if resource.closed || resource.statement == nil {
+			resource.mu.Unlock()
+			return sqliteExecError(resultTemplate.Struct, "invalid statement handle"), nil
+		}
+		statement := resource.statement
+		maxIndex := 0
+		for index := range resource.parameters {
+			if index > maxIndex {
+				maxIndex = index
 			}
-			vm.shared.StmtParams[handle][idx] = val
 		}
+		parameters := make([]interface{}, maxIndex)
+		for index := 1; index <= maxIndex; index++ {
+			parameters[index-1] = resource.parameters[index]
+		}
+		resource.parameters = make(map[int]interface{})
+		resource.mu.Unlock()
+
+		result, execErr := statement.Exec(parameters...)
+		return sqliteExecResult(resultTemplate.Struct, result, execErr), nil
+	})
+
+	vm.DefineContextualNative("sqlite_reset", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 1 {
+			return value.NewNull(), nil
+		}
+		statementInstance, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		if exists {
+			resource.mu.Lock()
+			if !resource.closed && resource.statement != nil {
+				resource.parameters = make(map[int]interface{})
+			}
+			resource.mu.Unlock()
+		}
+		return value.NewNull(), nil
+	})
+
+	vm.DefineContextualNative("sqlite_finalize", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 1 {
+			return value.NewNull(), nil
+		}
+		statementInstance, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		resource, exists := machine.shared.Statements.remove(int(statementInstance.Fields["handle"].AsInt))
+		if !exists {
+			return value.NewNull(), nil
+		}
+		resource.mu.Lock()
+		resource.closed = true
+		statement := resource.statement
+		resource.statement = nil
+		resource.parameters = nil
+		resource.mu.Unlock()
+		if statement != nil {
+			_ = statement.Close()
+		}
+		return value.NewNull(), nil
+	})
+
+	vm.DefineContextualNative("sqlite_query", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 4 {
+			return value.NewNull(), nil
+		}
+		databaseInstance, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		resultTemplate, ok := args[2].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+		rowTemplate, ok := args[3].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull(), nil
+		}
+
+		database, valid := sqliteDatabase(machine, databaseInstance)
+		if !valid {
+			return sqliteQueryError(resultTemplate.Struct, "invalid database handle"), nil
+		}
+		rows, queryErr := database.Query(args[1].String())
+		if queryErr != nil {
+			return sqliteQueryError(resultTemplate.Struct, queryErr.Error()), nil
+		}
+		defer rows.Close()
+
+		columns, _ := rows.Columns()
+		columnValues := make([]value.Value, len(columns))
+		for index, column := range columns {
+			columnValues[index] = value.NewString(column)
+		}
+		var rowValues []value.Value
+		for rows.Next() {
+			destination := make([]interface{}, len(columns))
+			destinationPointers := make([]interface{}, len(columns))
+			for index := range destination {
+				destinationPointers[index] = &destination[index]
+			}
+			_ = rows.Scan(destinationPointers...)
+
+			values := make([]value.Value, len(columns))
+			for index, item := range destination {
+				values[index] = sqliteValue(item)
+			}
+			row := value.NewInstance(rowTemplate.Struct).Obj.(*value.ObjInstance)
+			row.Fields["values"] = value.NewArray(values)
+			rowValues = append(rowValues, value.Value{Type: value.VAL_OBJ, Obj: row})
+		}
+
+		result := value.NewInstance(resultTemplate.Struct).Obj.(*value.ObjInstance)
+		result.Fields["columns"] = value.NewArray(columnValues)
+		result.Fields["rows"] = value.NewArray(rowValues)
+		result.Fields["row_count"] = value.NewInt(int64(len(rowValues)))
+		result.Fields["ok"] = value.NewBool(true)
+		result.Fields["error"] = value.NewString("")
+		return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
+	})
+}
+
+func sqliteDatabase(machine *VM, instance *value.ObjInstance) (*sql.DB, bool) {
+	resource, ok := machine.shared.Databases.get(int(instance.Fields["handle"].AsInt))
+	if !ok {
+		return nil, false
+	}
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.database == nil {
+		return nil, false
+	}
+	return resource.database, true
+}
+
+func bindSQLiteParameter(machine *VM, args []value.Value, parameter interface{}) value.Value {
+	statementInstance, ok := args[0].Obj.(*value.ObjInstance)
+	if !ok {
 		return value.NewNull()
 	}
-
-	vm.DefineNative("sqlite_bind_text", func(args []value.Value) value.Value {
-		return bindFunc(args, args[2].String())
-	})
-	vm.DefineNative("sqlite_bind_float", func(args []value.Value) value.Value {
-		return bindFunc(args, args[2].AsFloat)
-	})
-	vm.DefineNative("sqlite_bind_int", func(args []value.Value) value.Value {
-		return bindFunc(args, args[2].AsInt)
-	})
-
-	vm.DefineNative("sqlite_step_exec", func(args []value.Value) value.Value {
-		if len(args) < 2 {
-			return value.NewNull()
-		}
-		stmtInst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		resTmplInst, ok := args[1].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		resStruct := resTmplInst.Struct
-
-		handle := int(stmtInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		stmt, ok := vm.shared.StmtHandles[handle]
-		var params map[int]interface{}
-		if ok {
-			origParams := vm.shared.StmtParams[handle]
-			params = make(map[int]interface{})
-			for k, v := range origParams {
-				params[k] = v
-			}
-		}
-		vm.shared.DbLock.Unlock()
-
-		if ok {
-			// params := vm.stmtParams[handle] // Replaced by copy
-			var maxIdx int
-			for k := range params {
-				if k > maxIdx {
-					maxIdx = k
-				}
-			}
-			argsList := make([]interface{}, maxIdx)
-			for k, v := range params {
-				if k > 0 && k <= maxIdx {
-					argsList[k-1] = v
-				}
-			}
-			result, err := stmt.Exec(argsList...)
-
-			resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-			if err != nil {
-				resInst.Fields["ok"] = value.NewBool(false)
-				resInst.Fields["error"] = value.NewString(err.Error())
-				resInst.Fields["rows_affected"] = value.NewInt(0)
-				resInst.Fields["last_insert_id"] = value.NewInt(0)
-			} else {
-				rowsAffected, _ := result.RowsAffected()
-				lastId, _ := result.LastInsertId()
-				resInst.Fields["ok"] = value.NewBool(true)
-				resInst.Fields["error"] = value.NewString("")
-				resInst.Fields["rows_affected"] = value.NewInt(rowsAffected)
-				resInst.Fields["last_insert_id"] = value.NewInt(lastId)
-			}
-			return value.Value{Type: value.VAL_OBJ, Obj: resInst}
-		}
-
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["ok"] = value.NewBool(false)
-		resInst.Fields["error"] = value.NewString("invalid statement handle")
-		resInst.Fields["rows_affected"] = value.NewInt(0)
-		resInst.Fields["last_insert_id"] = value.NewInt(0)
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
-	})
-
-	vm.DefineNative("sqlite_reset", func(args []value.Value) value.Value {
-		if len(args) < 1 {
-			return value.NewNull()
-		}
-		stmtInst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		handle := int(stmtInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		defer vm.shared.DbLock.Unlock()
-
-		if _, ok := vm.shared.StmtHandles[handle]; ok {
-			vm.shared.StmtParams[handle] = make(map[int]interface{})
-		}
+	resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+	if !exists {
 		return value.NewNull()
-	})
-
-	vm.DefineNative("sqlite_finalize", func(args []value.Value) value.Value {
-		if len(args) < 1 {
-			return value.NewNull()
-		}
-		stmtInst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		handle := int(stmtInst.Fields["handle"].AsInt)
-
-		vm.shared.DbLock.Lock()
-		defer vm.shared.DbLock.Unlock()
-
-		if stmt, ok := vm.shared.StmtHandles[handle]; ok {
-			stmt.Close()
-			delete(vm.shared.StmtHandles, handle)
-			delete(vm.shared.StmtParams, handle)
-		}
+	}
+	resource.mu.Lock()
+	defer resource.mu.Unlock()
+	if resource.closed || resource.statement == nil {
 		return value.NewNull()
-	})
+	}
+	if resource.parameters == nil {
+		resource.parameters = make(map[int]interface{})
+	}
+	resource.parameters[int(args[1].AsInt)] = parameter
+	return value.NewNull()
+}
 
-	vm.DefineNative("sqlite_query", func(args []value.Value) value.Value {
-		if len(args) < 4 {
-			return value.NewNull()
-		} // db, sql, tmplQueryResult, tmplRow
-
-		dbInst, ok := args[0].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
+func sqliteParameter(parameter value.Value) interface{} {
+	switch parameter.Type {
+	case value.VAL_INT:
+		return parameter.AsInt
+	case value.VAL_FLOAT:
+		return parameter.AsFloat
+	case value.VAL_BOOL:
+		return parameter.AsBool
+	case value.VAL_NULL:
+		return nil
+	case value.VAL_OBJ:
+		if text, ok := parameter.Obj.(string); ok {
+			return text
 		}
-		sqlStr := args[1].String()
+		return parameter.String()
+	default:
+		return parameter.String()
+	}
+}
 
-		resTmplInst, ok := args[2].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		resStruct := resTmplInst.Struct
+func sqliteExecResult(definition *value.ObjStruct, result sql.Result, err error) value.Value {
+	if err != nil {
+		return sqliteExecError(definition, err.Error())
+	}
+	rowsAffected, _ := result.RowsAffected()
+	lastInsertID, _ := result.LastInsertId()
+	instance := value.NewInstance(definition).Obj.(*value.ObjInstance)
+	instance.Fields["ok"] = value.NewBool(true)
+	instance.Fields["error"] = value.NewString("")
+	instance.Fields["rows_affected"] = value.NewInt(rowsAffected)
+	instance.Fields["last_insert_id"] = value.NewInt(lastInsertID)
+	return value.Value{Type: value.VAL_OBJ, Obj: instance}
+}
 
-		rowTmplInst, ok := args[3].Obj.(*value.ObjInstance)
-		if !ok {
-			return value.NewNull()
-		}
-		rowStruct := rowTmplInst.Struct
+func sqliteExecError(definition *value.ObjStruct, errorText string) value.Value {
+	instance := value.NewInstance(definition).Obj.(*value.ObjInstance)
+	instance.Fields["ok"] = value.NewBool(false)
+	instance.Fields["error"] = value.NewString(errorText)
+	instance.Fields["rows_affected"] = value.NewInt(0)
+	instance.Fields["last_insert_id"] = value.NewInt(0)
+	return value.Value{Type: value.VAL_OBJ, Obj: instance}
+}
 
-		handle := int(dbInst.Fields["handle"].AsInt)
+func sqliteQueryError(definition *value.ObjStruct, errorText string) value.Value {
+	instance := value.NewInstance(definition).Obj.(*value.ObjInstance)
+	instance.Fields["columns"] = value.NewArray(nil)
+	instance.Fields["rows"] = value.NewArray(nil)
+	instance.Fields["row_count"] = value.NewInt(0)
+	instance.Fields["ok"] = value.NewBool(false)
+	instance.Fields["error"] = value.NewString(errorText)
+	return value.Value{Type: value.VAL_OBJ, Obj: instance}
+}
 
-		vm.shared.DbLock.Lock()
-		db, ok := vm.shared.DbHandles[handle]
-		vm.shared.DbLock.Unlock()
-
-		if ok {
-			rows, err := db.Query(sqlStr)
-			if err != nil {
-				// Return QueryResult with ok=false and error message
-				resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-				resInst.Fields["columns"] = value.NewArray(nil)
-				resInst.Fields["rows"] = value.NewArray(nil)
-				resInst.Fields["row_count"] = value.NewInt(0)
-				resInst.Fields["ok"] = value.NewBool(false)
-				resInst.Fields["error"] = value.NewString(err.Error())
-				return value.Value{Type: value.VAL_OBJ, Obj: resInst}
-			}
-			defer rows.Close()
-
-			cols, _ := rows.Columns()
-			colVals := make([]value.Value, len(cols))
-			for i, c := range cols {
-				colVals[i] = value.NewString(c)
-			}
-
-			var rowInsts []value.Value
-
-			for rows.Next() {
-				// Scan to interface{}
-				dest := make([]interface{}, len(cols))
-				destPtrs := make([]interface{}, len(cols))
-				for i := range dest {
-					destPtrs[i] = &dest[i]
-				}
-
-				rows.Scan(destPtrs...)
-
-				rowVals := make([]value.Value, len(cols))
-				for i, v := range dest {
-					// Convert Go type to Noxy value
-					switch tv := v.(type) {
-					case nil:
-						rowVals[i] = value.NewNull()
-					case int64:
-						rowVals[i] = value.NewInt(tv)
-					case float64:
-						rowVals[i] = value.NewFloat(tv)
-					case string:
-						rowVals[i] = value.NewString(tv)
-					case []byte:
-						rowVals[i] = value.NewString(string(tv))
-					default:
-						rowVals[i] = value.NewString(fmt.Sprintf("%v", tv))
-					}
-				}
-
-				// Create Row instance
-				rowInst := value.NewInstance(rowStruct).Obj.(*value.ObjInstance)
-				rowInst.Fields["values"] = value.NewArray(rowVals)
-				rowInsts = append(rowInsts, value.Value{Type: value.VAL_OBJ, Obj: rowInst})
-			}
-
-			// Create QueryResult instance with ok=true
-			resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-			resInst.Fields["columns"] = value.NewArray(colVals)
-			resInst.Fields["rows"] = value.NewArray(rowInsts)
-			resInst.Fields["row_count"] = value.NewInt(int64(len(rowInsts)))
-			resInst.Fields["ok"] = value.NewBool(true)
-			resInst.Fields["error"] = value.NewString("")
-
-			return value.Value{Type: value.VAL_OBJ, Obj: resInst}
-		}
-		// DB handle not found - return error result
-		resInst := value.NewInstance(resStruct).Obj.(*value.ObjInstance)
-		resInst.Fields["columns"] = value.NewArray(nil)
-		resInst.Fields["rows"] = value.NewArray(nil)
-		resInst.Fields["row_count"] = value.NewInt(0)
-		resInst.Fields["ok"] = value.NewBool(false)
-		resInst.Fields["error"] = value.NewString("invalid database handle")
-		return value.Value{Type: value.VAL_OBJ, Obj: resInst}
-	})
+func sqliteValue(item interface{}) value.Value {
+	switch typed := item.(type) {
+	case nil:
+		return value.NewNull()
+	case int64:
+		return value.NewInt(typed)
+	case float64:
+		return value.NewFloat(typed)
+	case string:
+		return value.NewString(typed)
+	case []byte:
+		return value.NewString(string(typed))
+	default:
+		return value.NewString(fmt.Sprintf("%v", typed))
+	}
 }

--- a/internal/vm/builtins_sqlite_test.go
+++ b/internal/vm/builtins_sqlite_test.go
@@ -1,7 +1,9 @@
 package vm
 
 import (
+	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"noxy-vm/internal/value"
@@ -37,21 +39,145 @@ func requireSQLiteExecResult(t *testing.T, got value.Value, definitions sqliteTe
 	return result
 }
 
+func cleanupSQLiteResources(t *testing.T, machine *VM) {
+	t.Helper()
+	t.Cleanup(func() {
+		for handle := range machine.shared.Statements.snapshot() {
+			resource, ok := machine.shared.Statements.remove(handle)
+			if !ok {
+				continue
+			}
+			resource.mu.Lock()
+			resource.closed = true
+			statement := resource.statement
+			resource.statement = nil
+			resource.parameters = nil
+			resource.mu.Unlock()
+			if statement != nil {
+				_ = statement.Close()
+			}
+		}
+		for handle := range machine.shared.Databases.snapshot() {
+			resource, ok := machine.shared.Databases.remove(handle)
+			if !ok {
+				continue
+			}
+			resource.stateMu.Lock()
+			resource.closed = true
+			database := resource.database
+			resource.stateMu.Unlock()
+			if database != nil {
+				_ = database.Close()
+			}
+		}
+	})
+}
+
+func TestSQLiteHandlesAreSharedAcrossVMs(t *testing.T) {
+	parent := New()
+	cleanupSQLiteResources(t, parent)
+	child := NewWithShared(parent.shared, parent.Config)
+	definitions := newSQLiteTestDefinitions()
+	database := callBuiltin(t, parent, "sqlite_open",
+		value.NewString(filepath.Join(t.TempDir(), "shared.sqlite")),
+		sqliteTemplate(definitions.database),
+	)
+	defer callBuiltin(t, parent, "sqlite_close", database)
+	databaseHandle := int(requireBuiltinInstance(t, database, definitions.database).Fields["handle"].AsInt)
+	if _, ok := parent.shared.Databases.get(databaseHandle); !ok {
+		t.Fatalf("database handle %d was not published to shared resources", databaseHandle)
+	}
+	requireSQLiteExecResult(t, callBuiltin(t, parent, "sqlite_exec",
+		database,
+		value.NewString("CREATE TABLE entries (id INTEGER, name TEXT)"),
+		sqliteTemplate(definitions.execResult),
+	), definitions, true, "")
+	statement := callBuiltin(t, parent, "sqlite_prepare",
+		database,
+		value.NewString("INSERT INTO entries VALUES (?, ?)"),
+		sqliteTemplate(definitions.statement),
+	)
+	defer callBuiltin(t, parent, "sqlite_finalize", statement)
+	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].AsInt)
+	if _, ok := parent.shared.Statements.get(statementHandle); !ok {
+		t.Fatalf("statement handle %d was not published to shared resources", statementHandle)
+	}
+	callBuiltin(t, parent, "sqlite_bind_int", statement, value.NewInt(1), value.NewInt(1))
+	callBuiltin(t, child, "sqlite_bind_text", statement, value.NewInt(2), value.NewString("shared"))
+	requireSQLiteExecResult(t, callBuiltin(t, child, "sqlite_step_exec",
+		statement, sqliteTemplate(definitions.execResult),
+	), definitions, true, "")
+
+	query := requireBuiltinInstance(t, callBuiltin(t, parent, "sqlite_query",
+		database,
+		value.NewString("SELECT id, name FROM entries"),
+		sqliteTemplate(definitions.queryResult),
+		sqliteTemplate(definitions.row),
+	), definitions.queryResult)
+	assertBuiltinValue(t, query.Fields["ok"], value.NewBool(true))
+	assertBuiltinValue(t, query.Fields["row_count"], value.NewInt(1))
+	rows := requireBuiltinArray(t, query.Fields["rows"])
+	row := requireBuiltinInstance(t, rows.Elements[0], definitions.row)
+	assertBuiltinArray(t, row.Fields["values"], []value.Value{value.NewInt(1), value.NewString("shared")})
+}
+
+func TestSQLiteStatementParametersConcurrent(t *testing.T) {
+	machine := New()
+	cleanupSQLiteResources(t, machine)
+	definitions := newSQLiteTestDefinitions()
+	database := callBuiltin(t, machine, "sqlite_open",
+		value.NewString(filepath.Join(t.TempDir(), "parameters.sqlite")),
+		sqliteTemplate(definitions.database),
+	)
+	defer callBuiltin(t, machine, "sqlite_close", database)
+	statement := callBuiltin(t, machine, "sqlite_prepare",
+		database,
+		value.NewString("SELECT ?, ?"),
+		sqliteTemplate(definitions.statement),
+	)
+	defer callBuiltin(t, machine, "sqlite_finalize", statement)
+	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].AsInt)
+	if _, ok := machine.shared.Statements.get(statementHandle); !ok {
+		t.Fatalf("statement handle %d was not published to shared resources", statementHandle)
+	}
+
+	bindInt := requireBuiltin(t, machine, "sqlite_bind_int")
+	bindText := requireBuiltin(t, machine, "sqlite_bind_text")
+	start := make(chan struct{})
+	errors := make(chan error, 16)
+	var workers sync.WaitGroup
+	for worker := 0; worker < 16; worker++ {
+		workers.Add(1)
+		go func(index int) {
+			defer workers.Done()
+			<-start
+			for iteration := 0; iteration < 100; iteration++ {
+				var err error
+				if index%2 == 0 {
+					_, err = bindInt.Invoke(machine, []value.Value{statement, value.NewInt(1), value.NewInt(int64(index))})
+				} else {
+					_, err = bindText.Invoke(machine, []value.Value{statement, value.NewInt(2), value.NewString(fmt.Sprint(index))})
+				}
+				if err != nil {
+					errors <- err
+					return
+				}
+			}
+		}(worker)
+	}
+	close(start)
+	workers.Wait()
+	close(errors)
+	for err := range errors {
+		t.Fatalf("concurrent bind: %v", err)
+	}
+	callBuiltin(t, machine, "sqlite_reset", statement)
+	callBuiltin(t, machine, "sqlite_finalize", statement)
+}
+
 func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	machine := New()
-	defer func() {
-		machine.shared.DbLock.Lock()
-		defer machine.shared.DbLock.Unlock()
-		for handle, statement := range machine.shared.StmtHandles {
-			_ = statement.Close()
-			delete(machine.shared.StmtHandles, handle)
-			delete(machine.shared.StmtParams, handle)
-		}
-		for handle, database := range machine.shared.DbHandles {
-			_ = database.Close()
-			delete(machine.shared.DbHandles, handle)
-		}
-	}()
+	cleanupSQLiteResources(t, machine)
 	definitions := newSQLiteTestDefinitions()
 	databasePath := filepath.Join(t.TempDir(), "stateful-builtins.sqlite")
 	databaseTemplate := sqliteTemplate(definitions.database)
@@ -59,7 +185,7 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	database := requireBuiltinInstance(t, databaseValue, definitions.database)
 	assertBuiltinValue(t, database.Fields["open"], value.NewBool(true))
 	databaseHandle := int(database.Fields["handle"].AsInt)
-	if _, ok := machine.shared.DbHandles[databaseHandle]; !ok {
+	if _, ok := machine.shared.Databases.get(databaseHandle); !ok {
 		t.Fatalf("database handle %d is not registered", databaseHandle)
 	}
 
@@ -85,7 +211,8 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	)
 	statement := requireBuiltinInstance(t, statementValue, definitions.statement)
 	statementHandle := int(statement.Fields["handle"].AsInt)
-	if _, ok := machine.shared.StmtHandles[statementHandle]; !ok {
+	statementResource, ok := machine.shared.Statements.get(statementHandle)
+	if !ok {
 		t.Fatalf("statement handle %d is not registered", statementHandle)
 	}
 
@@ -96,8 +223,11 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	assertBuiltinValue(t, stepResult.Fields["rows_affected"], value.NewInt(1))
 
 	assertBuiltinValue(t, callBuiltin(t, machine, "sqlite_reset", statementValue), value.NewNull())
-	if got := len(machine.shared.StmtParams[statementHandle]); got != 0 {
-		t.Fatalf("statement parameter count after reset = %d, want 0", got)
+	statementResource.mu.Lock()
+	parameterCount := len(statementResource.parameters)
+	statementResource.mu.Unlock()
+	if parameterCount != 0 {
+		t.Fatalf("statement parameter count after reset = %d, want 0", parameterCount)
 	}
 	assertBuiltinValue(t, callBuiltin(t, machine, "sqlite_bind_int", statementValue, value.NewInt(1), value.NewInt(3)), value.NewNull())
 	assertBuiltinValue(t, callBuiltin(t, machine, "sqlite_bind_text", statementValue, value.NewInt(2), value.NewString("gamma")), value.NewNull())
@@ -129,11 +259,8 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	}
 
 	assertBuiltinValue(t, callBuiltin(t, machine, "sqlite_finalize", statementValue), value.NewNull())
-	if _, ok := machine.shared.StmtHandles[statementHandle]; ok {
+	if _, ok := machine.shared.Statements.get(statementHandle); ok {
 		t.Fatalf("finalized statement handle %d remains registered", statementHandle)
-	}
-	if _, ok := machine.shared.StmtParams[statementHandle]; ok {
-		t.Fatalf("finalized statement parameters %d remain registered", statementHandle)
 	}
 	invalidStep := requireSQLiteExecResult(t, callBuiltin(t, machine, "sqlite_step_exec", statementValue, sqliteTemplate(definitions.execResult)), definitions, false, "invalid statement handle")
 	assertBuiltinValue(t, invalidStep.Fields["rows_affected"], value.NewInt(0))
@@ -143,7 +270,7 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 
 	assertBuiltinValue(t, callBuiltin(t, machine, "sqlite_close", databaseValue), value.NewNull())
 	assertBuiltinValue(t, database.Fields["open"], value.NewBool(false))
-	if _, ok := machine.shared.DbHandles[databaseHandle]; ok {
+	if _, ok := machine.shared.Databases.get(databaseHandle); ok {
 		t.Fatalf("closed database handle %d remains registered", databaseHandle)
 	}
 	requireSQLiteExecResult(t, callBuiltin(t, machine, "sqlite_exec", databaseValue, value.NewString("SELECT 1"), sqliteTemplate(definitions.execResult)), definitions, false, "invalid database handle")

--- a/internal/vm/builtins_sys.go
+++ b/internal/vm/builtins_sys.go
@@ -105,9 +105,13 @@ func (vm *VM) defineSystemBuiltins() {
 		return value.Value{Type: value.VAL_OBJ, Obj: inst}
 	})
 
-	vm.DefineNative("sys_load_plugin", func(args []value.Value) value.Value {
+	vm.DefineContextualNative("sys_load_plugin", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, contextErr := nativeVM(context)
+		if contextErr != nil {
+			return value.NewNull(), contextErr
+		}
 		if len(args) < 2 {
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 		name := args[0].String()
 		cmdName := args[1].String()
@@ -179,18 +183,18 @@ func (vm *VM) defineSystemBuiltins() {
 
 		if !found {
 			fmt.Printf("Plugin Load Error: command not found: %s\n", cmdName)
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 
 		client, err := plugin.LoadPlugin(name, cmdPath)
 		if err != nil {
 			fmt.Printf("Plugin Load Error: failed to load plugin: %v\n", err)
-			return value.NewBool(false)
+			return value.NewBool(false), nil
 		}
 
 		// Define Native dynamically
 		nativeName := name + "_request" // e.g. dynamodb_request
-		vm.DefineNative(nativeName, func(args []value.Value) value.Value {
+		machine.DefineNative(nativeName, func(args []value.Value) value.Value {
 			if len(args) < 1 {
 				return value.NewNull()
 			}
@@ -199,7 +203,7 @@ func (vm *VM) defineSystemBuiltins() {
 			return client.Call(method, params)
 		})
 
-		return value.NewBool(true)
+		return value.NewBool(true), nil
 	})
 
 	vm.DefineNative("sys_getenv", func(args []value.Value) value.Value {

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -118,10 +118,10 @@ func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip i
 	}
 
 	frame := &CallFrame{
-		Closure: closure,
-		IP:      0,
-		Slots:   vm.stackTop - argCount - 1, // Start of locals window (fn + args)
-		Globals: closure.Globals,
+		Closure:     closure,
+		IP:          0,
+		Slots:       vm.stackTop - argCount - 1, // Start of locals window (fn + args)
+		Environment: closure.Environment,
 	}
 	// Push new frame
 	vm.frames[vm.frameCount] = frame

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -142,13 +142,10 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		copied.Obj.(*value.ObjArray).RuntimeType.Store(obj.RuntimeType.Load())
 		return copied
 	case *value.ObjMap:
-		newData := make(map[interface{}]value.Value)
-		for k, val := range obj.Data {
-			newData[k] = val
-		}
+		newData := obj.Snapshot()
 		copied := value.NewMap()
 		copiedMap := copied.Obj.(*value.ObjMap)
-		copiedMap.Data = newData
+		copiedMap.Replace(newData)
 		copiedMap.RuntimeType.Store(obj.RuntimeType.Load())
 		return copied
 	case *value.ObjInstance:

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -75,8 +75,11 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 			args = callArgs
 		}
 		// fmt.Printf("Calling native %s with args: %v\n", native.Name, args)
-		result := native.Fn(args)
-		vm.stackTop -= argCount + 1 // args + function
+		result, err := native.Invoke(vm, args)
+		if err != nil {
+			return false, vm.runtimeError(c, ip, "%s", err)
+		}
+		vm.stackTop -= argCount + 1
 		vm.push(result)
 		return true, nil
 	}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -9,40 +9,37 @@ import (
 )
 
 func (vm *VM) Interpret(c *chunk.Chunk) error {
-	// Pass nil to indicate using Shared State Globals
-	return vm.InterpretWithGlobals(c, nil)
+	return vm.InterpretWithEnvironment(c, vm.shared.Root)
 }
 
-func (vm *VM) InterpretWithGlobals(c *chunk.Chunk, globals map[string]value.Value) error {
-	scriptFn := &value.ObjFunction{
-		Name:    "script",
-		Arity:   0,
-		Chunk:   c,
-		Globals: globals,
+func (vm *VM) InterpretWithGlobals(c *chunk.Chunk, globals map[string]value.Value) (err error) {
+	if globals == nil {
+		return vm.InterpretWithEnvironment(c, vm.shared.Root)
 	}
+	environment := value.NewGlobalEnvironmentFrom(globals, vm.shared.Root)
+	defer func() {
+		for name := range globals {
+			delete(globals, name)
+		}
+		for name, item := range environment.LocalSnapshot() {
+			globals[name] = item
+		}
+	}()
+	return vm.InterpretWithEnvironment(c, environment)
+}
 
+func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.GlobalEnvironment) error {
+	if environment == nil {
+		return fmt.Errorf("interpret requires a global environment")
+	}
+	scriptFunction := &value.ObjFunction{Name: "script", Arity: 0, Chunk: c, Environment: environment}
+	scriptClosure := &value.ObjClosure{Function: scriptFunction, Upvalues: []*value.ObjUpvalue{}, Environment: environment}
 	vm.stackTop = 0
-	vm.push(value.NewFunction("script", 0, 0, nil, c, globals)) // Push script function to stack slot 0
-
-	// Call frame for script
-	scriptClosure := &value.ObjClosure{Function: scriptFn, Upvalues: []*value.ObjUpvalue{}, Globals: globals}
-	frame := &CallFrame{
-		Closure: scriptClosure,
-		IP:      0,
-		Slots:   1,   // Locals start at 1
-		Globals: nil, // Use nil to force fallback to Shared VM Globals (Locked)
-	}
-
-	if globals != nil && len(globals) > 0 {
-		frame.Globals = globals
-	} else {
-		frame.Globals = nil
-	}
-
+	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: scriptClosure})
+	frame := &CallFrame{Closure: scriptClosure, IP: 0, Slots: 1, Environment: environment}
 	vm.frames[0] = frame
 	vm.frameCount = 1
 	vm.currentFrame = frame
-
 	return vm.run(1)
 }
 
@@ -67,17 +64,17 @@ func (vm *VM) run(minFrameCount int) error {
 			ip++
 			constant := c.Constants[index]
 
-			// If it's a function, bind it to current globals (Module binding)
+			// If it's a function, bind it to the current environment.
 			if constant.Type == value.VAL_FUNCTION {
 				fn := constant.Obj.(*value.ObjFunction)
-				// Clone to bind globals
+				// Clone so compiler constants remain unbound and reusable.
 				boundFn := &value.ObjFunction{
 					Name:         fn.Name,
 					Arity:        fn.Arity,
 					UpvalueCount: fn.UpvalueCount,
 					Params:       fn.Params,
 					Chunk:        fn.Chunk,
-					Globals:      frame.Globals,
+					Environment:  frame.Environment,
 					RuntimeType:  fn.RuntimeType,
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
@@ -98,7 +95,7 @@ func (vm *VM) run(minFrameCount int) error {
 					UpvalueCount: fn.UpvalueCount,
 					Params:       fn.Params,
 					Chunk:        fn.Chunk,
-					Globals:      frame.Globals,
+					Environment:  frame.Environment,
 					RuntimeType:  fn.RuntimeType,
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
@@ -179,14 +176,9 @@ func (vm *VM) run(minFrameCount int) error {
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
 
-			// Try frame globals (Module scope)
-			val, ok := frame.Globals[name]
+			val, ok := frame.Environment.Resolve(name)
 			if !ok {
-				// Try VM globals (Builtins / Shared)
-				val, ok = vm.GetGlobal(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
-				}
+				return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
 			}
 			vm.push(val)
 
@@ -195,12 +187,7 @@ func (vm *VM) run(minFrameCount int) error {
 			ip++
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
-			// Set in frame globals (Module scope)
-			if frame.Globals != nil {
-				frame.Globals[name] = vm.peek(0)
-			} else {
-				vm.SetGlobal(name, vm.peek(0))
-			}
+			frame.Environment.SetLocal(name, vm.peek(0))
 
 		case chunk.OP_GET_LOCAL:
 			slot := c.Code[ip]
@@ -246,17 +233,9 @@ func (vm *VM) run(minFrameCount int) error {
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
 
-			var owner *map[string]value.Value
-			if frame.Globals != nil {
-				if _, ok := frame.Globals[name]; ok {
-					owner = &frame.Globals
-				}
-			}
-			if owner == nil {
-				if _, ok := vm.GetGlobal(name); !ok {
-					return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
-				}
-				owner = &vm.shared.Globals
+			owner, ok := frame.Environment.ResolveOwner(name)
+			if !ok {
+				return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
 			}
 			vm.push(value.Value{
 				Type: value.VAL_REF,
@@ -883,11 +862,20 @@ func (vm *VM) run(minFrameCount int) error {
 			ip++
 			fnVal := c.Constants[idx]
 			fn := fnVal.Obj.(*value.ObjFunction)
+			boundFn := &value.ObjFunction{
+				Name:         fn.Name,
+				Arity:        fn.Arity,
+				UpvalueCount: fn.UpvalueCount,
+				Params:       fn.Params,
+				Chunk:        fn.Chunk,
+				Environment:  frame.Environment,
+				RuntimeType:  fn.RuntimeType,
+			}
 
 			closure := &value.ObjClosure{
-				Function: fn,
-				Upvalues: make([]*value.ObjUpvalue, fn.UpvalueCount),
-				Globals:  frame.Globals,
+				Function:    boundFn,
+				Upvalues:    make([]*value.ObjUpvalue, fn.UpvalueCount),
+				Environment: frame.Environment,
 			}
 
 			for i := 0; i < fn.UpvalueCount; i++ {
@@ -1031,11 +1019,7 @@ func (vm *VM) run(minFrameCount int) error {
 				if modMap, ok := modVal.Obj.(*value.ObjMap); ok {
 					for k, v := range modMap.Snapshot() {
 						if keyStr, ok := k.(string); ok {
-							if frame.Globals != nil {
-								frame.Globals[keyStr] = v
-							} else {
-								vm.SetGlobal(keyStr, v)
-							}
+							frame.Environment.SetLocal(keyStr, v)
 						}
 					}
 				} else {

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1001,7 +1001,8 @@ func (vm *VM) run(minFrameCount int) error {
 
 			mod, err := vm.loadModule(moduleName)
 			if err != nil {
-				return vm.runtimeError(c, ip, "failed to import module '%s': %v", moduleName, err)
+				context := vm.runtimeError(c, ip, "failed to import module '%s'", moduleName)
+				return fmt.Errorf("%v: %w", context, err)
 			}
 			vm.push(mod)
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -999,17 +999,11 @@ func (vm *VM) run(minFrameCount int) error {
 			nameConstant := c.Constants[index]
 			moduleName := nameConstant.Obj.(string)
 
-			// Check cache
-			if mod, ok := vm.GetModule(moduleName); ok {
-				vm.push(mod)
-			} else {
-				mod, err := vm.loadModule(moduleName)
-				if err != nil {
-					return vm.runtimeError(c, ip, "failed to import module '%s': %v", moduleName, err)
-				}
-				vm.SetModule(moduleName, mod)
-				vm.push(mod)
+			mod, err := vm.loadModule(moduleName)
+			if err != nil {
+				return vm.runtimeError(c, ip, "failed to import module '%s': %v", moduleName, err)
 			}
+			vm.push(mod)
 
 			frame = vm.currentFrame
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -372,7 +372,7 @@ func (vm *VM) run(minFrameCount int) error {
 				if err != nil {
 					return vm.runtimeError(c, ip, "%s", err)
 				}
-				stored = mapObj.Data[key]
+				stored, _ = mapObj.Get(key)
 			} else {
 				return vm.runtimeError(c, ip, "contextual index reference base must be an array or map")
 			}
@@ -582,7 +582,7 @@ func (vm *VM) run(minFrameCount int) error {
 				if arr, ok := val.Obj.(*value.ObjArray); ok {
 					vm.push(value.NewInt(int64(len(arr.Elements))))
 				} else if m, ok := val.Obj.(*value.ObjMap); ok {
-					vm.push(value.NewInt(int64(len(m.Data))))
+					vm.push(value.NewInt(int64(m.Len())))
 				} else if s, ok := val.Obj.(string); ok {
 					vm.push(value.NewInt(int64(utf8.RuneCountInString(s))))
 				} else {
@@ -980,7 +980,7 @@ func (vm *VM) run(minFrameCount int) error {
 
 			// Map expects keys and values on stack: K1, V1, K2, V2...
 			mapObj := value.NewMap()
-			mapData := mapObj.Obj.(*value.ObjMap).Data
+			mapping := mapObj.Obj.(*value.ObjMap)
 
 			for i := 0; i < count; i++ {
 				val := vm.pop()
@@ -998,7 +998,7 @@ func (vm *VM) run(minFrameCount int) error {
 				} else {
 					return vm.runtimeError(c, ip, "map key must be int or string")
 				}
-				mapData[key] = val
+				mapping.Set(key, val)
 			}
 			vm.push(mapObj)
 
@@ -1029,7 +1029,7 @@ func (vm *VM) run(minFrameCount int) error {
 			modVal := vm.pop()
 			if modVal.Type == value.VAL_OBJ {
 				if modMap, ok := modVal.Obj.(*value.ObjMap); ok {
-					for k, v := range modMap.Data {
+					for k, v := range modMap.Snapshot() {
 						if keyStr, ok := k.(string); ok {
 							if frame.Globals != nil {
 								frame.Globals[keyStr] = v
@@ -1074,7 +1074,7 @@ func (vm *VM) run(minFrameCount int) error {
 						return vm.runtimeError(c, ip, "map key must be int or string")
 					}
 
-					val, ok := mapObj.Data[key]
+					val, ok := mapObj.Get(key)
 					if !ok {
 						vm.push(value.NewNull())
 					} else {
@@ -1140,7 +1140,7 @@ func (vm *VM) run(minFrameCount int) error {
 					} else {
 						return vm.runtimeError(c, ip, "map key must be int or string")
 					}
-					mapObj.Data[key] = val
+					mapObj.Set(key, val)
 					vm.push(val)
 					continue
 				}
@@ -1176,7 +1176,7 @@ func (vm *VM) run(minFrameCount int) error {
 				vm.push(val)
 			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
 				// Allow accessing map keys as properties (for modules)
-				val, ok := mapObj.Data[name]
+				val, ok := mapObj.Get(name)
 				if !ok {
 					return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
 				}

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -164,14 +164,11 @@ func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.Ru
 	if !ok {
 		return nil, false
 	}
-	newData := make(map[interface{}]value.Value, len(mapping.Data)+len(dataMap))
-	for key, item := range mapping.Data {
-		newData[key] = item
-	}
+	newData := mapping.Snapshot()
 	commits := make([]jsonCommit, 0, len(dataMap))
 	for key, item := range dataMap {
 		mapKey := key
-		if current, exists := mapping.Data[mapKey]; exists {
+		if current, exists := newData[mapKey]; exists {
 			commit, ok := prepareJSONMutation(vm, current, valueSchema, item, func(updated value.Value) {
 				newData[mapKey] = updated
 			})
@@ -199,7 +196,7 @@ func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.Ru
 		for _, commit := range commits {
 			commit()
 		}
-		mapping.Data = newData
+		mapping.Replace(newData)
 	}, true
 }
 
@@ -312,7 +309,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 		mapping := value.NewMap()
 		mapObject := mapping.Obj.(*value.ObjMap)
 		mapObject.RuntimeType.Store(schema)
-		mapData := mapObject.Data
+		mapData := make(map[interface{}]value.Value, len(items))
 		for key, item := range items {
 			created, ok := buildTypedJSONValue(schema.Value, item)
 			if !ok {
@@ -320,6 +317,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			}
 			mapData[key] = created
 		}
+		mapObject.Replace(mapData)
 		return mapping, true
 	case value.TYPE_STRUCT:
 		if data == nil {
@@ -420,7 +418,8 @@ func dynamicJSONValue(data interface{}) (value.Value, bool) {
 		return value.NewArray(elements), true
 	case map[string]interface{}:
 		mapping := value.NewMap()
-		dataMap := mapping.Obj.(*value.ObjMap).Data
+		mapObject := mapping.Obj.(*value.ObjMap)
+		dataMap := make(map[interface{}]value.Value, len(actual))
 		for key, item := range actual {
 			converted, ok := dynamicJSONValue(item)
 			if !ok {
@@ -428,6 +427,7 @@ func dynamicJSONValue(data interface{}) (value.Value, bool) {
 			}
 			dataMap[key] = converted
 		}
+		mapObject.Replace(dataMap)
 		return mapping, true
 	default:
 		return value.Value{}, false

--- a/internal/vm/json_strict.go
+++ b/internal/vm/json_strict.go
@@ -89,8 +89,9 @@ func (t *strictJSONTraversal) convertMap(mapping *value.ObjMap) (map[string]inte
 	}
 	t.maps[mapping] = true
 	defer delete(t.maps, mapping)
-	converted := make(map[string]interface{}, len(mapping.Data))
-	for key, item := range mapping.Data {
+	values := mapping.Snapshot()
+	converted := make(map[string]interface{}, len(values))
+	for key, item := range values {
 		stringKey, ok := key.(string)
 		if !ok {
 			return nil, errJSONUnsupported

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -61,7 +61,6 @@ dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)
 
 func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
 	moduleGlobals := map[string]value.Value{"present": value.NewInt(1)}
-	nilDataMap := value.Value{Type: value.VAL_OBJ, Obj: &value.ObjMap{}}
 	tests := []struct {
 		name      string
 		malformed value.Value
@@ -76,7 +75,6 @@ func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
 		{name: "array index type", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewBool(false)}}},
 		{name: "array bounds", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewInt(2)}}},
 		{name: "map key", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewMap(), Index: value.Value{Type: value.VAL_OBJ, Obj: []int{1}}}}},
-		{name: "nil map data", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: nilDataMap, Index: value.NewString("key")}}},
 		{name: "index container", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewInt(1), Index: value.NewInt(0)}}},
 	}
 

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -60,7 +60,7 @@ dynamic(malformed_ref())`, value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)
 }
 
 func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
-	moduleGlobals := map[string]value.Value{"present": value.NewInt(1)}
+	moduleEnvironment := value.NewGlobalEnvironmentFrom(map[string]value.Value{"present": value.NewInt(1)}, nil)
 	tests := []struct {
 		name      string
 		malformed value.Value
@@ -70,7 +70,7 @@ func TestMalformedReferenceMetadataIsRuntimeErrorForReadAndWrite(t *testing.T) {
 		{name: "nil upvalue", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE}}},
 		{name: "nil upvalue location", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_UPVALUE, Upvalue: &value.ObjUpvalue{}}}},
 		{name: "nil global owner", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "present"}}},
-		{name: "missing global", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: &moduleGlobals}}},
+		{name: "missing global", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: moduleEnvironment}}},
 		{name: "property container", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PROPERTY, Container: value.NewInt(1), Name: "field"}}},
 		{name: "array index type", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewBool(false)}}},
 		{name: "array bounds", malformed: value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_INDEX, Container: value.NewArray([]value.Value{value.NewInt(1)}), Index: value.NewInt(2)}}},

--- a/internal/vm/module_cache.go
+++ b/internal/vm/module_cache.go
@@ -26,6 +26,14 @@ type moduleCache struct {
 	dependencies map[moduleKey]map[moduleKey]struct{}
 }
 
+type moduleCycleError struct {
+	path []moduleKey
+}
+
+func (err *moduleCycleError) Error() string {
+	return fmt.Sprintf("module import cycle: %s", formatModulePath(err.path))
+}
+
 func newModuleCache() *moduleCache {
 	return &moduleCache{
 		entries:      make(map[moduleKey]*moduleEntry),
@@ -74,7 +82,7 @@ func (cache *moduleCache) Do(key moduleKey, parent *moduleKey, load func() (valu
 		if path, found := cache.pathLocked(key, *parent); found {
 			cycle := append(path, key)
 			cache.mu.Unlock()
-			return value.NewNull(), fmt.Errorf("module import cycle: %s", formatModulePath(cycle))
+			return value.NewNull(), &moduleCycleError{path: cycle}
 		}
 		children := cache.dependencies[*parent]
 		if children == nil {

--- a/internal/vm/module_cache.go
+++ b/internal/vm/module_cache.go
@@ -1,0 +1,173 @@
+package vm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"noxy-vm/internal/value"
+)
+
+type moduleKey struct {
+	Root string
+	Name string
+}
+
+type moduleEntry struct {
+	done   chan struct{}
+	result value.Value
+	err    error
+}
+
+type moduleCache struct {
+	mu           sync.Mutex
+	entries      map[moduleKey]*moduleEntry
+	dependencies map[moduleKey]map[moduleKey]struct{}
+}
+
+func newModuleCache() *moduleCache {
+	return &moduleCache{
+		entries:      make(map[moduleKey]*moduleEntry),
+		dependencies: make(map[moduleKey]map[moduleKey]struct{}),
+	}
+}
+
+func (cache *moduleCache) get(key moduleKey) (value.Value, bool) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry, exists := cache.entries[key]
+	if !exists {
+		return value.NewNull(), false
+	}
+	select {
+	case <-entry.done:
+		return entry.result, entry.err == nil
+	default:
+		return value.NewNull(), false
+	}
+}
+
+func (cache *moduleCache) store(key moduleKey, result value.Value) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry := &moduleEntry{done: make(chan struct{}), result: result}
+	close(entry.done)
+	cache.entries[key] = entry
+}
+
+func (cache *moduleCache) Do(key moduleKey, parent *moduleKey, load func() (value.Value, error)) (value.Value, error) {
+	cache.mu.Lock()
+	entry, exists := cache.entries[key]
+	if exists {
+		select {
+		case <-entry.done:
+			result, err := entry.result, entry.err
+			cache.mu.Unlock()
+			return result, err
+		default:
+		}
+	}
+
+	edgeAdded := false
+	if parent != nil {
+		if path, found := cache.pathLocked(key, *parent); found {
+			cycle := append(path, key)
+			cache.mu.Unlock()
+			return value.NewNull(), fmt.Errorf("module import cycle: %s", formatModulePath(cycle))
+		}
+		children := cache.dependencies[*parent]
+		if children == nil {
+			children = make(map[moduleKey]struct{})
+			cache.dependencies[*parent] = children
+		}
+		if _, exists := children[key]; !exists {
+			children[key] = struct{}{}
+			edgeAdded = true
+		}
+	}
+
+	owner := !exists
+	if owner {
+		entry = &moduleEntry{done: make(chan struct{})}
+		cache.entries[key] = entry
+	}
+	cache.mu.Unlock()
+
+	if edgeAdded {
+		defer cache.removeDependency(*parent, key)
+	}
+
+	if !owner {
+		<-entry.done
+		return entry.result, entry.err
+	}
+
+	result, err := load()
+	cache.mu.Lock()
+	entry.result = result
+	entry.err = err
+	if err != nil {
+		delete(cache.entries, key)
+	}
+	close(entry.done)
+	cache.mu.Unlock()
+	return result, err
+}
+
+func (cache *moduleCache) pathLocked(from, to moduleKey) ([]moduleKey, bool) {
+	path := make([]moduleKey, 0, 4)
+	visited := make(map[moduleKey]struct{})
+	var visit func(moduleKey) bool
+	visit = func(current moduleKey) bool {
+		if _, seen := visited[current]; seen {
+			return false
+		}
+		visited[current] = struct{}{}
+		path = append(path, current)
+		if current == to {
+			return true
+		}
+
+		children := make([]moduleKey, 0, len(cache.dependencies[current]))
+		for child := range cache.dependencies[current] {
+			children = append(children, child)
+		}
+		sort.Slice(children, func(i, j int) bool {
+			if children[i].Root == children[j].Root {
+				return children[i].Name < children[j].Name
+			}
+			return children[i].Root < children[j].Root
+		})
+		for _, child := range children {
+			if visit(child) {
+				return true
+			}
+		}
+		path = path[:len(path)-1]
+		return false
+	}
+
+	if !visit(from) {
+		return nil, false
+	}
+	return append([]moduleKey(nil), path...), true
+}
+
+func (cache *moduleCache) removeDependency(parent, child moduleKey) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	children := cache.dependencies[parent]
+	delete(children, child)
+	if len(children) == 0 {
+		delete(cache.dependencies, parent)
+	}
+}
+
+func formatModulePath(path []moduleKey) string {
+	names := make([]string, len(path))
+	for i, key := range path {
+		names[i] = key.Name
+	}
+	return strings.Join(names, " -> ")
+}

--- a/internal/vm/module_cache_test.go
+++ b/internal/vm/module_cache_test.go
@@ -1,0 +1,118 @@
+package vm
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"noxy-vm/internal/value"
+)
+
+func TestModuleCacheInitializesKeyOnce(t *testing.T) {
+	cache := newModuleCache()
+	key := moduleKey{Root: "root", Name: "module"}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	load := func() (value.Value, error) {
+		if calls.Add(1) == 1 {
+			close(entered)
+		}
+		<-release
+		return value.NewInt(42), nil
+	}
+	results := make(chan value.Value, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			got, err := cache.Do(key, nil, load)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			results <- got
+		}()
+	}
+	<-entered
+	close(release)
+	<-results
+	<-results
+	if calls.Load() != 1 {
+		t.Fatalf("loads=%d", calls.Load())
+	}
+}
+
+func TestModuleCacheRetriesFailedLoad(t *testing.T) {
+	cache := newModuleCache()
+	key := moduleKey{Root: "root", Name: "module"}
+	var calls atomic.Int32
+
+	if _, err := cache.Do(key, nil, func() (value.Value, error) {
+		calls.Add(1)
+		return value.NewNull(), errors.New("first load failed")
+	}); err == nil {
+		t.Fatal("first load succeeded")
+	}
+	got, err := cache.Do(key, nil, func() (value.Value, error) {
+		calls.Add(1)
+		return value.NewInt(42), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("result=%v, want 42", got)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("loads=%d, want 2", calls.Load())
+	}
+}
+
+func TestModuleCacheDetectsCrossFlightCycle(t *testing.T) {
+	cache := newModuleCache()
+	a := moduleKey{Root: "root", Name: "A"}
+	b := moduleKey{Root: "root", Name: "B"}
+	aEntered := make(chan struct{})
+	bEntered := make(chan struct{})
+	releaseB := make(chan struct{})
+	aResult := make(chan error, 1)
+
+	go func() {
+		_, err := cache.Do(a, nil, func() (value.Value, error) {
+			close(aEntered)
+			_, err := cache.Do(b, &a, func() (value.Value, error) {
+				close(bEntered)
+				<-releaseB
+				return value.NewNull(), nil
+			})
+			return value.NewNull(), err
+		})
+		aResult <- err
+	}()
+
+	<-aEntered
+	<-bEntered
+	cycleResult := make(chan error, 1)
+	go func() {
+		_, err := cache.Do(a, &b, func() (value.Value, error) {
+			t.Error("cycle load callback unexpectedly ran")
+			return value.NewNull(), nil
+		})
+		cycleResult <- err
+	}()
+
+	select {
+	case err := <-cycleResult:
+		if err == nil || !strings.Contains(err.Error(), "A -> B -> A") {
+			t.Fatalf("cycle error=%v, want path A -> B -> A", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cycle detection waited for an in-flight module")
+	}
+
+	close(releaseB)
+	if err := <-aResult; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -81,7 +81,7 @@ func TestRuntimeFileModuleGlobalsContainDirectExports(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data := module.Obj.(*value.ObjMap).Data
+	data := module.Obj.(*value.ObjMap).Snapshot()
 	if _, ok := data["delete"]; !ok {
 		t.Fatal("runtime file module omitted direct delete export")
 	}
@@ -92,7 +92,7 @@ func TestRuntimeEmbeddedWildcardExportsAreDurable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data := module.Obj.(*value.ObjMap).Data
+	data := module.Obj.(*value.ObjMap).Snapshot()
 	if _, ok := data["delete"]; !ok {
 		t.Fatal("runtime http module omitted wildcard-imported delete")
 	}
@@ -132,8 +132,8 @@ func TestRuntimeModuleCachePreservesStructConstructorCallableSchema(t *testing.T
 	if !ok {
 		t.Fatal("missing cached module alias")
 	}
-	firstConstructor := first.Obj.(*value.ObjMap).Data["Box"]
-	secondConstructor := second.Obj.(*value.ObjMap).Data["Box"]
+	firstConstructor := requireTestMapValue(t, first.Obj.(*value.ObjMap), "Box")
+	secondConstructor := requireTestMapValue(t, second.Obj.(*value.ObjMap), "Box")
 	if firstConstructor.Obj != secondConstructor.Obj {
 		t.Fatal("cached import replaced the constructor definition")
 	}
@@ -159,7 +159,7 @@ func TestRuntimeDirectoryModuleGlobalsContainOnlyLoadableChildren(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	data := module.Obj.(*value.ObjMap).Data
+	data := module.Obj.(*value.ObjMap).Snapshot()
 	if _, ok := data["delete"]; !ok {
 		t.Fatal("runtime directory module omitted loadable file child")
 	}
@@ -257,7 +257,7 @@ func TestRuntimeFunctionBodyOnlyWildcardDoesNotInvalidateModule(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if _, ok := module.Obj.(*value.ObjMap).Data["delete"]; !ok {
+			if _, ok := module.Obj.(*value.ObjMap).Get("delete"); !ok {
 				t.Fatal("runtime module omitted direct delete export")
 			}
 		})
@@ -346,7 +346,7 @@ end
 			if err != nil {
 				t.Fatal(err)
 			}
-			deleteBinding, ok := module.Obj.(*value.ObjMap).Data["delete"]
+			deleteBinding, ok := module.Obj.(*value.ObjMap).Get("delete")
 			if !ok {
 				t.Fatal("nested wrapper omitted root dependency delete")
 			}

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/compiler"
 	"noxy-vm/internal/lexer"
 	"noxy-vm/internal/parser"
@@ -9,8 +10,105 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func TestConcurrentModuleImportInitializesOnce(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "counter.nx"), []byte("test_module_init()\nlet answer: int = 42\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := NewWithConfig(VMConfig{RootPath: root})
+	var initializations atomic.Int32
+	entered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	release := make(chan struct{})
+	parent.DefineNative("test_module_init", func([]value.Value) value.Value {
+		switch initializations.Add(1) {
+		case 1:
+			close(entered)
+		case 2:
+			close(secondEntered)
+		}
+		<-release
+		return value.NewNull()
+	})
+	code := compileModuleProgram(t, root, "use counter\n")
+	machines := []*VM{
+		NewWithShared(parent.shared, parent.Config),
+		NewWithShared(parent.shared, parent.Config),
+	}
+	start := make(chan struct{})
+	errors := make(chan error, len(machines))
+	for _, machine := range machines {
+		go func(machine *VM) {
+			<-start
+			errors <- machine.Interpret(code)
+		}(machine)
+	}
+	close(start)
+	<-entered
+	select {
+	case <-secondEntered:
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	for range machines {
+		select {
+		case err := <-errors:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("concurrent imports did not complete")
+		}
+	}
+	if initializations.Load() != 1 {
+		t.Fatalf("initializations=%d, want 1", initializations.Load())
+	}
+}
+
+func TestDirectImportCycleReportsPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.nx"), []byte("use b\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.nx"), []byte("use a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code := compileModuleProgram(t, root, "use a\n")
+	result := make(chan error, 1)
+	go func() {
+		result <- NewWithConfig(VMConfig{RootPath: root}).Interpret(code)
+	}()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "a -> b -> a") {
+			t.Fatalf("cycle error=%v, want path a -> b -> a", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("direct import cycle did not complete")
+	}
+}
+
+func compileModuleProgram(t *testing.T, root, source string) *chunk.Chunk {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"), root).Compile(program)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return code
+}
 
 func TestRuntimeModuleCacheSharesIdentityAcrossImportsAndChildVM(t *testing.T) {
 	root := t.TempDir()

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -95,6 +95,31 @@ func TestDirectImportCycleReportsPath(t *testing.T) {
 	}
 }
 
+func TestDirectoryImportCycleReportsPath(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "bundle", "child")
+	if err := os.MkdirAll(child, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "child.nx"), []byte("use bundle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code := compileModuleProgram(t, root, "use bundle\n")
+	result := make(chan error, 1)
+	go func() {
+		result <- NewWithConfig(VMConfig{RootPath: root}).Interpret(code)
+	}()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "bundle -> bundle.child -> bundle") {
+			t.Fatalf("cycle error=%v, want path bundle -> bundle.child -> bundle", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("directory import cycle did not complete")
+	}
+}
+
 func compileModuleProgram(t *testing.T, root, source string) *chunk.Chunk {
 	t.Helper()
 	l := lexer.New(source)

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -120,6 +120,31 @@ func TestDirectoryImportCycleReportsPath(t *testing.T) {
 	}
 }
 
+func TestNestedDirectoryImportCycleReportsPath(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "bundle", "child")
+	if err := os.MkdirAll(child, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "x.nx"), []byte("use bundle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code := compileModuleProgram(t, root, "use bundle\n")
+	result := make(chan error, 1)
+	go func() {
+		result <- NewWithConfig(VMConfig{RootPath: root}).Interpret(code)
+	}()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "bundle -> bundle.child -> bundle.child.x -> bundle") {
+			t.Fatalf("cycle error=%v, want path bundle -> bundle.child -> bundle.child.x -> bundle", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("nested directory import cycle did not complete")
+	}
+}
+
 func compileModuleProgram(t *testing.T, root, source string) *chunk.Chunk {
 	t.Helper()
 	l := lexer.New(source)

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/compiler"
@@ -148,8 +149,13 @@ func (vm *VM) loadResolvedDirectory(source resolvedModule) (value.Value, error) 
 	moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
 	for _, file := range files {
 		if file.IsDir() {
-			submodule, loadErr := vm.loadModule(source.Name + "." + file.Name())
+			submoduleName := source.Name + "." + file.Name()
+			submodule, loadErr := vm.loadModule(submoduleName)
 			if loadErr != nil {
+				var cycleErr *moduleCycleError
+				if errors.As(loadErr, &cycleErr) {
+					return value.NewNull(), fmt.Errorf("failed to load submodule %s: %w", submoduleName, loadErr)
+				}
 				continue
 			}
 			moduleEnvironment.SetLocal(file.Name(), submodule)

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -168,7 +168,7 @@ func (vm *VM) loadResolvedDirectory(source resolvedModule) (value.Value, error) 
 		submoduleName := source.Name + "." + baseName
 		submodule, loadErr := vm.loadModule(submoduleName)
 		if loadErr != nil {
-			return value.NewNull(), fmt.Errorf("failed to load submodule %s: %v", submoduleName, loadErr)
+			return value.NewNull(), fmt.Errorf("failed to load submodule %s: %w", submoduleName, loadErr)
 		}
 		moduleEnvironment.SetLocal(baseName, submodule)
 	}

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -13,221 +13,192 @@ import (
 	"strings"
 )
 
+type resolvedModuleKind uint8
+
+const (
+	resolvedEmbeddedModule resolvedModuleKind = iota
+	resolvedFileModule
+	resolvedDirectoryModule
+)
+
+type resolvedModule struct {
+	Key     moduleKey
+	Name    string
+	Kind    resolvedModuleKind
+	Path    string
+	Content string
+}
+
+func (vm *VM) resolveModule(name string) (resolvedModule, error) {
+	root, err := filepath.Abs(vm.Config.RootPath)
+	if err != nil {
+		return resolvedModule{}, fmt.Errorf("resolve module root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return resolvedModule{}, fmt.Errorf("resolve module root: %w", err)
+		}
+		root = filepath.Clean(root)
+	}
+	canonicalName := strings.TrimSpace(name)
+	key := moduleKey{Root: root + "\x00" + os.Getenv("NOXY_PATH"), Name: canonicalName}
+	pathName := strings.ReplaceAll(canonicalName, ".", string(filepath.Separator))
+
+	checkLocations := func(suffix string) (string, bool, bool) {
+		candidates := make([]string, 0, 16)
+		if noxyPath := os.Getenv("NOXY_PATH"); noxyPath != "" {
+			for _, searchRoot := range filepath.SplitList(noxyPath) {
+				candidates = append(candidates,
+					filepath.Join(searchRoot, suffix, suffix+".nx"),
+					filepath.Join(searchRoot, suffix),
+					filepath.Join(searchRoot, suffix+".nx"),
+				)
+			}
+		}
+		candidates = append(candidates,
+			filepath.Join(vm.Config.RootPath, "noxy_libs", suffix, suffix+".nx"),
+			filepath.Join(vm.Config.RootPath, "noxy_libs", suffix),
+			filepath.Join(vm.Config.RootPath, "stdlib", suffix),
+			filepath.Join(vm.Config.RootPath, suffix),
+			filepath.Join("noxy_libs", suffix, suffix+".nx"),
+			filepath.Join("noxy_libs", suffix),
+			filepath.Join("stdlib", suffix),
+			suffix,
+		)
+		for _, candidate := range candidates {
+			info, statErr := os.Stat(candidate)
+			if statErr == nil {
+				absolute, absErr := filepath.Abs(candidate)
+				if absErr != nil {
+					return "", false, false
+				}
+				return filepath.Clean(absolute), info.IsDir(), true
+			}
+		}
+		return "", false, false
+	}
+
+	path, isDir, found := checkLocations(pathName + ".nx")
+	if !found || isDir {
+		path, isDir, found = checkLocations(pathName)
+	}
+	if found {
+		if isDir {
+			baseName := filepath.Base(path)
+			for _, candidate := range []string{baseName + ".nx", "main.nx"} {
+				entryPath := filepath.Join(path, candidate)
+				if info, statErr := os.Stat(entryPath); statErr == nil && !info.IsDir() {
+					return resolvedModule{Key: key, Name: canonicalName, Kind: resolvedFileModule, Path: entryPath}, nil
+				}
+			}
+			return resolvedModule{Key: key, Name: canonicalName, Kind: resolvedDirectoryModule, Path: path}, nil
+		}
+		return resolvedModule{Key: key, Name: canonicalName, Kind: resolvedFileModule, Path: path}, nil
+	}
+
+	content, readErr := stdlib.FS.ReadFile(pathName + ".nx")
+	if readErr != nil {
+		return resolvedModule{}, fmt.Errorf("module not found: %s", canonicalName)
+	}
+	return resolvedModule{Key: key, Name: canonicalName, Kind: resolvedEmbeddedModule, Content: string(content)}, nil
+}
+
 func (vm *VM) loadModule(name string) (value.Value, error) {
-	// Convert dot notation to path path separator
-	pathName := strings.ReplaceAll(name, ".", string(filepath.Separator))
-
-	// Search paths candidates (File .nx OR Directory)
-	// We prefer file over directory if both exist? usually explicit file wins.
-	// But let's check both possibilities.
-
-	var path string
-	var isDir bool
-	// found := false // Unused
-
-	// Helper to check locations
-	checkLocations := func(suffix string) bool {
-		candidates := []string{}
-
-		// 0. NOXY_PATH Environment Variable
-		noxyPath := os.Getenv("NOXY_PATH")
-		if noxyPath != "" {
-			paths := filepath.SplitList(noxyPath)
-			for _, p := range paths {
-				// Check for:
-				// $PATH/mod/mod.nx
-				// $PATH/mod (dir)
-				// $PATH/mod.nx (file)
-				candidates = append(candidates, filepath.Join(p, suffix, suffix+".nx"))
-				candidates = append(candidates, filepath.Join(p, suffix))
-				candidates = append(candidates, filepath.Join(p, suffix+".nx"))
-			}
-		}
-
-		// 1. RootPath (Config)
-		candidates = append(candidates, filepath.Join(vm.Config.RootPath, "noxy_libs", suffix, suffix+".nx"))
-		candidates = append(candidates, filepath.Join(vm.Config.RootPath, "noxy_libs", suffix))
-		candidates = append(candidates, filepath.Join(vm.Config.RootPath, "stdlib", suffix))
-		candidates = append(candidates, filepath.Join(vm.Config.RootPath, suffix))
-
-		// 2. Fallbacks (Working Directory)
-		candidates = append(candidates, filepath.Join("noxy_libs", suffix, suffix+".nx"))
-		candidates = append(candidates, filepath.Join("noxy_libs", suffix))
-		candidates = append(candidates, filepath.Join("stdlib", suffix))
-		candidates = append(candidates, suffix)
-
-		for _, p := range candidates {
-			// fmt.Printf("Checking path: %s\n", p)
-			info, err := os.Stat(p)
-			if err == nil {
-				// fmt.Printf("Found: %s (IsDir: %v)\n", p, info.IsDir())
-				path = p
-				isDir = info.IsDir()
-				// found = true
-				return true
-			}
-		}
-		return false
+	source, err := vm.resolveModule(name)
+	if err != nil {
+		return value.NewNull(), err
 	}
-
-	// 1. Check for .nx file
-	if checkLocations(pathName+".nx") && !isDir {
-		// Found file
-	} else if checkLocations(pathName) {
-		// Found directory OR file (noxy_libs/mod/mod.nx)
-		// If isDir is false, it means we found .../mod.nx via the mod name check,
-		// which acts as the module entry point.
-	} else {
-		// Not found on disk, check embedded stdlib
-		// Stdlib is flat in embed.go usually? Or structure preserved?
-		// We moved stdlib/* to internal/stdlib.
-		// So internal/stdlib has *.nx files directly.
-		// Name would be "time" "io" etc.
-		// pathName for "time" is "time".
-		// embedded file is "time.nx".
-
-		// Check if it exists in embedded FS
-		embedPath := pathName + ".nx"
-		content, err := stdlib.FS.ReadFile(embedPath)
-		if err == nil {
-			// Found in embedded stdlib!
-			l := lexer.New(string(content))
-			p := parser.New(l)
-			prog := p.ParseProgram()
-			if len(p.Errors()) > 0 {
-				return value.NewNull(), fmt.Errorf("parse error in embedded module %s: %v", name, p.Errors())
-			}
-			c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), name, vm.Config.RootPath)
-			chunk, _, err := c.Compile(prog)
-			if err != nil {
-				return value.NewNull(), err
-			}
-			moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
-			modFn := &value.ObjFunction{
-				Name:        name,
-				Arity:       0,
-				Chunk:       chunk,
-				Environment: moduleEnvironment,
-			}
-			modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
-			modVal := value.Value{Type: value.VAL_FUNCTION, Obj: modClosure}
-			vm.push(modVal)
-			if ok, err := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
-				return value.NewNull(), err
-			}
-			startFrameCount := vm.frameCount
-			err = vm.run(startFrameCount)
-			if err != nil {
-				return value.NewNull(), err
-			}
-			vm.pop()
-			return moduleEnvironment.ExportMap(), nil
-		}
-
-		return value.NewNull(), fmt.Errorf("module not found: %s", name)
+	var parent *moduleKey
+	if count := len(vm.moduleLoadStack); count != 0 {
+		parentKey := vm.moduleLoadStack[count-1]
+		parent = &parentKey
 	}
+	return vm.shared.Modules.Do(source.Key, parent, func() (value.Value, error) {
+		vm.moduleLoadStack = append(vm.moduleLoadStack, source.Key)
+		defer func() {
+			vm.moduleLoadStack = vm.moduleLoadStack[:len(vm.moduleLoadStack)-1]
+		}()
+		return vm.loadResolvedModule(source)
+	})
+}
 
-	// Case 1: Directory Import (Implicit Module)
-	if isDir {
-		// Check for entry point file (e.g. <dirname>.nx, main.nx)
-		// If found, load that file directly instead of treating dir as a map of files.
-		// Removed mod.nx and lib.nx to avoid shadowing directory contents when those files exist as children.
-		baseName := filepath.Base(path)
-		candidates := []string{baseName + ".nx", "main.nx"}
-
-		for _, cand := range candidates {
-			entryPath := filepath.Join(path, cand)
-			if _, err := os.Stat(entryPath); err == nil {
-				// Found entry point, verify it is not a directory
-				// (It shouldn't be given the extension, but safety first)
-				path = entryPath
-				isDir = false
-				goto FileImport
-			}
-		}
-
-		files, err := os.ReadDir(path)
+func (vm *VM) loadResolvedModule(source resolvedModule) (value.Value, error) {
+	switch source.Kind {
+	case resolvedDirectoryModule:
+		return vm.loadResolvedDirectory(source)
+	case resolvedEmbeddedModule:
+		return vm.compileAndRunModule(source, source.Content)
+	case resolvedFileModule:
+		content, err := os.ReadFile(source.Path)
 		if err != nil {
 			return value.NewNull(), err
 		}
-
-		moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
-
-		for _, f := range files {
-			if f.IsDir() {
-				// Recursively load subdirectory as a nested module
-				subDirName := name + "." + f.Name()
-				subMod, err := vm.loadModule(subDirName)
-				if err != nil {
-					// Ignore subdirectories that fail to load (e.g., empty or invalid)
-					continue
-				}
-				moduleEnvironment.SetLocal(f.Name(), subMod)
-			} else if strings.HasSuffix(f.Name(), ".nx") {
-				baseName := strings.TrimSuffix(f.Name(), ".nx")
-				subModuleName := name + "." + baseName
-
-				// Recursive load
-				subMod, err := vm.loadModule(subModuleName)
-				if err != nil {
-					return value.NewNull(), fmt.Errorf("failed to load submodule %s: %v", subModuleName, err)
-				}
-				moduleEnvironment.SetLocal(baseName, subMod)
-			}
-		}
-		return moduleEnvironment.ExportMap(), nil
+		return vm.compileAndRunModule(source, string(content))
+	default:
+		return value.NewNull(), fmt.Errorf("unknown resolved module kind for %s", source.Name)
 	}
+}
 
-FileImport:
-	// Case 2: File Import
-	content, err := os.ReadFile(path)
+func (vm *VM) loadResolvedDirectory(source resolvedModule) (value.Value, error) {
+	files, err := os.ReadDir(source.Path)
 	if err != nil {
 		return value.NewNull(), err
 	}
-
-	l := lexer.New(string(content))
-	p := parser.New(l)
-	prog := p.ParseProgram()
-	if len(p.Errors()) > 0 {
-		return value.NewNull(), fmt.Errorf("parse error in module %s: %v", name, p.Errors())
-	}
-
-	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), path, vm.Config.RootPath)
-	chunk, _, err := c.Compile(prog)
-	if err != nil {
-		return value.NewNull(), err
-	}
-
-	// Create an isolated module environment with root builtins as fallback.
 	moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
-
-	// Prepare Module Function
-	modFn := &value.ObjFunction{
-		Name:        name,
-		Arity:       0,
-		Chunk:       chunk,
-		Environment: moduleEnvironment,
+	for _, file := range files {
+		if file.IsDir() {
+			submodule, loadErr := vm.loadModule(source.Name + "." + file.Name())
+			if loadErr != nil {
+				continue
+			}
+			moduleEnvironment.SetLocal(file.Name(), submodule)
+			continue
+		}
+		if !strings.HasSuffix(file.Name(), ".nx") {
+			continue
+		}
+		baseName := strings.TrimSuffix(file.Name(), ".nx")
+		submoduleName := source.Name + "." + baseName
+		submodule, loadErr := vm.loadModule(submoduleName)
+		if loadErr != nil {
+			return value.NewNull(), fmt.Errorf("failed to load submodule %s: %v", submoduleName, loadErr)
+		}
+		moduleEnvironment.SetLocal(baseName, submodule)
 	}
-	modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
-	modVal := value.Value{Type: value.VAL_FUNCTION, Obj: modClosure}
+	return moduleEnvironment.ExportMap(), nil
+}
 
-	// Execute Module Synchronously
-	vm.push(modVal)
-	if ok, err := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
-		return value.NewNull(), err
+func (vm *VM) compileAndRunModule(source resolvedModule, content string) (value.Value, error) {
+	l := lexer.New(content)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) > 0 {
+		if source.Kind == resolvedEmbeddedModule {
+			return value.NewNull(), fmt.Errorf("parse error in embedded module %s: %v", source.Name, p.Errors())
+		}
+		return value.NewNull(), fmt.Errorf("parse error in module %s: %v", source.Name, p.Errors())
 	}
-
-	// Run until this frame returns
-	startFrameCount := vm.frameCount
-	err = vm.run(startFrameCount)
+	compilerPath := source.Path
+	if source.Kind == resolvedEmbeddedModule {
+		compilerPath = source.Name
+	}
+	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), compilerPath, vm.Config.RootPath)
+	code, _, err := c.Compile(program)
 	if err != nil {
 		return value.NewNull(), err
 	}
-
-	// Module execution finished.
-	// The result of module (usually null) is on stack. Pop it.
+	moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
+	modFn := &value.ObjFunction{Name: source.Name, Arity: 0, Chunk: code, Environment: moduleEnvironment}
+	modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
+	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: modClosure})
+	if ok, callErr := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
+		return value.NewNull(), callErr
+	}
+	startFrameCount := vm.frameCount
+	if err := vm.run(startFrameCount); err != nil {
+		return value.NewNull(), err
+	}
 	vm.pop()
-
-	// Return a live view containing only the module's local exports.
 	return moduleEnvironment.ExportMap(), nil
 }

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -102,25 +102,26 @@ func (vm *VM) loadModule(name string) (value.Value, error) {
 			if err != nil {
 				return value.NewNull(), err
 			}
-			moduleGlobals := make(map[string]value.Value)
+			moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
 			modFn := &value.ObjFunction{
-				Name:    name,
-				Arity:   0,
-				Chunk:   chunk,
-				Globals: moduleGlobals,
+				Name:        name,
+				Arity:       0,
+				Chunk:       chunk,
+				Environment: moduleEnvironment,
 			}
-			modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Globals: moduleGlobals}
+			modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
 			modVal := value.Value{Type: value.VAL_FUNCTION, Obj: modClosure}
 			vm.push(modVal)
-			if ok, err := vm.callValue(modVal, 0, nil, 0); !ok {
+			if ok, err := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
 				return value.NewNull(), err
 			}
-			err = vm.run(vm.frameCount) // Run until return
+			startFrameCount := vm.frameCount
+			err = vm.run(startFrameCount)
 			if err != nil {
 				return value.NewNull(), err
 			}
-			vm.pop() // Pop result
-			return value.NewMapWithData(moduleGlobals), nil
+			vm.pop()
+			return moduleEnvironment.ExportMap(), nil
 		}
 
 		return value.NewNull(), fmt.Errorf("module not found: %s", name)
@@ -150,7 +151,7 @@ func (vm *VM) loadModule(name string) (value.Value, error) {
 			return value.NewNull(), err
 		}
 
-		moduleGlobals := make(map[string]value.Value)
+		moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
 
 		for _, f := range files {
 			if f.IsDir() {
@@ -161,7 +162,7 @@ func (vm *VM) loadModule(name string) (value.Value, error) {
 					// Ignore subdirectories that fail to load (e.g., empty or invalid)
 					continue
 				}
-				moduleGlobals[f.Name()] = subMod
+				moduleEnvironment.SetLocal(f.Name(), subMod)
 			} else if strings.HasSuffix(f.Name(), ".nx") {
 				baseName := strings.TrimSuffix(f.Name(), ".nx")
 				subModuleName := name + "." + baseName
@@ -171,10 +172,10 @@ func (vm *VM) loadModule(name string) (value.Value, error) {
 				if err != nil {
 					return value.NewNull(), fmt.Errorf("failed to load submodule %s: %v", subModuleName, err)
 				}
-				moduleGlobals[baseName] = subMod
+				moduleEnvironment.SetLocal(baseName, subMod)
 			}
 		}
-		return value.NewMapWithData(moduleGlobals), nil
+		return moduleEnvironment.ExportMap(), nil
 	}
 
 FileImport:
@@ -197,22 +198,22 @@ FileImport:
 		return value.NewNull(), err
 	}
 
-	// Create isolated Module Globals
-	moduleGlobals := make(map[string]value.Value)
+	// Create an isolated module environment with root builtins as fallback.
+	moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
 
 	// Prepare Module Function
 	modFn := &value.ObjFunction{
-		Name:    name,
-		Arity:   0,
-		Chunk:   chunk,
-		Globals: moduleGlobals,
+		Name:        name,
+		Arity:       0,
+		Chunk:       chunk,
+		Environment: moduleEnvironment,
 	}
-	modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Globals: moduleGlobals}
+	modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
 	modVal := value.Value{Type: value.VAL_FUNCTION, Obj: modClosure}
 
 	// Execute Module Synchronously
 	vm.push(modVal)
-	if ok, err := vm.callValue(modVal, 0, nil, 0); !ok {
+	if ok, err := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
 		return value.NewNull(), err
 	}
 
@@ -227,6 +228,6 @@ FileImport:
 	// The result of module (usually null) is on stack. Pop it.
 	vm.pop()
 
-	// Return the Module Map
-	return value.NewMapWithData(moduleGlobals), nil
+	// Return a live view containing only the module's local exports.
+	return moduleEnvironment.ExportMap(), nil
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -270,9 +270,9 @@ test_report(targets["slot"]["answer"])`)
 func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 	machine := New()
 	moduleTarget := value.NewMapWithData(map[string]value.Value{"old": value.NewInt(0)})
-	moduleGlobals := map[string]value.Value{"target": moduleTarget}
-	machine.currentFrame = &CallFrame{Globals: moduleGlobals}
-	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "target", GlobalOwner: &moduleGlobals}}
+	moduleEnvironment := value.NewGlobalEnvironmentFrom(map[string]value.Value{"target": moduleTarget}, machine.shared.Root)
+	machine.currentFrame = &CallFrame{Environment: moduleEnvironment}
+	target := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "target", GlobalOwner: moduleEnvironment}}
 
 	jsonLoadsValue, ok := machine.GetGlobal("json_loads")
 	if !ok {
@@ -282,9 +282,10 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 	if result := jsonLoads.Fn([]value.Value{value.NewString(`{"answer":42}`), target}); result.Type != value.VAL_BOOL || !result.AsBool {
 		t.Fatal("module-frame global target was rejected")
 	}
-	got := requireTestMapValue(t, moduleGlobals["target"].Obj.(*value.ObjMap), "answer")
+	moduleTarget, _ = moduleEnvironment.GetLocal("target")
+	got := requireTestMapValue(t, moduleTarget.Obj.(*value.ObjMap), "answer")
 	if got.Type != value.VAL_INT || got.AsInt != 42 {
-		t.Fatalf("module target=%v, want answer=42", moduleGlobals["target"])
+		t.Fatalf("module target=%v, want answer=42", moduleTarget)
 	}
 	if _, leaked := machine.GetGlobal("target"); leaked {
 		t.Fatal("module target must not be written to shared globals")
@@ -293,7 +294,7 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 
 func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 	machine := New()
-	missingGlobals := map[string]value.Value{}
+	missingEnvironment := value.NewGlobalEnvironment(nil)
 	instance := value.NewInstance(&value.ObjStruct{Name: "Holder", Fields: []string{"known"}})
 	instance.Obj.(*value.ObjInstance).Fields["known"] = value.NewInt(1)
 	tests := []struct {
@@ -302,7 +303,7 @@ func TestPopulateTargetRejectsInvalidReferences(t *testing.T) {
 	}{
 		{
 			name: "missing global",
-			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: &missingGlobals},
+			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: missingEnvironment},
 		},
 		{
 			name: "missing property",

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -282,7 +282,7 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 	if result := jsonLoads.Fn([]value.Value{value.NewString(`{"answer":42}`), target}); result.Type != value.VAL_BOOL || !result.AsBool {
 		t.Fatal("module-frame global target was rejected")
 	}
-	got := moduleGlobals["target"].Obj.(*value.ObjMap).Data["answer"]
+	got := requireTestMapValue(t, moduleGlobals["target"].Obj.(*value.ObjMap), "answer")
 	if got.Type != value.VAL_INT || got.AsInt != 42 {
 		t.Fatalf("module target=%v, want answer=42", moduleGlobals["target"])
 	}
@@ -739,7 +739,7 @@ func TestPopulateTargetRetainsCompatibleCompositeFields(t *testing.T) {
 		t.Fatalf("items=%v, want [42]", fields["items"])
 	}
 	metadata := fields["metadata"].Obj.(*value.ObjMap)
-	if got := metadata.Data["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got := requireTestMapValue(t, metadata, "answer"); got.Type != value.VAL_INT || got.AsInt != 42 {
 		t.Fatalf("metadata=%v, want answer=42", fields["metadata"])
 	}
 }
@@ -1883,11 +1883,11 @@ func TestCollectionRuntimeMetadataPreservesShallowCopyAndIdentity(t *testing.T) 
 
 	mapping := value.NewMap()
 	mapObject := mapping.Obj.(*value.ObjMap)
-	mapObject.Data["item"] = shared
+	setTestMap(mapObject, "item", shared)
 	mapObject.RuntimeType.Store(mapSchema)
 	mapCopy := machine.copyValue(mapping)
 	mapCopyObject := mapCopy.Obj.(*value.ObjMap)
-	if mapCopyObject == mapObject || mapCopyObject.RuntimeType.Load() != mapSchema || mapCopyObject.Data["item"].Obj != shared.Obj {
+	if mapCopyObject == mapObject || mapCopyObject.RuntimeType.Load() != mapSchema || requireTestMapValue(t, mapCopyObject, "item").Obj != shared.Obj {
 		t.Fatal("map shallow copy lost collection schema or nested identity")
 	}
 }
@@ -2296,7 +2296,7 @@ test_report(length(sliced) * 10 + length(generated))`
 	if !ok {
 		t.Fatal("array_utils was not cached")
 	}
-	exports := module.Obj.(*value.ObjMap).Data
+	exports := module.Obj.(*value.ObjMap).Snapshot()
 	if _, ok := exports["slice"]; !ok {
 		t.Fatal("array_utils omitted slice export")
 	}

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -279,7 +279,8 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 		t.Fatal("missing json_loads native")
 	}
 	jsonLoads := jsonLoadsValue.Obj.(*value.ObjNative)
-	if result := jsonLoads.Fn([]value.Value{value.NewString(`{"answer":42}`), target}); result.Type != value.VAL_BOOL || !result.AsBool {
+	result, err := jsonLoads.Invoke(machine, []value.Value{value.NewString(`{"answer":42}`), target})
+	if err != nil || result.Type != value.VAL_BOOL || !result.AsBool {
 		t.Fatal("module-frame global target was rejected")
 	}
 	moduleTarget, _ = moduleEnvironment.GetLocal("target")

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -2293,7 +2293,7 @@ test_report(length(sliced) * 10 + length(generated))`
 	if len(results) != 2 || results[0] != 23 || results[1] != 23 {
 		t.Fatalf("wildcard first/cache results=%v, want [23 23]", results)
 	}
-	module, ok := machine.shared.Modules["array_utils"]
+	module, ok := machine.GetModule("array_utils")
 	if !ok {
 		t.Fatal("array_utils was not cached")
 	}

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -39,3 +39,31 @@ func TestModuleFrameGlobalReferenceCapturesSharedFallbackOwner(t *testing.T) {
 		t.Fatalf("shared fallback=%v, want 42", got)
 	}
 }
+
+func TestInterpretWithGlobalsUsesNonNilEmptyEnvironment(t *testing.T) {
+	code := compileVMSource(t, "let answer: int = 42")
+	globals := map[string]value.Value{}
+	if err := New().InterpretWithGlobals(code, globals); err != nil {
+		t.Fatal(err)
+	}
+	if got := globals["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("answer=%v", got)
+	}
+}
+
+func TestModuleGlobalReferenceRetainsResolvedEnvironment(t *testing.T) {
+	root := value.NewGlobalEnvironment(nil)
+	root.SetLocal("root", value.NewInt(1))
+	module := value.NewGlobalEnvironment(root)
+	module.SetLocal("module", value.NewInt(2))
+	machine := New()
+	machine.shared.Root = root
+	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "module", GlobalOwner: module}
+	if err := machine.storeGlobalReferenceValue(ref, value.NewInt(3)); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := module.GetLocal("module")
+	if got.AsInt != 3 {
+		t.Fatalf("module value=%v", got)
+	}
+}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -69,22 +69,14 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 	}
 	switch ref.RefType {
 	case value.REF_GLOBAL:
-		if ref.GlobalOwner == nil || *ref.GlobalOwner == nil {
+		if ref.GlobalOwner == nil {
 			return value.Value{}, false, nil, fmt.Errorf("invalid global reference owner")
 		}
-		if ref.GlobalOwner == &vm.shared.Globals {
-			stored, ok := vm.GetGlobal(ref.Name)
-			if !ok {
-				return value.Value{}, false, nil, fmt.Errorf("undefined global variable '%s'", ref.Name)
-			}
-			return stored, true, func(updated value.Value) { vm.SetGlobal(ref.Name, updated) }, nil
-		}
-		owner := *ref.GlobalOwner
-		stored, ok := owner[ref.Name]
+		stored, ok := ref.GlobalOwner.GetLocal(ref.Name)
 		if !ok {
 			return value.Value{}, false, nil, fmt.Errorf("undefined global variable '%s'", ref.Name)
 		}
-		return stored, true, func(updated value.Value) { owner[ref.Name] = updated }, nil
+		return stored, true, func(updated value.Value) { ref.GlobalOwner.SetLocal(ref.Name, updated) }, nil
 	case value.REF_UPVALUE:
 		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
 			return value.Value{}, false, nil, fmt.Errorf("invalid upvalue reference")

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -117,18 +117,15 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 			return array.Elements[index], true, func(updated value.Value) { array.Elements[index] = updated }, nil
 		}
 		if mapping, ok := ref.Container.Obj.(*value.ObjMap); ref.Container.Type == value.VAL_OBJ && ok && mapping != nil {
-			if mapping.Data == nil {
-				return value.Value{}, false, nil, fmt.Errorf("invalid map reference container")
-			}
 			key, err := referenceMapKey(ref.Index)
 			if err != nil {
 				return value.Value{}, false, nil, err
 			}
-			stored, exists := mapping.Data[key]
+			stored, exists := mapping.Get(key)
 			if !exists {
 				stored = value.NewNull()
 			}
-			return stored, exists, func(updated value.Value) { mapping.Data[key] = updated }, nil
+			return stored, exists, func(updated value.Value) { mapping.Set(key, updated) }, nil
 		}
 		return value.Value{}, false, nil, fmt.Errorf("Target is not indexable")
 	default:

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -100,8 +100,8 @@ func TestMutatingNativesTreatMalformedReferencesAsLegacyNoOps(t *testing.T) {
 }
 
 func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
-	globals := map[string]value.Value{"answer": value.NewInt(41)}
-	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "answer", GlobalOwner: &globals}
+	environment := value.NewGlobalEnvironmentFrom(map[string]value.Value{"answer": value.NewInt(41)}, nil)
+	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "answer", GlobalOwner: environment}
 	machine := New()
 
 	got, err := machine.lookupGlobalReferenceValue(ref)
@@ -114,7 +114,7 @@ func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
 	if err := machine.storeGlobalReferenceValue(ref, value.NewInt(42)); err != nil {
 		t.Fatal(err)
 	}
-	if got := globals["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got, _ := environment.GetLocal("answer"); got.Type != value.VAL_INT || got.AsInt != 42 {
 		t.Fatalf("stored value=%v, want 42", got)
 	}
 
@@ -130,7 +130,7 @@ func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
 		},
 		{
 			name: "missing global",
-			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: &globals},
+			ref:  &value.ObjRef{RefType: value.REF_GLOBAL, Name: "missing", GlobalOwner: environment},
 			want: "undefined global variable 'missing'",
 		},
 	} {

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -90,7 +90,10 @@ func TestMutatingNativesTreatMalformedReferencesAsLegacyNoOps(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing native %s", native.name)
 				}
-				result := nativeValue.Obj.(*value.ObjNative).Fn(native.args(target.value))
+				result, err := nativeValue.Obj.(*value.ObjNative).Invoke(machine, native.args(target.value))
+				if err != nil {
+					t.Fatal(err)
+				}
 				if result.Type != value.VAL_NULL {
 					t.Fatalf("result=%v, want null", result)
 				}

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"os"
 	"sync"
+
+	"noxy-vm/internal/value"
 )
 
 type handleRegistry[T any] struct {
@@ -46,11 +48,48 @@ func (registry *handleRegistry[T]) remove(handle int) (T, bool) {
 	return item, ok
 }
 
+func (registry *handleRegistry[T]) snapshot() map[int]T {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+
+	items := make(map[int]T, len(registry.items))
+	for handle, item := range registry.items {
+		items[handle] = item
+	}
+	return items
+}
+
 type FileResource struct {
 	stateMu     sync.Mutex
 	operationMu sync.Mutex
 	file        *os.File
 	closed      bool
+}
+
+func (resource *FileResource) use(operation func(*os.File) value.Value) (value.Value, bool) {
+	resource.operationMu.Lock()
+	defer resource.operationMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.file == nil {
+		resource.stateMu.Unlock()
+		return value.NewNull(), false
+	}
+	file := resource.file
+	resource.stateMu.Unlock()
+	return operation(file), true
+}
+
+func (resource *FileResource) close() error {
+	resource.stateMu.Lock()
+	if resource.closed || resource.file == nil {
+		resource.stateMu.Unlock()
+		return os.ErrClosed
+	}
+	resource.closed = true
+	file := resource.file
+	resource.stateMu.Unlock()
+	return file.Close()
 }
 
 type ListenerResource struct {

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -12,11 +12,16 @@ import (
 type handleRegistry[T any] struct {
 	mu    sync.RWMutex
 	next  int
+	step  int
 	items map[int]T
 }
 
 func newHandleRegistry[T any]() *handleRegistry[T] {
-	return &handleRegistry[T]{next: 1, items: make(map[int]T)}
+	return newSequencedHandleRegistry[T](1, 1)
+}
+
+func newSequencedHandleRegistry[T any](next int, step int) *handleRegistry[T] {
+	return &handleRegistry[T]{next: next, step: step, items: make(map[int]T)}
 }
 
 func (registry *handleRegistry[T]) add(item T) int {
@@ -24,7 +29,7 @@ func (registry *handleRegistry[T]) add(item T) int {
 	defer registry.mu.Unlock()
 
 	handle := registry.next
-	registry.next++
+	registry.next += registry.step
 	registry.items[handle] = item
 	return handle
 }

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -1,0 +1,84 @@
+package vm
+
+import (
+	"database/sql"
+	"net"
+	"os"
+	"sync"
+)
+
+type handleRegistry[T any] struct {
+	mu    sync.RWMutex
+	next  int
+	items map[int]T
+}
+
+func newHandleRegistry[T any]() *handleRegistry[T] {
+	return &handleRegistry[T]{next: 1, items: make(map[int]T)}
+}
+
+func (registry *handleRegistry[T]) add(item T) int {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	handle := registry.next
+	registry.next++
+	registry.items[handle] = item
+	return handle
+}
+
+func (registry *handleRegistry[T]) get(handle int) (T, bool) {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+
+	item, ok := registry.items[handle]
+	return item, ok
+}
+
+func (registry *handleRegistry[T]) remove(handle int) (T, bool) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	item, ok := registry.items[handle]
+	if ok {
+		delete(registry.items, handle)
+	}
+	return item, ok
+}
+
+type FileResource struct {
+	stateMu     sync.Mutex
+	operationMu sync.Mutex
+	file        *os.File
+	closed      bool
+}
+
+type ListenerResource struct {
+	stateMu        sync.Mutex
+	acceptMu       sync.Mutex
+	listener       net.Listener
+	bufferedAccept net.Conn
+	closed         bool
+}
+
+type SocketResource struct {
+	stateMu      sync.Mutex
+	readMu       sync.Mutex
+	writeMu      sync.Mutex
+	connection   net.Conn
+	bufferedRead []byte
+	closed       bool
+}
+
+type DatabaseResource struct {
+	stateMu  sync.Mutex
+	database *sql.DB
+	closed   bool
+}
+
+type StatementResource struct {
+	mu         sync.Mutex
+	statement  *sql.Stmt
+	parameters map[int]interface{}
+	closed     bool
+}

--- a/internal/vm/resources_test.go
+++ b/internal/vm/resources_test.go
@@ -1,0 +1,49 @@
+package vm
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestHandleRegistryUsesMonotonicNonReusableHandles(t *testing.T) {
+	registry := newHandleRegistry[string]()
+	first := registry.add("first")
+	if _, ok := registry.remove(first); !ok {
+		t.Fatal("remove failed")
+	}
+	second := registry.add("second")
+	if second <= first {
+		t.Fatalf("handles %d then %d", first, second)
+	}
+	if _, ok := registry.get(first); ok {
+		t.Fatal("removed handle resolved")
+	}
+}
+
+func TestHandleRegistryConcurrentAddsAssignDistinctHandles(t *testing.T) {
+	registry := newHandleRegistry[int]()
+	const workers = 64
+
+	handles := make(chan int, workers)
+	var group sync.WaitGroup
+	group.Add(workers)
+	for index := 0; index < workers; index++ {
+		go func(item int) {
+			defer group.Done()
+			handles <- registry.add(item)
+		}(index)
+	}
+	group.Wait()
+	close(handles)
+
+	seen := make(map[int]bool, workers)
+	for handle := range handles {
+		if seen[handle] {
+			t.Fatalf("duplicate handle %d", handle)
+		}
+		seen[handle] = true
+	}
+	if len(seen) != workers {
+		t.Fatalf("registered %d handles, want %d", len(seen), workers)
+	}
+}

--- a/internal/vm/runtime_context_test.go
+++ b/internal/vm/runtime_context_test.go
@@ -28,3 +28,25 @@ func TestDefineContextualNativeReplacesExistingGlobal(t *testing.T) {
 
 	assertBuiltinValue(t, callBuiltin(t, machine, "replacement"), value.NewString("contextual"))
 }
+
+func TestSharedVMsReuseBuiltinValuesButInvokeActiveContext(t *testing.T) {
+	parent := NewWithConfig(VMConfig{RootPath: "parent"})
+	parentBuiltins := make(map[string]value.Value)
+	for _, name := range []string{"spawn", "io_open", "net_listen", "sqlite_open"} {
+		item, ok := parent.GetGlobal(name)
+		if !ok {
+			t.Fatalf("parent is missing %s", name)
+		}
+		parentBuiltins[name] = item
+	}
+	child := NewWithShared(parent.shared, VMConfig{RootPath: "child"})
+	for name, parentBuiltin := range parentBuiltins {
+		childBuiltin, ok := child.GetGlobal(name)
+		if !ok {
+			t.Fatalf("child is missing %s", name)
+		}
+		if parentBuiltin.Obj != childBuiltin.Obj {
+			t.Errorf("shared VM registered a second %s native", name)
+		}
+	}
+}

--- a/internal/vm/runtime_context_test.go
+++ b/internal/vm/runtime_context_test.go
@@ -1,0 +1,20 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestContextualNativeReceivesCallingVM(t *testing.T) {
+	parent := NewWithConfig(VMConfig{RootPath: "parent"})
+	child := NewWithShared(parent.shared, VMConfig{RootPath: "child"})
+	parent.DefineContextualNative("active_root", func(context value.NativeContext, _ []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		return value.NewString(machine.Config.RootPath), nil
+	})
+	assertBuiltinValue(t, callBuiltin(t, child, "active_root"), value.NewString("child"))
+}

--- a/internal/vm/runtime_context_test.go
+++ b/internal/vm/runtime_context_test.go
@@ -18,3 +18,13 @@ func TestContextualNativeReceivesCallingVM(t *testing.T) {
 	})
 	assertBuiltinValue(t, callBuiltin(t, child, "active_root"), value.NewString("child"))
 }
+
+func TestDefineContextualNativeReplacesExistingGlobal(t *testing.T) {
+	machine := New()
+	machine.SetGlobal("replacement", value.NewString("previous"))
+	machine.DefineContextualNative("replacement", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewString("contextual"), nil
+	})
+
+	assertBuiltinValue(t, callBuiltin(t, machine, "replacement"), value.NewString("contextual"))
+}

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -149,10 +149,10 @@ func (vm *VM) runtimeValueMatchesType(actual value.Value, expected *value.Runtim
 			if !runtimeTypeComplete(actualType, make(map[*value.RuntimeTypeInfo]bool)) || !runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool)) {
 				return false
 			}
-		} else if len(mapping.Data) == 0 {
+		} else if mapping.Len() == 0 {
 			return false
 		}
-		for key, element := range mapping.Data {
+		for key, element := range mapping.Snapshot() {
 			if !runtimeMapKeyMatchesType(key, expected.Key) || !vm.runtimeValueMatchesType(element, expected.Value) {
 				return false
 			}
@@ -355,7 +355,7 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 			}
 			effectiveSchema = actualType
 		}
-		for key, element := range mapping.Data {
+		for key, element := range mapping.Snapshot() {
 			if !runtimeMapKeyMatchesType(key, effectiveSchema.Key) || !vm.walkRuntimeValueType(element, effectiveSchema.Value, apply, seen) {
 				return false
 			}

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -225,7 +225,7 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 			}
 		case value.VAL_NATIVE:
 			native, ok := actual.Obj.(*value.ObjNative)
-			return ok && native != nil && native.Fn != nil
+			return ok && native.IsCallable()
 		}
 		return false
 	}
@@ -250,7 +250,7 @@ func runtimeCallableMatchesType(actual value.Value, expected *value.RuntimeTypeI
 		return actualType != nil && runtimeTypeAccepts(expected, actualType, make(map[runtimeTypePair]bool))
 	case value.VAL_NATIVE:
 		native, ok := actual.Obj.(*value.ObjNative)
-		return ok && native != nil && native.Fn != nil && nativeSignatureMatchesRuntimeType(native.Signature, expected)
+		return ok && native.IsCallable() && nativeSignatureMatchesRuntimeType(native.Signature, expected)
 	default:
 		return false
 	}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -34,8 +34,14 @@ type CallFrame struct {
 }
 
 type SharedState struct {
-	Root    *value.GlobalEnvironment
-	Modules *moduleCache
+	Root       *value.GlobalEnvironment
+	Modules    *moduleCache
+	Files      *handleRegistry[*FileResource]
+	Listeners  *handleRegistry[*ListenerResource]
+	Sockets    *handleRegistry[*SocketResource]
+	Databases  *handleRegistry[*DatabaseResource]
+	Statements *handleRegistry[*StatementResource]
+	initOnce   sync.Once
 
 	// Shared Network Resources
 	NetListeners map[int]net.Listener
@@ -104,6 +110,11 @@ func NewWithConfig(cfg VMConfig) *VM {
 	shared := &SharedState{
 		Root:         value.NewGlobalEnvironment(nil),
 		Modules:      newModuleCache(),
+		Files:        newHandleRegistry[*FileResource](),
+		Listeners:    newHandleRegistry[*ListenerResource](),
+		Sockets:      newHandleRegistry[*SocketResource](),
+		Databases:    newHandleRegistry[*DatabaseResource](),
+		Statements:   newHandleRegistry[*StatementResource](),
 		NetListeners: make(map[int]net.Listener),
 		NetConns:     make(map[int]net.Conn),
 		NextNetID:    1,

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -146,9 +146,6 @@ func (vm *VM) DefineNativeWithSignature(name string, signature value.NativeSigna
 }
 
 func (vm *VM) DefineContextualNative(name string, fn value.ContextualNativeFunc) {
-	if _, ok := vm.GetGlobal(name); ok {
-		return
-	}
 	vm.SetGlobal(name, value.NewContextualNative(name, fn))
 }
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
-	"os"
 	"sync"
 )
 
@@ -74,10 +73,6 @@ type VM struct {
 
 	moduleLoadStack []moduleKey
 
-	// IO Management
-	openFiles map[int64]*os.File
-	nextFD    int64
-
 	// Net Management (Moved to SharedState)
 	netBufferedData  map[int][]byte   // For peeked data during select (Local to thread/VM?)
 	netBufferedConns map[int]net.Conn // For peeked accepts (Local to thread/VM?)
@@ -135,10 +130,8 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 		shared.Modules = newModuleCache()
 	}
 	vm := &VM{
-		shared:    shared,
-		Config:    cfg,
-		openFiles: make(map[int64]*os.File),
-		nextFD:    1,
+		shared: shared,
+		Config: cfg,
 
 		netBufferedData:  make(map[int][]byte),
 		netBufferedConns: make(map[int]net.Conn),

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -81,6 +81,16 @@ type VM struct {
 	openUpvalues *value.ObjUpvalue // Head of linked list of open upvalues
 }
 
+func (*VM) IsNativeContext() {}
+
+func nativeVM(context value.NativeContext) (*VM, error) {
+	machine, ok := context.(*VM)
+	if !ok || machine == nil {
+		return nil, fmt.Errorf("invalid VM native context")
+	}
+	return machine, nil
+}
+
 type VMConfig struct {
 	RootPath string
 }
@@ -133,6 +143,20 @@ func (vm *VM) DefineNativeWithSignature(name string, signature value.NativeSigna
 		return
 	}
 	vm.SetGlobal(name, value.NewNativeWithSignature(name, signature, fn))
+}
+
+func (vm *VM) DefineContextualNative(name string, fn value.ContextualNativeFunc) {
+	if _, ok := vm.GetGlobal(name); ok {
+		return
+	}
+	vm.SetGlobal(name, value.NewContextualNative(name, fn))
+}
+
+func (vm *VM) DefineContextualNativeWithSignature(name string, signature value.NativeSignature, fn value.ContextualNativeFunc) {
+	if _, ok := vm.GetGlobal(name); ok {
+		return
+	}
+	vm.SetGlobal(name, value.NewContextualNativeWithSignature(name, signature, fn))
 }
 
 func (vm *VM) SetGlobal(name string, val value.Value) {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"database/sql"
 	"fmt"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
@@ -41,14 +40,6 @@ type SharedState struct {
 	Databases  *handleRegistry[*DatabaseResource]
 	Statements *handleRegistry[*StatementResource]
 	initOnce   sync.Once
-
-	// Shared Database Resources
-	DbHandles   map[int]*sql.DB
-	StmtHandles map[int]*sql.Stmt
-	StmtParams  map[int]map[int]interface{}
-	NextDbID    int
-	NextStmtID  int
-	DbLock      sync.Mutex
 }
 
 type VM struct {
@@ -92,18 +83,13 @@ func New() *VM {
 
 func NewWithConfig(cfg VMConfig) *VM {
 	shared := &SharedState{
-		Root:        value.NewGlobalEnvironment(nil),
-		Modules:     newModuleCache(),
-		Files:       newHandleRegistry[*FileResource](),
-		Listeners:   newSequencedHandleRegistry[*ListenerResource](1, 2),
-		Sockets:     newSequencedHandleRegistry[*SocketResource](2, 2),
-		Databases:   newHandleRegistry[*DatabaseResource](),
-		Statements:  newHandleRegistry[*StatementResource](),
-		DbHandles:   make(map[int]*sql.DB),
-		StmtHandles: make(map[int]*sql.Stmt),
-		StmtParams:  make(map[int]map[int]interface{}),
-		NextDbID:    1,
-		NextStmtID:  1,
+		Root:       value.NewGlobalEnvironment(nil),
+		Modules:    newModuleCache(),
+		Files:      newHandleRegistry[*FileResource](),
+		Listeners:  newSequencedHandleRegistry[*ListenerResource](1, 2),
+		Sockets:    newSequencedHandleRegistry[*SocketResource](2, 2),
+		Databases:  newHandleRegistry[*DatabaseResource](),
+		Statements: newHandleRegistry[*StatementResource](),
 	}
 	return NewWithShared(shared, cfg)
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -34,9 +34,8 @@ type CallFrame struct {
 }
 
 type SharedState struct {
-	Root        *value.GlobalEnvironment
-	Modules     map[string]value.Value // Cached modules (Name -> ObjMap)
-	GlobalsLock sync.RWMutex
+	Root    *value.GlobalEnvironment
+	Modules *moduleCache
 
 	// Shared Network Resources
 	NetListeners map[int]net.Listener
@@ -66,6 +65,8 @@ type VM struct {
 
 	shared *SharedState
 	Config VMConfig
+
+	moduleLoadStack []moduleKey
 
 	// IO Management
 	openFiles map[int64]*os.File
@@ -102,7 +103,7 @@ func New() *VM {
 func NewWithConfig(cfg VMConfig) *VM {
 	shared := &SharedState{
 		Root:         value.NewGlobalEnvironment(nil),
-		Modules:      make(map[string]value.Value),
+		Modules:      newModuleCache(),
 		NetListeners: make(map[int]net.Listener),
 		NetConns:     make(map[int]net.Conn),
 		NextNetID:    1,
@@ -118,6 +119,9 @@ func NewWithConfig(cfg VMConfig) *VM {
 func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 	if shared.Root == nil {
 		shared.Root = value.NewGlobalEnvironment(nil)
+	}
+	if shared.Modules == nil {
+		shared.Modules = newModuleCache()
 	}
 	vm := &VM{
 		shared:    shared,
@@ -158,14 +162,16 @@ func (vm *VM) GetGlobal(name string) (value.Value, bool) {
 }
 
 func (vm *VM) SetModule(name string, val value.Value) {
-	vm.shared.GlobalsLock.Lock()
-	defer vm.shared.GlobalsLock.Unlock()
-	vm.shared.Modules[name] = val
+	source, err := vm.resolveModule(name)
+	if err == nil {
+		vm.shared.Modules.store(source.Key, val)
+	}
 }
 
 func (vm *VM) GetModule(name string) (value.Value, bool) {
-	vm.shared.GlobalsLock.RLock()
-	defer vm.shared.GlobalsLock.RUnlock()
-	val, ok := vm.shared.Modules[name]
-	return val, ok
+	source, err := vm.resolveModule(name)
+	if err != nil {
+		return value.NewNull(), false
+	}
+	return vm.shared.Modules.get(source.Key)
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -27,14 +27,14 @@ func (vm *VM) runtimeError(c *chunk.Chunk, ip int, format string, args ...interf
 }
 
 type CallFrame struct {
-	Closure *value.ObjClosure
-	IP      int
-	Slots   int                    // Offset in stack where this frame's locals start
-	Globals map[string]value.Value // Globals visible to this frame
+	Closure     *value.ObjClosure
+	IP          int
+	Slots       int // Offset in stack where this frame's locals start
+	Environment *value.GlobalEnvironment
 }
 
 type SharedState struct {
-	Globals     map[string]value.Value // Global variables/functions
+	Root        *value.GlobalEnvironment
 	Modules     map[string]value.Value // Cached modules (Name -> ObjMap)
 	GlobalsLock sync.RWMutex
 
@@ -101,7 +101,7 @@ func New() *VM {
 
 func NewWithConfig(cfg VMConfig) *VM {
 	shared := &SharedState{
-		Globals:      make(map[string]value.Value),
+		Root:         value.NewGlobalEnvironment(nil),
 		Modules:      make(map[string]value.Value),
 		NetListeners: make(map[int]net.Listener),
 		NetConns:     make(map[int]net.Conn),
@@ -116,6 +116,9 @@ func NewWithConfig(cfg VMConfig) *VM {
 }
 
 func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
+	if shared.Root == nil {
+		shared.Root = value.NewGlobalEnvironment(nil)
+	}
 	vm := &VM{
 		shared:    shared,
 		Config:    cfg,
@@ -131,18 +134,11 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 }
 
 func (vm *VM) DefineNative(name string, fn value.NativeFunc) {
-	// Check if already defined in shared globals to avoid overwriting with thread-local closure
-	if _, ok := vm.GetGlobal(name); ok {
-		return
-	}
-	vm.SetGlobal(name, value.NewNative(name, fn))
+	vm.shared.Root.DefineLocalIfAbsent(name, value.NewNative(name, fn))
 }
 
 func (vm *VM) DefineNativeWithSignature(name string, signature value.NativeSignature, fn value.NativeFunc) {
-	if _, ok := vm.GetGlobal(name); ok {
-		return
-	}
-	vm.SetGlobal(name, value.NewNativeWithSignature(name, signature, fn))
+	vm.shared.Root.DefineLocalIfAbsent(name, value.NewNativeWithSignature(name, signature, fn))
 }
 
 func (vm *VM) DefineContextualNative(name string, fn value.ContextualNativeFunc) {
@@ -150,23 +146,15 @@ func (vm *VM) DefineContextualNative(name string, fn value.ContextualNativeFunc)
 }
 
 func (vm *VM) DefineContextualNativeWithSignature(name string, signature value.NativeSignature, fn value.ContextualNativeFunc) {
-	if _, ok := vm.GetGlobal(name); ok {
-		return
-	}
-	vm.SetGlobal(name, value.NewContextualNativeWithSignature(name, signature, fn))
+	vm.shared.Root.DefineLocalIfAbsent(name, value.NewContextualNativeWithSignature(name, signature, fn))
 }
 
 func (vm *VM) SetGlobal(name string, val value.Value) {
-	vm.shared.GlobalsLock.Lock()
-	defer vm.shared.GlobalsLock.Unlock()
-	vm.shared.Globals[name] = val
+	vm.shared.Root.SetLocal(name, val)
 }
 
 func (vm *VM) GetGlobal(name string) (value.Value, bool) {
-	vm.shared.GlobalsLock.RLock()
-	defer vm.shared.GlobalsLock.RUnlock()
-	val, ok := vm.shared.Globals[name]
-	return val, ok
+	return vm.shared.Root.GetLocal(name)
 }
 
 func (vm *VM) SetModule(name string, val value.Value) {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -31,15 +31,16 @@ type CallFrame struct {
 }
 
 type SharedState struct {
-	Root       *value.GlobalEnvironment
-	Modules    *moduleCache
-	Files      *handleRegistry[*FileResource]
-	fileMetaMu sync.RWMutex
-	Listeners  *handleRegistry[*ListenerResource]
-	Sockets    *handleRegistry[*SocketResource]
-	Databases  *handleRegistry[*DatabaseResource]
-	Statements *handleRegistry[*StatementResource]
-	initOnce   sync.Once
+	Root         *value.GlobalEnvironment
+	Modules      *moduleCache
+	Files        *handleRegistry[*FileResource]
+	fileMetaMu   sync.RWMutex
+	Listeners    *handleRegistry[*ListenerResource]
+	Sockets      *handleRegistry[*SocketResource]
+	Databases    *handleRegistry[*DatabaseResource]
+	Statements   *handleRegistry[*StatementResource]
+	stateOnce    sync.Once
+	builtinsOnce sync.Once
 }
 
 type VM struct {
@@ -82,37 +83,17 @@ func New() *VM {
 }
 
 func NewWithConfig(cfg VMConfig) *VM {
-	shared := &SharedState{
-		Root:       value.NewGlobalEnvironment(nil),
-		Modules:    newModuleCache(),
-		Files:      newHandleRegistry[*FileResource](),
-		Listeners:  newSequencedHandleRegistry[*ListenerResource](1, 2),
-		Sockets:    newSequencedHandleRegistry[*SocketResource](2, 2),
-		Databases:  newHandleRegistry[*DatabaseResource](),
-		Statements: newHandleRegistry[*StatementResource](),
-	}
-	return NewWithShared(shared, cfg)
+	return NewWithShared(&SharedState{}, cfg)
 }
 
 func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
-	if shared.Root == nil {
-		shared.Root = value.NewGlobalEnvironment(nil)
-	}
-	if shared.Modules == nil {
-		shared.Modules = newModuleCache()
-	}
-	if shared.Listeners == nil {
-		shared.Listeners = newSequencedHandleRegistry[*ListenerResource](1, 2)
-	}
-	if shared.Sockets == nil {
-		shared.Sockets = newSequencedHandleRegistry[*SocketResource](2, 2)
-	}
+	shared.initializeState()
 	vm := &VM{
 		shared: shared,
 		Config: cfg,
 	}
 
-	vm.defineBuiltins()
+	shared.builtinsOnce.Do(vm.defineBuiltins)
 	return vm
 }
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -36,6 +36,7 @@ type SharedState struct {
 	Root       *value.GlobalEnvironment
 	Modules    *moduleCache
 	Files      *handleRegistry[*FileResource]
+	fileMetaMu sync.RWMutex
 	Listeners  *handleRegistry[*ListenerResource]
 	Sockets    *handleRegistry[*SocketResource]
 	Databases  *handleRegistry[*DatabaseResource]

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"database/sql"
 	"fmt"
-	"net"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
 	"sync"
@@ -43,12 +42,6 @@ type SharedState struct {
 	Statements *handleRegistry[*StatementResource]
 	initOnce   sync.Once
 
-	// Shared Network Resources
-	NetListeners map[int]net.Listener
-	NetConns     map[int]net.Conn
-	NextNetID    int
-	NetLock      sync.Mutex
-
 	// Shared Database Resources
 	DbHandles   map[int]*sql.DB
 	StmtHandles map[int]*sql.Stmt
@@ -73,11 +66,6 @@ type VM struct {
 	Config VMConfig
 
 	moduleLoadStack []moduleKey
-
-	// Net Management (Moved to SharedState)
-	netBufferedData  map[int][]byte   // For peeked data during select (Local to thread/VM?)
-	netBufferedConns map[int]net.Conn // For peeked accepts (Local to thread/VM?)
-	// netListeners, netConns, nextNetID removed from VM
 
 	LastPopped value.Value
 
@@ -104,21 +92,18 @@ func New() *VM {
 
 func NewWithConfig(cfg VMConfig) *VM {
 	shared := &SharedState{
-		Root:         value.NewGlobalEnvironment(nil),
-		Modules:      newModuleCache(),
-		Files:        newHandleRegistry[*FileResource](),
-		Listeners:    newHandleRegistry[*ListenerResource](),
-		Sockets:      newHandleRegistry[*SocketResource](),
-		Databases:    newHandleRegistry[*DatabaseResource](),
-		Statements:   newHandleRegistry[*StatementResource](),
-		NetListeners: make(map[int]net.Listener),
-		NetConns:     make(map[int]net.Conn),
-		NextNetID:    1,
-		DbHandles:    make(map[int]*sql.DB),
-		StmtHandles:  make(map[int]*sql.Stmt),
-		StmtParams:   make(map[int]map[int]interface{}),
-		NextDbID:     1,
-		NextStmtID:   1,
+		Root:        value.NewGlobalEnvironment(nil),
+		Modules:     newModuleCache(),
+		Files:       newHandleRegistry[*FileResource](),
+		Listeners:   newSequencedHandleRegistry[*ListenerResource](1, 2),
+		Sockets:     newSequencedHandleRegistry[*SocketResource](2, 2),
+		Databases:   newHandleRegistry[*DatabaseResource](),
+		Statements:  newHandleRegistry[*StatementResource](),
+		DbHandles:   make(map[int]*sql.DB),
+		StmtHandles: make(map[int]*sql.Stmt),
+		StmtParams:  make(map[int]map[int]interface{}),
+		NextDbID:    1,
+		NextStmtID:  1,
 	}
 	return NewWithShared(shared, cfg)
 }
@@ -130,12 +115,15 @@ func NewWithShared(shared *SharedState, cfg VMConfig) *VM {
 	if shared.Modules == nil {
 		shared.Modules = newModuleCache()
 	}
+	if shared.Listeners == nil {
+		shared.Listeners = newSequencedHandleRegistry[*ListenerResource](1, 2)
+	}
+	if shared.Sockets == nil {
+		shared.Sockets = newSequencedHandleRegistry[*SocketResource](2, 2)
+	}
 	vm := &VM{
 		shared: shared,
 		Config: cfg,
-
-		netBufferedData:  make(map[int][]byte),
-		netBufferedConns: make(map[int]net.Conn),
 	}
 
 	vm.defineBuiltins()

--- a/internal/vm/vm_test_helpers_test.go
+++ b/internal/vm/vm_test_helpers_test.go
@@ -60,5 +60,9 @@ func requireBuiltin(t *testing.T, machine *VM, name string) *value.ObjNative {
 
 func callBuiltin(t *testing.T, machine *VM, name string, args ...value.Value) value.Value {
 	t.Helper()
-	return requireBuiltin(t, machine, name).Fn(args)
+	result, err := requireBuiltin(t, machine, name).Invoke(machine, args)
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	return result
 }


### PR DESCRIPTION
## Summary
- Add a backward-compatible contextual native ABI so stateful builtins use the active VM.
- Share synchronized globals, module initialization, maps, file handles, sockets, and SQLite resources across related VMs.
- Fix concurrent `net_select` buffer access and preserve module globals in spawned execution contexts.
- Add architectural regression guards and document the runtime concurrency guarantees and remaining limitations.

## Components
- Native invocation and one-time builtin initialization
- Hierarchical global environments and synchronized map storage
- Single-flight module cache with cycle detection
- Shared file, network, and SQLite resource registries
- Concurrency documentation, changelog, and architecture tests

## Related Issues
- No linked Jira card.

## Test Plan
- [x] Implementação
- [x] Testes unitários passando
- [x] Testado integrado (157/157 Noxy examples)
- [x] Race detector, build, and vet passing

## Follow-up Work
- Real non-blocking/deadline and full multiplexing semantics for `net_select`
- Supervised spawned tasks and error propagation
- Signals, `defer`, substring consistency, and HTTP server improvements
