### PR TITLE
feat(vm): add Go-style defer and safe runtime unwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `defer call(...)` with immediate argument capture and frame-level LIFO cleanup across functions, scripts, modules, loops, and spawned functions.
+
+### Fixed
+
+- Normal returns and runtime failures now share safe frame unwinding, preserving primary errors while collecting observable cleanup failures.
+
 ## [0.2.0] - 2026-08-13
 
 ### Added

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -23,7 +23,7 @@ The current implementation is a **Stack-based VM** written in **Go**.
 | Category | Keywords |
 |----------|----------|
 | Declarations | `let`, `global`, `func`, `struct` |
-| Control Flow | `if`, `elif`, `then`, `else`, `end`, `while`, `do`, `return`, `break`, `for`, `in` |
+| Control Flow | `if`, `elif`, `then`, `else`, `end`, `while`, `do`, `return`, `break`, `for`, `in`, `defer` |
 | Types | `int`, `float`, `string`, `str`, `bool`, `void`, `ref`, `bytes`, `func` |
 | Literals | `true`, `false`, `null` |
 | Modules | `use`, `select`, `as` |
@@ -562,6 +562,55 @@ for char in "hello" do
     print(char)
 end
 ```
+
+### Defer and deterministic cleanup
+
+`defer` registers a call to run when its containing call frame exits. Its
+operand must be a real call; arbitrary expressions and non-call operations
+such as `defer addr(ref value)` are compile-time errors.
+
+```noxy
+let file: io.File = io.open(path, "w")
+defer io.close(file)
+```
+
+The callee and every argument are evaluated immediately, from left to right,
+when the `defer` statement executes. An evaluation or registration error does
+not register that call, although calls registered earlier in the frame still
+run. For typed Noxy functions and signed natives, non-`ref` arguments receive
+the normal top-level shallow copy at registration time, while `ref` parameters
+retain their reference. Nested composite identities therefore remain shared as
+described in [Shallow-Copy Semantics](#shallow-copy-semantics). Legacy untyped
+natives retain values using their existing dynamic calling convention because
+they expose no parameter-mode metadata. Struct constructors retain evaluated
+field values directly, matching their existing constructor semantics.
+
+Deferred calls execute once in last-in, first-out (LIFO) order for each frame.
+A `defer` inside a loop registers once per executed iteration and belongs to
+the containing frame, not to the loop or block. The same frame rule applies to
+ordinary functions, the main script, module initialization, and functions run
+by detached `spawn`. Deferred calls run on explicit and implicit returns, on
+successful script or module completion, and while unwinding runtime errors.
+Nested calls finish their own deferred work before the owning frame continues
+with its next older entry.
+
+An ordinary return value from a deferred call is discarded, including an
+error-shaped Noxy result value. A runtime failure is different: the original
+runtime error remains primary, every observable deferred failure is collected
+in LIFO execution order with its registration location, and older deferred
+calls continue to run. Nested cleanup and module failures remain nested,
+structured causes rather than being flattened into one message. If cleanup is
+the first failure, it converts an otherwise successful return into a runtime
+error.
+
+Resource cleanup uses the existing explicit close APIs. Register dependent
+resources after their owners so LIFO order closes the dependent first; for
+example, register `sqlite.close(db)` before `sqlite.finalize(statement)`.
+Current file, network, and SQLite close builtins suppress some underlying
+Go/operating-system close errors and return success-compatible Noxy values.
+Those suppressed errors cannot participate in defer aggregation; only runtime
+errors observable from the deferred call are aggregated. Likewise, the
+ordinary result from `io.close_result(...)` is discarded when deferred.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-14-runtime-defer-unwind.md
+++ b/docs/superpowers/plans/2026-08-14-runtime-defer-unwind.md
@@ -1,0 +1,1110 @@
+# Runtime Defer and Unwind Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Go-style `defer call(...)` and a bounded central unwind machine that runs LIFO cleanup on normal return and runtime error without corrupting frames, stack, instruction pointers, or upvalues.
+
+**Architecture:** The frontend emits `OP_DEFER` after the same operand preparation used by ordinary calls. Each `CallFrame` stores already prepared calls and distinct stack/local bases; `finishFrame` handles one normal return, while `unwindTo` removes frames only to an active error boundary. Structured runtime and unwind errors preserve original and nested cleanup causes.
+
+**Tech Stack:** Go 1.24.0, toolchain Go 1.24.11, Noxy bytecode VM, `modernc.org/sqlite`, Go `errors` and `testing` packages.
+
+## Global Constraints
+
+- Accept only `defer call(...)`; do not add deferred blocks, `try`, `catch`, or `finally`.
+- Evaluate the callee and arguments left-to-right at registration time.
+- Apply Noxy's shallow-copy rule once at registration for non-`ref` closure and signed-native parameters; preserve explicit references.
+- Preserve legacy unsigned-native and struct-constructor argument behavior exactly as specified in the approved design.
+- Execute deferred calls exactly once in LIFO order per frame on explicit return, implicit return, script/module completion, and runtime error.
+- Normal return finalizes exactly one frame; runtime failure unwinds only to the active `run` boundary.
+- Keep slots and upvalues live until all deferred calls owned by that frame finish.
+- Continue older cleanups after a cleanup failure; preserve nested errors without flattening them.
+- Keep existing public resource ownership, builtin signatures, result shapes, and suppressed underlying `Close()` behavior unchanged.
+- Preserve detached `spawn` behavior; this feature only guarantees cleanup inside its independent VM.
+- Use test-first red-green-refactor for every behavior.
+- Keep unrelated user changes untouched.
+
+---
+
+## Planned File Structure
+
+### New files
+
+- `internal/vm/runtime_errors.go` â€” structured source, runtime, deferred, and unwind errors.
+- `internal/vm/runtime_errors_test.go` â€” wrapping, ordering, nesting, and rendering tests.
+- `internal/vm/defer.go` â€” prepared-call capture and invocation.
+- `internal/vm/defer_test.go` â€” registration timing, callable matrix, LIFO, and cleanup behavior.
+- `internal/vm/unwind.go` â€” single-frame finalization and bounded error unwind.
+- `internal/vm/unwind_test.go` â€” boundary and runtime invariant tests.
+- `noxy_examples/defer_lifo.nx` â€” executable language example.
+
+### Modified files
+
+- `internal/token/token.go`, `internal/lexer/lexer_test.go` â€” keyword and lexing.
+- `internal/ast/ast.go`, `internal/parser/parser.go`, `internal/parser/parser_test.go` â€” call-only statement syntax.
+- `internal/chunk/chunk.go` â€” opcode name and disassembly.
+- `internal/compiler/compiler.go`, `internal/compiler/builtin_calls.go` and tests â€” selectable call emission.
+- `internal/vm/vm.go`, `calls.go`, `executor.go`, `modules.go`, `builtins_concurrency.go` â€” preparation, frame layout, unwind, and boundaries.
+- `internal/vm/module_exports_test.go`, `builtins_concurrency_test.go`, resource tests, and `architecture_test.go` â€” regressions and guards.
+- `docs/NOXY_LANGUAGE_SPEC.md`, `CHANGELOG.md` â€” public contract.
+
+---
+
+### Task 1: Add `defer` syntax restricted to call expressions
+
+**Files:**
+- Modify: `internal/token/token.go:18-40,117-150`
+- Modify: `internal/lexer/lexer_test.go`
+- Modify: `internal/ast/ast.go:140-223`
+- Modify: `internal/parser/parser.go:120-187,308-336`
+- Modify: `internal/parser/parser_test.go`
+
+**Interfaces:**
+- Produces: `token.DEFER` and `*ast.DeferStmt` with `Call *ast.CallExpression`.
+- Preserves: existing statement and newline parsing.
+
+- [ ] **Step 1: Write failing lexer and parser tests**
+
+```go
+func TestDeferIsKeyword(t *testing.T) {
+	lex := New("defer cleanup(1)\n")
+	if got := lex.NextToken(); got.Type != token.DEFER || got.Literal != "defer" {
+		t.Fatalf("token=%#v, want DEFER", got)
+	}
+}
+
+func TestParseDeferCallStatement(t *testing.T) {
+	p := New(lexer.New("defer cleanup(1)\n"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	stmt, ok := program.Statements[0].(*ast.DeferStmt)
+	if !ok || stmt.Call == nil || stmt.Call.Function.String() != "cleanup" || len(stmt.Call.Arguments) != 1 {
+		t.Fatalf("statement=%#v, want deferred cleanup call", program.Statements[0])
+	}
+}
+
+func TestParseDeferRejectsNonCallExpression(t *testing.T) {
+	for _, source := range []string{"defer value\n", "defer 1 + 2\n"} {
+		p := New(lexer.New(source))
+		_ = p.ParseProgram()
+		if len(p.Errors()) == 0 || !strings.Contains(strings.Join(p.Errors(), "\n"), "defer expects a call") {
+			t.Fatalf("source=%q errors=%v", source, p.Errors())
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `go test ./internal/lexer ./internal/parser -run 'TestDefer' -v`
+
+Expected: build failure because `token.DEFER` and `ast.DeferStmt` do not exist.
+
+- [ ] **Step 3: Add the token, AST node, and parser path**
+
+Add `DEFER TokenType = "DEFER"` beside `RETURN`, add `"defer": DEFER` to
+`keywords`, and add:
+
+```go
+type DeferStmt struct {
+	Token token.Token
+	Call  *CallExpression
+}
+
+func (ds *DeferStmt) statementNode()       {}
+func (ds *DeferStmt) TokenLiteral() string { return ds.Token.Literal }
+func (ds *DeferStmt) String() string       { return "defer " + ds.Call.String() }
+```
+
+Route `token.DEFER` from `parseStatement` to:
+
+```go
+func (p *Parser) parseDeferStatement() ast.Statement {
+	stmt := &ast.DeferStmt{Token: p.curToken}
+	p.nextToken()
+	expression := p.parseExpression(LOWEST)
+	call, ok := expression.(*ast.CallExpression)
+	if !ok {
+		p.errors = append(p.errors, fmt.Sprintf(
+			"[%d:%d] SyntaxError: defer expects a call expression",
+			stmt.Token.Line, stmt.Token.Column,
+		))
+		return nil
+	}
+	stmt.Call = call
+	if p.peekTokenIs(token.NEWLINE) { p.nextToken() }
+	return stmt
+}
+```
+
+- [ ] **Step 4: Run syntax tests and the parser suite**
+
+Run: `go test ./internal/lexer ./internal/parser -run 'TestDefer' -v`
+
+Run: `go test ./internal/lexer ./internal/parser`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/token/token.go internal/lexer/lexer_test.go internal/ast/ast.go internal/parser/parser.go internal/parser/parser_test.go
+git commit -m "feat(parser): add defer call syntax"
+```
+
+---
+
+### Task 2: Emit `OP_DEFER` through every real call path
+
+**Files:**
+- Modify: `internal/chunk/chunk.go:7-80,82-190,330-390`
+- Modify: `internal/compiler/compiler.go:1390-1520,1570-1752`
+- Modify: `internal/compiler/builtin_calls.go`
+- Modify: `internal/compiler/compiler_test.go`
+- Modify: `internal/compiler/builtin_calls_test.go`
+
+**Interfaces:**
+- Produces: `chunk.OP_DEFER`, `callEmission`, `emitCall`, and selectable immediate/deferred dispatch.
+- Consumes: `ast.DeferStmt` from Task 1.
+
+- [ ] **Step 1: Write failing compiler and opcode tests**
+
+```go
+func compiledFunction(t *testing.T, source, name string) *value.ObjFunction {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil { t.Fatal(err) }
+	for _, constant := range code.Constants {
+		if constant.Type == value.VAL_FUNCTION {
+			fn := constant.Obj.(*value.ObjFunction)
+			if fn.Name == name { return fn }
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return nil
+}
+
+func TestCompileDeferEmitsArgCount(t *testing.T) {
+	fn := compiledFunction(t, `
+func cleanup(value: int) -> void
+end
+func run() -> void
+    defer cleanup(7)
+end`, "run")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	for index, instruction := range code {
+		if chunk.OpCode(instruction) == chunk.OP_DEFER {
+			if index+1 >= len(code) || code[index+1] != 1 { t.Fatalf("bad OP_DEFER operand") }
+			return
+		}
+	}
+	t.Fatal("compiled function omitted OP_DEFER")
+}
+
+func TestCompileDeferRejectsAddrPseudoCall(t *testing.T) {
+	_, _, err := New().Compile(parse("let value: int = 1\ndefer addr(ref value)\n"))
+	if err == nil || !strings.Contains(err.Error(), "cannot defer addr") { t.Fatalf("error=%v", err) }
+}
+```
+
+Add this source table to `builtin_calls_test.go` and compile each `run` body:
+
+```go
+tests := []struct{ name, body string }{
+	{"append", "let items: int[] = [1]\ndefer append(ref items, 2)"},
+	{"pop", "let items: int[] = [1]\ndefer pop(ref items)"},
+	{"delete", "let items: map[string, int] = {\"x\": 1}\ndefer delete(ref items, \"x\")"},
+	{"json_loads", "let target: int = 0\ndefer json_loads(\"1\", ref target)"},
+	{"chan_send", "let ch: chan int = make_chan(1)\ndefer chan_send(ch, 1)"},
+	{"chan_recv", "let ch: chan int = make_chan(1)\ndefer chan_recv(ch)"},
+}
+for _, test := range tests {
+	t.Run(test.name, func(t *testing.T) {
+		fn := compiledFunction(t, "func run() -> void\n"+test.body+"\nend\n", "run")
+		if !containsOpcode(fn.Chunk.(*chunk.Chunk).Code, chunk.OP_DEFER) {
+			t.Fatalf("%s omitted OP_DEFER", test.name)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/compiler -run 'TestCompileDefer' -v`
+
+Expected: build failure because `chunk.OP_DEFER` is undefined.
+
+- [ ] **Step 3: Add opcode naming and disassembly**
+
+Add `OP_DEFER` immediately after `OP_CALL`, map it in `OpCode.String`, and
+disassemble it with `byteInstruction("OP_DEFER", offset)`.
+
+- [ ] **Step 4: Factor selectable call emission**
+
+```go
+type callEmission uint8
+
+const (
+	emitImmediateCall callEmission = iota
+	emitDeferredCall
+)
+
+func (c *Compiler) emitCall(argCount int, emission callEmission) {
+	op := chunk.OP_CALL
+	if emission == emitDeferredCall { op = chunk.OP_DEFER }
+	c.emitBytes(byte(op), byte(argCount))
+}
+```
+
+Extract the current call-expression compiler to
+`compileCallExpression(call *ast.CallExpression, emission callEmission)`.
+Make the expression case immediate and the `DeferStmt` case deferred. Reject
+`addr`. Pass `emission` through `compileBuiltinCall` and the `chan_send` and
+`chan_recv` branches, preserving all type/reference markers before the final
+selected opcode.
+
+- [ ] **Step 5: Run compiler and chunk tests**
+
+Run: `go test ./internal/compiler ./internal/chunk -run 'TestCompileDefer|Test.*Builtin' -v`
+
+Run: `go test ./internal/compiler ./internal/chunk`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/builtin_calls.go internal/compiler/compiler_test.go internal/compiler/builtin_calls_test.go
+git commit -m "feat(compiler): emit deferred calls"
+```
+
+---
+
+### Task 3: Preserve runtime and cleanup errors structurally
+
+**Files:**
+- Create: `internal/vm/runtime_errors.go`
+- Create: `internal/vm/runtime_errors_test.go`
+- Modify: `internal/vm/vm.go:13-24`
+- Modify: `internal/vm/calls.go:40-88`
+- Modify: `internal/vm/executor.go:996-1007`
+
+**Interfaces:**
+- Produces: `SourceLocation`, `RuntimeError`, `DeferredError`, `UnwindError`, and `runtimeErrorCause`.
+- Preserves: the existing leading `[file:line N]` error text.
+
+- [ ] **Step 1: Write failing structured-error tests**
+
+```go
+func TestRuntimeErrorPreservesCause(t *testing.T) {
+	sentinel := errors.New("native sentinel")
+	err := &RuntimeError{Location: SourceLocation{File: "main.nx", Line: 4}, Message: "native failed", Cause: sentinel}
+	if !errors.Is(err, sentinel) || err.Error() != "[main.nx:line 4] native failed: native sentinel" {
+		t.Fatalf("error=%q unwrap=%v", err, errors.Is(err, sentinel))
+	}
+}
+
+func TestUnwindErrorPreservesLIFOOrderAndNestedCause(t *testing.T) {
+	original := errors.New("original")
+	nested := &UnwindError{Deferred: []DeferredError{{Registration: SourceLocation{File: "cleanup.nx", Line: 9}, Cause: errors.New("nested")}}}
+	err := &UnwindError{Primary: original, Deferred: []DeferredError{
+		{Registration: SourceLocation{File: "main.nx", Line: 8}, Cause: nested},
+		{Registration: SourceLocation{File: "main.nx", Line: 7}, Cause: errors.New("older")},
+	}}
+	if !errors.Is(err, original) { t.Fatal("primary cause lost") }
+	text := err.Error()
+	if strings.Index(text, "line 8") > strings.Index(text, "line 7") || strings.Count(text, "cleanup.nx:line 9") != 1 {
+		t.Fatalf("bad nested rendering:\n%s", text)
+	}
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestRuntimeError|TestUnwindError' -v`
+
+Expected: build failure for missing structured error types.
+
+- [ ] **Step 3: Implement error types and constructors**
+
+```go
+type SourceLocation struct { File string; Line int }
+type RuntimeError struct { Location SourceLocation; Message string; Cause error }
+type DeferredError struct { Registration SourceLocation; Cause error }
+type UnwindError struct { Primary error; Deferred []DeferredError }
+
+func (e *RuntimeError) Unwrap() error { return e.Cause }
+func (e DeferredError) Unwrap() error { return e.Cause }
+func (e *UnwindError) Unwrap() []error {
+	causes := make([]error, 0, len(e.Deferred)+1)
+	if e.Primary != nil { causes = append(causes, e.Primary) }
+	for index := range e.Deferred { causes = append(causes, &e.Deferred[index]) }
+	return causes
+}
+```
+
+Implement deterministic `Error()` rendering with nested indentation. Add
+`sourceLocation(c, ip)`, `runtimeErrorCause`, and keep `runtimeError` as the
+cause-free convenience constructor.
+
+- [ ] **Step 4: Preserve native and module causes**
+
+Use `runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)` for
+native errors. Wrap import failures with an explicit `Cause`; never pass an
+existing error through `%s`.
+
+- [ ] **Step 5: Run focused and VM regression tests**
+
+Run: `go test ./internal/vm -run 'TestRuntimeError|TestUnwindError|Test.*Module.*Error' -v`
+
+Run: `go test ./internal/vm`
+
+Expected: PASS and existing error substrings remain compatible.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/runtime_errors.go internal/vm/runtime_errors_test.go internal/vm/vm.go internal/vm/calls.go internal/vm/executor.go
+git commit -m "refactor(vm): preserve structured runtime errors"
+```
+
+---
+
+### Task 4: Prepare deferred calls and separate frame bases
+
+**Files:**
+- Create: `internal/vm/defer.go`
+- Create: `internal/vm/defer_test.go`
+- Modify: `internal/vm/vm.go:26-57`
+- Modify: `internal/vm/calls.go`
+- Modify: `internal/vm/executor.go:31-42,190-220,425-440,880-895`
+- Modify: `internal/vm/builtins_concurrency.go:55-70`
+
+**Interfaces:**
+- Produces: `PreparedCall`, `prepareDeferredCall`, `invokePreparedCall`, `CallFrame.StackBase`, and `CallFrame.LocalBase`.
+- Consumes: `SourceLocation` from Task 3.
+- Preserves: immediate-call behavior and compiler local-slot numbering.
+
+- [ ] **Step 1: Write failing prepared-call and frame-layout tests**
+
+Create `internal/vm/defer_test.go` and cover the four callable kinds. The
+legacy-native case is:
+
+```go
+func TestPrepareDeferredCallLegacyNativeKeepsValueIdentity(t *testing.T) {
+	machine := New()
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	legacy := value.NewNative("legacy", func([]value.Value) value.Value { return value.NewNull() })
+	prepared, err := machine.prepareDeferredCall(legacy, []value.Value{array}, SourceLocation{File: "test.nx", Line: 1})
+	if err != nil || prepared.Arguments[0].Obj != array.Obj {
+		t.Fatalf("prepared=%#v error=%v, want unchanged identity", prepared, err)
+	}
+}
+```
+
+Add direct preparation assertions for every remaining row:
+
+```go
+closureValue := value.NewFunction("cleanup", 1, 0, []value.ParamInfo{{TypeName: "int[]"}}, chunk.New(), machine.shared.Root)
+closure := &value.ObjClosure{Function: closureValue.Obj.(*value.ObjFunction), Environment: machine.shared.Root}
+prepared, err := machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{array}, SourceLocation{})
+if err != nil || prepared.Arguments[0].Obj == array.Obj { t.Fatalf("closure did not shallow-copy array") }
+
+reference := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "items", GlobalOwner: machine.shared.Root}}
+closure.Function.Params[0].IsRef = true
+prepared, err = machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{reference}, SourceLocation{})
+if err != nil || prepared.Arguments[0].Obj != reference.Obj { t.Fatalf("reference identity changed") }
+
+signature := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int[]"}}}
+signed := value.NewNativeWithSignature("signed", signature, func([]value.Value) value.Value { return value.NewNull() })
+prepared, err = machine.prepareDeferredCall(signed, []value.Value{array}, SourceLocation{})
+if err != nil || prepared.Arguments[0].Obj == array.Obj { t.Fatalf("signed native did not shallow-copy array") }
+
+constructor := value.NewStruct("Box", []string{"items"})
+prepared, err = machine.prepareDeferredCall(constructor, []value.Value{array}, SourceLocation{})
+if err != nil || prepared.Arguments[0].Obj != array.Obj { t.Fatalf("constructor capture changed identity") }
+
+if _, err = machine.prepareDeferredCall(constructor, nil, SourceLocation{}); err == nil { t.Fatal("constructor arity accepted") }
+```
+
+Add the source-level local-layout regression:
+
+```go
+func TestScriptLocalBaseDoesNotCollideWithCalleeSlot(t *testing.T) {
+	got := captureVMSource(t, `
+if true then
+    let local: int = 42
+    test_report(local)
+end`)
+	if !valuesEqual(got, value.NewInt(42)) { t.Fatalf("local=%v, want 42", got) }
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestPrepareDeferredCall|TestScriptLocalBase' -v`
+
+Expected: build failure for the missing prepared-call API and frame bases.
+
+- [ ] **Step 3: Split `Slots` into `StackBase` and `LocalBase`**
+
+Change `CallFrame` and every `.Slots` use:
+
+- script frame: `StackBase: 0`, `LocalBase: 1`;
+- ordinary call: both `vm.stackTop - argCount - 1`;
+- spawn frame: both zero;
+- `OP_GET_LOCAL`, `OP_SET_LOCAL`, `OP_REF_LOCAL`, and local-upvalue capture use
+  `LocalBase`;
+- terminal window cleanup will use `StackBase` in Task 5.
+
+- [ ] **Step 4: Implement preparation by callable kind**
+
+```go
+type PreparedCall struct {
+	Callee       value.Value
+	Arguments    []value.Value
+	Registration SourceLocation
+}
+
+func (vm *VM) prepareDeferredCall(callee value.Value, args []value.Value, registration SourceLocation) (PreparedCall, error)
+```
+
+Reuse `validateParameterModes`, native signatures, closure parameter metadata,
+and `validateStructConstructorArguments`. Copy non-`ref` signed parameters with
+`vm.copyValue`; copy only the `[]value.Value` slice for unsigned natives and
+constructors. Never retain an operand-stack slice.
+
+- [ ] **Step 5: Add prepared dispatch without a second copy**
+
+Factor call dispatch so normal calls prepare arguments and prepared calls skip
+that preparation:
+
+```go
+func (vm *VM) callPreparedValue(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error)
+func (vm *VM) invokePreparedCall(call PreparedCall) error
+```
+
+`invokePreparedCall` records `base := vm.stackTop`, pushes callee and captured
+arguments, dispatches, runs any new Noxy frame to the owner boundary, discards
+the result, clears temporary slots, and restores `stackTop = base` on every
+exit path.
+
+- [ ] **Step 6: Run preparation, call, and local-layout tests**
+
+Run: `go test ./internal/vm -run 'TestPrepareDeferredCall|TestScriptLocalBase|Test.*ClosureCall|Test.*Native' -v`
+
+Run: `go test ./internal/vm`
+
+Expected: PASS with no immediate-call regression.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add internal/vm/defer.go internal/vm/defer_test.go internal/vm/vm.go internal/vm/calls.go internal/vm/executor.go internal/vm/builtins_concurrency.go
+git commit -m "refactor(vm): prepare deferred calls"
+```
+
+---
+
+### Task 5: Execute LIFO cleanup on normal return
+
+**Files:**
+- Create: `internal/vm/unwind.go`
+- Create: `internal/vm/unwind_test.go`
+- Modify: `internal/vm/executor.go:46-60,846-955`
+- Modify: `internal/vm/defer.go`
+
+**Interfaces:**
+- Produces: `frameOutcome`, `finishFrame`, `finalizeCurrentFrame`, and executable `OP_DEFER`.
+- Consumes: `PreparedCall` and structured errors.
+
+- [ ] **Step 1: Write failing normal-return tests**
+
+```go
+func TestDeferredCallsRunLIFOOnExplicitReturn(t *testing.T) {
+	machine := New()
+	var order []int64
+	machine.DefineNative("record", func(args []value.Value) value.Value {
+		order = append(order, args[0].AsInt)
+		return value.NewNull()
+	})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+	err := interpretVMSource(t, machine, `
+func work() -> int
+    defer record(1)
+    defer record(2)
+    return 7
+end
+test_report(work())`)
+	if err != nil || !slices.Equal(order, []int64{2, 1}) || !valuesEqual(captured, value.NewInt(7)) {
+		t.Fatalf("error=%v order=%v result=%v", err, order, captured)
+	}
+}
+```
+
+Add these exact sources using the same `record` native:
+
+```go
+cases := []struct { source string; want []int64 }{
+	{`func work() -> void
+    defer record(1)
+    record(0)
+end
+work()`, []int64{0, 1}},
+	{`defer record(1)
+defer record(2)
+record(0)`, []int64{0, 2, 1}},
+}
+```
+
+Interpret each source in a fresh VM and compare `order` with `want` using
+`slices.Equal`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestDeferredCallsRun' -v`
+
+Expected: failure because `OP_DEFER` is not executed.
+
+- [ ] **Step 3: Register prepared calls in the executor**
+
+Handle `OP_DEFER`: read argument count; derive the registration location from
+the opcode position; prepare `vm.peek(argCount)` and the arguments; consume
+callee plus arguments; append to `frame.Deferred`; push no value. On failure,
+append nothing and return a structured runtime error.
+
+- [ ] **Step 4: Implement single-frame finalization**
+
+Create `unwind.go`:
+
+```go
+type frameOutcome struct {
+	Result value.Value
+	Err    error
+}
+
+func (vm *VM) finishFrame(outcome frameOutcome) frameOutcome
+func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome
+```
+
+Remove each deferred entry before invocation. After all entries, close
+upvalues, clear from `StackBase` to the old `stackTop`, nil the frame-array
+entry, decrement `frameCount`, and update `currentFrame`. Push a successful
+result only when a caller survives; terminal script/spawn completion leaves
+`stackTop == 0`.
+
+- [ ] **Step 5: Route `OP_RETURN` through `finishFrame`**
+
+Replace inline return teardown with a successful `frameOutcome`. Return a
+cleanup error; otherwise return from `run` only when below `minFrameCount`, or
+reload the surviving frame/chunk/IP and continue.
+
+- [ ] **Step 6: Verify upvalues and terminal state**
+
+Add a deferred closure reading a captured local, then assert:
+
+```go
+if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil || machine.openUpvalues != nil {
+	t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
+}
+```
+
+Run: `go test ./internal/vm -run 'TestDeferred|Test.*Upvalue|TestStack' -v`
+
+Run: `go test ./internal/vm`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add internal/vm/unwind.go internal/vm/unwind_test.go internal/vm/defer.go internal/vm/defer_test.go internal/vm/executor.go
+git commit -m "feat(vm): run defers on normal return"
+```
+
+---
+
+### Task 6: Unwind runtime errors to the active boundary
+
+**Files:**
+- Modify: `internal/vm/unwind.go`
+- Modify: `internal/vm/unwind_test.go`
+- Modify: `internal/vm/executor.go:46-60`
+- Modify: `internal/vm/defer_test.go`
+
+**Interfaces:**
+- Produces: `unwindTo(targetFrameCount, errorOutcome)` and the `run` error funnel.
+- Preserves: inner successful returns continue the active run.
+
+- [ ] **Step 1: Write failing runtime-error tests**
+
+```go
+func TestRuntimeErrorRunsAllDeferredCalls(t *testing.T) {
+	machine := New()
+	var order []int64
+	machine.DefineNative("record", func(args []value.Value) value.Value {
+		order = append(order, args[0].AsInt)
+		return value.NewNull()
+	})
+	err := interpretVMSource(t, machine, `
+func fail() -> void
+    defer record(1)
+    defer record(2)
+    let zero: int = 0
+    print(1 / zero)
+end
+fail()`)
+	if err == nil || !slices.Equal(order, []int64{2, 1}) { t.Fatalf("error=%v order=%v", err, order) }
+}
+
+func TestCleanupFailuresAggregateAndDoNotSkipOlderEntries(t *testing.T) {
+	machine := New()
+	first, second := errors.New("first cleanup"), errors.New("second cleanup")
+	var completed bool
+	machine.DefineContextualNative("fail_first", func(value.NativeContext, []value.Value) (value.Value, error) { return value.NewNull(), first })
+	machine.DefineContextualNative("fail_second", func(value.NativeContext, []value.Value) (value.Value, error) { return value.NewNull(), second })
+	machine.DefineNative("complete", func([]value.Value) value.Value { completed = true; return value.NewNull() })
+	err := interpretVMSource(t, machine, "defer complete()\ndefer fail_first()\ndefer fail_second()\n")
+	var unwind *UnwindError
+	if !errors.As(err, &unwind) || !errors.Is(err, first) || !errors.Is(err, second) || !completed || len(unwind.Deferred) != 2 {
+		t.Fatalf("error=%v unwind=%#v completed=%v", err, unwind, completed)
+	}
+}
+```
+
+Add a normal-return conversion source:
+
+```noxy
+func inner() -> void
+    defer fail_first()
+end
+func outer() -> void
+    defer complete()
+    inner()
+end
+outer()
+```
+
+Assert `complete` runs and `errors.Is(err, first)` succeeds. Add the nested
+aggregate source:
+
+```noxy
+func nested_cleanup() -> void
+    defer fail_second()
+    fail_first()
+end
+defer nested_cleanup()
+```
+
+Assert the outer `UnwindError` has one `Deferred` entry, its `Cause` is an
+inner `*UnwindError`, the inner primary matches `first`, and its sole deferred
+cause matches `second`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestRuntimeErrorRuns|TestCleanupFailures|TestNormalReturnCleanupFailure|TestNestedCleanup' -v`
+
+Expected: runtime-error cleanup or aggregation fails.
+
+- [ ] **Step 3: Implement bounded error unwind**
+
+```go
+func (vm *VM) unwindTo(targetFrameCount int, outcome frameOutcome) frameOutcome {
+	for vm.frameCount > targetFrameCount {
+		outcome = vm.finalizeCurrentFrame(outcome)
+	}
+	return outcome
+}
+```
+
+Keep the first runtime failure as `Primary`. Append cleanup failures in
+execution order. When cleanup converts a normal return to error, finish that
+frame's older entries before unwinding callers.
+
+- [ ] **Step 4: Add the `run` error funnel and persist IP**
+
+Make `run` return a named error. Its deferred epilogue persists cached IP to a
+still-current cached frame and calls `unwindTo(minFrameCount-1, ...)` for every
+non-nil error. Persist `frame.IP` before `OP_RETURN`, recursive execution, and
+error transfer; reload frame/chunk/IP after any surviving inner run.
+
+- [ ] **Step 5: Test VM reuse and terminal invariants**
+
+After failed interpretation, run these exact assertions and reuse sequence:
+
+```go
+if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.openUpvalues != nil {
+	t.Fatalf("dirty VM after error: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
+}
+if err := interpretVMSource(t, machine, "test_report(42)\n"); err != nil { t.Fatal(err) }
+if !valuesEqual(captured, value.NewInt(42)) { t.Fatalf("reuse result=%v", captured) }
+```
+
+For pre-dispatch restoration, register `defer one_arg()` against a dynamic
+one-argument Noxy function with zero supplied arguments; assert the registration
+error leaves the same terminal invariants.
+
+Run: `go test ./internal/vm -run 'TestRuntimeErrorRuns|TestCleanupFailures|TestNormalReturnCleanupFailure|TestNestedCleanup|TestVMReusable' -v`
+
+Run: `go test ./internal/vm`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/unwind.go internal/vm/unwind_test.go internal/vm/defer_test.go internal/vm/executor.go
+git commit -m "feat(vm): unwind defers on runtime error"
+```
+
+---
+
+### Task 7: Preserve module and spawn execution boundaries
+
+**Files:**
+- Modify: `internal/vm/modules.go:178-209`
+- Modify: `internal/vm/executor.go:996-1010`
+- Modify: `internal/vm/module_exports_test.go`
+- Modify: `internal/vm/builtins_concurrency_test.go`
+
+**Interfaces:**
+- Consumes: bounded `run`/unwind from Task 6.
+- Produces: saved importer IP, structured module causes, and detached cleanup coverage.
+
+- [ ] **Step 1: Write a failing nested-module boundary test**
+
+Create the module and compile the importer exactly as follows:
+
+```go
+root := t.TempDir()
+moduleSource := `
+defer module_record("module-old")
+defer module_fail()
+let zero: int = 0
+print(1 / zero)
+`
+if err := os.WriteFile(filepath.Join(root, "broken.nx"), []byte(moduleSource), 0o600); err != nil { t.Fatal(err) }
+code := compileModuleProgram(t, root, `
+defer module_record("importer-old")
+defer module_record("importer-new")
+use broken
+`)
+```
+
+The module source is:
+
+```noxy
+defer module_record("module-old")
+defer module_fail()
+let zero: int = 0
+print(1 / zero)
+```
+
+Register `module_record` to append strings and `module_fail` to return a
+sentinel. Assert `order == []string{"module-old", "importer-new",
+"importer-old"}`, `errors.Is(err, sentinel)`, and that the outer error contains
+a structured import `RuntimeError` whose cause is the module `UnwindError`.
+
+- [ ] **Step 2: Write a detached spawn cleanup test**
+
+Register a native that sends an integer to a buffered Go channel:
+
+```go
+completed := make(chan int64, 1)
+machine.DefineNative("spawned_record", func(args []value.Value) value.Value {
+	completed <- args[0].AsInt
+	return value.NewNull()
+})
+```
+
+Interpret:
+
+```noxy
+func worker() -> void
+    defer spawned_record(1)
+end
+spawn(worker)
+```
+
+Wait with:
+
+```go
+select {
+case got := <-completed:
+	if got != 1 { t.Fatalf("cleanup=%d, want 1", got) }
+case <-time.After(2 * time.Second):
+	t.Fatal("spawned defer did not execute")
+}
+```
+
+Repeat with `let zero: int = 0; print(1 / zero)` after registration and assert
+the same channel result. Do not assert parent propagation because spawn remains
+detached.
+
+- [ ] **Step 3: Verify RED**
+
+Run: `go test ./internal/vm -run 'TestNestedModuleDeferBoundary|TestSpawnRunsDeferredCleanup' -v`
+
+Expected: module boundary/IP or detached cleanup behavior fails.
+
+- [ ] **Step 4: Persist importer state and wrap module errors**
+
+Before `loadModule`, save `frame.IP = ip`. After return, reload the current
+frame and its chunk/IP. Use `runtimeErrorCause` on failure. Keep
+`run(startFrameCount)` scoped to module-owned frames so the importer survives
+the inner boundary.
+
+- [ ] **Step 5: Run module, spawn, and full VM tests**
+
+Run: `go test ./internal/vm -run 'TestNestedModuleDeferBoundary|TestSpawnRunsDeferredCleanup|Test.*Module|Test.*Spawn' -v`
+
+Run: `go test ./internal/vm`
+
+Expected: PASS without changing cache or detached-task semantics.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/modules.go internal/vm/executor.go internal/vm/module_exports_test.go internal/vm/builtins_concurrency_test.go
+git commit -m "test(vm): cover defer execution boundaries"
+```
+
+---
+
+### Task 8: Prove cleanup of files, sockets, and SQLite resources
+
+**Files:**
+- Modify: `internal/vm/defer_test.go`
+- Modify: `internal/vm/builtins_io_test.go`
+- Modify: `internal/vm/builtins_net_test.go`
+- Modify: `internal/vm/builtins_sqlite_test.go`
+
+**Interfaces:**
+- Consumes: unchanged `io.close`, `net.socket_close`, `sqlite.finalize`, and `sqlite.close` APIs.
+- Produces: integration evidence for registry and underlying-resource cleanup.
+
+- [ ] **Step 1: Write failing file cleanup tests**
+
+Use this table with a fresh VM and `path := filepath.Join(t.TempDir(),
+"deferred.txt")`:
+
+```go
+tests := []struct{ name, suffix string; wantError bool }{
+	{"normal", "", false},
+	{"runtime error", "\nlet zero: int = 0\nprint(1 / zero)", true},
+}
+source := "use io\nlet file: io.File = io.open(" + strconv.Quote(path) + ", \"w\")\ndefer io.close(file)" + test.suffix
+```
+
+Capture the sole `FileResource` from the registry before cleanup via a
+test-only recording native invoked after open. After interpretation assert
+`len(machine.shared.Files.snapshot()) == 0`, `resource.closed`, error presence
+matches `wantError`, and `os.Remove(path)` succeeds.
+
+- [ ] **Step 2: Write failing socket/listener cleanup tests**
+
+```noxy
+use net
+let listener: net.Socket = net.listen("127.0.0.1", 0)
+defer net.socket_close(listener)
+```
+
+Use normal and division-by-zero suffixes as in the file table. After each run:
+
+```go
+if got := len(machine.shared.Listeners.snapshot()); got != 0 { t.Fatalf("listeners=%d", got) }
+if got := len(machine.shared.Sockets.snapshot()); got != 0 { t.Fatalf("sockets=%d", got) }
+```
+
+Capture the created listener resource through a test native receiving the
+`Socket`, lock `stateMu`, and assert `closed`. Run interpretation through the
+existing bounded helper so networking cannot hang.
+
+- [ ] **Step 3: Write failing SQLite LIFO cleanup tests**
+
+```noxy
+use sqlite
+let db: sqlite.Database = sqlite.open(PATH)
+defer sqlite.close(db)
+let stmt: sqlite.Statement = sqlite.prepare(db, "SELECT 1")
+defer sqlite.finalize(stmt)
+```
+
+Run normal and division-by-zero variants. Register a test native between the
+database and statement defers:
+
+```noxy
+defer sqlite.close(db)
+defer assert_statement_finalized()
+defer sqlite.finalize(stmt)
+```
+
+`assert_statement_finalized` inspects the shared registries when invoked and
+records that statements are already absent while the database is still
+present. Before return, call another test native with `db` and `stmt` so the
+test retains both resource pointers. After interpretation:
+
+```go
+if got := len(machine.shared.Statements.snapshot()); got != 0 { t.Fatalf("statements=%d", got) }
+if got := len(machine.shared.Databases.snapshot()); got != 0 { t.Fatalf("databases=%d", got) }
+if !statementResource.closed || !databaseResource.closed { t.Fatalf("resources remain open") }
+```
+
+Assert the intermediate native observed `(statements=0, databases=1)`, proving
+statement-before-database order without production instrumentation.
+
+- [ ] **Step 4: Add failure-among-cleanups coverage**
+
+Register resource close first and a sentinel-error contextual native second:
+
+```noxy
+defer io.close(file)
+defer cleanup_fail()
+```
+
+Assert `errors.Is(err, sentinel)`, `len(machine.shared.Files.snapshot()) == 0`,
+and the captured resource is closed. Repeat the ordering pattern for listener
+and SQLite resources. Do not assert aggregation of suppressed OS close errors.
+
+- [ ] **Step 5: Verify RED, then GREEN without changing resource APIs**
+
+Run RED: `go test ./internal/vm -run 'TestDeferred(File|Socket|SQLite|Resource)' -v`
+
+Fix only unwind or test-observability issues. Then run:
+
+```powershell
+go test ./internal/vm -run 'TestDeferred(File|Socket|SQLite|Resource)' -v
+go test -race ./internal/vm -run 'TestDeferred(File|Socket|SQLite|Resource)' -count=1
+```
+
+Expected: PASS and race detector clean.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm/defer_test.go internal/vm/builtins_io_test.go internal/vm/builtins_net_test.go internal/vm/builtins_sqlite_test.go
+git commit -m "test(vm): cover deferred resource cleanup"
+```
+
+---
+
+### Task 9: Add architecture guards, docs, example, and full validation
+
+**Files:**
+- Modify: `internal/vm/architecture_test.go`
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `CHANGELOG.md`
+- Create: `noxy_examples/defer_lifo.nx`
+
+**Interfaces:**
+- Produces: documented public contract and a guard against split teardown.
+- Consumes: all prior tasks.
+
+- [ ] **Step 1: Write a failing architecture guard**
+
+Assert `CallFrame` contains:
+
+```go
+want := map[string]string{
+	"StackBase": "int",
+	"LocalBase": "int",
+	"Deferred":  "[]PreparedCall",
+}
+```
+
+Parse production files and reject terminal mutations such as `frameCount--`,
+nil frame assignment, or clearing from `StackBase` outside `unwind.go`. Permit
+frame construction in `executor.go`, `calls.go`, and `builtins_concurrency.go`.
+
+- [ ] **Step 2: Verify the architecture guard**
+
+Run: `go test ./internal/vm -run 'Test.*Unwind.*Architecture|TestRuntimeFoundationRequires' -v`
+
+Expected RED until old `OP_RETURN` teardown is absent; PASS afterward.
+
+- [ ] **Step 3: Document the language feature**
+
+Add `Defer and deterministic cleanup` to `docs/NOXY_LANGUAGE_SPEC.md` covering
+call-only syntax, immediate evaluation, shallow-copy/ref capture, frame-level
+LIFO, loops/scripts/modules/spawn, success/error cleanup, discarded ordinary
+results, aggregated runtime errors, and suppressed underlying close errors.
+Add concise `CHANGELOG.md` entries under `Added` and `Fixed`.
+
+- [ ] **Step 4: Add an executable example**
+
+Create `noxy_examples/defer_lifo.nx`:
+
+```noxy
+let order: string = ""
+
+func record(label: string) -> void
+    order = order + label
+end
+
+func cleanup_demo() -> void
+    defer record("1")
+    defer record("2")
+end
+
+cleanup_demo()
+assert(order == "21", "defer must execute in LIFO order")
+print("defer LIFO: " + order)
+```
+
+- [ ] **Step 5: Format and run targeted verification**
+
+```powershell
+gofmt -w internal/token/token.go internal/ast/ast.go internal/parser/parser.go internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/builtin_calls.go internal/vm/vm.go internal/vm/calls.go internal/vm/executor.go internal/vm/modules.go internal/vm/builtins_concurrency.go internal/vm/runtime_errors.go internal/vm/defer.go internal/vm/unwind.go
+go test ./internal/lexer ./internal/parser ./internal/compiler ./internal/chunk ./internal/vm
+go run cmd/noxy/main.go noxy_examples/defer_lifo.nx
+```
+
+Expected: PASS and `defer LIFO: 21`.
+
+- [ ] **Step 6: Run project-required validation**
+
+```powershell
+go test ./internal/...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+go test ./...
+go vet ./...
+go build ./...
+go test -race ./internal/vm -count=1
+```
+
+Expected: all Go checks pass, concurrent Noxy examples report no failures, and
+the race detector is clean.
+
+- [ ] **Step 7: Review scope and placeholders**
+
+```powershell
+git diff --check
+git status --short
+rg -n "TBD|TODO|implement later" internal docs noxy_examples/defer_lifo.nx
+```
+
+Confirm unrelated files are untouched and pre-existing TODOs outside changed
+hunks are not attributed to this feature.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add internal/vm/architecture_test.go docs/NOXY_LANGUAGE_SPEC.md CHANGELOG.md noxy_examples/defer_lifo.nx
+git commit -m "docs: specify defer and safe unwind"
+```
+
+---
+
+## Plan Self-Review Checklist
+
+- Every approved requirement maps to a task and test.
+- `finishFrame` and `unwindTo` stay distinct.
+- Script `StackBase = 0` and `LocalBase = 1` are tested.
+- Every prepared callable kind has an explicit registration rule.
+- Specialized real calls are supported; `addr` is rejected.
+- Nested cleanup/module errors remain structured and unflattened.
+- Resource tests do not claim visibility into suppressed OS close errors.
+- No task introduces `try/finally`, auto-close, supervised tasks, or changed public close APIs.

--- a/docs/superpowers/specs/2026-08-14-runtime-defer-unwind-design.md
+++ b/docs/superpowers/specs/2026-08-14-runtime-defer-unwind-design.md
@@ -57,7 +57,7 @@ The only accepted form is a statement whose operand is a real call:
 
 ```noxy
 defer io.close(file)
-defer net.close(socket)
+defer net.socket_close(socket)
 defer sqlite.finalize(statement)
 ```
 
@@ -66,11 +66,14 @@ and functions executed by `spawn`. It is not a lexical-scope cleanup: a
 `defer` inside an `if` or loop belongs to the containing call frame. A loop
 registers one entry for every executed iteration.
 
-Arbitrary expressions and pseudo-calls that compile without `OP_CALL` are
-rejected. In particular, `defer value`, `defer 1 + 2`, and `defer addr(ref x)`
-produce compile errors. Compiler-special operations such as channel
-pseudo-calls are rejected unless they are later represented as ordinary
-callables and emit the standard call sequence.
+Arbitrary expressions and pseudo-calls that compile without an invocable
+callee are rejected. In particular, `defer value`, `defer 1 + 2`, and
+`defer addr(ref x)` produce compile errors. Specialized compiler paths remain
+eligible when they still prepare a real callable and end in ordinary call
+dispatch. This includes the current `append`, `pop`, `delete`, `json_loads`,
+`chan_send`, and `chan_recv` paths. Each eligible path must accept an emission
+mode that selects `OP_CALL` or `OP_DEFER`; `addr` remains ineligible because it
+produces `OP_ADDR` and no deferred callable.
 
 ### 4.2 Registration timing
 
@@ -114,9 +117,10 @@ The compiler factors the ordinary call pipeline into two stages:
    type-marker, and reference-mode checks used by an immediate call;
 2. emit either `OP_CALL <argCount>` or `OP_DEFER <argCount>`.
 
-Compiler-special builtins that directly emit collection, channel, reference,
-or other dedicated opcodes cannot use the second stage and are rejected in a
-defer statement with a targeted diagnostic.
+Compiler-special paths that still end in ordinary call dispatch reuse their
+existing operand preparation and select `OP_DEFER` as the final instruction.
+Paths that do not leave an invocable callee and arguments, currently `addr`,
+are rejected with a targeted diagnostic.
 
 `OP_DEFER <argCount>` consumes the callee and arguments from the operand stack,
 creates a prepared call, appends it to the current frame, and produces no
@@ -140,10 +144,40 @@ type PreparedCall struct {
 }
 
 type CallFrame struct {
-	// Existing closure, IP, slots, and environment fields.
+	// Existing closure, IP, and environment fields.
+	StackBase int
+	LocalBase int
 	Deferred []PreparedCall
 }
 ```
+
+`StackBase` is the callee/call slot and the first slot owned by the frame. It
+replaces the use of `Slots` as a cleanup boundary. `LocalBase` is a separate,
+mandatory offset used exclusively by `OP_GET_LOCAL`, `OP_SET_LOCAL`,
+`OP_REF_LOCAL`, and local-upvalue capture. The layouts are explicit:
+
+- main script: `StackBase = 0`, `LocalBase = 1`;
+- ordinary function: `StackBase = LocalBase = stackTop - argCount - 1`,
+  preserving compiler slot zero for the callee/function instance;
+- spawned function: `StackBase = LocalBase = 0` in its independent VM stack.
+
+Terminal cleanup always starts at `StackBase`; local access and capture always
+start at `LocalBase`. A successful ordinary return replaces the call slot with
+the result. Terminal script and spawned-frame completion clear that slot and
+leave no callee residual.
+
+Preparation is defined per callable kind:
+
+| Callable | Registration behavior |
+|----------|-----------------------|
+| Noxy closure | Validate arity and parameter modes; shallow-copy every non-`ref` parameter and retain explicit references. |
+| Signed native | Validate published arity and modes; shallow-copy every non-`ref` parameter and retain explicit references. |
+| Legacy unsigned native | Capture each evaluated `value.Value` exactly as current unsigned-native calls receive it; perform no unavailable mode validation or additional copy. |
+| Struct constructor | Validate field arity and runtime field types; capture evaluated field values directly, preserving the constructor's existing no-`copyValue` behavior. |
+
+Prepared invocation has a dedicated path and must not re-enter the normal
+argument-preparation code. Native handler errors and errors produced by the
+deferred Noxy body occur during invocation, not registration.
 
 The final names may follow existing package conventions, but these boundaries
 are mandatory:
@@ -160,31 +194,39 @@ unwind component. Frame construction can remain beside its current call sites.
 
 ## 7. Bounded Unwind Machine
 
-### 7.1 Boundary contract
+### 7.1 Return and error contracts
 
-Unwind is defined as `unwindFrames(targetFrameCount, outcome)`: remove frames
-until exactly `targetFrameCount` frames remain. Frames below that boundary are
-never touched by the operation.
+The machine exposes two distinct transitions:
 
-This single contract covers all execution contexts:
+- `finishFrame(returnOutcome)` finalizes only the current frame. It is used for
+  an explicit or implicit normal return, regardless of the active `run`
+  boundary.
+- `unwindTo(targetFrameCount, errorOutcome)` finalizes frames until exactly
+  `targetFrameCount` frames remain. It is used only after a runtime failure or
+  after a deferred failure converts a normal return into an error.
 
-- main interpretation unwinds to zero frames;
-- recursive module execution unwinds only the module frames and leaves the
-  importing frame intact;
-- a Noxy cleanup call unwinds only frames created by that cleanup and leaves
-  the frame that owns the remaining deferred entries intact;
-- detached spawn execution unwinds its independent VM to zero frames.
+This distinction is mandatory. During the main `run(1)`, a normal return from
+an inner function removes only that function and resumes the script. It never
+unwinds directly to zero. If one of that function's deferred calls fails,
+`finishFrame` completes all of that frame's cleanups, converts the return to an
+error outcome, and then `unwindTo` continues toward the active run boundary.
 
-The current recursive `run(minFrameCount)` behavior maps to a target of
-`minFrameCount - 1`. A module error is first unwound to its caller boundary and
-returned to `OP_IMPORT`; the outer run then treats it as its own runtime failure
-and unwinds its remaining frames. This sequencing ensures that cached
-`frame`, chunk, and instruction-pointer state never references a frame removed
-by an inner run.
+The active error boundary remains execution-context specific:
 
-### 7.2 Frame transition
+- main interpretation and detached spawn execution target zero frames;
+- recursive module execution targets the importing frame count;
+- a deferred Noxy call targets the count that retains its owner frame.
 
-For each frame being removed, the machine performs these steps in order:
+The current recursive `run(minFrameCount)` behavior maps error unwind to
+`minFrameCount - 1`. A module error first unwinds only module-created frames
+and returns to `OP_IMPORT`; the outer run wraps that structured cause and then
+unwinds toward its own boundary. A cleanup error similarly unwinds only frames
+created by the cleanup and returns to the still-live owner frame.
+
+### 7.2 Single-frame finalization
+
+Both transitions call the same single-frame finalizer. For each frame being
+removed, it performs these steps in order:
 
 1. preserve the pending return value or error outcome;
 2. remove the newest prepared call from the frame;
@@ -200,10 +242,16 @@ For each frame being removed, the machine performs these steps in order:
 10. either place a successful return value in the caller's call slot or
     propagate the error outcome to the next frame.
 
-The caller's IP is saved before every immediate or prepared call. A frame is
-never popped by `OP_RETURN` itself; that opcode only constructs a return
-outcome and transfers control to the unwind machine. Runtime instruction
-failures follow the same transfer path rather than performing separate cleanup.
+All cached execution state is persisted to its frame before control can enter
+another run loop or the unwind machine. In particular, `frame.IP` is saved
+before every immediate call, prepared call, recursive module `run`,
+`OP_RETURN`, and transfer of a runtime error. Restoring a surviving frame
+always reloads chunk and IP from that frame rather than from stale executor
+locals.
+
+A frame is never popped by `OP_RETURN` itself; that opcode constructs a return
+outcome and calls `finishFrame`. Runtime instruction failures call
+`unwindTo` rather than performing separate cleanup.
 
 If a deferred Noxy function fails, its own frames and deferred entries unwind
 to the owner boundary. The returned error is recorded against the owner's
@@ -213,9 +261,11 @@ entries.
 ### 7.3 Return-to-error conversion
 
 A normal return remains successful only if every deferred call succeeds. The
-first cleanup failure converts the outcome to an unwind error. That failure is
-then propagated through caller frames, so deferred calls in those frames also
-run. Explicit returns, implicit void returns, script completion, and module
+first cleanup failure converts the outcome to an unwind error. The current
+frame still executes all older entries and completes its single-frame
+finalization. The error is then propagated with `unwindTo` through caller
+frames up to the active boundary, so deferred calls in those frames also run.
+Explicit returns, implicit void returns, script completion, and module
 completion all follow this rule.
 
 ## 8. Structured Errors
@@ -241,10 +291,24 @@ type UnwindError struct {
 ```
 
 `RuntimeError.Unwrap` preserves an underlying native or module error when one
-exists. `UnwindError` preserves the primary error as its principal unwrap
-cause; when a normal return has no primary error, its first deferred failure is
-the unwrap cause. All deferred failures remain available through a typed
-accessor and in deterministic LIFO execution order.
+exists. `DeferredError.Unwrap` exposes its cause. `UnwindError.Unwrap() []error`
+returns the primary error first, when present, followed by the deferred errors
+in execution order. This keeps the original cause first while allowing
+`errors.Is` and `errors.As` to discover every structured cause. When a normal
+return has no primary error, the slice begins with the first deferred failure.
+
+Nested aggregates are preserved, not flattened. If a deferred Noxy call fails
+and its own deferred calls also fail, that entire inner `UnwindError` is the
+`Cause` of one outer `DeferredError` associated with the owner's registration
+site. An import failure is a `RuntimeError` whose `Cause` is the module's
+structured error. This preserves frame ownership and ordering at every level.
+Rendering recursively indents a nested cause under its single outer prefix; it
+does not copy inner entries into the outer slice or manufacture new source
+locations.
+
+Every path that adds context to an existing error uses an explicit constructor
+with `Cause` or `%w`. Runtime/native/module errors are never passed through
+`runtimeError(..., "%s", err)` or another formatter that destroys identity.
 
 The text representation is stable and non-duplicative:
 
@@ -267,6 +331,9 @@ Deferred resource cleanup uses existing public APIs and shared registries:
 let file: io.File = io.open(path, "w")
 defer io.close(file)
 
+let socket: net.Socket = net.connect(host, port)
+defer net.socket_close(socket)
+
 let db: sqlite.Database = sqlite.open(path)
 defer sqlite.close(db)
 let stmt: sqlite.Statement = sqlite.prepare(db, query)
@@ -278,21 +345,26 @@ statement finalization executes first. Socket and listener handles use the
 same explicit pattern.
 
 This version does not claim to aggregate operating-system close failures that
-existing builtins suppress. `io_close`, `net_close`, `sqlite_close`, and
-`sqlite_finalize` currently return success-compatible Noxy values while some
-underlying Go close errors are discarded. Changing those public behaviors or
-adding strict close APIs is separate work. Here, "cleanup failure" means a
-runtime error observable from the deferred call. Tests combine real resources
-with a controlled failing native to prove that such a failure never prevents
-the remaining resources from closing.
+existing underlying builtins suppress. `io_close`, `net_close`,
+`sqlite_close`, and `sqlite_finalize` currently return success-compatible Noxy
+values while some underlying Go close errors are discarded. Changing those
+public behaviors or adding strict close APIs is separate work. Here, "cleanup
+failure" means a runtime error observable from the deferred call. Tests
+combine real resources with a controlled failing native to prove that such a
+failure never prevents the remaining resources from closing.
+
+`io.close_result(...)` also returns an ordinary result value. When deferred,
+that value is discarded and does not become an unwind error.
 
 ## 10. Edge Cases
 
 - An argument-evaluation error does not register the incomplete defer.
 - A dynamic callee that is not callable fails at registration, after earlier
   deferred calls have already been retained.
-- A deferred constructor is allowed only if it uses the ordinary `OP_CALL`
-  path; its constructed value is discarded.
+- A deferred constructor uses existing constructor capture semantics: field
+  values are evaluated and retained directly without `copyValue`; its
+  constructed value is discarded. A composite mutated after registration
+  therefore follows the same identity behavior as an immediate constructor.
 - A cleanup may register more cleanup work in its own frame. That nested work
   finishes before the owner proceeds to its next entry.
 - There is no arbitrary fixed defer-count limit. Entries use heap-backed frame
@@ -315,6 +387,8 @@ All behavior is developed test-first.
 - reject non-call expressions and unsupported pseudo-calls;
 - verify ordinary call type, arity, and reference diagnostics still apply;
 - verify disassembly and exact `OP_DEFER` operands;
+- verify specialized `append`, `pop`, `delete`, `json_loads`, `chan_send`, and
+  `chan_recv` paths can select deferred emission while `addr` is rejected;
 - verify argument evaluation order and failure before registration.
 
 ### 11.2 Runtime semantics
@@ -325,6 +399,9 @@ All behavior is developed test-first.
   loop registrations, and a spawned function;
 - prove deferred results are discarded;
 - prove deferred closures can read captured locals and upvalues;
+- prove script locals address from `LocalBase = 1` while teardown clears from
+  `StackBase = 0`;
+- prove the preparation matrix for signed/unsigned natives and constructors;
 - prove a cleanup can register and execute its own deferred calls.
 
 ### 11.3 Error and boundary behavior
@@ -336,6 +413,9 @@ All behavior is developed test-first.
 - retain registration and execution locations without duplicate formatting;
 - keep an importing frame alive while an inner module run unwinds;
 - keep an owner frame alive while a failing Noxy cleanup unwinds;
+- preserve a nested cleanup aggregate as one outer deferred cause;
+- wrap a failing module without flattening or duplicating its error locations;
+- persist and restore IP across a recursive import and a prepared Noxy call;
 - restore stack base after pre-call validation failure, native failure, and
   Noxy cleanup failure.
 
@@ -343,13 +423,20 @@ All behavior is developed test-first.
 
 - assert `frameCount`, `currentFrame`, frame-array entries, `stackTop`, cached
   IP, and `openUpvalues` after normal and error exits;
+- assert main-frame completion leaves `stackTop == 0`, `frames[0] == nil`, and
+  no closure residual in `stack[0]`;
 - interpret another program successfully on the same VM after a failure;
-- close and remove a real temporary file on normal return and runtime error;
+- close a real temporary file on normal return and runtime error, verify its
+  registry entry and closed state, and then remove it as a secondary check;
 - close real sockets and listeners and verify registry removal;
 - finalize a real SQLite statement before closing its database and verify both
   registries are empty;
 - place a controlled failing native between resource cleanups and prove all
-  remaining resources still close in LIFO order.
+  remaining resources still close in LIFO order;
+- execute a nested import whose module defer fails while the importer owns
+  multiple deferred calls;
+- defer a struct constructor with a composite argument mutated after
+  registration and verify the documented direct-capture behavior.
 
 ### 11.5 Project validation
 
@@ -384,8 +471,8 @@ The subproject is complete when:
 
 1. every exiting frame executes its registered calls exactly once in LIFO
    order;
-2. normal return and every surfaced runtime-error path use bounded central
-   unwind;
+2. normal return finalizes exactly one frame, while every surfaced runtime
+   error unwinds only to the active boundary;
 3. cleanup failure never skips older deferred calls;
 4. original and cleanup errors retain structured identity and source context;
 5. frame, stack, IP, and upvalue invariants remain valid and the VM is reusable;

--- a/docs/superpowers/specs/2026-08-14-runtime-defer-unwind-design.md
+++ b/docs/superpowers/specs/2026-08-14-runtime-defer-unwind-design.md
@@ -1,0 +1,396 @@
+# Runtime Defer and Unwind Design
+
+**Date:** 2026-08-14
+**Status:** Approved design, awaiting written-spec review
+**Scope:** Resolve point 10 from PR #17 through deterministic deferred calls
+
+## 1. Purpose
+
+Noxy exposes files, sockets, listeners, SQLite databases, and prepared
+statements, but it has no construct that guarantees cleanup after a runtime
+error. A call placed at the end of a function is skipped by an early return or
+an error such as division by zero. The language also has no `try/finally`, RAII,
+or deterministic garbage-collection hook that can fill this role.
+
+This subproject adds a small `defer` statement and the runtime machinery needed
+to execute deferred calls safely. The implementation must not merely inject
+cleanup calls before explicit returns: normal return, implicit return, module
+execution, script execution, and runtime failure all use the same frame-unwind
+mechanism.
+
+## 2. Goals
+
+1. Add `defer call(...)` with Go-style registration semantics.
+2. Execute deferred calls in last-in, first-out order for every exiting frame.
+3. Run deferred calls after normal return and after runtime failure.
+4. Keep frame slots and open upvalues valid until that frame's deferred calls
+   finish.
+5. Continue running older deferred calls when a newer cleanup fails.
+6. Preserve the original runtime error and report every cleanup failure with
+   its registration location.
+7. Leave frames, stack, instruction pointers, and upvalues in a reusable state
+   after both successful and failed interpretation.
+8. Support deterministic explicit cleanup of files, sockets, listeners,
+   SQLite statements, and SQLite databases without changing their ownership.
+
+## 3. Non-goals
+
+This subproject does not add:
+
+- `try`, `catch`, `finally`, or runtime-error recovery in Noxy source;
+- automatic resource closing based on frame ownership or garbage collection;
+- supervised tasks or changes to detached `spawn` error propagation;
+- panic recovery as a language-level error mechanism;
+- cancellation, signals, or process-shutdown hooks;
+- new public close signatures or changed result shapes for existing builtins;
+- a general deferred block or arbitrary deferred expression.
+
+The existing shared-resource ownership from PR #17 remains authoritative. A
+resource can outlive the frame that opened it when another shared VM or value
+still owns its handle. Only an explicit deferred close changes resource state.
+
+## 4. Source Semantics
+
+### 4.1 Syntax
+
+The only accepted form is a statement whose operand is a real call:
+
+```noxy
+defer io.close(file)
+defer net.close(socket)
+defer sqlite.finalize(statement)
+```
+
+`defer` is valid in functions, the main script frame, module initialization,
+and functions executed by `spawn`. It is not a lexical-scope cleanup: a
+`defer` inside an `if` or loop belongs to the containing call frame. A loop
+registers one entry for every executed iteration.
+
+Arbitrary expressions and pseudo-calls that compile without `OP_CALL` are
+rejected. In particular, `defer value`, `defer 1 + 2`, and `defer addr(ref x)`
+produce compile errors. Compiler-special operations such as channel
+pseudo-calls are rejected unless they are later represented as ordinary
+callables and emit the standard call sequence.
+
+### 4.2 Registration timing
+
+The callee and arguments are evaluated immediately, from left to right, when
+the `defer` statement executes. An error while evaluating them prevents that
+specific entry from being registered and begins ordinary error unwind; entries
+registered earlier still run.
+
+Runtime arity and parameter-mode validation also happen at registration.
+Parameters passed by value receive Noxy's normal top-level shallow copy at
+that time. Parameters declared `ref` retain the reference. Untyped legacy
+natives preserve their current dynamic behavior because they do not publish
+parameter-mode metadata.
+
+The prepared callee and arguments are invoked exactly once during unwind.
+They are not re-evaluated or copied a second time. Mutating or rebinding a
+source variable after registration therefore does not replace the captured
+top-level value, while nested composite identities retain the language's
+documented shallow-copy behavior.
+
+### 4.3 Execution and results
+
+Entries execute in LIFO order within each frame. A deferred call can invoke a
+Noxy closure or native callable and can register its own deferred calls. Its
+return value is always discarded. Returning an error-shaped ordinary Noxy
+value is not a runtime failure; only a runtime error from the call participates
+in unwind error aggregation.
+
+## 5. Frontend and Bytecode
+
+The frontend adds:
+
+- a `DEFER` keyword token;
+- `ast.DeferStmt`, containing the source token and `*ast.CallExpression`;
+- parser validation that the operand is a call expression;
+- compiler validation that the call uses the ordinary callable path.
+
+The compiler factors the ordinary call pipeline into two stages:
+
+1. compile the callee and arguments with the same static type, arity, runtime
+   type-marker, and reference-mode checks used by an immediate call;
+2. emit either `OP_CALL <argCount>` or `OP_DEFER <argCount>`.
+
+Compiler-special builtins that directly emit collection, channel, reference,
+or other dedicated opcodes cannot use the second stage and are rejected in a
+defer statement with a targeted diagnostic.
+
+`OP_DEFER <argCount>` consumes the callee and arguments from the operand stack,
+creates a prepared call, appends it to the current frame, and produces no
+stack value. The opcode and its operand are included in opcode naming and
+disassembly.
+
+## 6. Runtime Data Model
+
+Conceptually, each frame gains a LIFO collection:
+
+```go
+type SourceLocation struct {
+	File string
+	Line int
+}
+
+type PreparedCall struct {
+	Callee       value.Value
+	Arguments    []value.Value
+	Registration SourceLocation
+}
+
+type CallFrame struct {
+	// Existing closure, IP, slots, and environment fields.
+	Deferred []PreparedCall
+}
+```
+
+The final names may follow existing package conventions, but these boundaries
+are mandatory:
+
+- preparation validates the callable and captures arguments at registration;
+- prepared invocation never repeats parameter copying;
+- an entry is removed from the frame before invocation, which guarantees
+  exactly-once behavior even when that invocation fails;
+- every invocation records its stack base and restores `stackTop` to that base
+  after success or failure.
+
+An architecture test prevents direct terminal frame teardown outside the
+unwind component. Frame construction can remain beside its current call sites.
+
+## 7. Bounded Unwind Machine
+
+### 7.1 Boundary contract
+
+Unwind is defined as `unwindFrames(targetFrameCount, outcome)`: remove frames
+until exactly `targetFrameCount` frames remain. Frames below that boundary are
+never touched by the operation.
+
+This single contract covers all execution contexts:
+
+- main interpretation unwinds to zero frames;
+- recursive module execution unwinds only the module frames and leaves the
+  importing frame intact;
+- a Noxy cleanup call unwinds only frames created by that cleanup and leaves
+  the frame that owns the remaining deferred entries intact;
+- detached spawn execution unwinds its independent VM to zero frames.
+
+The current recursive `run(minFrameCount)` behavior maps to a target of
+`minFrameCount - 1`. A module error is first unwound to its caller boundary and
+returned to `OP_IMPORT`; the outer run then treats it as its own runtime failure
+and unwinds its remaining frames. This sequencing ensures that cached
+`frame`, chunk, and instruction-pointer state never references a frame removed
+by an inner run.
+
+### 7.2 Frame transition
+
+For each frame being removed, the machine performs these steps in order:
+
+1. preserve the pending return value or error outcome;
+2. remove the newest prepared call from the frame;
+3. record the current stack base and invoke that prepared call;
+4. if it creates Noxy frames, run them with the owner frame as their unwind
+   boundary;
+5. discard the cleanup result and restore the recorded stack base;
+6. append any cleanup error and continue with the next prepared call;
+7. after the deferred stack is empty, close every upvalue into the frame's
+   slots exactly once;
+8. clear the frame's complete stack window and nil the frame-array entry;
+9. update `frameCount`, `currentFrame`, stack top, chunk, and cached IP;
+10. either place a successful return value in the caller's call slot or
+    propagate the error outcome to the next frame.
+
+The caller's IP is saved before every immediate or prepared call. A frame is
+never popped by `OP_RETURN` itself; that opcode only constructs a return
+outcome and transfers control to the unwind machine. Runtime instruction
+failures follow the same transfer path rather than performing separate cleanup.
+
+If a deferred Noxy function fails, its own frames and deferred entries unwind
+to the owner boundary. The returned error is recorded against the owner's
+registration entry. The owner remains alive and proceeds with its older
+entries.
+
+### 7.3 Return-to-error conversion
+
+A normal return remains successful only if every deferred call succeeds. The
+first cleanup failure converts the outcome to an unwind error. That failure is
+then propagated through caller frames, so deferred calls in those frames also
+run. Explicit returns, implicit void returns, script completion, and module
+completion all follow this rule.
+
+## 8. Structured Errors
+
+Runtime errors become structured rather than flattened strings:
+
+```go
+type RuntimeError struct {
+	Location SourceLocation
+	Message  string
+	Cause    error
+}
+
+type DeferredError struct {
+	Registration SourceLocation
+	Cause        error
+}
+
+type UnwindError struct {
+	Primary  error
+	Deferred []DeferredError
+}
+```
+
+`RuntimeError.Unwrap` preserves an underlying native or module error when one
+exists. `UnwindError` preserves the primary error as its principal unwrap
+cause; when a normal return has no primary error, its first deferred failure is
+the unwrap cause. All deferred failures remain available through a typed
+accessor and in deterministic LIFO execution order.
+
+The text representation is stable and non-duplicative:
+
+```text
+[source.nx:line 12] division by zero
+defer registered at source.nx:line 8 failed: [cleanup.nx:line 3] cleanup failed
+defer registered at source.nx:line 7 failed: native close failed
+```
+
+The original failure is printed first. Each deferred failure prints its
+registration site once and retains the cleanup's own execution location in its
+cause. `errors.Is` and `errors.As` continue to discover the original wrapped
+Go error instead of seeing only formatted text.
+
+## 9. Resource Cleanup
+
+Deferred resource cleanup uses existing public APIs and shared registries:
+
+```noxy
+let file: io.File = io.open(path, "w")
+defer io.close(file)
+
+let db: sqlite.Database = sqlite.open(path)
+defer sqlite.close(db)
+let stmt: sqlite.Statement = sqlite.prepare(db, query)
+defer sqlite.finalize(stmt)
+```
+
+The SQLite order is intentional: database close is registered first so
+statement finalization executes first. Socket and listener handles use the
+same explicit pattern.
+
+This version does not claim to aggregate operating-system close failures that
+existing builtins suppress. `io_close`, `net_close`, `sqlite_close`, and
+`sqlite_finalize` currently return success-compatible Noxy values while some
+underlying Go close errors are discarded. Changing those public behaviors or
+adding strict close APIs is separate work. Here, "cleanup failure" means a
+runtime error observable from the deferred call. Tests combine real resources
+with a controlled failing native to prove that such a failure never prevents
+the remaining resources from closing.
+
+## 10. Edge Cases
+
+- An argument-evaluation error does not register the incomplete defer.
+- A dynamic callee that is not callable fails at registration, after earlier
+  deferred calls have already been retained.
+- A deferred constructor is allowed only if it uses the ordinary `OP_CALL`
+  path; its constructed value is discarded.
+- A cleanup may register more cleanup work in its own frame. That nested work
+  finishes before the owner proceeds to its next entry.
+- There is no arbitrary fixed defer-count limit. Entries use heap-backed frame
+  storage and remain subject to ordinary process memory limits.
+- Internal Go panics are not converted into unwind outcomes by this feature.
+- A detached spawned function executes its own deferred calls, but its final
+  error remains subject to the existing detached reporting behavior.
+- Returning a reference to a local retains existing return-reference rules;
+  the local and its upvalue remain alive throughout cleanup and are closed only
+  after the deferred stack is empty.
+
+## 11. Testing Strategy
+
+All behavior is developed test-first.
+
+### 11.1 Frontend and compiler
+
+- recognize `defer` as a keyword and preserve its source location;
+- parse a valid deferred call;
+- reject non-call expressions and unsupported pseudo-calls;
+- verify ordinary call type, arity, and reference diagnostics still apply;
+- verify disassembly and exact `OP_DEFER` operands;
+- verify argument evaluation order and failure before registration.
+
+### 11.2 Runtime semantics
+
+- prove immediate callee and argument evaluation;
+- prove shallow-copy capture and `ref` preservation;
+- prove LIFO ordering for explicit return, implicit return, script, module,
+  loop registrations, and a spawned function;
+- prove deferred results are discarded;
+- prove deferred closures can read captured locals and upvalues;
+- prove a cleanup can register and execute its own deferred calls.
+
+### 11.3 Error and boundary behavior
+
+- unwind division-by-zero and contextual-native errors;
+- aggregate several cleanup errors without skipping older entries;
+- convert a normal return into an error when cleanup fails;
+- preserve the original error through `errors.Is` and `errors.As`;
+- retain registration and execution locations without duplicate formatting;
+- keep an importing frame alive while an inner module run unwinds;
+- keep an owner frame alive while a failing Noxy cleanup unwinds;
+- restore stack base after pre-call validation failure, native failure, and
+  Noxy cleanup failure.
+
+### 11.4 Runtime invariants and resources
+
+- assert `frameCount`, `currentFrame`, frame-array entries, `stackTop`, cached
+  IP, and `openUpvalues` after normal and error exits;
+- interpret another program successfully on the same VM after a failure;
+- close and remove a real temporary file on normal return and runtime error;
+- close real sockets and listeners and verify registry removal;
+- finalize a real SQLite statement before closing its database and verify both
+  registries are empty;
+- place a controlled failing native between resource cleanups and prove all
+  remaining resources still close in LIFO order.
+
+### 11.5 Project validation
+
+The completed implementation must pass:
+
+```powershell
+gofmt -w <modified-go-files>
+go test ./internal/...
+go test ./...
+go vet ./...
+go build ./...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Targeted VM tests run before the full suite, and race-sensitive resource tests
+also run under `go test -race` where practical.
+
+## 12. Documentation
+
+`docs/NOXY_LANGUAGE_SPEC.md` will document syntax, immediate evaluation,
+shallow-copy/ref capture, frame-level LIFO order, script/module behavior,
+return-to-error conversion, and the distinction between runtime errors and
+ordinary result values.
+
+`CHANGELOG.md` will record the new language feature and safe error unwind. A
+focused Noxy example will demonstrate nested file and SQLite cleanup without
+adding an interactive or long-running integration test.
+
+## 13. Success Criteria
+
+The subproject is complete when:
+
+1. every exiting frame executes its registered calls exactly once in LIFO
+   order;
+2. normal return and every surfaced runtime-error path use bounded central
+   unwind;
+3. cleanup failure never skips older deferred calls;
+4. original and cleanup errors retain structured identity and source context;
+5. frame, stack, IP, and upvalue invariants remain valid and the VM is reusable;
+6. real file, network, and SQLite resources can be deterministically closed by
+   deferred calls on both success and error paths;
+7. existing public resource ownership and close APIs remain compatible;
+8. all targeted, full, race-sensitive, build, vet, and Noxy integration checks
+   pass.

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -187,6 +187,15 @@ func (rs *ReturnStmt) String() string {
 	return out
 }
 
+type DeferStmt struct {
+	Token token.Token
+	Call  *CallExpression
+}
+
+func (ds *DeferStmt) statementNode()       {}
+func (ds *DeferStmt) TokenLiteral() string { return ds.Token.Literal }
+func (ds *DeferStmt) String() string       { return "defer " + ds.Call.String() }
+
 type BreakStmt struct {
 	Token token.Token
 }

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -47,6 +47,7 @@ const (
 	OP_SHIFT_LEFT
 	OP_SHIFT_RIGHT
 	OP_CALL
+	OP_DEFER
 	OP_INVOKE
 	OP_RETURN
 	OP_PRINT
@@ -167,6 +168,8 @@ func (op OpCode) String() string {
 		return "OP_SHIFT_RIGHT"
 	case OP_CALL:
 		return "OP_CALL"
+	case OP_DEFER:
+		return "OP_DEFER"
 	case OP_INVOKE:
 		return "OP_INVOKE"
 	case OP_RETURN:
@@ -366,6 +369,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.shortInstruction("OP_LOOP", offset)
 	case OP_CALL:
 		return c.byteInstruction("OP_CALL", offset)
+	case OP_DEFER:
+		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:
 		return c.simpleInstruction("OP_RETURN", offset)
 	case OP_ARRAY:

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -26,7 +26,7 @@ func (c *Compiler) compileBuiltinValueArgument(expression ast.Expression) (ast.N
 	return actual, nil
 }
 
-func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyType, error) {
+func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmission) (bool, ast.NoxyType, error) {
 	ident, ok := call.Function.(*ast.Identifier)
 	if !ok {
 		return false, nil, nil
@@ -99,7 +99,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 				return true, nil, err
 			}
 		}
-		c.emitBytes(byte(chunk.OP_CALL), 2)
+		c.emitCall(2, emission)
 		return true, builtinType("void"), nil
 	case "pop":
 		container, err := c.compileReferenceArgument(call.Arguments[0])
@@ -110,7 +110,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 		if !ok {
 			return true, nil, fmt.Errorf("[line %d] pop expects an array, got %s", c.currentLine, noxyTypeName(container))
 		}
-		c.emitBytes(byte(chunk.OP_CALL), 1)
+		c.emitCall(1, emission)
 		return true, array.ElementType, nil
 	case "delete":
 		container, err := c.compileReferenceArgument(call.Arguments[0])
@@ -137,7 +137,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
 			)
 		}
-		c.emitBytes(byte(chunk.OP_CALL), 2)
+		c.emitCall(2, emission)
 		return true, builtinType("void"), nil
 	case "json_loads":
 		jsonText, err := c.compileBuiltinValueArgument(call.Arguments[0])
@@ -157,7 +157,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression) (bool, ast.NoxyT
 		if primitive, ok := targetType.(*ast.PrimitiveType); ok && primitive.Name == "any" {
 			c.emitByte(byte(chunk.OP_MARK_REF_JSON_DYNAMIC))
 		}
-		c.emitBytes(byte(chunk.OP_CALL), 2)
+		c.emitCall(2, emission)
 		return true, builtinType("bool"), nil
 	default:
 		return false, nil, nil

--- a/internal/compiler/builtin_calls_test.go
+++ b/internal/compiler/builtin_calls_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"noxy-vm/internal/chunk"
 	"strings"
 	"testing"
 )
@@ -378,5 +379,24 @@ let mapping: map[any, int] = {"a": 1}
 delete(mapping, key)`)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCompileDeferBuiltinCallsEmitDeferredOpcode(t *testing.T) {
+	tests := []struct{ name, body string }{
+		{"append", "let items: int[] = [1]\ndefer append(ref items, 2)"},
+		{"pop", "let items: int[] = [1]\ndefer pop(ref items)"},
+		{"delete", "let items: map[string, int] = {\"x\": 1}\ndefer delete(ref items, \"x\")"},
+		{"json_loads", "let target: int = 0\ndefer json_loads(\"1\", ref target)"},
+		{"chan_send", "let ch: chan int = make_chan(1)\ndefer chan_send(ch, 1)"},
+		{"chan_recv", "let ch: chan int = make_chan(1)\ndefer chan_recv(ch)"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fn := compiledFunction(t, "func run() -> void\n"+test.body+"\nend\n", "run")
+			if !containsOpcode(fn.Chunk.(*chunk.Chunk).Code, chunk.OP_DEFER) {
+				t.Fatalf("%s omitted OP_DEFER", test.name)
+			}
+		})
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -54,6 +54,13 @@ type Compiler struct {
 	moduleDiscovery     *moduleDiscoveryState
 }
 
+type callEmission uint8
+
+const (
+	emitImmediateCall callEmission = iota
+	emitDeferredCall
+)
+
 func New() *Compiler {
 	return NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), "")
 }
@@ -1567,189 +1574,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		c.endScope()
 		return c.currentChunk, nil, nil
 
+	case *ast.DeferStmt:
+		c.setLine(n.Token.Line)
+		return c.compileCallExpression(n.Call, emitDeferredCall)
+
 	case *ast.CallExpression:
-		if handled, resultType, err := c.compileBuiltinCall(n); handled {
-			return c.currentChunk, resultType, err
-		}
-
-		// Check for special functions: chan_send, chan_recv
-		if ident, ok := n.Function.(*ast.Identifier); ok {
-			if ident.Value == "chan_send" {
-				if len(n.Arguments) != 2 {
-					return nil, nil, fmt.Errorf("[line %d] chan_send expects 2 arguments", c.currentLine)
-				}
-				_, _, err := c.Compile(n.Function)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// 2. Compile Arg 0 (Channel)
-				_, chType, err := c.Compile(n.Arguments[0])
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// Verify it is a channel OR any
-				var isAnyChannel bool
-				chanType, ok := chType.(*ast.ChanType)
-				if !ok {
-					// Check if it is 'any'
-					if chType != nil && chType.String() == "any" {
-						isAnyChannel = true
-					} else {
-						typeStr := "unknown/nil"
-						if chType != nil {
-							typeStr = chType.String()
-						}
-						return nil, nil, fmt.Errorf("[line %d] first argument to chan_send must be a channel, got %s", c.currentLine, typeStr)
-					}
-				}
-
-				// 3. Compile Arg 1 (Value)
-				_, valType, err := c.Compile(n.Arguments[1])
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// Verify Type Match (only if not any)
-				if !isAnyChannel {
-					if !c.areTypesCompatible(chanType.ElementType, valType) {
-						return nil, nil, fmt.Errorf("[line %d] cannot send %s to %s", c.currentLine, valType.String(), chType.String())
-					}
-				}
-
-				// Emit Call
-				c.emitBytes(byte(chunk.OP_CALL), 2)
-				return c.currentChunk, valType, nil // send returns value sent
-			} else if ident.Value == "chan_recv" {
-				if len(n.Arguments) != 1 {
-					return nil, nil, fmt.Errorf("[line %d] chan_recv expects 1 argument", c.currentLine)
-				}
-				// 1. Compile Function
-				_, _, err := c.Compile(n.Function)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// 2. Compile Arg (Channel)
-				_, chType, err := c.Compile(n.Arguments[0])
-				if err != nil {
-					return nil, nil, err
-				}
-
-				var retType ast.NoxyType
-
-				chanType, ok := chType.(*ast.ChanType)
-				if !ok {
-					if chType.String() == "any" {
-						retType = &ast.PrimitiveType{Name: "any"}
-					} else {
-						return nil, nil, fmt.Errorf("[line %d] argument to chan_recv must be a channel, got %s", c.currentLine, chType.String())
-					}
-				} else {
-					retType = chanType.ElementType
-				}
-
-				// Emit Call
-				c.emitBytes(byte(chunk.OP_CALL), 1)
-				return c.currentChunk, retType, nil
-			} else if ident.Value == "addr" {
-				// addr(ref x) debug function
-				if len(n.Arguments) != 1 {
-					return nil, nil, fmt.Errorf("[line %d] addr expects 1 argument", c.currentLine)
-				}
-				// Compile Argument
-				// We expect a Reference on the stack (ObjRef).
-				// We do NOT want auto-dereference.
-				_, argType, err := c.Compile(n.Arguments[0])
-				if err != nil {
-					return nil, nil, err
-				}
-
-				if _, isRef := argType.(*ast.RefType); !isRef {
-					// Check if user passed `ref x` (PrefixExpression) which returns RefType
-					// Or a variable that is RefType.
-					// If they passed `x` which is int, argType is int.
-					return nil, nil, fmt.Errorf("[line %d] addr() requires a reference. Try 'addr(ref %s)'", c.currentLine, n.Arguments[0].String())
-				}
-
-				c.emitByte(byte(chunk.OP_ADDR))
-				return c.currentChunk, &ast.PrimitiveType{Name: "string"}, nil
-			}
-		}
-
-		// Normal Call
-		_, fnType, err := c.Compile(n.Function)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		funcType, isExact := fnType.(*ast.FunctionType)
-		if isExact && len(n.Arguments) != len(funcType.Params) {
-			return nil, nil, fmt.Errorf(
-				"[line %d] function '%s' expects %d arguments, got %d",
-				c.currentLine, callableName(n.Function), len(funcType.Params), len(n.Arguments),
-			)
-		}
-
-		for i, arg := range n.Arguments {
-			if isExact {
-				if expectedRef, ok := funcType.Params[i].(*ast.RefType); ok {
-					actualElement, err := c.compileReferenceArgument(arg)
-					if err != nil {
-						return nil, nil, err
-					}
-					if _, isNull := arg.(*ast.NullLiteral); isNull {
-						continue
-					}
-					if !c.areStrictTypesCompatible(expectedRef.ElementType, actualElement) {
-						actual := &ast.RefType{ElementType: actualElement}
-						return nil, nil, fmt.Errorf(
-							"[line %d] argument %d to '%s': expected %s, got %s",
-							c.currentLine, i+1, callableName(n.Function), expectedRef.String(), actual.String(),
-						)
-					}
-					if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
-						return nil, nil, err
-					}
-					continue
-				}
-			}
-
-			_, argType, err := c.Compile(arg)
-			if err != nil {
-				return nil, nil, err
-			}
-			explicitReference := false
-			if prefix, ok := arg.(*ast.PrefixExpression); ok {
-				explicitReference = prefix.Operator == "ref"
-			}
-			if ref, ok := argType.(*ast.RefType); ok && !explicitReference {
-				c.emitByte(byte(chunk.OP_DEREF))
-				argType = ref.ElementType
-			}
-			if isExact && !c.areStrictTypesCompatible(funcType.Params[i], argType) {
-				return nil, nil, fmt.Errorf(
-					"[line %d] argument %d to '%s': expected %s, got %s",
-					c.currentLine, i+1, callableName(n.Function),
-					funcType.Params[i].String(), noxyTypeName(argType),
-				)
-			}
-			if isExact {
-				if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
-					return nil, nil, err
-				}
-			}
-		}
-
-		c.emitBytes(byte(chunk.OP_CALL), byte(len(n.Arguments)))
-		if isExact {
-			return c.currentChunk, funcType.Return, nil
-		}
-		if fnType == nil {
-			return c.currentChunk, nil, nil
-		}
-		return c.currentChunk, &ast.PrimitiveType{Name: "any"}, nil
+		return c.compileCallExpression(n, emitImmediateCall)
 
 	case nil:
 		// Skip
@@ -1757,6 +1587,192 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 	default:
 		return nil, nil, fmt.Errorf("unsupported node type %T", n)
 	}
+}
+
+func (c *Compiler) emitCall(argCount int, emission callEmission) {
+	op := chunk.OP_CALL
+	if emission == emitDeferredCall {
+		op = chunk.OP_DEFER
+	}
+	c.emitBytes(byte(op), byte(argCount))
+}
+
+func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission callEmission) (*chunk.Chunk, ast.NoxyType, error) {
+	if handled, resultType, err := c.compileBuiltinCall(call, emission); handled {
+		return c.currentChunk, resultType, err
+	}
+
+	// Check for special functions: chan_send, chan_recv.
+	if ident, ok := call.Function.(*ast.Identifier); ok {
+		if ident.Value == "chan_send" {
+			if len(call.Arguments) != 2 {
+				return nil, nil, fmt.Errorf("[line %d] chan_send expects 2 arguments", c.currentLine)
+			}
+			_, _, err := c.Compile(call.Function)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Compile Arg 0 (Channel).
+			_, chType, err := c.Compile(call.Arguments[0])
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Verify it is a channel OR any.
+			var isAnyChannel bool
+			chanType, ok := chType.(*ast.ChanType)
+			if !ok {
+				if chType != nil && chType.String() == "any" {
+					isAnyChannel = true
+				} else {
+					typeStr := "unknown/nil"
+					if chType != nil {
+						typeStr = chType.String()
+					}
+					return nil, nil, fmt.Errorf("[line %d] first argument to chan_send must be a channel, got %s", c.currentLine, typeStr)
+				}
+			}
+
+			// Compile Arg 1 (Value).
+			_, valType, err := c.Compile(call.Arguments[1])
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Verify Type Match (only if not any).
+			if !isAnyChannel {
+				if !c.areTypesCompatible(chanType.ElementType, valType) {
+					return nil, nil, fmt.Errorf("[line %d] cannot send %s to %s", c.currentLine, valType.String(), chType.String())
+				}
+			}
+
+			c.emitCall(2, emission)
+			return c.currentChunk, valType, nil // send returns value sent
+		} else if ident.Value == "chan_recv" {
+			if len(call.Arguments) != 1 {
+				return nil, nil, fmt.Errorf("[line %d] chan_recv expects 1 argument", c.currentLine)
+			}
+			_, _, err := c.Compile(call.Function)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			_, chType, err := c.Compile(call.Arguments[0])
+			if err != nil {
+				return nil, nil, err
+			}
+
+			var retType ast.NoxyType
+
+			chanType, ok := chType.(*ast.ChanType)
+			if !ok {
+				if chType.String() == "any" {
+					retType = &ast.PrimitiveType{Name: "any"}
+				} else {
+					return nil, nil, fmt.Errorf("[line %d] argument to chan_recv must be a channel, got %s", c.currentLine, chType.String())
+				}
+			} else {
+				retType = chanType.ElementType
+			}
+
+			c.emitCall(1, emission)
+			return c.currentChunk, retType, nil
+		} else if ident.Value == "addr" {
+			if emission == emitDeferredCall {
+				return nil, nil, fmt.Errorf("[line %d] cannot defer addr: addr does not produce a callable", c.currentLine)
+			}
+			// addr(ref x) debug function.
+			if len(call.Arguments) != 1 {
+				return nil, nil, fmt.Errorf("[line %d] addr expects 1 argument", c.currentLine)
+			}
+			// We expect a Reference on the stack (ObjRef), without auto-dereference.
+			_, argType, err := c.Compile(call.Arguments[0])
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if _, isRef := argType.(*ast.RefType); !isRef {
+				return nil, nil, fmt.Errorf("[line %d] addr() requires a reference. Try 'addr(ref %s)'", c.currentLine, call.Arguments[0].String())
+			}
+
+			c.emitByte(byte(chunk.OP_ADDR))
+			return c.currentChunk, &ast.PrimitiveType{Name: "string"}, nil
+		}
+	}
+
+	// Normal call.
+	_, fnType, err := c.Compile(call.Function)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	funcType, isExact := fnType.(*ast.FunctionType)
+	if isExact && len(call.Arguments) != len(funcType.Params) {
+		return nil, nil, fmt.Errorf(
+			"[line %d] function '%s' expects %d arguments, got %d",
+			c.currentLine, callableName(call.Function), len(funcType.Params), len(call.Arguments),
+		)
+	}
+
+	for i, arg := range call.Arguments {
+		if isExact {
+			if expectedRef, ok := funcType.Params[i].(*ast.RefType); ok {
+				actualElement, err := c.compileReferenceArgument(arg)
+				if err != nil {
+					return nil, nil, err
+				}
+				if _, isNull := arg.(*ast.NullLiteral); isNull {
+					continue
+				}
+				if !c.areStrictTypesCompatible(expectedRef.ElementType, actualElement) {
+					actual := &ast.RefType{ElementType: actualElement}
+					return nil, nil, fmt.Errorf(
+						"[line %d] argument %d to '%s': expected %s, got %s",
+						c.currentLine, i+1, callableName(call.Function), expectedRef.String(), actual.String(),
+					)
+				}
+				if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
+					return nil, nil, err
+				}
+				continue
+			}
+		}
+
+		_, argType, err := c.Compile(arg)
+		if err != nil {
+			return nil, nil, err
+		}
+		explicitReference := false
+		if prefix, ok := arg.(*ast.PrefixExpression); ok {
+			explicitReference = prefix.Operator == "ref"
+		}
+		if ref, ok := argType.(*ast.RefType); ok && !explicitReference {
+			c.emitByte(byte(chunk.OP_DEREF))
+			argType = ref.ElementType
+		}
+		if isExact && !c.areStrictTypesCompatible(funcType.Params[i], argType) {
+			return nil, nil, fmt.Errorf(
+				"[line %d] argument %d to '%s': expected %s, got %s",
+				c.currentLine, i+1, callableName(call.Function),
+				funcType.Params[i].String(), noxyTypeName(argType),
+			)
+		}
+		if isExact {
+			if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	c.emitCall(len(call.Arguments), emission)
+	if isExact {
+		return c.currentChunk, funcType.Return, nil
+	}
+	if fnType == nil {
+		return c.currentChunk, nil, nil
+	}
+	return c.currentChunk, &ast.PrimitiveType{Name: "any"}, nil
 }
 
 func (c *Compiler) memberType(owner ast.NoxyType, member string) ast.NoxyType {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -54,12 +54,16 @@ type Compiler struct {
 	moduleDiscovery     *moduleDiscoveryState
 }
 
-type callEmission uint8
+type callEmission struct {
+	deferred         bool
+	registrationLine int
+}
 
-const (
-	emitImmediateCall callEmission = iota
-	emitDeferredCall
-)
+var emitImmediateCall callEmission
+
+func emitDeferredCall(line int) callEmission {
+	return callEmission{deferred: true, registrationLine: line}
+}
 
 func New() *Compiler {
 	return NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), "")
@@ -1576,7 +1580,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 	case *ast.DeferStmt:
 		c.setLine(n.Token.Line)
-		return c.compileCallExpression(n.Call, emitDeferredCall)
+		return c.compileCallExpression(n.Call, emitDeferredCall(n.Token.Line))
 
 	case *ast.CallExpression:
 		return c.compileCallExpression(n, emitImmediateCall)
@@ -1591,10 +1595,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 func (c *Compiler) emitCall(argCount int, emission callEmission) {
 	op := chunk.OP_CALL
-	if emission == emitDeferredCall {
+	line := c.currentLine
+	if emission.deferred {
 		op = chunk.OP_DEFER
+		line = emission.registrationLine
 	}
-	c.emitBytes(byte(op), byte(argCount))
+	c.currentChunk.Write(byte(op), line)
+	c.currentChunk.Write(byte(argCount), line)
 }
 
 func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission callEmission) (*chunk.Chunk, ast.NoxyType, error) {
@@ -1679,7 +1686,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 			c.emitCall(1, emission)
 			return c.currentChunk, retType, nil
 		} else if ident.Value == "addr" {
-			if emission == emitDeferredCall {
+			if emission.deferred {
 				return nil, nil, fmt.Errorf("[line %d] cannot defer addr: addr does not produce a callable", c.currentLine)
 			}
 			// addr(ref x) debug function.

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2,8 +2,11 @@ package compiler
 
 import (
 	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/lexer"
 	"noxy-vm/internal/parser"
+	"noxy-vm/internal/value"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +29,59 @@ func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)
 	return p.ParseProgram()
+}
+
+func compiledFunction(t *testing.T, source, name string) *value.ObjFunction {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, constant := range code.Constants {
+		if constant.Type == value.VAL_FUNCTION {
+			fn := constant.Obj.(*value.ObjFunction)
+			if fn.Name == name {
+				return fn
+			}
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return nil
+}
+
+func containsOpcode(code []byte, opcode chunk.OpCode) bool {
+	for _, instruction := range code {
+		if chunk.OpCode(instruction) == opcode {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompileDeferEmitsArgCount(t *testing.T) {
+	fn := compiledFunction(t, `
+func cleanup(value: int) -> void
+end
+func run() -> void
+    defer cleanup(7)
+end`, "run")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	for index, instruction := range code {
+		if chunk.OpCode(instruction) == chunk.OP_DEFER {
+			if index+1 >= len(code) || code[index+1] != 1 {
+				t.Fatalf("bad OP_DEFER operand")
+			}
+			return
+		}
+	}
+	t.Fatal("compiled function omitted OP_DEFER")
+}
+
+func TestCompileDeferRejectsAddrPseudoCall(t *testing.T) {
+	_, _, err := New().Compile(parse("let value: int = 1\ndefer addr(ref value)\n"))
+	if err == nil || !strings.Contains(err.Error(), "cannot defer addr") {
+		t.Fatalf("error=%v", err)
+	}
 }
 
 func runCompilerTests(t *testing.T, tests []compilerTestCase) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -77,6 +77,85 @@ end`, "run")
 	t.Fatal("compiled function omitted OP_DEFER")
 }
 
+func TestCompileMultilineDeferUsesRegistrationLineForCallOpcode(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        string
+		deferLine     int
+		argumentCount byte
+	}{
+		{
+			name: "ordinary call",
+			source: `func cleanup(value: int) -> void
+end
+func run() -> void
+    defer cleanup(
+        7
+    )
+end`,
+			deferLine:     4,
+			argumentCount: 1,
+		},
+		{
+			name: "special builtin call",
+			source: `func run() -> void
+    let items: int[] = [1]
+    defer append(
+        ref items,
+        2
+    )
+end`,
+			deferLine:     3,
+			argumentCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fn := compiledFunction(t, test.source, "run")
+			compiled := fn.Chunk.(*chunk.Chunk)
+			for offset := 0; offset+1 < len(compiled.Code); offset++ {
+				if chunk.OpCode(compiled.Code[offset]) != chunk.OP_DEFER || compiled.Code[offset+1] != test.argumentCount {
+					continue
+				}
+				if got := compiled.Lines[offset]; got != test.deferLine {
+					t.Fatalf("OP_DEFER line=%d, want defer token line %d", got, test.deferLine)
+				}
+				return
+			}
+			t.Fatal("compiled function omitted OP_DEFER")
+		})
+	}
+}
+
+func TestCompileMultilineDeferKeepsOperandDiagnosticLine(t *testing.T) {
+	_, _, err := New().Compile(parse(`func cleanup(value: string) -> void
+end
+func run() -> void
+    defer cleanup(
+		42
+    )
+end`))
+	if err == nil || !strings.Contains(err.Error(), "[line 5]") || !strings.Contains(err.Error(), "expected string, got int") {
+		t.Fatalf("error=%v, want argument diagnostic on line 5", err)
+	}
+}
+
+func TestCompileImmediateCallEmitsCallAndNotDefer(t *testing.T) {
+	fn := compiledFunction(t, `func cleanup(value: int) -> void
+end
+func run() -> void
+    cleanup(7)
+end`, "run")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_CALL) {
+		t.Fatal("ordinary call omitted OP_CALL")
+	}
+	if containsOpcode(code, chunk.OP_DEFER) {
+		t.Fatal("ordinary call emitted OP_DEFER")
+	}
+}
+
 func TestCompileDeferRejectsAddrPseudoCall(t *testing.T) {
 	_, _, err := New().Compile(parse("let value: int = 1\ndefer addr(ref value)\n"))
 	if err == nil || !strings.Contains(err.Error(), "cannot defer addr") {

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+func TestDeferIsKeyword(t *testing.T) {
+	lex := New("defer cleanup(1)\n")
+	if got := lex.NextToken(); got.Type != token.DEFER || got.Literal != "defer" {
+		t.Fatalf("token=%#v, want DEFER", got)
+	}
+}
+
 func TestNextToken(t *testing.T) {
 	input := `let five = 5
 let ten = 10

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -123,6 +123,8 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseLetStatement()
 	case token.RETURN:
 		return p.parseReturnStatement()
+	case token.DEFER:
+		return p.parseDeferStatement()
 	case token.IF:
 		return p.parseIfStatement()
 	case token.WHILE:
@@ -322,6 +324,25 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStmt {
 		p.nextToken()
 	}
 
+	return stmt
+}
+
+func (p *Parser) parseDeferStatement() ast.Statement {
+	stmt := &ast.DeferStmt{Token: p.curToken}
+	p.nextToken()
+	expression := p.parseExpression(LOWEST)
+	call, ok := expression.(*ast.CallExpression)
+	if !ok {
+		p.errors = append(p.errors, fmt.Sprintf(
+			"[%d:%d] SyntaxError: defer expects a call expression",
+			stmt.Token.Line, stmt.Token.Column,
+		))
+		return nil
+	}
+	stmt.Call = call
+	if p.peekTokenIs(token.NEWLINE) {
+		p.nextToken()
+	}
 	return stmt
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -3,8 +3,29 @@ package parser
 import (
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/lexer"
+	"strings"
 	"testing"
 )
+
+func TestParseDeferCallStatement(t *testing.T) {
+	p := New(lexer.New("defer cleanup(1)\n"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	stmt, ok := program.Statements[0].(*ast.DeferStmt)
+	if !ok || stmt.Call == nil || stmt.Call.Function.String() != "cleanup" || len(stmt.Call.Arguments) != 1 {
+		t.Fatalf("statement=%#v, want deferred cleanup call", program.Statements[0])
+	}
+}
+
+func TestParseDeferRejectsNonCallExpression(t *testing.T) {
+	for _, source := range []string{"defer value\n", "defer 1 + 2\n"} {
+		p := New(lexer.New(source))
+		_ = p.ParseProgram()
+		if len(p.Errors()) == 0 || !strings.Contains(strings.Join(p.Errors(), "\n"), "defer expects a call") {
+			t.Fatalf("source=%q errors=%v", source, p.Errors())
+		}
+	}
+}
 
 func TestLetStatements(t *testing.T) {
 	input := `

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -30,6 +30,7 @@ const (
 	WHILE   TokenType = "WHILE"
 	DO      TokenType = "DO"
 	RETURN  TokenType = "RETURN"
+	DEFER   TokenType = "DEFER"
 	BREAK   TokenType = "BREAK"
 	FOR     TokenType = "FOR"
 	IN      TokenType = "IN"
@@ -126,6 +127,7 @@ var keywords = map[string]TokenType{
 	"while":   WHILE,
 	"do":      DO,
 	"return":  RETURN,
+	"defer":   DEFER,
 	"break":   BREAK,
 	"int":     TYPE_INT,
 	"float":   TYPE_FLOAT,

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -245,6 +245,153 @@ func sourceStructFields(t *testing.T, filename, structName string) map[string]st
 	return fields
 }
 
+func selectorNamed(expression ast.Expr, name string) bool {
+	for {
+		switch typed := expression.(type) {
+		case *ast.ParenExpr:
+			expression = typed.X
+		case *ast.SelectorExpr:
+			return typed.Sel.Name == name
+		default:
+			return false
+		}
+	}
+}
+
+func expressionContainsSelector(expression ast.Expr, name string) bool {
+	found := false
+	ast.Inspect(expression, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if ok && selector.Sel.Name == name {
+			found = true
+			return false
+		}
+		return !found
+	})
+	return found
+}
+
+func indexesSelector(expression ast.Expr, name string) bool {
+	index, ok := expression.(*ast.IndexExpr)
+	return ok && selectorNamed(index.X, name)
+}
+
+func isNilExpression(expression ast.Expr) bool {
+	identifier, ok := expression.(*ast.Ident)
+	return ok && identifier.Name == "nil"
+}
+
+func isEmptyValueLiteral(expression ast.Expr) bool {
+	literal, ok := expression.(*ast.CompositeLit)
+	return ok && len(literal.Elts) == 0 && expressionTextForArchitecture(literal.Type) == "value.Value"
+}
+
+func expressionTextForArchitecture(expression ast.Expr) string {
+	var text strings.Builder
+	_ = printer.Fprint(&text, token.NewFileSet(), expression)
+	return text.String()
+}
+
+func forClearsStackFromStackBase(loop *ast.ForStmt) bool {
+	initialization, ok := loop.Init.(*ast.AssignStmt)
+	if !ok || len(initialization.Lhs) != len(initialization.Rhs) {
+		return false
+	}
+	loopIndexes := make(map[string]bool)
+	for index, left := range initialization.Lhs {
+		identifier, ok := left.(*ast.Ident)
+		if ok && expressionContainsSelector(initialization.Rhs[index], "StackBase") {
+			loopIndexes[identifier.Name] = true
+		}
+	}
+	if len(loopIndexes) == 0 {
+		return false
+	}
+
+	clears := false
+	ast.Inspect(loop.Body, func(node ast.Node) bool {
+		assignment, ok := node.(*ast.AssignStmt)
+		if !ok || len(assignment.Lhs) != len(assignment.Rhs) {
+			return !clears
+		}
+		for index, left := range assignment.Lhs {
+			stackIndex, ok := left.(*ast.IndexExpr)
+			if !ok {
+				continue
+			}
+			identifier, indexOK := stackIndex.Index.(*ast.Ident)
+			if indexOK && selectorNamed(stackIndex.X, "stack") && loopIndexes[identifier.Name] && isEmptyValueLiteral(assignment.Rhs[index]) {
+				clears = true
+				return false
+			}
+		}
+		return !clears
+	})
+	return clears
+}
+
+func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte) []string {
+	t.Helper()
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, filename, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+
+	var matches []string
+	record := func(node ast.Node, description string) {
+		matches = append(matches, description+" at line "+fileSet.Position(node.Pos()).String())
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.IncDecStmt:
+			if typed.Tok == token.DEC && selectorNamed(typed.X, "frameCount") {
+				record(typed, "decrements frameCount")
+			}
+		case *ast.AssignStmt:
+			for index, left := range typed.Lhs {
+				if selectorNamed(left, "frameCount") && typed.Tok == token.SUB_ASSIGN {
+					record(typed, "decrements frameCount")
+				}
+				if index >= len(typed.Rhs) {
+					continue
+				}
+				right := typed.Rhs[index]
+				if selectorNamed(left, "frameCount") && typed.Tok == token.ASSIGN {
+					binary, ok := right.(*ast.BinaryExpr)
+					if ok && binary.Op == token.SUB && expressionContainsSelector(binary.X, "frameCount") {
+						record(typed, "decrements frameCount")
+					}
+				}
+				if indexesSelector(left, "frames") && isNilExpression(right) {
+					record(typed, "removes a frame")
+				}
+				if selectorNamed(left, "currentFrame") && isNilExpression(right) {
+					record(typed, "clears currentFrame")
+				}
+				if selectorNamed(left, "stackTop") && expressionContainsSelector(right, "StackBase") {
+					record(typed, "resets stackTop to StackBase")
+				}
+			}
+		case *ast.CallExpr:
+			identifier, ok := typed.Fun.(*ast.Ident)
+			if !ok || identifier.Name != "clear" || len(typed.Args) != 1 {
+				break
+			}
+			slice, ok := typed.Args[0].(*ast.SliceExpr)
+			if ok && selectorNamed(slice.X, "stack") && slice.Low != nil && expressionContainsSelector(slice.Low, "StackBase") {
+				record(typed, "clears stack from StackBase")
+			}
+		case *ast.ForStmt:
+			if forClearsStackFromStackBase(typed) {
+				record(typed, "clears stack from StackBase")
+			}
+		}
+		return true
+	})
+	return matches
+}
+
 func runtimeTargetTypeName(expression ast.Expr, aliases map[string]string) string {
 	var name string
 	switch typed := expression.(type) {
@@ -587,6 +734,146 @@ func TestResourceRegistriesAndModuleCacheHaveSharedOwners(t *testing.T) {
 		}
 	}
 	requireSourceFunctions(t, "module_cache.go", "newModuleCache")
+}
+
+func TestUnwindArchitectureCentralizesTerminalFrameTeardown(t *testing.T) {
+	callFrame := sourceStructFields(t, "vm.go", "CallFrame")
+	want := map[string]string{
+		"StackBase": "int",
+		"LocalBase": "int",
+		"Deferred":  "[]PreparedCall",
+	}
+	for name, expectedType := range want {
+		if got := callFrame[name]; got != expectedType {
+			t.Errorf("CallFrame.%s=%q want %q", name, got, expectedType)
+		}
+	}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, filename := range files {
+		if filename == "unwind.go" || strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+		source, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, match := range unwindTerminalMutationMatches(t, filename, source) {
+			t.Errorf("terminal frame teardown must remain in unwind.go: %s", match)
+		}
+	}
+}
+
+func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name: "decrement operator",
+			source: `package vm
+				type VM struct { frameCount int }
+				func teardown(vm *VM) { vm.frameCount-- }`,
+			want: []string{"decrements frameCount"},
+		},
+		{
+			name: "subtract assignment",
+			source: `package vm
+				type VM struct { frameCount int }
+				func teardown(vm *VM) { vm.frameCount -= 2 }`,
+			want: []string{"decrements frameCount"},
+		},
+		{
+			name: "explicit subtraction",
+			source: `package vm
+				type VM struct { frameCount int }
+				func teardown(vm *VM) { vm.frameCount = vm.frameCount - 1 }`,
+			want: []string{"decrements frameCount"},
+		},
+		{
+			name: "nil frame assignment",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { frames []*CallFrame }
+				func teardown(vm *VM, index int) { vm.frames[index] = nil }`,
+			want: []string{"removes a frame"},
+		},
+		{
+			name: "nil current frame assignment",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { currentFrame *CallFrame }
+				func teardown(vm *VM) { vm.currentFrame = nil }`,
+			want: []string{"clears currentFrame"},
+		},
+		{
+			name: "stack clearing loop",
+			source: `package vm
+				import "noxy-vm/internal/value"
+				type CallFrame struct { StackBase int }
+				type VM struct { stack []value.Value }
+				func teardown(vm *VM, frame *CallFrame, top int) {
+					for index := frame.StackBase; index < top; index++ { vm.stack[index] = value.Value{} }
+				}`,
+			want: []string{"clears stack from StackBase"},
+		},
+		{
+			name: "stack clear builtin",
+			source: `package vm
+				type CallFrame struct { StackBase int }
+				type VM struct { stack []int }
+				func teardown(vm *VM, frame *CallFrame, top int) { clear(vm.stack[frame.StackBase:top]) }`,
+			want: []string{"clears stack from StackBase"},
+		},
+		{
+			name: "stack top reset",
+			source: `package vm
+				type CallFrame struct { StackBase int }
+				type VM struct { stackTop int }
+				func teardown(vm *VM, frame *CallFrame) { vm.stackTop = frame.StackBase }`,
+			want: []string{"resets stackTop to StackBase"},
+		},
+		{
+			name: "non-clearing stack window loop is allowed",
+			source: `package vm
+				type CallFrame struct { StackBase int }
+				func inspect(frame *CallFrame, top int) {
+					for index := frame.StackBase; index < top; index++ { current := index; _ = current }
+				}`,
+		},
+		{
+			name: "frame construction and similar text are allowed",
+			source: `package vm
+				type PreparedCall struct{}
+				type CallFrame struct { StackBase int; LocalBase int; Deferred []PreparedCall }
+				type VM struct { frames []*CallFrame; frameCount int }
+				var note = "vm.frameCount--; vm.frames[index] = nil"
+				func install(vm *VM) {
+					// clear(vm.stack[frame.StackBase:])
+					frame := &CallFrame{StackBase: 0, LocalBase: 1}
+					vm.frames[vm.frameCount] = frame
+					vm.frameCount++
+					_ = frame.StackBase
+				}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matches := unwindTerminalMutationMatches(t, "architecture.go", []byte(test.source))
+			got := make([]string, len(matches))
+			for index, match := range matches {
+				got[index] = strings.SplitN(match, " at line ", 2)[0]
+			}
+			if strings.Join(got, "|") != strings.Join(test.want, "|") {
+				t.Fatalf("matches=%v want=%v", got, test.want)
+			}
+		})
+	}
 }
 
 func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -245,24 +246,235 @@ func sourceStructFields(t *testing.T, filename, structName string) map[string]st
 	return fields
 }
 
-func selectorNamed(expression ast.Expr, name string) bool {
-	for {
-		switch typed := expression.(type) {
-		case *ast.ParenExpr:
-			expression = typed.X
-		case *ast.SelectorExpr:
-			return typed.Sel.Name == name
-		default:
-			return false
+type architectureTypeInfo struct {
+	aliases   map[string]string
+	fields    map[string]map[string]string
+	functions map[string]string
+	known     map[string]bool
+	globals   map[string]string
+}
+
+type architectureTypeResolver struct {
+	info      *architectureTypeInfo
+	variables map[string]string
+}
+
+func newArchitectureTypeInfo(file *ast.File) *architectureTypeInfo {
+	info := &architectureTypeInfo{
+		aliases: map[string]string{},
+		fields: map[string]map[string]string{
+			"VM": {
+				"frameCount":   "int",
+				"frames":       "CallFrame",
+				"currentFrame": "CallFrame",
+				"stack":        "Value",
+				"stackTop":     "int",
+			},
+			"CallFrame": {
+				"StackBase": "int",
+			},
+		},
+		functions: map[string]string{
+			"New":           "VM",
+			"NewWithConfig": "VM",
+			"NewWithShared": "VM",
+		},
+		known: map[string]bool{
+			"VM":        true,
+			"CallFrame": true,
+		},
+		globals: map[string]string{},
+	}
+
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.TYPE {
+			continue
+		}
+		for _, specification := range general.Specs {
+			typeSpec, ok := specification.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			info.known[typeSpec.Name.Name] = true
+			if _, structure := typeSpec.Type.(*ast.StructType); !structure {
+				if target := architectureDeclaredTypeName(typeSpec.Type, nil); target != "" {
+					info.aliases[typeSpec.Name.Name] = target
+				}
+			}
+		}
+	}
+
+	for _, declaration := range file.Decls {
+		switch typed := declaration.(type) {
+		case *ast.GenDecl:
+			for _, specification := range typed.Specs {
+				switch spec := specification.(type) {
+				case *ast.TypeSpec:
+					structure, ok := spec.Type.(*ast.StructType)
+					if !ok {
+						continue
+					}
+					fields := info.fields[spec.Name.Name]
+					if fields == nil {
+						fields = make(map[string]string)
+						info.fields[spec.Name.Name] = fields
+					}
+					for _, field := range structure.Fields.List {
+						fieldType := architectureDeclaredTypeName(field.Type, info.aliases)
+						for _, name := range field.Names {
+							fields[name.Name] = fieldType
+						}
+					}
+				case *ast.ValueSpec:
+					if typed.Tok == token.VAR {
+						info.recordValueSpec(spec, info.globals)
+					}
+				}
+			}
+		case *ast.FuncDecl:
+			if typed.Type.Results != nil && len(typed.Type.Results.List) == 1 {
+				if result := architectureDeclaredTypeName(typed.Type.Results.List[0].Type, info.aliases); result != "" {
+					info.functions[typed.Name.Name] = result
+				}
+			}
+		}
+	}
+	return info
+}
+
+func architectureDeclaredTypeName(expression ast.Expr, aliases map[string]string) string {
+	var name string
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		name = typed.Name
+	case *ast.SelectorExpr:
+		name = typed.Sel.Name
+	case *ast.StarExpr:
+		return architectureDeclaredTypeName(typed.X, aliases)
+	case *ast.ParenExpr:
+		return architectureDeclaredTypeName(typed.X, aliases)
+	case *ast.ArrayType:
+		return architectureDeclaredTypeName(typed.Elt, aliases)
+	case *ast.Ellipsis:
+		return architectureDeclaredTypeName(typed.Elt, aliases)
+	}
+	for aliases != nil && name != "" {
+		next, ok := aliases[name]
+		if !ok || next == name {
+			break
+		}
+		name = next
+	}
+	return name
+}
+
+func (info *architectureTypeInfo) recordValueSpec(spec *ast.ValueSpec, variables map[string]string) {
+	declared := architectureDeclaredTypeName(spec.Type, info.aliases)
+	resolver := &architectureTypeResolver{info: info, variables: variables}
+	for index, name := range spec.Names {
+		actual := declared
+		if actual == "" && index < len(spec.Values) {
+			actual = resolver.expressionType(spec.Values[index])
+		}
+		if actual != "" {
+			variables[name.Name] = actual
 		}
 	}
 }
 
-func expressionContainsSelector(expression ast.Expr, name string) bool {
+func newArchitectureTypeResolver(info *architectureTypeInfo, function *ast.FuncDecl) *architectureTypeResolver {
+	variables := make(map[string]string, len(info.globals))
+	for name, target := range info.globals {
+		variables[name] = target
+	}
+	resolver := &architectureTypeResolver{info: info, variables: variables}
+	resolver.recordFieldList(function.Recv)
+	resolver.recordFieldList(function.Type.Params)
+	return resolver
+}
+
+func (resolver *architectureTypeResolver) clone() *architectureTypeResolver {
+	variables := make(map[string]string, len(resolver.variables))
+	for name, target := range resolver.variables {
+		variables[name] = target
+	}
+	return &architectureTypeResolver{info: resolver.info, variables: variables}
+}
+
+func (resolver *architectureTypeResolver) recordFieldList(fields *ast.FieldList) {
+	if fields == nil {
+		return
+	}
+	for _, field := range fields.List {
+		target := architectureDeclaredTypeName(field.Type, resolver.info.aliases)
+		for _, name := range field.Names {
+			resolver.variables[name.Name] = target
+		}
+	}
+}
+
+func (resolver *architectureTypeResolver) expressionType(expression ast.Expr) string {
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		return resolver.variables[typed.Name]
+	case *ast.ParenExpr:
+		return resolver.expressionType(typed.X)
+	case *ast.UnaryExpr:
+		return resolver.expressionType(typed.X)
+	case *ast.CompositeLit:
+		return architectureDeclaredTypeName(typed.Type, resolver.info.aliases)
+	case *ast.SelectorExpr:
+		owner := resolver.expressionType(typed.X)
+		return resolver.info.fields[owner][typed.Sel.Name]
+	case *ast.IndexExpr:
+		return resolver.expressionType(typed.X)
+	case *ast.CallExpr:
+		if identifier, ok := typed.Fun.(*ast.Ident); ok {
+			if result := resolver.info.functions[identifier.Name]; result != "" {
+				return result
+			}
+		}
+		converted := architectureDeclaredTypeName(typed.Fun, resolver.info.aliases)
+		if resolver.info.known[converted] {
+			return converted
+		}
+	}
+	return ""
+}
+
+func (resolver *architectureTypeResolver) recordAssignment(assignment *ast.AssignStmt) {
+	if len(assignment.Lhs) != len(assignment.Rhs) {
+		return
+	}
+	for index, left := range assignment.Lhs {
+		identifier, ok := left.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if target := resolver.expressionType(assignment.Rhs[index]); target != "" {
+			resolver.variables[identifier.Name] = target
+		}
+	}
+}
+
+func (resolver *architectureTypeResolver) isField(expression ast.Expr, ownerType, fieldName string) bool {
+	for {
+		parenthesized, ok := expression.(*ast.ParenExpr)
+		if !ok {
+			break
+		}
+		expression = parenthesized.X
+	}
+	selector, ok := expression.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == fieldName && resolver.expressionType(selector.X) == ownerType
+}
+
+func (resolver *architectureTypeResolver) containsField(expression ast.Expr, ownerType, fieldName string) bool {
 	found := false
 	ast.Inspect(expression, func(node ast.Node) bool {
 		selector, ok := node.(*ast.SelectorExpr)
-		if ok && selector.Sel.Name == name {
+		if ok && resolver.isField(selector, ownerType, fieldName) {
 			found = true
 			return false
 		}
@@ -271,14 +483,38 @@ func expressionContainsSelector(expression ast.Expr, name string) bool {
 	return found
 }
 
-func indexesSelector(expression ast.Expr, name string) bool {
+func (resolver *architectureTypeResolver) indexesField(expression ast.Expr, ownerType, fieldName string) bool {
 	index, ok := expression.(*ast.IndexExpr)
-	return ok && selectorNamed(index.X, name)
+	return ok && resolver.isField(index.X, ownerType, fieldName)
 }
 
-func isNilExpression(expression ast.Expr) bool {
-	identifier, ok := expression.(*ast.Ident)
-	return ok && identifier.Name == "nil"
+func (resolver *architectureTypeResolver) isNilForType(expression ast.Expr, target string) bool {
+	if identifier, ok := expression.(*ast.Ident); ok {
+		return identifier.Name == "nil"
+	}
+	call, ok := expression.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	identifier, ok := call.Args[0].(*ast.Ident)
+	return ok && identifier.Name == "nil" && architectureDeclaredTypeName(call.Fun, resolver.info.aliases) == target
+}
+
+func isZeroInteger(expression ast.Expr) bool {
+	if parenthesized, ok := expression.(*ast.ParenExpr); ok {
+		return isZeroInteger(parenthesized.X)
+	}
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.INT {
+		return false
+	}
+	value, err := strconv.ParseInt(literal.Value, 0, 64)
+	return err == nil && value == 0
+}
+
+func isEmptyCompositeLiteral(expression ast.Expr) bool {
+	literal, ok := expression.(*ast.CompositeLit)
+	return ok && len(literal.Elts) == 0
 }
 
 func isEmptyValueLiteral(expression ast.Expr) bool {
@@ -292,7 +528,7 @@ func expressionTextForArchitecture(expression ast.Expr) string {
 	return text.String()
 }
 
-func forClearsStackFromStackBase(loop *ast.ForStmt) bool {
+func forClearsStackFromStackBase(loop *ast.ForStmt, resolver *architectureTypeResolver) bool {
 	initialization, ok := loop.Init.(*ast.AssignStmt)
 	if !ok || len(initialization.Lhs) != len(initialization.Rhs) {
 		return false
@@ -300,7 +536,7 @@ func forClearsStackFromStackBase(loop *ast.ForStmt) bool {
 	loopIndexes := make(map[string]bool)
 	for index, left := range initialization.Lhs {
 		identifier, ok := left.(*ast.Ident)
-		if ok && expressionContainsSelector(initialization.Rhs[index], "StackBase") {
+		if ok && resolver.containsField(initialization.Rhs[index], "CallFrame", "StackBase") {
 			loopIndexes[identifier.Name] = true
 		}
 	}
@@ -320,7 +556,7 @@ func forClearsStackFromStackBase(loop *ast.ForStmt) bool {
 				continue
 			}
 			identifier, indexOK := stackIndex.Index.(*ast.Ident)
-			if indexOK && selectorNamed(stackIndex.X, "stack") && loopIndexes[identifier.Name] && isEmptyValueLiteral(assignment.Rhs[index]) {
+			if indexOK && resolver.isField(stackIndex.X, "VM", "stack") && loopIndexes[identifier.Name] && isEmptyValueLiteral(assignment.Rhs[index]) {
 				clears = true
 				return false
 			}
@@ -328,6 +564,16 @@ func forClearsStackFromStackBase(loop *ast.ForStmt) bool {
 		return !clears
 	})
 	return clears
+}
+
+func architectureIntroducesScope(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt,
+		*ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt,
+		*ast.CaseClause, *ast.CommClause, *ast.FuncLit:
+		return true
+	}
+	return false
 }
 
 func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte) []string {
@@ -338,57 +584,105 @@ func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte)
 		t.Fatalf("parse %s: %v", filename, err)
 	}
 
+	info := newArchitectureTypeInfo(file)
 	var matches []string
 	record := func(node ast.Node, description string) {
 		matches = append(matches, description+" at line "+fileSet.Position(node.Pos()).String())
 	}
-	ast.Inspect(file, func(node ast.Node) bool {
-		switch typed := node.(type) {
-		case *ast.IncDecStmt:
-			if typed.Tok == token.DEC && selectorNamed(typed.X, "frameCount") {
-				record(typed, "decrements frameCount")
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		resolvers := []*architectureTypeResolver{newArchitectureTypeResolver(info, function)}
+		var nodes []ast.Node
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			if node == nil {
+				last := nodes[len(nodes)-1]
+				nodes = nodes[:len(nodes)-1]
+				if architectureIntroducesScope(last) {
+					resolvers = resolvers[:len(resolvers)-1]
+				}
+				return true
 			}
-		case *ast.AssignStmt:
-			for index, left := range typed.Lhs {
-				if selectorNamed(left, "frameCount") && typed.Tok == token.SUB_ASSIGN {
+			nodes = append(nodes, node)
+			if architectureIntroducesScope(node) {
+				nested := resolvers[len(resolvers)-1].clone()
+				if literal, ok := node.(*ast.FuncLit); ok {
+					nested.recordFieldList(literal.Type.Params)
+				}
+				resolvers = append(resolvers, nested)
+			}
+			resolver := resolvers[len(resolvers)-1]
+			switch typed := node.(type) {
+			case *ast.IncDecStmt:
+				if typed.Tok == token.DEC && resolver.isField(typed.X, "VM", "frameCount") {
 					record(typed, "decrements frameCount")
 				}
-				if index >= len(typed.Rhs) {
-					continue
-				}
-				right := typed.Rhs[index]
-				if selectorNamed(left, "frameCount") && typed.Tok == token.ASSIGN {
-					binary, ok := right.(*ast.BinaryExpr)
-					if ok && binary.Op == token.SUB && expressionContainsSelector(binary.X, "frameCount") {
+			case *ast.AssignStmt:
+				for index, left := range typed.Lhs {
+					frameCount := resolver.isField(left, "VM", "frameCount")
+					if frameCount && typed.Tok == token.SUB_ASSIGN {
 						record(typed, "decrements frameCount")
 					}
+					if index >= len(typed.Rhs) {
+						continue
+					}
+					right := typed.Rhs[index]
+					if frameCount && typed.Tok == token.ASSIGN {
+						binary, subtraction := right.(*ast.BinaryExpr)
+						if subtraction && binary.Op == token.SUB && resolver.containsField(binary.X, "VM", "frameCount") {
+							record(typed, "decrements frameCount")
+						} else if isZeroInteger(right) {
+							record(typed, "resets frameCount")
+						}
+					}
+					if resolver.isField(left, "VM", "frames") && isEmptyCompositeLiteral(right) {
+						record(typed, "resets frames")
+					}
+					if resolver.indexesField(left, "VM", "frames") && resolver.isNilForType(right, "CallFrame") {
+						record(typed, "removes a frame")
+					}
+					if resolver.isField(left, "VM", "currentFrame") && resolver.isNilForType(right, "CallFrame") {
+						record(typed, "clears currentFrame")
+					}
+					if resolver.isField(left, "VM", "stackTop") && resolver.containsField(right, "CallFrame", "StackBase") {
+						record(typed, "resets stackTop to StackBase")
+					}
 				}
-				if indexesSelector(left, "frames") && isNilExpression(right) {
-					record(typed, "removes a frame")
+				resolver.recordAssignment(typed)
+			case *ast.DeclStmt:
+				general, ok := typed.Decl.(*ast.GenDecl)
+				if ok && general.Tok == token.VAR {
+					for _, specification := range general.Specs {
+						if valueSpec, ok := specification.(*ast.ValueSpec); ok {
+							info.recordValueSpec(valueSpec, resolver.variables)
+						}
+					}
 				}
-				if selectorNamed(left, "currentFrame") && isNilExpression(right) {
-					record(typed, "clears currentFrame")
+			case *ast.CallExpr:
+				identifier, ok := typed.Fun.(*ast.Ident)
+				if !ok || identifier.Name != "clear" || len(typed.Args) != 1 {
+					break
 				}
-				if selectorNamed(left, "stackTop") && expressionContainsSelector(right, "StackBase") {
-					record(typed, "resets stackTop to StackBase")
+				slice, ok := typed.Args[0].(*ast.SliceExpr)
+				if !ok {
+					break
+				}
+				if resolver.isField(slice.X, "VM", "frames") {
+					record(typed, "clears frames")
+				}
+				if resolver.isField(slice.X, "VM", "stack") && slice.Low != nil && resolver.containsField(slice.Low, "CallFrame", "StackBase") {
+					record(typed, "clears stack from StackBase")
+				}
+			case *ast.ForStmt:
+				if forClearsStackFromStackBase(typed, resolver) {
+					record(typed, "clears stack from StackBase")
 				}
 			}
-		case *ast.CallExpr:
-			identifier, ok := typed.Fun.(*ast.Ident)
-			if !ok || identifier.Name != "clear" || len(typed.Args) != 1 {
-				break
-			}
-			slice, ok := typed.Args[0].(*ast.SliceExpr)
-			if ok && selectorNamed(slice.X, "stack") && slice.Low != nil && expressionContainsSelector(slice.Low, "StackBase") {
-				record(typed, "clears stack from StackBase")
-			}
-		case *ast.ForStmt:
-			if forClearsStackFromStackBase(typed) {
-				record(typed, "clears stack from StackBase")
-			}
-		}
-		return true
-	})
+			return true
+		})
+	}
 	return matches
 }
 
@@ -795,6 +1089,22 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 			want: []string{"decrements frameCount"},
 		},
 		{
+			name: "frame count reset assignment",
+			source: `package vm
+				type VM struct { frameCount int }
+				func teardown(vm *VM) { vm.frameCount = 0 }`,
+			want: []string{"resets frameCount"},
+		},
+		{
+			name: "whole frame array reset",
+			source: `package vm
+				const FramesMax = 4
+				type CallFrame struct{}
+				type VM struct { frames [FramesMax]*CallFrame }
+				func teardown(vm *VM) { vm.frames = [FramesMax]*CallFrame{} }`,
+			want: []string{"resets frames"},
+		},
+		{
 			name: "nil frame assignment",
 			source: `package vm
 				type CallFrame struct{}
@@ -809,6 +1119,25 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 				type VM struct { currentFrame *CallFrame }
 				func teardown(vm *VM) { vm.currentFrame = nil }`,
 			want: []string{"clears currentFrame"},
+		},
+		{
+			name: "typed nil frame assignments",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { frames []*CallFrame; currentFrame *CallFrame }
+				func teardown(vm *VM, index int) {
+					vm.frames[index] = (*CallFrame)(nil)
+					vm.currentFrame = (*CallFrame)(nil)
+				}`,
+			want: []string{"removes a frame", "clears currentFrame"},
+		},
+		{
+			name: "clear frame array",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { frames [4]*CallFrame }
+				func teardown(vm *VM) { clear(vm.frames[:]) }`,
+			want: []string{"clears frames"},
 		},
 		{
 			name: "stack clearing loop",
@@ -844,6 +1173,35 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 				func inspect(frame *CallFrame, top int) {
 					for index := frame.StackBase; index < top; index++ { current := index; _ = current }
 				}`,
+		},
+		{
+			name: "homonymous fields on non runtime types are allowed",
+			source: `package vm
+				type CallFrame struct{}
+				type queue struct { frameCount int }
+				type cache struct { frames []*CallFrame; currentFrame *CallFrame; stackTop int }
+				type window struct { StackBase int }
+				func mutate(queue *queue, cache *cache, window *window, index int) {
+					queue.frameCount--
+					cache.frames[index] = nil
+					cache.currentFrame = (*CallFrame)(nil)
+					cache.stackTop = window.StackBase
+					clear(cache.frames[:])
+				}`,
+		},
+		{
+			name: "shadowed receiver types stay in lexical scope",
+			source: `package vm
+				type VM struct { frameCount int }
+				type queue struct { frameCount int }
+				func inspect(vm *VM, queue *queue) {
+					if true {
+						vm := queue
+						vm.frameCount--
+					}
+					vm.frameCount = 0
+				}`,
+			want: []string{"resets frameCount"},
 		},
 		{
 			name: "frame construction and similar text are allowed",

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -3,12 +3,15 @@ package vm
 import (
 	"bytes"
 	"go/ast"
+	"go/constant"
+	"go/importer"
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
-	"strconv"
+	"sort"
 	"strings"
 	"testing"
 
@@ -246,225 +249,184 @@ func sourceStructFields(t *testing.T, filename, structName string) map[string]st
 	return fields
 }
 
-type architectureTypeInfo struct {
-	aliases   map[string]string
-	fields    map[string]map[string]string
-	functions map[string]string
-	known     map[string]bool
-	globals   map[string]string
+type architectureSource struct {
+	filename string
+	source   string
 }
 
-type architectureTypeResolver struct {
-	info      *architectureTypeInfo
-	variables map[string]string
+type architecturePackage struct {
+	fileSet *token.FileSet
+	files   []*ast.File
+	info    *types.Info
+	pkg     *types.Package
+	errors  []error
 }
 
-func newArchitectureTypeInfo(file *ast.File) *architectureTypeInfo {
-	info := &architectureTypeInfo{
-		aliases: map[string]string{},
-		fields: map[string]map[string]string{
-			"VM": {
-				"frameCount":   "int",
-				"frames":       "CallFrame",
-				"currentFrame": "CallFrame",
-				"stack":        "Value",
-				"stackTop":     "int",
-			},
-			"CallFrame": {
-				"StackBase": "int",
-			},
-		},
-		functions: map[string]string{
-			"New":           "VM",
-			"NewWithConfig": "VM",
-			"NewWithShared": "VM",
-		},
-		known: map[string]bool{
-			"VM":        true,
-			"CallFrame": true,
-		},
-		globals: map[string]string{},
+type architectureImporter struct {
+	moduleRoot string
+	packages   map[string]*types.Package
+	loading    map[string]bool
+	fallback   types.Importer
+}
+
+func newArchitectureImporter(t *testing.T) *architectureImporter {
+	t.Helper()
+	moduleRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
 	}
+	return &architectureImporter{
+		moduleRoot: moduleRoot,
+		packages:   make(map[string]*types.Package),
+		loading:    make(map[string]bool),
+		fallback:   importer.Default(),
+	}
+}
 
-	for _, declaration := range file.Decls {
-		general, ok := declaration.(*ast.GenDecl)
-		if !ok || general.Tok != token.TYPE {
+func (loader *architectureImporter) Import(importPath string) (*types.Package, error) {
+	if loaded := loader.packages[importPath]; loaded != nil {
+		return loaded, nil
+	}
+	if strings.HasPrefix(importPath, "noxy-vm/") && !loader.loading[importPath] {
+		loader.loading[importPath] = true
+		defer delete(loader.loading, importPath)
+		directory := filepath.Join(loader.moduleRoot, filepath.FromSlash(strings.TrimPrefix(importPath, "noxy-vm/")))
+		sources, err := readArchitectureSources(directory)
+		if err == nil && len(sources) != 0 {
+			checked := checkArchitecturePackage(importPath, sources, loader, true)
+			if checked.pkg != nil {
+				loader.packages[importPath] = checked.pkg
+				return checked.pkg, nil
+			}
+		}
+	}
+	if loaded, err := loader.fallback.Import(importPath); err == nil {
+		loader.packages[importPath] = loaded
+		return loaded, nil
+	}
+	name := importPath[strings.LastIndex(importPath, "/")+1:]
+	stub := types.NewPackage(importPath, name)
+	stub.MarkComplete()
+	loader.packages[importPath] = stub
+	return stub, nil
+}
+
+func readArchitectureSources(directory string) ([]architectureSource, error) {
+	filenames, err := filepath.Glob(filepath.Join(directory, "*.go"))
+	if err != nil {
+		return nil, err
+	}
+	var sources []architectureSource
+	for _, filename := range filenames {
+		if strings.HasSuffix(filename, "_test.go") {
 			continue
 		}
-		for _, specification := range general.Specs {
-			typeSpec, ok := specification.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			info.known[typeSpec.Name.Name] = true
-			if typeSpec.Assign.IsValid() {
-				if target := architectureDeclaredTypeName(typeSpec.Type, nil); target != "" {
-					info.aliases[typeSpec.Name.Name] = target
-				}
-			}
+		source, err := os.ReadFile(filename)
+		if err != nil {
+			return nil, err
 		}
+		sources = append(sources, architectureSource{filename: filename, source: string(source)})
 	}
-
-	for _, declaration := range file.Decls {
-		switch typed := declaration.(type) {
-		case *ast.GenDecl:
-			for _, specification := range typed.Specs {
-				switch spec := specification.(type) {
-				case *ast.TypeSpec:
-					structure, ok := spec.Type.(*ast.StructType)
-					if !ok {
-						continue
-					}
-					fields := info.fields[spec.Name.Name]
-					if fields == nil {
-						fields = make(map[string]string)
-						info.fields[spec.Name.Name] = fields
-					}
-					for _, field := range structure.Fields.List {
-						fieldType := architectureDeclaredTypeName(field.Type, info.aliases)
-						for _, name := range field.Names {
-							fields[name.Name] = fieldType
-						}
-					}
-				case *ast.ValueSpec:
-					if typed.Tok == token.VAR {
-						info.recordValueSpec(spec, info.globals)
-					}
-				}
-			}
-		case *ast.FuncDecl:
-			if typed.Type.Results != nil && len(typed.Type.Results.List) == 1 {
-				if result := architectureDeclaredTypeName(typed.Type.Results.List[0].Type, info.aliases); result != "" {
-					info.functions[typed.Name.Name] = result
-				}
-			}
-		}
-	}
-	return info
+	sort.Slice(sources, func(left, right int) bool { return sources[left].filename < sources[right].filename })
+	return sources, nil
 }
 
-func architectureDeclaredTypeName(expression ast.Expr, aliases map[string]string) string {
-	var name string
-	switch typed := expression.(type) {
-	case *ast.Ident:
-		name = typed.Name
-	case *ast.SelectorExpr:
-		name = typed.Sel.Name
-	case *ast.StarExpr:
-		return architectureDeclaredTypeName(typed.X, aliases)
-	case *ast.ParenExpr:
-		return architectureDeclaredTypeName(typed.X, aliases)
-	case *ast.ArrayType:
-		return architectureDeclaredTypeName(typed.Elt, aliases)
-	case *ast.Ellipsis:
-		return architectureDeclaredTypeName(typed.Elt, aliases)
+func checkArchitecturePackage(packagePath string, sources []architectureSource, loader types.Importer, ignoreBodies bool) *architecturePackage {
+	fileSet := token.NewFileSet()
+	files := make([]*ast.File, 0, len(sources))
+	for _, source := range sources {
+		file, err := parser.ParseFile(fileSet, source.filename, source.source, 0)
+		if err != nil {
+			return &architecturePackage{fileSet: fileSet, errors: []error{err}}
+		}
+		files = append(files, file)
 	}
-	for aliases != nil && name != "" {
-		next, ok := aliases[name]
-		if !ok || next == name {
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+	var typeErrors []error
+	configuration := types.Config{
+		Importer:                 loader,
+		IgnoreFuncBodies:         ignoreBodies,
+		DisableUnusedImportCheck: true,
+		Error:                    func(err error) { typeErrors = append(typeErrors, err) },
+	}
+	pkg, _ := configuration.Check(packagePath, fileSet, files, info)
+	return &architecturePackage{fileSet: fileSet, files: files, info: info, pkg: pkg, errors: typeErrors}
+}
+
+func typeCheckArchitecturePackage(t *testing.T, packagePath string, sources []architectureSource) *architecturePackage {
+	t.Helper()
+	checked := checkArchitecturePackage(packagePath, sources, newArchitectureImporter(t), false)
+	if checked.pkg == nil || len(checked.files) != len(sources) || len(checked.errors) != 0 {
+		t.Fatalf("could not parse and type-check architecture package %s: %v", packagePath, checked.errors)
+	}
+	return checked
+}
+
+func typeCheckProductionPackages(t *testing.T) []*architecturePackage {
+	t.Helper()
+	loader := newArchitectureImporter(t)
+	grouped := make(map[string][]architectureSource)
+	for _, filename := range productionGoFiles(t) {
+		source, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		directory := filepath.Clean(filepath.Dir(filename))
+		grouped[directory] = append(grouped[directory], architectureSource{filename: filename, source: string(source)})
+	}
+	directories := make([]string, 0, len(grouped))
+	for directory := range grouped {
+		directories = append(directories, directory)
+	}
+	sort.Strings(directories)
+	packages := make([]*architecturePackage, 0, len(directories))
+	for _, directory := range directories {
+		absoluteDirectory, err := filepath.Abs(directory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relativeDirectory, err := filepath.Rel(loader.moduleRoot, absoluteDirectory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		packagePath := "noxy-vm"
+		if relativeDirectory != "." {
+			packagePath += "/" + filepath.ToSlash(relativeDirectory)
+		}
+		checked := checkArchitecturePackage(packagePath, grouped[directory], loader, false)
+		if checked.pkg == nil || len(checked.files) != len(grouped[directory]) || len(checked.errors) != 0 {
+			t.Fatalf("could not parse and type-check architecture package %s: %v", packagePath, checked.errors)
+		}
+		packages = append(packages, checked)
+	}
+	return packages
+}
+
+func architectureNamedType(typ types.Type) *types.TypeName {
+	if typ == nil {
+		return nil
+	}
+	for {
+		typ = types.Unalias(typ)
+		pointer, ok := typ.(*types.Pointer)
+		if !ok {
 			break
 		}
-		name = next
+		typ = pointer.Elem()
 	}
-	return name
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return nil
+	}
+	return named.Obj()
 }
 
-func (info *architectureTypeInfo) recordValueSpec(spec *ast.ValueSpec, variables map[string]string) {
-	declared := architectureDeclaredTypeName(spec.Type, info.aliases)
-	resolver := &architectureTypeResolver{info: info, variables: variables}
-	for index, name := range spec.Names {
-		actual := declared
-		if actual == "" && index < len(spec.Values) {
-			actual = resolver.expressionType(spec.Values[index])
-		}
-		if actual != "" {
-			variables[name.Name] = actual
-		}
-	}
-}
-
-func newArchitectureTypeResolver(info *architectureTypeInfo, function *ast.FuncDecl) *architectureTypeResolver {
-	variables := make(map[string]string, len(info.globals))
-	for name, target := range info.globals {
-		variables[name] = target
-	}
-	resolver := &architectureTypeResolver{info: info, variables: variables}
-	resolver.recordFieldList(function.Recv)
-	resolver.recordFieldList(function.Type.Params)
-	return resolver
-}
-
-func (resolver *architectureTypeResolver) clone() *architectureTypeResolver {
-	variables := make(map[string]string, len(resolver.variables))
-	for name, target := range resolver.variables {
-		variables[name] = target
-	}
-	return &architectureTypeResolver{info: resolver.info, variables: variables}
-}
-
-func (resolver *architectureTypeResolver) recordFieldList(fields *ast.FieldList) {
-	if fields == nil {
-		return
-	}
-	for _, field := range fields.List {
-		target := architectureDeclaredTypeName(field.Type, resolver.info.aliases)
-		for _, name := range field.Names {
-			resolver.variables[name.Name] = target
-		}
-	}
-}
-
-func (resolver *architectureTypeResolver) expressionType(expression ast.Expr) string {
-	switch typed := expression.(type) {
-	case *ast.Ident:
-		return resolver.variables[typed.Name]
-	case *ast.ParenExpr:
-		return resolver.expressionType(typed.X)
-	case *ast.UnaryExpr:
-		return resolver.expressionType(typed.X)
-	case *ast.CompositeLit:
-		return architectureDeclaredTypeName(typed.Type, resolver.info.aliases)
-	case *ast.SelectorExpr:
-		owner := resolver.expressionType(typed.X)
-		return resolver.info.fields[owner][typed.Sel.Name]
-	case *ast.IndexExpr:
-		return resolver.expressionType(typed.X)
-	case *ast.CallExpr:
-		if identifier, ok := typed.Fun.(*ast.Ident); ok {
-			if result := resolver.info.functions[identifier.Name]; result != "" {
-				return result
-			}
-			if identifier.Name == "new" && len(typed.Args) == 1 {
-				target := architectureDeclaredTypeName(typed.Args[0], resolver.info.aliases)
-				if resolver.info.known[target] {
-					return target
-				}
-			}
-		}
-		converted := architectureDeclaredTypeName(typed.Fun, resolver.info.aliases)
-		if resolver.info.known[converted] {
-			return converted
-		}
-	}
-	return ""
-}
-
-func (resolver *architectureTypeResolver) recordAssignment(assignment *ast.AssignStmt) {
-	if len(assignment.Lhs) != len(assignment.Rhs) {
-		return
-	}
-	for index, left := range assignment.Lhs {
-		identifier, ok := left.(*ast.Ident)
-		if !ok {
-			continue
-		}
-		if target := resolver.expressionType(assignment.Rhs[index]); target != "" {
-			resolver.variables[identifier.Name] = target
-		}
-	}
-}
-
-func (resolver *architectureTypeResolver) isField(expression ast.Expr, ownerType, fieldName string) bool {
+func (checked *architecturePackage) selectorIsField(expression ast.Expr, ownerType, fieldName string) bool {
 	for {
 		parenthesized, ok := expression.(*ast.ParenExpr)
 		if !ok {
@@ -473,14 +435,18 @@ func (resolver *architectureTypeResolver) isField(expression ast.Expr, ownerType
 		expression = parenthesized.X
 	}
 	selector, ok := expression.(*ast.SelectorExpr)
-	return ok && selector.Sel.Name == fieldName && resolver.expressionType(selector.X) == ownerType
+	if !ok || selector.Sel.Name != fieldName {
+		return false
+	}
+	selection := checked.info.Selections[selector]
+	owner := architectureNamedType(checked.info.TypeOf(selector.X))
+	return selection != nil && selection.Kind() == types.FieldVal && owner != nil && owner.Pkg() == checked.pkg && owner.Name() == ownerType
 }
 
-func (resolver *architectureTypeResolver) containsField(expression ast.Expr, ownerType, fieldName string) bool {
+func (checked *architecturePackage) expressionContainsField(expression ast.Expr, ownerType, fieldName string) bool {
 	found := false
 	ast.Inspect(expression, func(node ast.Node) bool {
-		selector, ok := node.(*ast.SelectorExpr)
-		if ok && resolver.isField(selector, ownerType, fieldName) {
+		if selector, ok := node.(*ast.SelectorExpr); ok && checked.selectorIsField(selector, ownerType, fieldName) {
 			found = true
 			return false
 		}
@@ -489,33 +455,28 @@ func (resolver *architectureTypeResolver) containsField(expression ast.Expr, own
 	return found
 }
 
-func (resolver *architectureTypeResolver) indexesField(expression ast.Expr, ownerType, fieldName string) bool {
+func (checked *architecturePackage) indexesField(expression ast.Expr, ownerType, fieldName string) bool {
 	index, ok := expression.(*ast.IndexExpr)
-	return ok && resolver.isField(index.X, ownerType, fieldName)
+	return ok && checked.selectorIsField(index.X, ownerType, fieldName)
 }
 
-func (resolver *architectureTypeResolver) isNilForType(expression ast.Expr, target string) bool {
+func (checked *architecturePackage) isNil(expression ast.Expr) bool {
+	if parenthesized, ok := expression.(*ast.ParenExpr); ok {
+		return checked.isNil(parenthesized.X)
+	}
 	if identifier, ok := expression.(*ast.Ident); ok {
-		return identifier.Name == "nil"
+		return checked.info.Uses[identifier] == types.Universe.Lookup("nil")
 	}
 	call, ok := expression.(*ast.CallExpr)
-	if !ok || len(call.Args) != 1 {
+	if !ok || len(call.Args) != 1 || !checked.info.Types[call.Fun].IsType() {
 		return false
 	}
-	identifier, ok := call.Args[0].(*ast.Ident)
-	return ok && identifier.Name == "nil" && architectureDeclaredTypeName(call.Fun, resolver.info.aliases) == target
+	return checked.isNil(call.Args[0])
 }
 
-func isZeroInteger(expression ast.Expr) bool {
-	if parenthesized, ok := expression.(*ast.ParenExpr); ok {
-		return isZeroInteger(parenthesized.X)
-	}
-	literal, ok := expression.(*ast.BasicLit)
-	if !ok || literal.Kind != token.INT {
-		return false
-	}
-	value, err := strconv.ParseInt(literal.Value, 0, 64)
-	return err == nil && value == 0
+func (checked *architecturePackage) isZero(expression ast.Expr) bool {
+	value := checked.info.Types[expression].Value
+	return value != nil && constant.Sign(value) == 0
 }
 
 func isEmptyCompositeLiteral(expression ast.Expr) bool {
@@ -523,33 +484,29 @@ func isEmptyCompositeLiteral(expression ast.Expr) bool {
 	return ok && len(literal.Elts) == 0
 }
 
-func isEmptyValueLiteral(expression ast.Expr) bool {
-	literal, ok := expression.(*ast.CompositeLit)
-	return ok && len(literal.Elts) == 0 && expressionTextForArchitecture(literal.Type) == "value.Value"
+func (checked *architecturePackage) isBuiltin(identifier *ast.Ident, name string) bool {
+	return identifier != nil && checked.info.Uses[identifier] == types.Universe.Lookup(name)
 }
 
-func expressionTextForArchitecture(expression ast.Expr) string {
-	var text strings.Builder
-	_ = printer.Fprint(&text, token.NewFileSet(), expression)
-	return text.String()
+func (checked *architecturePackage) assignmentObject(identifier *ast.Ident) types.Object {
+	if object := checked.info.Defs[identifier]; object != nil {
+		return object
+	}
+	return checked.info.Uses[identifier]
 }
 
-func forClearsStackFromStackBase(loop *ast.ForStmt, resolver *architectureTypeResolver) bool {
+func (checked *architecturePackage) forClearsStackFromStackBase(loop *ast.ForStmt) bool {
 	initialization, ok := loop.Init.(*ast.AssignStmt)
 	if !ok || len(initialization.Lhs) != len(initialization.Rhs) {
 		return false
 	}
-	loopIndexes := make(map[string]bool)
+	loopIndexes := make(map[types.Object]bool)
 	for index, left := range initialization.Lhs {
 		identifier, ok := left.(*ast.Ident)
-		if ok && resolver.containsField(initialization.Rhs[index], "CallFrame", "StackBase") {
-			loopIndexes[identifier.Name] = true
+		if ok && checked.expressionContainsField(initialization.Rhs[index], "CallFrame", "StackBase") {
+			loopIndexes[checked.assignmentObject(identifier)] = true
 		}
 	}
-	if len(loopIndexes) == 0 {
-		return false
-	}
-
 	clears := false
 	ast.Inspect(loop.Body, func(node ast.Node) bool {
 		assignment, ok := node.(*ast.AssignStmt)
@@ -558,11 +515,11 @@ func forClearsStackFromStackBase(loop *ast.ForStmt, resolver *architectureTypeRe
 		}
 		for index, left := range assignment.Lhs {
 			stackIndex, ok := left.(*ast.IndexExpr)
-			if !ok {
+			if !ok || !checked.selectorIsField(stackIndex.X, "VM", "stack") || !isEmptyCompositeLiteral(assignment.Rhs[index]) {
 				continue
 			}
-			identifier, indexOK := stackIndex.Index.(*ast.Ident)
-			if indexOK && resolver.isField(stackIndex.X, "VM", "stack") && loopIndexes[identifier.Name] && isEmptyValueLiteral(assignment.Rhs[index]) {
+			identifier, ok := stackIndex.Index.(*ast.Ident)
+			if ok && loopIndexes[checked.info.Uses[identifier]] {
 				clears = true
 				return false
 			}
@@ -572,62 +529,28 @@ func forClearsStackFromStackBase(loop *ast.ForStmt, resolver *architectureTypeRe
 	return clears
 }
 
-func architectureIntroducesScope(node ast.Node) bool {
-	switch node.(type) {
-	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt,
-		*ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt,
-		*ast.CaseClause, *ast.CommClause, *ast.FuncLit:
-		return true
+func (checked *architecturePackage) unwindTerminalMutationMatches(ignoredFiles ...string) []string {
+	ignored := make(map[string]bool, len(ignoredFiles))
+	for _, filename := range ignoredFiles {
+		ignored[filename] = true
 	}
-	return false
-}
-
-func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte) []string {
-	t.Helper()
-	fileSet := token.NewFileSet()
-	file, err := parser.ParseFile(fileSet, filename, source, 0)
-	if err != nil {
-		t.Fatalf("parse %s: %v", filename, err)
-	}
-
-	info := newArchitectureTypeInfo(file)
 	var matches []string
 	record := func(node ast.Node, description string) {
-		matches = append(matches, description+" at line "+fileSet.Position(node.Pos()).String())
+		matches = append(matches, description+" at line "+checked.fileSet.Position(node.Pos()).String())
 	}
-	for _, declaration := range file.Decls {
-		function, ok := declaration.(*ast.FuncDecl)
-		if !ok || function.Body == nil {
+	for _, file := range checked.files {
+		if ignored[filepath.Base(checked.fileSet.Position(file.Pos()).Filename)] {
 			continue
 		}
-		resolvers := []*architectureTypeResolver{newArchitectureTypeResolver(info, function)}
-		var nodes []ast.Node
-		ast.Inspect(function.Body, func(node ast.Node) bool {
-			if node == nil {
-				last := nodes[len(nodes)-1]
-				nodes = nodes[:len(nodes)-1]
-				if architectureIntroducesScope(last) {
-					resolvers = resolvers[:len(resolvers)-1]
-				}
-				return true
-			}
-			nodes = append(nodes, node)
-			if architectureIntroducesScope(node) {
-				nested := resolvers[len(resolvers)-1].clone()
-				if literal, ok := node.(*ast.FuncLit); ok {
-					nested.recordFieldList(literal.Type.Params)
-				}
-				resolvers = append(resolvers, nested)
-			}
-			resolver := resolvers[len(resolvers)-1]
+		ast.Inspect(file, func(node ast.Node) bool {
 			switch typed := node.(type) {
 			case *ast.IncDecStmt:
-				if typed.Tok == token.DEC && resolver.isField(typed.X, "VM", "frameCount") {
+				if typed.Tok == token.DEC && checked.selectorIsField(typed.X, "VM", "frameCount") {
 					record(typed, "decrements frameCount")
 				}
 			case *ast.AssignStmt:
 				for index, left := range typed.Lhs {
-					frameCount := resolver.isField(left, "VM", "frameCount")
+					frameCount := checked.selectorIsField(left, "VM", "frameCount")
 					if frameCount && typed.Tok == token.SUB_ASSIGN {
 						record(typed, "decrements frameCount")
 					}
@@ -637,52 +560,42 @@ func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte)
 					right := typed.Rhs[index]
 					if frameCount && typed.Tok == token.ASSIGN {
 						binary, subtraction := right.(*ast.BinaryExpr)
-						if subtraction && binary.Op == token.SUB && resolver.containsField(binary.X, "VM", "frameCount") {
+						if subtraction && binary.Op == token.SUB && checked.expressionContainsField(binary.X, "VM", "frameCount") {
 							record(typed, "decrements frameCount")
-						} else if isZeroInteger(right) {
+						} else if checked.isZero(right) {
 							record(typed, "resets frameCount")
 						}
 					}
-					if resolver.isField(left, "VM", "frames") && isEmptyCompositeLiteral(right) {
+					if checked.selectorIsField(left, "VM", "frames") && isEmptyCompositeLiteral(right) {
 						record(typed, "resets frames")
 					}
-					if resolver.indexesField(left, "VM", "frames") && resolver.isNilForType(right, "CallFrame") {
+					if checked.indexesField(left, "VM", "frames") && checked.isNil(right) {
 						record(typed, "removes a frame")
 					}
-					if resolver.isField(left, "VM", "currentFrame") && resolver.isNilForType(right, "CallFrame") {
+					if checked.selectorIsField(left, "VM", "currentFrame") && checked.isNil(right) {
 						record(typed, "clears currentFrame")
 					}
-					if resolver.isField(left, "VM", "stackTop") && resolver.containsField(right, "CallFrame", "StackBase") {
+					if checked.selectorIsField(left, "VM", "stackTop") && checked.expressionContainsField(right, "CallFrame", "StackBase") {
 						record(typed, "resets stackTop to StackBase")
-					}
-				}
-				resolver.recordAssignment(typed)
-			case *ast.DeclStmt:
-				general, ok := typed.Decl.(*ast.GenDecl)
-				if ok && general.Tok == token.VAR {
-					for _, specification := range general.Specs {
-						if valueSpec, ok := specification.(*ast.ValueSpec); ok {
-							info.recordValueSpec(valueSpec, resolver.variables)
-						}
 					}
 				}
 			case *ast.CallExpr:
 				identifier, ok := typed.Fun.(*ast.Ident)
-				if !ok || identifier.Name != "clear" || len(typed.Args) != 1 {
+				if !ok || !checked.isBuiltin(identifier, "clear") || len(typed.Args) != 1 {
 					break
 				}
 				slice, ok := typed.Args[0].(*ast.SliceExpr)
 				if !ok {
 					break
 				}
-				if resolver.isField(slice.X, "VM", "frames") {
+				if checked.selectorIsField(slice.X, "VM", "frames") {
 					record(typed, "clears frames")
 				}
-				if resolver.isField(slice.X, "VM", "stack") && slice.Low != nil && resolver.containsField(slice.Low, "CallFrame", "StackBase") {
+				if checked.selectorIsField(slice.X, "VM", "stack") && slice.Low != nil && checked.expressionContainsField(slice.Low, "CallFrame", "StackBase") {
 					record(typed, "clears stack from StackBase")
 				}
 			case *ast.ForStmt:
-				if forClearsStackFromStackBase(typed, resolver) {
+				if checked.forClearsStackFromStackBase(typed) {
 					record(typed, "clears stack from StackBase")
 				}
 			}
@@ -692,216 +605,112 @@ func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte)
 	return matches
 }
 
-func runtimeTargetTypeName(expression ast.Expr, aliases map[string]string) string {
-	var name string
-	switch typed := expression.(type) {
-	case *ast.Ident:
-		name = typed.Name
-	case *ast.SelectorExpr:
-		name = typed.Sel.Name
-	case *ast.StarExpr:
-		return runtimeTargetTypeName(typed.X, aliases)
-	case *ast.ParenExpr:
-		return runtimeTargetTypeName(typed.X, aliases)
-	}
-	for name != "" {
-		if name == "ObjMap" || name == "ObjNative" {
-			return name
-		}
-		next, ok := aliases[name]
-		if !ok || next == name {
-			break
-		}
-		name = next
-	}
-	return ""
-}
-
-func runtimeValueTargetType(expression ast.Expr, variables, aliases map[string]string) string {
-	switch typed := expression.(type) {
-	case *ast.Ident:
-		return variables[typed.Name]
-	case *ast.ParenExpr:
-		return runtimeValueTargetType(typed.X, variables, aliases)
-	case *ast.UnaryExpr:
-		return runtimeValueTargetType(typed.X, variables, aliases)
-	case *ast.TypeAssertExpr:
-		return runtimeTargetTypeName(typed.Type, aliases)
-	case *ast.CallExpr:
-		return runtimeTargetTypeName(typed.Fun, aliases)
-	}
-	return ""
-}
-
-func recordRuntimeVariableField(field *ast.Field, variables, aliases map[string]string) {
-	target := runtimeTargetTypeName(field.Type, aliases)
-	if target == "" {
-		return
-	}
-	for _, name := range field.Names {
-		variables[name.Name] = target
-	}
-}
-
-func recordRuntimeVariableSpec(specification *ast.ValueSpec, variables, aliases map[string]string) {
-	target := runtimeTargetTypeName(specification.Type, aliases)
-	for index, name := range specification.Names {
-		actual := target
-		if actual == "" && index < len(specification.Values) {
-			actual = runtimeValueTargetType(specification.Values[index], variables, aliases)
-		}
-		if actual != "" {
-			variables[name.Name] = actual
-		}
-	}
-}
-
-func recordRuntimeAssignment(assignment *ast.AssignStmt, variables, aliases map[string]string) {
-	if len(assignment.Lhs) != len(assignment.Rhs) {
-		return
-	}
-	for index, left := range assignment.Lhs {
-		name, ok := left.(*ast.Ident)
-		if !ok {
-			continue
-		}
-		if target := runtimeValueTargetType(assignment.Rhs[index], variables, aliases); target != "" {
-			variables[name.Name] = target
-		}
-	}
-}
-
-func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte) []string {
+func unwindTerminalMutationMatches(t *testing.T, filename string, source []byte) []string {
 	t.Helper()
-	file, err := parser.ParseFile(token.NewFileSet(), filename, source, 0)
-	if err != nil {
-		t.Fatalf("parse %s: %v", filename, err)
+	return unwindTerminalPackageMutationMatches(t, []architectureSource{{filename: filename, source: string(source)}})
+}
+
+func unwindTerminalPackageMutationMatches(t *testing.T, sources []architectureSource) []string {
+	t.Helper()
+	return typeCheckArchitecturePackage(t, "architecture/unwind", sources).unwindTerminalMutationMatches()
+}
+
+func runtimeNamedType(typ types.Type, checked *architecturePackage, name string) bool {
+	object := architectureNamedType(typ)
+	if object == nil || object.Name() != name {
+		return false
 	}
+	return object.Pkg() == checked.pkg || object.Pkg() != nil && object.Pkg().Path() == "noxy-vm/internal/value"
+}
+
+func (checked *architecturePackage) runtimeSelectorIsField(selector *ast.SelectorExpr, ownerType, fieldName string) bool {
+	selection := checked.info.Selections[selector]
+	return selector.Sel.Name == fieldName && selection != nil && selection.Kind() == types.FieldVal && runtimeNamedType(checked.info.TypeOf(selector.X), checked, ownerType)
+}
+
+func isMapType(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	_, ok := types.Unalias(typ).Underlying().(*types.Map)
+	return ok
+}
+
+func isMapPointerType(typ types.Type) bool {
+	pointer, ok := types.Unalias(typ).(*types.Pointer)
+	return ok && isMapType(pointer.Elem())
+}
+
+func (checked *architecturePackage) runtimeForbiddenMatches() []string {
 	found := make(map[string]bool)
-	aliases := make(map[string]string)
-	for _, declaration := range file.Decls {
-		general, ok := declaration.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, specification := range general.Specs {
-			typeSpec, ok := specification.(*ast.TypeSpec)
-			if !ok {
+	for _, file := range checked.files {
+		for _, declaration := range file.Decls {
+			if general, ok := declaration.(*ast.GenDecl); ok {
+				for _, specification := range general.Specs {
+					typeSpec, ok := specification.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					structure, ok := typeSpec.Type.(*ast.StructType)
+					if !ok {
+						continue
+					}
+					for _, field := range structure.Fields.List {
+						fieldType := checked.info.TypeOf(field.Type)
+						for _, name := range field.Names {
+							switch {
+							case typeSpec.Name.Name == "VM" && name.Name == "openFiles":
+								found["VM.openFiles field"] = true
+							case typeSpec.Name.Name == "VM" && name.Name == "netBufferedData":
+								found["VM.netBufferedData field"] = true
+							case typeSpec.Name.Name == "VM" && name.Name == "netBufferedConns":
+								found["VM.netBufferedConns field"] = true
+							case name.Name == "Globals" && isMapType(fieldType):
+								found["Globals raw map field"] = true
+							case name.Name == "GlobalOwner" && isMapPointerType(fieldType):
+								found["GlobalOwner raw map pointer field"] = true
+							case name.Name == "DbHandles" && isMapType(fieldType):
+								found["DbHandles raw map field"] = true
+							case name.Name == "StmtHandles" && isMapType(fieldType):
+								found["StmtHandles raw map field"] = true
+							case name.Name == "StmtParams" && isMapType(fieldType):
+								found["StmtParams raw map field"] = true
+							}
+						}
+					}
+				}
+			}
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
 				continue
 			}
-			if target := runtimeTargetTypeName(typeSpec.Type, aliases); target != "" {
-				aliases[typeSpec.Name.Name] = target
-			}
-		}
-	}
-	globalVariables := make(map[string]string)
-	for _, declaration := range file.Decls {
-		general, ok := declaration.(*ast.GenDecl)
-		if !ok || general.Tok != token.VAR {
-			continue
-		}
-		for _, specification := range general.Specs {
-			if valueSpec, ok := specification.(*ast.ValueSpec); ok {
-				recordRuntimeVariableSpec(valueSpec, globalVariables, aliases)
-			}
-		}
-	}
-	for _, declaration := range file.Decls {
-		if general, ok := declaration.(*ast.GenDecl); ok {
-			for _, specification := range general.Specs {
-				typeSpec, ok := specification.(*ast.TypeSpec)
-				if !ok {
-					continue
+			var legacyDispatchReceiver types.Object
+			if function.Name.Name == "Invoke" && function.Recv != nil && len(function.Recv.List) == 1 {
+				receiver := function.Recv.List[0]
+				if len(receiver.Names) == 1 && runtimeNamedType(checked.info.TypeOf(receiver.Type), checked, "ObjNative") {
+					legacyDispatchReceiver = checked.info.Defs[receiver.Names[0]]
 				}
-				structure, ok := typeSpec.Type.(*ast.StructType)
-				if !ok {
-					continue
-				}
-				for _, field := range structure.Fields.List {
-					_, rawMap := field.Type.(*ast.MapType)
-					pointer, pointerType := field.Type.(*ast.StarExpr)
-					rawMapPointer := false
-					if pointerType {
-						_, rawMapPointer = pointer.X.(*ast.MapType)
+			}
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				switch typed := node.(type) {
+				case *ast.SelectorExpr:
+					if checked.runtimeSelectorIsField(typed, "ObjMap", "Data") {
+						found["ObjMap.Data selector"] = true
 					}
-					for _, name := range field.Names {
-						switch {
-						case typeSpec.Name.Name == "VM" && name.Name == "openFiles":
-							found["VM.openFiles field"] = true
-						case typeSpec.Name.Name == "VM" && name.Name == "netBufferedData":
-							found["VM.netBufferedData field"] = true
-						case typeSpec.Name.Name == "VM" && name.Name == "netBufferedConns":
-							found["VM.netBufferedConns field"] = true
-						case name.Name == "Globals" && rawMap:
-							found["Globals raw map field"] = true
-						case name.Name == "GlobalOwner" && pointerType && rawMapPointer:
-							found["GlobalOwner raw map pointer field"] = true
-						case name.Name == "DbHandles" && rawMap:
-							found["DbHandles raw map field"] = true
-						case name.Name == "StmtHandles" && rawMap:
-							found["StmtHandles raw map field"] = true
-						case name.Name == "StmtParams" && rawMap:
-							found["StmtParams raw map field"] = true
-						}
+				case *ast.CallExpr:
+					selector, ok := typed.Fun.(*ast.SelectorExpr)
+					if !ok || !checked.runtimeSelectorIsField(selector, "ObjNative", "Fn") {
+						break
+					}
+					receiver, identifier := selector.X.(*ast.Ident)
+					allowed := identifier && checked.info.Uses[receiver] == legacyDispatchReceiver
+					if !allowed {
+						found["direct native.Fn invocation"] = true
 					}
 				}
-			}
+				return true
+			})
 		}
-		function, ok := declaration.(*ast.FuncDecl)
-		if !ok || function.Body == nil {
-			continue
-		}
-		legacyDispatchReceiver := ""
-		if function.Name.Name == "Invoke" && function.Recv != nil && len(function.Recv.List) == 1 {
-			receiver := function.Recv.List[0]
-			if len(receiver.Names) == 1 && expressionText(t, receiver.Type) == "*ObjNative" {
-				legacyDispatchReceiver = receiver.Names[0].Name
-			}
-		}
-		variables := make(map[string]string, len(globalVariables))
-		for name, target := range globalVariables {
-			variables[name] = target
-		}
-		if function.Recv != nil {
-			for _, field := range function.Recv.List {
-				recordRuntimeVariableField(field, variables, aliases)
-			}
-		}
-		if function.Type.Params != nil {
-			for _, field := range function.Type.Params.List {
-				recordRuntimeVariableField(field, variables, aliases)
-			}
-		}
-		ast.Inspect(function.Body, func(node ast.Node) bool {
-			switch typed := node.(type) {
-			case *ast.AssignStmt:
-				recordRuntimeAssignment(typed, variables, aliases)
-			case *ast.DeclStmt:
-				general, ok := typed.Decl.(*ast.GenDecl)
-				if ok && general.Tok == token.VAR {
-					for _, specification := range general.Specs {
-						if valueSpec, ok := specification.(*ast.ValueSpec); ok {
-							recordRuntimeVariableSpec(valueSpec, variables, aliases)
-						}
-					}
-				}
-			case *ast.SelectorExpr:
-				if typed.Sel.Name == "Data" && runtimeValueTargetType(typed.X, variables, aliases) == "ObjMap" {
-					found["ObjMap.Data selector"] = true
-				}
-			case *ast.CallExpr:
-				selector, ok := typed.Fun.(*ast.SelectorExpr)
-				allowedLegacyDispatch := false
-				if ok && legacyDispatchReceiver != "" {
-					receiver, isIdentifier := selector.X.(*ast.Ident)
-					allowedLegacyDispatch = isIdentifier && receiver.Name == legacyDispatchReceiver
-				}
-				if ok && selector.Sel.Name == "Fn" && !allowedLegacyDispatch && runtimeValueTargetType(selector.X, variables, aliases) == "ObjNative" {
-					found["direct native.Fn invocation"] = true
-				}
-			}
-			return true
-		})
 	}
 	order := []string{
 		"ObjMap.Data selector",
@@ -924,14 +733,15 @@ func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte)
 	return matches
 }
 
+func runtimeForbiddenSourceMatches(t *testing.T, filename string, source []byte) []string {
+	t.Helper()
+	return typeCheckArchitecturePackage(t, "architecture/runtime", []architectureSource{{filename: filename, source: string(source)}}).runtimeForbiddenMatches()
+}
+
 func TestRuntimeFoundationExcludesObsoleteProductionStructures(t *testing.T) {
-	for _, filename := range productionGoFiles(t) {
-		source, err := os.ReadFile(filename)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, issue := range runtimeForbiddenSourceMatches(t, filename, source) {
-			t.Errorf("%s: %s", filename, issue)
+	for _, checked := range typeCheckProductionPackages(t) {
+		for _, issue := range checked.runtimeForbiddenMatches() {
+			t.Errorf("%s: %s", checked.pkg.Path(), issue)
 		}
 	}
 }
@@ -1049,21 +859,13 @@ func TestUnwindArchitectureCentralizesTerminalFrameTeardown(t *testing.T) {
 		}
 	}
 
-	files, err := filepath.Glob("*.go")
+	sources, err := readArchitectureSources(".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, filename := range files {
-		if filename == "unwind.go" || strings.HasSuffix(filename, "_test.go") {
-			continue
-		}
-		source, err := os.ReadFile(filename)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, match := range unwindTerminalMutationMatches(t, filename, source) {
-			t.Errorf("terminal frame teardown must remain in unwind.go: %s", match)
-		}
+	checked := typeCheckArchitecturePackage(t, "noxy-vm/internal/vm", sources)
+	for _, match := range checked.unwindTerminalMutationMatches("unwind.go") {
+		t.Errorf("terminal frame teardown must remain in unwind.go: %s", match)
 	}
 }
 
@@ -1138,12 +940,27 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 			want: []string{"removes a frame", "clears currentFrame"},
 		},
 		{
+			name: "shadowed nil identifier is allowed",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { currentFrame *CallFrame }
+				func install(vm *VM, nil *CallFrame) { vm.currentFrame = nil }`,
+		},
+		{
 			name: "clear frame array",
 			source: `package vm
 				type CallFrame struct{}
 				type VM struct { frames [4]*CallFrame }
 				func teardown(vm *VM) { clear(vm.frames[:]) }`,
 			want: []string{"clears frames"},
+		},
+		{
+			name: "declared clear function shadows builtin",
+			source: `package vm
+				type CallFrame struct{}
+				type VM struct { frames [4]*CallFrame }
+				func clear(frames []*CallFrame) {}
+				func reset(vm *VM) { clear(vm.frames[:]) }`,
 		},
 		{
 			name: "stack clearing loop",
@@ -1215,7 +1032,7 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 				type VM struct { frameCount int }
 				type Mirror VM
 				func new(value VM) *Mirror { return nil }
-				func reset() { vm := new(VM); vm.frameCount = 0 }`,
+				func reset() { vm := new(VM{}); vm.frameCount = 0 }`,
 		},
 		{
 			name: "shadowed receiver types stay in lexical scope",
@@ -1251,6 +1068,80 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			matches := unwindTerminalMutationMatches(t, "architecture.go", []byte(test.source))
+			got := make([]string, len(matches))
+			for index, match := range matches {
+				got[index] = strings.SplitN(match, " at line ", 2)[0]
+			}
+			if strings.Join(got, "|") != strings.Join(test.want, "|") {
+				t.Fatalf("matches=%v want=%v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUnwindArchitectureMatcherResolvesCrossFileFunctionResults(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []architectureSource
+		want    []string
+	}{
+		{
+			name: "function result",
+			sources: []architectureSource{
+				{
+					filename: "runtime_types.go",
+					source: `package vm
+						type VM struct { frameCount int }
+						func currentVM() *VM { return nil }`,
+				},
+				{
+					filename: "teardown.go",
+					source: `package vm
+						func teardown() { currentVM().frameCount-- }`,
+				},
+			},
+			want: []string{"decrements frameCount"},
+		},
+		{
+			name: "aliased function result",
+			sources: []architectureSource{
+				{
+					filename: "runtime_types.go",
+					source: `package vm
+						type VM struct { frameCount int }
+						type ActiveVM = VM
+						func currentVM() *ActiveVM { return nil }`,
+				},
+				{
+					filename: "teardown.go",
+					source: `package vm
+						func teardown() { currentVM().frameCount-- }`,
+				},
+			},
+			want: []string{"decrements frameCount"},
+		},
+		{
+			name: "method result",
+			sources: []architectureSource{
+				{
+					filename: "runtime_types.go",
+					source: `package vm
+						type VM struct { frameCount int }
+						type runtimeState struct { active *VM }
+						func (state *runtimeState) currentVM() *VM { return state.active }`,
+				},
+				{
+					filename: "teardown.go",
+					source: `package vm
+						func teardown(state *runtimeState) { state.currentVM().frameCount-- }`,
+				},
+			},
+			want: []string{"decrements frameCount"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matches := unwindTerminalPackageMutationMatches(t, test.sources)
 			got := make([]string, len(matches))
 			for index, match := range matches {
 				got[index] = strings.SplitN(match, " at line ", 2)[0]
@@ -1309,7 +1200,7 @@ func TestRuntimeForbiddenSourceMatchesExactSyntax(t *testing.T) {
 			source: `package vm
 				var assertion = "openFiles netBufferedData DbHandles native.Fn(args) .Data"
 				// Globals map[string]int; GlobalOwner *map[string]int
-				type holder struct { Data int }
+				type holder struct { Data int; Dataset int }
 				type callable struct { Fn func([]int) int }
 				type SharedState struct { Databases int }
 				func use(item *holder, function *callable, args []int) {

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -431,14 +431,14 @@ func (resolver *architectureTypeResolver) expressionType(expression ast.Expr) st
 		return resolver.expressionType(typed.X)
 	case *ast.CallExpr:
 		if identifier, ok := typed.Fun.(*ast.Ident); ok {
+			if result := resolver.info.functions[identifier.Name]; result != "" {
+				return result
+			}
 			if identifier.Name == "new" && len(typed.Args) == 1 {
 				target := architectureDeclaredTypeName(typed.Args[0], resolver.info.aliases)
 				if resolver.info.known[target] {
 					return target
 				}
-			}
-			if result := resolver.info.functions[identifier.Name]; result != "" {
-				return result
 			}
 		}
 		converted := architectureDeclaredTypeName(typed.Fun, resolver.info.aliases)
@@ -1208,6 +1208,14 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 				type VM struct { frameCount int }
 				func reset() { vm := new(VM); vm.frameCount = 0 }`,
 			want: []string{"resets frameCount"},
+		},
+		{
+			name: "declared new function shadows builtin",
+			source: `package vm
+				type VM struct { frameCount int }
+				type Mirror VM
+				func new(value VM) *Mirror { return nil }
+				func reset() { vm := new(VM); vm.frameCount = 0 }`,
 		},
 		{
 			name: "shadowed receiver types stay in lexical scope",

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -297,7 +297,7 @@ func newArchitectureTypeInfo(file *ast.File) *architectureTypeInfo {
 				continue
 			}
 			info.known[typeSpec.Name.Name] = true
-			if _, structure := typeSpec.Type.(*ast.StructType); !structure {
+			if typeSpec.Assign.IsValid() {
 				if target := architectureDeclaredTypeName(typeSpec.Type, nil); target != "" {
 					info.aliases[typeSpec.Name.Name] = target
 				}
@@ -431,6 +431,12 @@ func (resolver *architectureTypeResolver) expressionType(expression ast.Expr) st
 		return resolver.expressionType(typed.X)
 	case *ast.CallExpr:
 		if identifier, ok := typed.Fun.(*ast.Ident); ok {
+			if identifier.Name == "new" && len(typed.Args) == 1 {
+				target := architectureDeclaredTypeName(typed.Args[0], resolver.info.aliases)
+				if resolver.info.known[target] {
+					return target
+				}
+			}
 			if result := resolver.info.functions[identifier.Name]; result != "" {
 				return result
 			}
@@ -1188,6 +1194,20 @@ func TestUnwindArchitectureMatcherUsesExactSyntax(t *testing.T) {
 					cache.stackTop = window.StackBase
 					clear(cache.frames[:])
 				}`,
+		},
+		{
+			name: "defined type based on VM is not VM",
+			source: `package vm
+				type VM struct { frameCount int }
+				type Mirror VM
+				func reset(mirror *Mirror) { mirror.frameCount = 0 }`,
+		},
+		{
+			name: "new VM receiver reset is detected",
+			source: `package vm
+				type VM struct { frameCount int }
+				func reset() { vm := new(VM); vm.frameCount = 0 }`,
+			want: []string{"resets frameCount"},
 		},
 		{
 			name: "shadowed receiver types stay in lexical scope",

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -60,7 +60,8 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		frame := &CallFrame{
 			Closure:     closure,
 			IP:          0,
-			Slots:       0,
+			StackBase:   0,
+			LocalBase:   0,
 			Environment: closure.Environment,
 		}
 

--- a/internal/vm/builtins_concurrency_test.go
+++ b/internal/vm/builtins_concurrency_test.go
@@ -147,3 +147,45 @@ test_report(chan_recv(channel))
 	}
 	assertBuiltinValue(t, captured, value.NewString("child"))
 }
+
+func TestSpawnRunsDeferredCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "normal return"},
+		{name: "runtime error", body: `
+    let zero: int = 0
+    print(1 / zero)`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machine := New()
+			completed := make(chan int64, 1)
+			machine.DefineNative("spawned_record", func(args []value.Value) value.Value {
+				completed <- args[0].AsInt
+				return value.NewNull()
+			})
+
+			code := compileVMSource(t, `
+func worker() -> void
+    defer spawned_record(1)`+test.body+`
+end
+spawn(worker)
+`)
+			if err := machine.Interpret(code); err != nil {
+				t.Fatalf("parent error: %v", err)
+			}
+
+			select {
+			case got := <-completed:
+				if got != 1 {
+					t.Fatalf("cleanup=%d, want 1", got)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("spawned defer did not execute")
+			}
+		})
+	}
+}

--- a/internal/vm/builtins_io_test.go
+++ b/internal/vm/builtins_io_test.go
@@ -1,8 +1,10 @@
 package vm
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -37,6 +39,84 @@ func cleanupFileResources(t *testing.T, machine *VM) {
 			}
 		}
 	})
+}
+
+func recordDeferredFileResource(machine *VM, captured **FileResource) {
+	machine.DefineNative("record_file_resource", func(args []value.Value) value.Value {
+		if len(args) != 1 {
+			return value.NewNull()
+		}
+		instance, ok := args[0].Obj.(*value.ObjInstance)
+		if !ok {
+			return value.NewNull()
+		}
+		*captured, _ = machine.shared.Files.get(fileHandle(machine.shared, instance))
+		return value.NewNull()
+	})
+}
+
+func requireDeferredFileClosed(t *testing.T, machine *VM, resource *FileResource, path string) {
+	t.Helper()
+	if got := len(machine.shared.Files.snapshot()); got != 0 {
+		t.Fatalf("files=%d, want 0", got)
+	}
+	if resource == nil {
+		t.Fatal("file resource was not recorded")
+	}
+	resource.stateMu.Lock()
+	closed := resource.closed
+	resource.stateMu.Unlock()
+	if !closed {
+		t.Fatal("file resource remains open")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove deferred file: %v", err)
+	}
+}
+
+func TestDeferredFileCleanupClosesResourceOnEveryExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		suffix    string
+		wantError bool
+	}{
+		{"normal", "", false},
+		{"runtime error", "\nlet zero: int = 0\nprint(1 / zero)", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machine := New()
+			cleanupFileResources(t, machine)
+			path := filepath.Join(t.TempDir(), "deferred.txt")
+			var resource *FileResource
+			recordDeferredFileResource(machine, &resource)
+
+			source := "use io\nlet file: io.File = io.open(" + strconv.Quote(path) + ", \"w\")\n" +
+				"record_file_resource(file)\ndefer io.close(file)" + test.suffix
+			err := interpretVMSource(t, machine, source)
+			if (err != nil) != test.wantError {
+				t.Fatalf("error=%v, wantError=%v", err, test.wantError)
+			}
+			requireDeferredFileClosed(t, machine, resource, path)
+		})
+	}
+}
+
+func TestDeferredFileResourceCleanupContinuesAfterFailure(t *testing.T) {
+	machine := New()
+	cleanupFileResources(t, machine)
+	path := filepath.Join(t.TempDir(), "deferred-failure.txt")
+	var resource *FileResource
+	recordDeferredFileResource(machine, &resource)
+	sentinel := errors.New("sentinel cleanup failure")
+	defineCleanupFailureNative(machine, sentinel)
+
+	err := interpretVMSource(t, machine, "use io\nlet file: io.File = io.open("+strconv.Quote(path)+", \"w\")\n"+
+		"record_file_resource(file)\ndefer io.close(file)\ndefer cleanup_fail()")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v, want sentinel cleanup failure", err)
+	}
+	requireDeferredFileClosed(t, machine, resource, path)
 }
 
 func TestFileHandleIsUsableAcrossSharedVMs(t *testing.T) {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -86,6 +86,32 @@ func requireDeferredListenerClosed(t *testing.T, machine *VM, resource *Listener
 	}
 }
 
+func requireSocketResource(t *testing.T, machine *VM, socket value.Value) (int, *SocketResource) {
+	t.Helper()
+	handle := int(builtinMapField(t, socket, "fd").AsInt)
+	resource, exists := machine.shared.Sockets.get(handle)
+	if !exists {
+		t.Fatalf("socket descriptor %d is not registered", handle)
+	}
+	return handle, resource
+}
+
+func requireDeferredSocketsClosed(t *testing.T, machine *VM, resources map[int]*SocketResource) {
+	t.Helper()
+	registered := machine.shared.Sockets.snapshot()
+	for handle, resource := range resources {
+		if _, exists := registered[handle]; exists {
+			t.Errorf("socket descriptor %d remains registered", handle)
+		}
+		resource.stateMu.Lock()
+		closed := resource.closed
+		resource.stateMu.Unlock()
+		if !closed {
+			t.Errorf("socket descriptor %d remains open", handle)
+		}
+	}
+}
+
 func cleanupNetworkResources(t *testing.T, machine *VM) {
 	t.Helper()
 	t.Cleanup(func() {
@@ -147,6 +173,57 @@ defer cleanup_fail()`
 		t.Fatalf("error=%v, want sentinel cleanup failure", err)
 	}
 	requireDeferredListenerClosed(t, machine, resource)
+}
+
+func TestDeferredConnectedSocketCleanupClosesEverySocketOnEveryExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		suffix    string
+		sentinel  error
+		wantError bool
+	}{
+		{name: "normal"},
+		{name: "runtime error", suffix: "\nlet zero: int = 0\nprint(1 / zero)", wantError: true},
+		{name: "newer cleanup failure", suffix: "\ndefer cleanup_fail()", sentinel: errors.New("sentinel cleanup failure"), wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machine := New()
+			cleanupNetworkResources(t, machine)
+			listener, client, accepted := setupAcceptedLoopback(t, machine)
+			clientHandle, clientResource := requireSocketResource(t, machine, client)
+			acceptedHandle, acceptedResource := requireSocketResource(t, machine, accepted)
+
+			callBuiltinWithinBound(t, machine, "net_close", listener)
+			if got := len(machine.shared.Listeners.snapshot()); got != 0 {
+				t.Fatalf("listeners after explicit close=%d, want 0", got)
+			}
+
+			machine.DefineNative("deferred_client_socket", func([]value.Value) value.Value { return client })
+			machine.DefineNative("deferred_accepted_socket", func([]value.Value) value.Value { return accepted })
+			if test.sentinel != nil {
+				defineCleanupFailureNative(machine, test.sentinel)
+			}
+			source := `use net
+let client: net.Socket = deferred_client_socket()
+let accepted: net.Socket = deferred_accepted_socket()
+defer net.socket_close(client)
+defer net.socket_close(accepted)` + test.suffix
+
+			err := interpretVMSourceWithinBound(t, machine, source)
+			if test.sentinel != nil {
+				if !errors.Is(err, test.sentinel) {
+					t.Fatalf("error=%v, want sentinel cleanup failure", err)
+				}
+			} else if (err != nil) != test.wantError {
+				t.Fatalf("error=%v, wantError=%v", err, test.wantError)
+			}
+			requireDeferredSocketsClosed(t, machine, map[int]*SocketResource{
+				clientHandle:   clientResource,
+				acceptedHandle: acceptedResource,
+			})
+		})
+	}
 }
 
 func builtinMapField(t *testing.T, object value.Value, field string) value.Value {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -30,6 +31,122 @@ func callBuiltinWithinBound(t *testing.T, machine *VM, name string, args ...valu
 		t.Fatalf("%s did not complete within %s", name, statefulBuiltinTimeout)
 		return value.NewNull()
 	}
+}
+
+func interpretVMSourceWithinBound(t *testing.T, machine *VM, source string) error {
+	t.Helper()
+	code := compileVMSource(t, source)
+	result := make(chan error, 1)
+	go func() {
+		result <- machine.Interpret(code)
+	}()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatalf("network program did not complete within %s", statefulBuiltinTimeout)
+		return nil
+	}
+}
+
+func recordDeferredListenerResource(machine *VM, captured **ListenerResource) {
+	machine.DefineNative("record_listener_resource", func(args []value.Value) value.Value {
+		if len(args) != 1 {
+			return value.NewNull()
+		}
+		socket, ok := args[0].Obj.(*value.ObjMap)
+		if !ok {
+			return value.NewNull()
+		}
+		handle, ok := socket.Get("fd")
+		if !ok {
+			return value.NewNull()
+		}
+		*captured, _ = machine.shared.Listeners.get(int(handle.AsInt))
+		return value.NewNull()
+	})
+}
+
+func requireDeferredListenerClosed(t *testing.T, machine *VM, resource *ListenerResource) {
+	t.Helper()
+	if got := len(machine.shared.Listeners.snapshot()); got != 0 {
+		t.Fatalf("listeners=%d, want 0", got)
+	}
+	if got := len(machine.shared.Sockets.snapshot()); got != 0 {
+		t.Fatalf("sockets=%d, want 0", got)
+	}
+	if resource == nil {
+		t.Fatal("listener resource was not recorded")
+	}
+	resource.stateMu.Lock()
+	closed := resource.closed
+	resource.stateMu.Unlock()
+	if !closed {
+		t.Fatal("listener resource remains open")
+	}
+}
+
+func cleanupNetworkResources(t *testing.T, machine *VM) {
+	t.Helper()
+	t.Cleanup(func() {
+		for handle, listener := range machine.shared.Listeners.snapshot() {
+			machine.shared.Listeners.remove(handle)
+			closeListener(listener)
+		}
+		for handle, socket := range machine.shared.Sockets.snapshot() {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(socket)
+		}
+	})
+}
+
+func TestDeferredSocketCleanupClosesListenerOnEveryExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		suffix    string
+		wantError bool
+	}{
+		{"normal", "", false},
+		{"runtime error", "\nlet zero: int = 0\nprint(1 / zero)", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machine := New()
+			cleanupNetworkResources(t, machine)
+			var resource *ListenerResource
+			recordDeferredListenerResource(machine, &resource)
+			source := `use net
+let listener: net.Socket = net.listen("127.0.0.1", 0)
+record_listener_resource(listener)
+defer net.socket_close(listener)` + test.suffix
+
+			err := interpretVMSourceWithinBound(t, machine, source)
+			if (err != nil) != test.wantError {
+				t.Fatalf("error=%v, wantError=%v", err, test.wantError)
+			}
+			requireDeferredListenerClosed(t, machine, resource)
+		})
+	}
+}
+
+func TestDeferredSocketResourceCleanupContinuesAfterFailure(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	var resource *ListenerResource
+	recordDeferredListenerResource(machine, &resource)
+	sentinel := errors.New("sentinel cleanup failure")
+	defineCleanupFailureNative(machine, sentinel)
+	source := `use net
+let listener: net.Socket = net.listen("127.0.0.1", 0)
+record_listener_resource(listener)
+defer net.socket_close(listener)
+defer cleanup_fail()`
+
+	err := interpretVMSourceWithinBound(t, machine, source)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v, want sentinel cleanup failure", err)
+	}
+	requireDeferredListenerClosed(t, machine, resource)
 }
 
 func builtinMapField(t *testing.T, object value.Value, field string) value.Value {

--- a/internal/vm/builtins_sqlite_test.go
+++ b/internal/vm/builtins_sqlite_test.go
@@ -169,16 +169,28 @@ func TestDeferredSQLiteResourceCleanupContinuesAfterFailure(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "deferred-failure.sqlite")
 	var database *DatabaseResource
 	var statement *StatementResource
+	var observations []sqliteResourceObservation
 	recordDeferredSQLiteResources(machine, &database, &statement)
+	machine.DefineContextualNative("assert_statement_finalized", func(value.NativeContext, []value.Value) (value.Value, error) {
+		observations = append(observations, sqliteResourceObservation{
+			statements: len(machine.shared.Statements.snapshot()),
+			databases:  len(machine.shared.Databases.snapshot()),
+		})
+		return value.NewNull(), nil
+	})
 	sentinel := errors.New("sentinel cleanup failure")
 	defineCleanupFailureNative(machine, sentinel)
 	source := "use sqlite\nlet db: sqlite.Database = sqlite.open(" + strconv.Quote(path) + ")\n" +
 		"defer sqlite.close(db)\nlet stmt: sqlite.Statement = sqlite.prepare(db, \"SELECT 1\")\n" +
-		"defer sqlite.finalize(stmt)\nrecord_sqlite_resources(db, stmt)\ndefer cleanup_fail()"
+		"defer assert_statement_finalized()\ndefer sqlite.finalize(stmt)\n" +
+		"record_sqlite_resources(db, stmt)\ndefer cleanup_fail()"
 
 	err := interpretVMSource(t, machine, source)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("error=%v, want sentinel cleanup failure", err)
+	}
+	if len(observations) != 1 || observations[0] != (sqliteResourceObservation{statements: 0, databases: 1}) {
+		t.Fatalf("observations=%v, want [{statements:0 databases:1}]", observations)
 	}
 	requireDeferredSQLiteClosed(t, machine, database, statement, path)
 }

--- a/internal/vm/builtins_sqlite_test.go
+++ b/internal/vm/builtins_sqlite_test.go
@@ -1,8 +1,11 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -71,6 +74,113 @@ func cleanupSQLiteResources(t *testing.T, machine *VM) {
 			}
 		}
 	})
+}
+
+type sqliteResourceObservation struct {
+	statements int
+	databases  int
+}
+
+func recordDeferredSQLiteResources(machine *VM, database **DatabaseResource, statement **StatementResource) {
+	machine.DefineNative("record_sqlite_resources", func(args []value.Value) value.Value {
+		if len(args) != 2 {
+			return value.NewNull()
+		}
+		databaseInstance, databaseOK := args[0].Obj.(*value.ObjInstance)
+		statementInstance, statementOK := args[1].Obj.(*value.ObjInstance)
+		if !databaseOK || !statementOK {
+			return value.NewNull()
+		}
+		*database, _ = machine.shared.Databases.get(int(databaseInstance.Fields["handle"].AsInt))
+		*statement, _ = machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		return value.NewNull()
+	})
+}
+
+func requireDeferredSQLiteClosed(t *testing.T, machine *VM, database *DatabaseResource, statement *StatementResource, path string) {
+	t.Helper()
+	if got := len(machine.shared.Statements.snapshot()); got != 0 {
+		t.Fatalf("statements=%d, want 0", got)
+	}
+	if got := len(machine.shared.Databases.snapshot()); got != 0 {
+		t.Fatalf("databases=%d, want 0", got)
+	}
+	if database == nil || statement == nil {
+		t.Fatalf("resources not recorded: database=%p statement=%p", database, statement)
+	}
+	statement.mu.Lock()
+	statementClosed := statement.closed
+	statement.mu.Unlock()
+	database.stateMu.Lock()
+	databaseClosed := database.closed
+	database.stateMu.Unlock()
+	if !statementClosed || !databaseClosed {
+		t.Fatalf("resources remain open: statement=%v database=%v", statementClosed, databaseClosed)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove deferred database: %v", err)
+	}
+}
+
+func TestDeferredSQLiteCleanupFinalizesStatementBeforeDatabaseOnEveryExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		suffix    string
+		wantError bool
+	}{
+		{"normal", "", false},
+		{"runtime error", "\nlet zero: int = 0\nprint(1 / zero)", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machine := New()
+			cleanupSQLiteResources(t, machine)
+			path := filepath.Join(t.TempDir(), "deferred.sqlite")
+			var database *DatabaseResource
+			var statement *StatementResource
+			var observations []sqliteResourceObservation
+			recordDeferredSQLiteResources(machine, &database, &statement)
+			machine.DefineContextualNative("assert_statement_finalized", func(value.NativeContext, []value.Value) (value.Value, error) {
+				observations = append(observations, sqliteResourceObservation{
+					statements: len(machine.shared.Statements.snapshot()),
+					databases:  len(machine.shared.Databases.snapshot()),
+				})
+				return value.NewNull(), nil
+			})
+			source := "use sqlite\nlet db: sqlite.Database = sqlite.open(" + strconv.Quote(path) + ")\n" +
+				"defer sqlite.close(db)\nlet stmt: sqlite.Statement = sqlite.prepare(db, \"SELECT 1\")\n" +
+				"defer assert_statement_finalized()\ndefer sqlite.finalize(stmt)\nrecord_sqlite_resources(db, stmt)" + test.suffix
+
+			err := interpretVMSource(t, machine, source)
+			if (err != nil) != test.wantError {
+				t.Fatalf("error=%v, wantError=%v", err, test.wantError)
+			}
+			if len(observations) != 1 || observations[0] != (sqliteResourceObservation{statements: 0, databases: 1}) {
+				t.Fatalf("observations=%v, want [{statements:0 databases:1}]", observations)
+			}
+			requireDeferredSQLiteClosed(t, machine, database, statement, path)
+		})
+	}
+}
+
+func TestDeferredSQLiteResourceCleanupContinuesAfterFailure(t *testing.T) {
+	machine := New()
+	cleanupSQLiteResources(t, machine)
+	path := filepath.Join(t.TempDir(), "deferred-failure.sqlite")
+	var database *DatabaseResource
+	var statement *StatementResource
+	recordDeferredSQLiteResources(machine, &database, &statement)
+	sentinel := errors.New("sentinel cleanup failure")
+	defineCleanupFailureNative(machine, sentinel)
+	source := "use sqlite\nlet db: sqlite.Database = sqlite.open(" + strconv.Quote(path) + ")\n" +
+		"defer sqlite.close(db)\nlet stmt: sqlite.Statement = sqlite.prepare(db, \"SELECT 1\")\n" +
+		"defer sqlite.finalize(stmt)\nrecord_sqlite_resources(db, stmt)\ndefer cleanup_fail()"
+
+	err := interpretVMSource(t, machine, source)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v, want sentinel cleanup failure", err)
+	}
+	requireDeferredSQLiteClosed(t, machine, database, statement, path)
 }
 
 func TestSQLiteHandlesAreSharedAcrossVMs(t *testing.T) {

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -8,7 +8,6 @@ import (
 func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
 	if callee.Type == value.VAL_OBJ {
 		if structDef, ok := callee.Obj.(*value.ObjStruct); ok && structDef != nil {
-			// Instantiate
 			if argCount != len(structDef.Fields) {
 				return false, vm.runtimeError(c, ip, "expected %d arguments for struct %s but got %d", len(structDef.Fields), structDef.Name, argCount)
 			}
@@ -16,22 +15,7 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 			if err := vm.validateStructConstructorArguments(structDef, args); err != nil {
 				return false, vm.runtimeError(c, ip, "%s", err)
 			}
-
-			instance := value.NewInstance(structDef)
-			instObj := instance.Obj.(*value.ObjInstance)
-
-			// Args are on stack.
-			for i := 0; i < argCount; i++ {
-				arg := vm.peek(argCount - 1 - i)
-				fieldName := structDef.Fields[i]
-				instObj.Fields[fieldName] = arg
-			}
-
-			// Pop args AND callee (struct def)
-			vm.stackTop -= argCount + 1
-			// Push instance
-			vm.push(instance)
-			return true, nil
+			return vm.callPreparedValue(callee, argCount, c, ip)
 		}
 	}
 	if callee.Type == value.VAL_FUNCTION {
@@ -41,49 +25,54 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 		native := callee.Obj.(*value.ObjNative)
 		args := vm.stack[vm.stackTop-argCount : vm.stackTop]
 		if native.Signature != nil {
-			sig := native.Signature
-			if !sig.Variadic && argCount != sig.Arity {
-				return false, vm.runtimeError(c, ip, "native '%s' expects %d arguments, got %d", native.Name, sig.Arity, argCount)
-			}
-			if sig.Variadic && argCount < sig.Arity {
-				return false, vm.runtimeError(c, ip, "native '%s' expects at least %d arguments, got %d", native.Name, sig.Arity, argCount)
-			}
-
-			params := sig.Params
-			if sig.Variadic && len(params) > 0 && argCount > len(params) {
-				expanded := make([]value.ParamInfo, argCount)
-				copy(expanded, params)
-				for i := len(params); i < argCount; i++ {
-					expanded[i] = params[len(params)-1]
-				}
-				params = expanded
+			params, err := nativeParameters(native, argCount)
+			if err != nil {
+				return false, vm.runtimeError(c, ip, "%s", err)
 			}
 			if err := validateParameterModes(native.Name, params, args); err != nil {
 				return false, vm.runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)
 			}
-
-			callArgs := make([]value.Value, len(args))
-			copy(callArgs, args)
-			for i, param := range params {
-				if i >= len(callArgs) {
-					break
-				}
-				if !param.IsRef {
-					callArgs[i] = vm.copyValue(callArgs[i])
-				}
-			}
+			callArgs := append([]value.Value(nil), args...)
+			vm.copyPreparedArguments(callArgs, params)
 			args = callArgs
 		}
-		// fmt.Printf("Calling native %s with args: %v\n", native.Name, args)
-		result, err := native.Invoke(vm, args)
-		if err != nil {
-			return false, vm.runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)
-		}
-		vm.stackTop -= argCount + 1
-		vm.push(result)
-		return true, nil
+		return vm.callNative(native, args, argCount, c, ip)
 	}
 	return false, vm.runtimeError(c, ip, "can only call functions and classes")
+}
+
+func (vm *VM) callPreparedValue(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
+	if callee.Type == value.VAL_OBJ {
+		if structDef, ok := callee.Obj.(*value.ObjStruct); ok && structDef != nil {
+			instance := value.NewInstance(structDef)
+			instObj := instance.Obj.(*value.ObjInstance)
+			for i := 0; i < argCount; i++ {
+				instObj.Fields[structDef.Fields[i]] = vm.peek(argCount - 1 - i)
+			}
+			vm.stackTop -= argCount + 1
+			vm.push(instance)
+			return true, nil
+		}
+	}
+	if callee.Type == value.VAL_FUNCTION {
+		return vm.callPreparedClosure(callee.Obj.(*value.ObjClosure), argCount, c, ip)
+	}
+	if callee.Type == value.VAL_NATIVE {
+		native := callee.Obj.(*value.ObjNative)
+		args := vm.stack[vm.stackTop-argCount : vm.stackTop]
+		return vm.callNative(native, args, argCount, c, ip)
+	}
+	return false, vm.runtimeError(c, ip, "can only call functions and classes")
+}
+
+func (vm *VM) callNative(native *value.ObjNative, args []value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
+	result, err := native.Invoke(vm, args)
+	if err != nil {
+		return false, vm.runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)
+	}
+	vm.stackTop -= argCount + 1
+	vm.push(result)
+	return true, nil
 }
 
 func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip int) (bool, error) {
@@ -116,11 +105,19 @@ func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip i
 			}
 		}
 	}
+	return vm.callPreparedClosure(closure, argCount, c, ip)
+}
+
+func (vm *VM) callPreparedClosure(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip int) (bool, error) {
+	if vm.frameCount == FramesMax {
+		return false, vm.runtimeError(c, ip, "stack overflow")
+	}
 
 	frame := &CallFrame{
 		Closure:     closure,
 		IP:          0,
-		Slots:       vm.stackTop - argCount - 1, // Start of locals window (fn + args)
+		StackBase:   vm.stackTop - argCount - 1,
+		LocalBase:   vm.stackTop - argCount - 1,
 		Environment: closure.Environment,
 	}
 	// Push new frame

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -59,7 +59,7 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 				params = expanded
 			}
 			if err := validateParameterModes(native.Name, params, args); err != nil {
-				return false, vm.runtimeError(c, ip, "%s", err)
+				return false, vm.runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)
 			}
 
 			callArgs := make([]value.Value, len(args))
@@ -77,7 +77,7 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 		// fmt.Printf("Calling native %s with args: %v\n", native.Name, args)
 		result, err := native.Invoke(vm, args)
 		if err != nil {
-			return false, vm.runtimeError(c, ip, "%s", err)
+			return false, vm.runtimeErrorCause(c, ip, err, "native '%s' failed", native.Name)
 		}
 		vm.stackTop -= argCount + 1
 		vm.push(result)

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -1,0 +1,130 @@
+package vm
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/value"
+)
+
+type PreparedCall struct {
+	Callee       value.Value
+	Arguments    []value.Value
+	Registration SourceLocation
+}
+
+func (vm *VM) prepareDeferredCall(callee value.Value, args []value.Value, registration SourceLocation) (PreparedCall, error) {
+	prepared := PreparedCall{
+		Callee:       callee,
+		Arguments:    append([]value.Value(nil), args...),
+		Registration: registration,
+	}
+
+	switch callee.Type {
+	case value.VAL_FUNCTION:
+		closure, ok := callee.Obj.(*value.ObjClosure)
+		if !ok || closure == nil || closure.Function == nil {
+			return PreparedCall{}, fmt.Errorf("invalid function")
+		}
+		fn := closure.Function
+		if len(args) != fn.Arity {
+			return PreparedCall{}, fmt.Errorf("expected %d arguments but got %d", fn.Arity, len(args))
+		}
+		if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
+			return PreparedCall{}, err
+		}
+		vm.copyPreparedArguments(prepared.Arguments, fn.Params)
+		return prepared, nil
+
+	case value.VAL_NATIVE:
+		native, ok := callee.Obj.(*value.ObjNative)
+		if !ok || native == nil {
+			return PreparedCall{}, fmt.Errorf("invalid native function")
+		}
+		if native.Signature == nil {
+			return prepared, nil
+		}
+		params, err := nativeParameters(native, len(args))
+		if err != nil {
+			return PreparedCall{}, err
+		}
+		if err := validateParameterModes(native.Name, params, args); err != nil {
+			return PreparedCall{}, err
+		}
+		vm.copyPreparedArguments(prepared.Arguments, params)
+		return prepared, nil
+
+	case value.VAL_OBJ:
+		definition, ok := callee.Obj.(*value.ObjStruct)
+		if !ok || definition == nil {
+			break
+		}
+		if len(args) != len(definition.Fields) {
+			return PreparedCall{}, fmt.Errorf("expected %d arguments for struct %s but got %d", len(definition.Fields), definition.Name, len(args))
+		}
+		if definition.ConstructorType != nil {
+			if err := vm.validateStructConstructorArguments(definition, args); err != nil {
+				return PreparedCall{}, err
+			}
+		}
+		return prepared, nil
+	}
+
+	return PreparedCall{}, fmt.Errorf("can only call functions and classes")
+}
+
+func nativeParameters(native *value.ObjNative, argCount int) ([]value.ParamInfo, error) {
+	signature := native.Signature
+	if !signature.Variadic && argCount != signature.Arity {
+		return nil, fmt.Errorf("native '%s' expects %d arguments, got %d", native.Name, signature.Arity, argCount)
+	}
+	if signature.Variadic && argCount < signature.Arity {
+		return nil, fmt.Errorf("native '%s' expects at least %d arguments, got %d", native.Name, signature.Arity, argCount)
+	}
+
+	params := signature.Params
+	if signature.Variadic && len(params) > 0 && argCount > len(params) {
+		expanded := make([]value.ParamInfo, argCount)
+		copy(expanded, params)
+		for i := len(params); i < argCount; i++ {
+			expanded[i] = params[len(params)-1]
+		}
+		params = expanded
+	}
+	return params, nil
+}
+
+func (vm *VM) copyPreparedArguments(args []value.Value, params []value.ParamInfo) {
+	for i, param := range params {
+		if i >= len(args) {
+			break
+		}
+		if !param.IsRef {
+			args[i] = vm.copyValue(args[i])
+		}
+	}
+}
+
+func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
+	base := vm.stackTop
+	defer func() {
+		for i := base; i < vm.stackTop; i++ {
+			vm.stack[i] = value.Value{}
+		}
+		vm.stackTop = base
+	}()
+
+	ownerFrameCount := vm.frameCount
+	vm.push(call.Callee)
+	for _, argument := range call.Arguments {
+		vm.push(argument)
+	}
+
+	ok, err := vm.callPreparedValue(call.Callee, len(call.Arguments), nil, 0)
+	if !ok {
+		return err
+	}
+	if vm.frameCount > ownerFrameCount {
+		return vm.run(ownerFrameCount + 1)
+	}
+	return nil
+}

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -106,8 +106,13 @@ func (vm *VM) copyPreparedArguments(args []value.Value, params []value.ParamInfo
 
 func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 	base := vm.stackTop
+	temporaryTop := base
 	defer func() {
-		for i := base; i < vm.stackTop; i++ {
+		cleanupTop := vm.stackTop
+		if temporaryTop > cleanupTop {
+			cleanupTop = temporaryTop
+		}
+		for i := base; i < cleanupTop; i++ {
 			vm.stack[i] = value.Value{}
 		}
 		vm.stackTop = base
@@ -118,6 +123,7 @@ func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 	for _, argument := range call.Arguments {
 		vm.push(argument)
 	}
+	temporaryTop = vm.stackTop
 
 	ok, err := vm.callPreparedValue(call.Callee, len(call.Arguments), nil, 0)
 	if !ok {

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -61,10 +61,8 @@ func (vm *VM) prepareDeferredCall(callee value.Value, args []value.Value, regist
 		if len(args) != len(definition.Fields) {
 			return PreparedCall{}, fmt.Errorf("expected %d arguments for struct %s but got %d", len(definition.Fields), definition.Name, len(args))
 		}
-		if definition.ConstructorType != nil {
-			if err := vm.validateStructConstructorArguments(definition, args); err != nil {
-				return PreparedCall{}, err
-			}
+		if err := vm.validateStructConstructorArguments(definition, args); err != nil {
+			return PreparedCall{}, err
 		}
 		return prepared, nil
 	}
@@ -106,6 +104,9 @@ func (vm *VM) copyPreparedArguments(args []value.Value, params []value.ParamInfo
 
 func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 	base := vm.stackTop
+	if base < 0 || base >= len(vm.stack) || len(call.Arguments) > len(vm.stack)-base-1 {
+		return fmt.Errorf("stack overflow while invoking deferred call")
+	}
 	temporaryTop := base
 	defer func() {
 		cleanupTop := vm.stackTop

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -45,8 +45,63 @@ func TestInvokePreparedCallDoesNotCopyArgumentsAgainAndRestoresStack(t *testing.
 	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
-	if machine.stack[base] != (value.Value{}) {
-		t.Fatalf("temporary slot was not cleared: %#v", machine.stack[base])
+	for i := base; i < base+2; i++ {
+		if machine.stack[i] != (value.Value{}) {
+			t.Fatalf("temporary slot %d was not cleared: %#v", i, machine.stack[i])
+		}
+	}
+}
+
+func TestInvokePreparedConstructorClearsAllTemporarySlots(t *testing.T) {
+	machine := New()
+	constructor := value.NewStruct("Pair", []string{"left", "right"})
+	prepared, err := machine.prepareDeferredCall(constructor, []value.Value{
+		value.NewArray([]value.Value{value.NewInt(1)}),
+		value.NewArray([]value.Value{value.NewInt(2)}),
+	}, SourceLocation{})
+	if err != nil {
+		t.Fatalf("prepare deferred constructor: %v", err)
+	}
+	machine.push(value.NewInt(42))
+	base := machine.stackTop
+
+	if err := machine.invokePreparedCall(prepared); err != nil {
+		t.Fatalf("invoke prepared constructor: %v", err)
+	}
+	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
+	}
+	for i := base; i < base+3; i++ {
+		if machine.stack[i] != (value.Value{}) {
+			t.Fatalf("temporary slot %d was not cleared: %#v", i, machine.stack[i])
+		}
+	}
+}
+
+func TestInvokePreparedClosureClearsAllTemporarySlots(t *testing.T) {
+	machine := New()
+	body := chunk.New()
+	body.Write(byte(chunk.OP_NULL), 1)
+	body.Write(byte(chunk.OP_RETURN), 1)
+	function := value.NewFunction("cleanup", 1, 0, []value.ParamInfo{{TypeName: "int"}}, body, machine.shared.Root)
+	closure := &value.ObjClosure{Function: function.Obj.(*value.ObjFunction), Environment: machine.shared.Root}
+	prepared, err := machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{value.NewInt(7)}, SourceLocation{})
+	if err != nil {
+		t.Fatalf("prepare deferred closure: %v", err)
+	}
+	machine.push(value.NewInt(42))
+	base := machine.stackTop
+
+	if err := machine.invokePreparedCall(prepared); err != nil {
+		t.Fatalf("invoke prepared closure: %v", err)
+	}
+	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
+	}
+	for i := base; i < base+2; i++ {
+		if machine.stack[i] != (value.Value{}) {
+			t.Fatalf("temporary slot %d was not cleared: %#v", i, machine.stack[i])
+		}
 	}
 }
 
@@ -56,7 +111,7 @@ func TestInvokePreparedCallRestoresStackAfterNativeFailure(t *testing.T) {
 	native := value.NewContextualNative("failing", func(value.NativeContext, []value.Value) (value.Value, error) {
 		return value.NewNull(), wantErr
 	})
-	prepared, err := machine.prepareDeferredCall(native, nil, SourceLocation{})
+	prepared, err := machine.prepareDeferredCall(native, []value.Value{value.NewArray([]value.Value{value.NewInt(1)})}, SourceLocation{})
 	if err != nil {
 		t.Fatalf("prepare deferred call: %v", err)
 	}
@@ -70,8 +125,10 @@ func TestInvokePreparedCallRestoresStackAfterNativeFailure(t *testing.T) {
 	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
-	if machine.stack[base] != (value.Value{}) {
-		t.Fatalf("temporary slot was not cleared: %#v", machine.stack[base])
+	for i := base; i < base+2; i++ {
+		if machine.stack[i] != (value.Value{}) {
+			t.Fatalf("temporary slot %d was not cleared: %#v", i, machine.stack[i])
+		}
 	}
 }
 

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -199,3 +199,30 @@ end`)
 		t.Fatalf("local=%v, want 42", got)
 	}
 }
+
+func TestVMReusableAfterDeferredRegistrationFailure(t *testing.T) {
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func one_arg(value: int) -> void
+end
+let dynamic: func = one_arg
+defer dynamic()`)
+	if err == nil {
+		t.Fatal("deferred registration accepted the wrong arity")
+	}
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.openUpvalues != nil {
+		t.Fatalf("dirty VM after error: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
+	}
+	if err := interpretVMSource(t, machine, "test_report(42)\n"); err != nil {
+		t.Fatal(err)
+	}
+	if !valuesEqual(captured, value.NewInt(42)) {
+		t.Fatalf("reuse result=%v", captured)
+	}
+}

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -8,6 +8,12 @@ import (
 	"noxy-vm/internal/value"
 )
 
+func defineCleanupFailureNative(machine *VM, sentinel error) {
+	machine.DefineContextualNative("cleanup_fail", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), sentinel
+	})
+}
+
 func TestPrepareDeferredCallLegacyNativeKeepsValueIdentity(t *testing.T) {
 	machine := New()
 	array := value.NewArray([]value.Value{value.NewInt(1)})

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -1,0 +1,144 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+func TestPrepareDeferredCallLegacyNativeKeepsValueIdentity(t *testing.T) {
+	machine := New()
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	legacy := value.NewNative("legacy", func([]value.Value) value.Value { return value.NewNull() })
+	prepared, err := machine.prepareDeferredCall(legacy, []value.Value{array}, SourceLocation{File: "test.nx", Line: 1})
+	if err != nil || prepared.Arguments[0].Obj != array.Obj {
+		t.Fatalf("prepared=%#v error=%v, want unchanged identity", prepared, err)
+	}
+}
+
+func TestInvokePreparedCallDoesNotCopyArgumentsAgainAndRestoresStack(t *testing.T) {
+	machine := New()
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	var received value.Value
+	signed := value.NewNativeWithSignature("signed", value.NativeSignature{
+		Arity:  1,
+		Params: []value.ParamInfo{{TypeName: "int[]"}},
+	}, func(args []value.Value) value.Value {
+		received = args[0]
+		return value.NewInt(9)
+	})
+	prepared, err := machine.prepareDeferredCall(signed, []value.Value{array}, SourceLocation{})
+	if err != nil {
+		t.Fatalf("prepare deferred call: %v", err)
+	}
+	machine.push(value.NewInt(42))
+	base := machine.stackTop
+
+	if err := machine.invokePreparedCall(prepared); err != nil {
+		t.Fatalf("invoke prepared call: %v", err)
+	}
+	if received.Obj != prepared.Arguments[0].Obj {
+		t.Fatal("prepared dispatch copied argument a second time")
+	}
+	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
+	}
+	if machine.stack[base] != (value.Value{}) {
+		t.Fatalf("temporary slot was not cleared: %#v", machine.stack[base])
+	}
+}
+
+func TestInvokePreparedCallRestoresStackAfterNativeFailure(t *testing.T) {
+	machine := New()
+	wantErr := errors.New("cleanup failed")
+	native := value.NewContextualNative("failing", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), wantErr
+	})
+	prepared, err := machine.prepareDeferredCall(native, nil, SourceLocation{})
+	if err != nil {
+		t.Fatalf("prepare deferred call: %v", err)
+	}
+	machine.push(value.NewInt(42))
+	base := machine.stackTop
+
+	err = machine.invokePreparedCall(prepared)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error=%v, want wrapped cleanup failure", err)
+	}
+	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
+	}
+	if machine.stack[base] != (value.Value{}) {
+		t.Fatalf("temporary slot was not cleared: %#v", machine.stack[base])
+	}
+}
+
+func TestImmediateSignedNativeFailurePreservesOperandIdentity(t *testing.T) {
+	machine := New()
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	native := value.NewContextualNativeWithSignature("failing", value.NativeSignature{
+		Arity:  1,
+		Params: []value.ParamInfo{{TypeName: "int[]"}},
+	}, func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), errors.New("failed")
+	})
+	machine.push(native)
+	machine.push(array)
+
+	ok, err := machine.callValue(native, 1, nil, 0)
+	if ok || err == nil {
+		t.Fatalf("ok=%v error=%v, want native failure", ok, err)
+	}
+	if machine.stackTop != 2 || machine.stack[1].Obj != array.Obj {
+		t.Fatalf("failed immediate call changed operand identity: %#v", machine.stack[1])
+	}
+}
+
+func TestPrepareDeferredCallUsesCallableCaptureSemantics(t *testing.T) {
+	machine := New()
+	array := value.NewArray([]value.Value{value.NewInt(1)})
+	closureValue := value.NewFunction("cleanup", 1, 0, []value.ParamInfo{{TypeName: "int[]"}}, chunk.New(), machine.shared.Root)
+	closure := &value.ObjClosure{Function: closureValue.Obj.(*value.ObjFunction), Environment: machine.shared.Root}
+
+	prepared, err := machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{array}, SourceLocation{})
+	if err != nil || prepared.Arguments[0].Obj == array.Obj {
+		t.Fatalf("closure did not shallow-copy array")
+	}
+
+	reference := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "items", GlobalOwner: machine.shared.Root}}
+	closure.Function.Params[0].IsRef = true
+	prepared, err = machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{reference}, SourceLocation{})
+	if err != nil || prepared.Arguments[0].Obj != reference.Obj {
+		t.Fatalf("reference identity changed")
+	}
+
+	signature := value.NativeSignature{Arity: 1, Params: []value.ParamInfo{{TypeName: "int[]"}}}
+	signed := value.NewNativeWithSignature("signed", signature, func([]value.Value) value.Value { return value.NewNull() })
+	prepared, err = machine.prepareDeferredCall(signed, []value.Value{array}, SourceLocation{})
+	if err != nil || prepared.Arguments[0].Obj == array.Obj {
+		t.Fatalf("signed native did not shallow-copy array")
+	}
+
+	constructor := value.NewStruct("Box", []string{"items"})
+	prepared, err = machine.prepareDeferredCall(constructor, []value.Value{array}, SourceLocation{})
+	if err != nil || prepared.Arguments[0].Obj != array.Obj {
+		t.Fatalf("constructor capture changed identity")
+	}
+
+	if _, err = machine.prepareDeferredCall(constructor, nil, SourceLocation{}); err == nil {
+		t.Fatal("constructor arity accepted")
+	}
+}
+
+func TestScriptLocalBaseDoesNotCollideWithCalleeSlot(t *testing.T) {
+	got := captureVMSource(t, `
+if true then
+    let local: int = 42
+    test_report(local)
+end`)
+	if !valuesEqual(got, value.NewInt(42)) {
+		t.Fatalf("local=%v, want 42", got)
+	}
+}

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -2,11 +2,31 @@ package vm
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
 )
+
+func testStructConstructor(name string, fields []string, params []*value.RuntimeTypeInfo) value.Value {
+	fieldTypes := make(map[string]*value.RuntimeTypeInfo, len(fields))
+	for index, field := range fields {
+		fieldTypes[field] = params[index]
+	}
+	constructor := value.NewStruct(name, fields)
+	constructor.Obj.(*value.ObjStruct).ConstructorType = &value.RuntimeTypeInfo{
+		Kind:       value.TYPE_CALLABLE,
+		Params:     append([]*value.RuntimeTypeInfo(nil), params...),
+		ParamIsRef: make([]bool, len(params)),
+		Return: &value.RuntimeTypeInfo{
+			Kind:   value.TYPE_STRUCT,
+			Name:   name,
+			Fields: fieldTypes,
+		},
+	}
+	return constructor
+}
 
 func defineCleanupFailureNative(machine *VM, sentinel error) {
 	machine.DefineContextualNative("cleanup_fail", func(value.NativeContext, []value.Value) (value.Value, error) {
@@ -60,7 +80,8 @@ func TestInvokePreparedCallDoesNotCopyArgumentsAgainAndRestoresStack(t *testing.
 
 func TestInvokePreparedConstructorClearsAllTemporarySlots(t *testing.T) {
 	machine := New()
-	constructor := value.NewStruct("Pair", []string{"left", "right"})
+	anyType := &value.RuntimeTypeInfo{Kind: value.TYPE_ANY}
+	constructor := testStructConstructor("Pair", []string{"left", "right"}, []*value.RuntimeTypeInfo{anyType, anyType})
 	prepared, err := machine.prepareDeferredCall(constructor, []value.Value{
 		value.NewArray([]value.Value{value.NewInt(1)}),
 		value.NewArray([]value.Value{value.NewInt(2)}),
@@ -184,7 +205,8 @@ func TestPrepareDeferredCallUsesCallableCaptureSemantics(t *testing.T) {
 		t.Fatalf("signed native did not shallow-copy array")
 	}
 
-	constructor := value.NewStruct("Box", []string{"items"})
+	intType := &value.RuntimeTypeInfo{Kind: value.TYPE_INT}
+	constructor := testStructConstructor("Box", []string{"items"}, []*value.RuntimeTypeInfo{{Kind: value.TYPE_ARRAY, Element: intType}})
 	prepared, err = machine.prepareDeferredCall(constructor, []value.Value{array}, SourceLocation{})
 	if err != nil || prepared.Arguments[0].Obj != array.Obj {
 		t.Fatalf("constructor capture changed identity")
@@ -192,6 +214,102 @@ func TestPrepareDeferredCallUsesCallableCaptureSemantics(t *testing.T) {
 
 	if _, err = machine.prepareDeferredCall(constructor, nil, SourceLocation{}); err == nil {
 		t.Fatal("constructor arity accepted")
+	}
+}
+
+func TestPrepareDeferredCallRejectsStructWithoutRuntimeMetadataLikeImmediateCall(t *testing.T) {
+	machine := New()
+	constructor := value.NewStruct("Box", []string{"value"})
+	argument := value.NewInt(1)
+
+	_, deferredErr := machine.prepareDeferredCall(constructor, []value.Value{argument}, SourceLocation{})
+	if deferredErr == nil {
+		t.Fatal("deferred constructor accepted incomplete runtime type metadata")
+	}
+
+	machine.push(constructor)
+	machine.push(argument)
+	ok, immediateErr := machine.callValue(constructor, 1, nil, 0)
+	if ok || immediateErr == nil {
+		t.Fatalf("ok=%v error=%v, want immediate constructor validation failure", ok, immediateErr)
+	}
+	if !strings.Contains(immediateErr.Error(), deferredErr.Error()) {
+		t.Fatalf("deferred error=%q immediate error=%q, want matching validation", deferredErr, immediateErr)
+	}
+}
+
+func TestDeferredStructConstructorTypeErrorOccursAtRegistration(t *testing.T) {
+	machine := New()
+	olderRan := false
+	machine.DefineNative("older_cleanup", func([]value.Value) value.Value {
+		olderRan = true
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `struct Box
+    value: int
+end
+let dynamic: func = Box
+defer older_cleanup()
+defer dynamic("wrong")
+`)
+	if err == nil {
+		t.Fatal("deferred constructor accepted wrong field type")
+	}
+	var runtimeErr *RuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error=%T %[1]v, want RuntimeError", err)
+	}
+	if runtimeErr.Location.Line != 6 || runtimeErr.Cause == nil || !strings.Contains(runtimeErr.Cause.Error(), "expected int, got object") {
+		t.Fatalf("runtime error=%#v, want registration-line constructor type error", runtimeErr)
+	}
+	if !olderRan {
+		t.Fatal("registration failure skipped an older defer")
+	}
+}
+
+func TestFinishFrameAggregatesPreparedCallHeadroomFailureAndContinues(t *testing.T) {
+	machine := New()
+	olderRan := false
+	older := value.NewNative("older", func([]value.Value) value.Value {
+		olderRan = true
+		return value.NewNull()
+	})
+	newer := value.NewNative("newer", func([]value.Value) value.Value {
+		t.Fatal("deferred call ran without enough fixed-stack headroom")
+		return value.NewNull()
+	})
+	frame := &CallFrame{
+		StackBase: 0,
+		LocalBase: 0,
+		Deferred: []PreparedCall{
+			{Callee: older, Registration: SourceLocation{File: "headroom.nx", Line: 4}},
+			{Callee: newer, Arguments: []value.Value{value.NewInt(1)}, Registration: SourceLocation{File: "headroom.nx", Line: 5}},
+		},
+	}
+	machine.frames[0] = frame
+	machine.frameCount = 1
+	machine.currentFrame = frame
+	machine.stackTop = StackMax - 1
+	machine.stack[StackMax-2] = value.NewInt(99)
+
+	outcome := machine.finishFrame(frameOutcome{Result: value.NewNull()})
+	var unwind *UnwindError
+	if !errors.As(outcome.Err, &unwind) || len(unwind.Deferred) != 1 {
+		t.Fatalf("error=%T %[1]v unwind=%#v, want one aggregated cleanup failure", outcome.Err, unwind)
+	}
+	deferred := unwind.Deferred[0]
+	if deferred.Registration != (SourceLocation{File: "headroom.nx", Line: 5}) || deferred.Cause == nil || !strings.Contains(deferred.Cause.Error(), "stack overflow") {
+		t.Fatalf("deferred=%#v, want registered headroom failure", deferred)
+	}
+	if !olderRan {
+		t.Fatal("headroom failure skipped the older deferred call")
+	}
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil || machine.openUpvalues != nil {
+		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d frame0=%p open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.frames[0], machine.openUpvalues)
+	}
+	if machine.stack[StackMax-2] != (value.Value{}) {
+		t.Fatalf("owned stack slot was not cleared: %#v", machine.stack[StackMax-2])
 	}
 }
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1001,8 +1001,7 @@ func (vm *VM) run(minFrameCount int) error {
 
 			mod, err := vm.loadModule(moduleName)
 			if err != nil {
-				context := vm.runtimeError(c, ip, "failed to import module '%s'", moduleName)
-				return fmt.Errorf("%v: %w", context, err)
+				return vm.runtimeErrorCause(c, ip, err, "failed to import module '%s'", moduleName)
 			}
 			vm.push(mod)
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -43,11 +43,19 @@ func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.Global
 	return vm.run(1)
 }
 
-func (vm *VM) run(minFrameCount int) error {
+func (vm *VM) run(minFrameCount int) (err error) {
 	// Cache current frame values for speed
 	frame := vm.currentFrame
 	c := frame.Closure.Function.Chunk.(*chunk.Chunk)
 	ip := frame.IP
+	defer func() {
+		if vm.currentFrame == frame {
+			frame.IP = ip
+		}
+		if err != nil {
+			err = vm.unwindTo(minFrameCount-1, frameOutcome{Err: err}).Err
+		}
+	}()
 
 	for {
 		if ip >= len(c.Code) {
@@ -994,13 +1002,15 @@ func (vm *VM) run(minFrameCount int) error {
 			nameConstant := c.Constants[index]
 			moduleName := nameConstant.Obj.(string)
 
+			frame.IP = ip
 			mod, err := vm.loadModule(moduleName)
 			if err != nil {
 				return vm.runtimeErrorCause(c, ip, err, "failed to import module '%s'", moduleName)
 			}
-			vm.push(mod)
-
 			frame = vm.currentFrame
+			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+			ip = frame.IP
+			vm.push(mod)
 
 		case chunk.OP_IMPORT_FROM_ALL:
 			modVal := vm.pop()

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -857,6 +857,30 @@ func (vm *VM) run(minFrameCount int) error {
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
 			ip = frame.IP
 
+		case chunk.OP_DEFER:
+			registration := sourceLocation(c, ip)
+			argCount := int(c.Code[ip])
+			ip++
+
+			frame.IP = ip
+			callee := vm.peek(argCount)
+			arguments := vm.stack[vm.stackTop-argCount : vm.stackTop]
+			prepared, err := vm.prepareDeferredCall(callee, arguments, registration)
+			if err != nil {
+				return &RuntimeError{
+					Location: registration,
+					Message:  "failed to register defer",
+					Cause:    err,
+				}
+			}
+
+			operandBase := vm.stackTop - argCount - 1
+			for index := operandBase; index < vm.stackTop; index++ {
+				vm.stack[index] = value.Value{}
+			}
+			vm.stackTop = operandBase
+			frame.Deferred = append(frame.Deferred, prepared)
+
 		case chunk.OP_CLOSURE:
 			idx := c.Code[ip]
 			ip++
@@ -908,47 +932,18 @@ func (vm *VM) run(minFrameCount int) error {
 			vm.pop()
 
 		case chunk.OP_RETURN:
-			// Return from function
-
-			// 1. Pop result
 			result := vm.pop()
-			calleeFrame := vm.currentFrame
-
-			// 2. Clear the stack range used by the function (args + locals)
-			// This is CRITICAL for GC. We must nullify the references.
-			// calleeFrame.StackBase points to the function object itself.
-			// We iterate up to stackTop (which is where result WAS before pop).
-			for i := calleeFrame.StackBase; i < vm.stackTop; i++ {
-				vm.closeUpvalue(&vm.stack[i]) // Close any upvalues pointing to this slot
-				vm.stack[i] = value.Value{}
+			frame.IP = ip
+			outcome := vm.finishFrame(frameOutcome{Result: result})
+			if outcome.Err != nil {
+				return outcome.Err
 			}
 
-			// 3. Decrement frame count
-			vm.frameCount--
-
-			// 4. Update current frame pointer
-			if vm.frameCount > 0 {
-				vm.currentFrame = vm.frames[vm.frameCount-1]
-			} else {
-				vm.currentFrame = nil
-			}
-
-			// 5. Return from run() if we drop below call depth
 			if vm.frameCount < minFrameCount {
-				// We are exiting the run loop.
-				// We need to place result at the location expected by the caller.
-				// The caller expects the function and args to be consumed, and result pushed.
-				// calleeFrame.StackBase is the start of the window (Function object).
-				vm.stackTop = calleeFrame.StackBase
-				vm.push(result)
 				return nil
 			}
 
-			// 6. Restore execution context
 			frame = vm.currentFrame
-			vm.stackTop = calleeFrame.StackBase // Drop args/locals/function from stackTop
-			vm.push(result)                     // Push result replacing the function
-
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
 			ip = frame.IP
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -36,7 +36,7 @@ func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.Global
 	scriptClosure := &value.ObjClosure{Function: scriptFunction, Upvalues: []*value.ObjUpvalue{}, Environment: environment}
 	vm.stackTop = 0
 	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: scriptClosure})
-	frame := &CallFrame{Closure: scriptClosure, IP: 0, Slots: 1, Environment: environment}
+	frame := &CallFrame{Closure: scriptClosure, IP: 0, StackBase: 0, LocalBase: 1, Environment: environment}
 	vm.frames[0] = frame
 	vm.frameCount = 1
 	vm.currentFrame = frame
@@ -192,19 +192,19 @@ func (vm *VM) run(minFrameCount int) error {
 		case chunk.OP_GET_LOCAL:
 			slot := c.Code[ip]
 			ip++
-			val := vm.stack[frame.Slots+int(slot)]
+			val := vm.stack[frame.LocalBase+int(slot)]
 			vm.push(val)
 
 		case chunk.OP_SET_LOCAL:
 			slot := c.Code[ip]
 			ip++
-			vm.stack[frame.Slots+int(slot)] = vm.peek(0)
+			vm.stack[frame.LocalBase+int(slot)] = vm.peek(0)
 
 		case chunk.OP_REF_LOCAL:
 			slot := int(c.Code[ip])
 			ip++
 			// Reference to a stack slot - Capture it!
-			upvalue := vm.captureUpvalue(&vm.stack[frame.Slots+slot])
+			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot])
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
@@ -429,7 +429,7 @@ func (vm *VM) run(minFrameCount int) error {
 			val := vm.pop() // Value to assign
 
 			// The reference itself is in a local variable (e.g., parameter 'x')
-			refVal := vm.stack[frame.Slots+slot]
+			refVal := vm.stack[frame.LocalBase+slot]
 
 			if err := vm.storeReferenceValue(refVal, val); err != nil {
 				return vm.runtimeError(c, ip, "%s", err)
@@ -885,7 +885,7 @@ func (vm *VM) run(minFrameCount int) error {
 				ip++
 
 				if isLocal == 1 {
-					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[frame.Slots+int(index)])
+					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[frame.LocalBase+int(index)])
 				} else {
 					closure.Upvalues[i] = frame.Closure.Upvalues[index]
 				}
@@ -916,9 +916,9 @@ func (vm *VM) run(minFrameCount int) error {
 
 			// 2. Clear the stack range used by the function (args + locals)
 			// This is CRITICAL for GC. We must nullify the references.
-			// calleeFrame.Slots points to the function object itself.
+			// calleeFrame.StackBase points to the function object itself.
 			// We iterate up to stackTop (which is where result WAS before pop).
-			for i := calleeFrame.Slots; i < vm.stackTop; i++ {
+			for i := calleeFrame.StackBase; i < vm.stackTop; i++ {
 				vm.closeUpvalue(&vm.stack[i]) // Close any upvalues pointing to this slot
 				vm.stack[i] = value.Value{}
 			}
@@ -938,16 +938,16 @@ func (vm *VM) run(minFrameCount int) error {
 				// We are exiting the run loop.
 				// We need to place result at the location expected by the caller.
 				// The caller expects the function and args to be consumed, and result pushed.
-				// calleeFrame.Slots is the start of the window (Function object).
-				vm.stackTop = calleeFrame.Slots
+				// calleeFrame.StackBase is the start of the window (Function object).
+				vm.stackTop = calleeFrame.StackBase
 				vm.push(result)
 				return nil
 			}
 
 			// 6. Restore execution context
 			frame = vm.currentFrame
-			vm.stackTop = calleeFrame.Slots // Drop args/locals/function from stackTop
-			vm.push(result)                 // Push result replacing the function
+			vm.stackTop = calleeFrame.StackBase // Drop args/locals/function from stackTop
+			vm.push(result)                     // Push result replacing the function
 
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
 			ip = frame.IP

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/compiler"
@@ -9,6 +10,7 @@ import (
 	"noxy-vm/internal/value"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -158,6 +160,57 @@ func compileModuleProgram(t *testing.T, root, source string) *chunk.Chunk {
 		t.Fatal(err)
 	}
 	return code
+}
+
+func TestNestedModuleDeferBoundary(t *testing.T) {
+	root := t.TempDir()
+	moduleSource := `
+defer module_record("module-old")
+defer module_fail()
+let zero: int = 0
+print(1 / zero)
+`
+	if err := os.WriteFile(filepath.Join(root, "broken.nx"), []byte(moduleSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code := compileModuleProgram(t, root, `
+defer module_record("importer-old")
+defer module_record("importer-new")
+use broken
+`)
+
+	machine := NewWithConfig(VMConfig{RootPath: root})
+	sentinel := errors.New("module cleanup failed")
+	var order []string
+	machine.DefineNative("module_record", func(args []value.Value) value.Value {
+		order = append(order, args[0].Obj.(string))
+		return value.NewNull()
+	})
+	machine.DefineContextualNative("module_fail", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), sentinel
+	})
+
+	err := machine.Interpret(code)
+	if !slices.Equal(order, []string{"module-old", "importer-new", "importer-old"}) {
+		t.Fatalf("cleanup order=%v, want [module-old importer-new importer-old]", order)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v, want module cleanup sentinel", err)
+	}
+	importError, ok := err.(*RuntimeError)
+	if !ok {
+		t.Fatalf("error=%T %v, want outer *RuntimeError", err, err)
+	}
+	if importError.Message != "failed to import module 'broken'" {
+		t.Fatalf("outer runtime message=%q, want structured import context", importError.Message)
+	}
+	moduleUnwind, ok := importError.Cause.(*UnwindError)
+	if !ok {
+		t.Fatalf("import cause=%T %v, want module *UnwindError", importError.Cause, importError.Cause)
+	}
+	if !errors.Is(moduleUnwind, sentinel) {
+		t.Fatalf("module unwind=%v, want cleanup sentinel", moduleUnwind)
+	}
 }
 
 func TestRuntimeModuleCacheSharesIdentityAcrossImportsAndChildVM(t *testing.T) {

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -197,6 +197,7 @@ func (vm *VM) compileAndRunModule(source resolvedModule, content string) (value.
 	moduleEnvironment := value.NewGlobalEnvironment(vm.shared.Root)
 	modFn := &value.ObjFunction{Name: source.Name, Arity: 0, Chunk: code, Environment: moduleEnvironment}
 	modClosure := &value.ObjClosure{Function: modFn, Upvalues: []*value.ObjUpvalue{}, Environment: moduleEnvironment}
+	callerFrameCount := vm.frameCount
 	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: modClosure})
 	if ok, callErr := vm.callValue(vm.peek(0), 0, nil, 0); !ok {
 		return value.NewNull(), callErr
@@ -205,6 +206,8 @@ func (vm *VM) compileAndRunModule(source resolvedModule, content string) (value.
 	if err := vm.run(startFrameCount); err != nil {
 		return value.NewNull(), err
 	}
-	vm.pop()
+	if callerFrameCount > 0 {
+		vm.pop()
+	}
 	return moduleEnvironment.ExportMap(), nil
 }

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -20,9 +20,13 @@ func TestModuleFrameGlobalReferenceCapturesSharedFallbackOwner(t *testing.T) {
 	code := chunk.New()
 	code.FileName = "shared_global_reference"
 	name := code.AddConstant(value.NewString("shared_value"))
+	captured := code.AddConstant(value.NewString("captured"))
 	for _, instruction := range []byte{
 		byte(chunk.OP_REF_GLOBAL), byte(name),
 		byte(chunk.OP_DEREF),
+		byte(chunk.OP_SET_GLOBAL), byte(captured),
+		byte(chunk.OP_POP),
+		byte(chunk.OP_NULL),
 		byte(chunk.OP_RETURN),
 	} {
 		code.Write(instruction, 1)
@@ -34,7 +38,7 @@ func TestModuleFrameGlobalReferenceCapturesSharedFallbackOwner(t *testing.T) {
 	if err := machine.InterpretWithGlobals(code, moduleGlobals); err != nil {
 		t.Fatal(err)
 	}
-	got := machine.pop()
+	got := moduleGlobals["captured"]
 	if got.Type != value.VAL_INT || got.AsInt != 42 {
 		t.Fatalf("shared fallback=%v, want 42", got)
 	}

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -72,6 +72,9 @@ func (err *UnwindError) Error() string {
 }
 
 func (err *UnwindError) Unwrap() []error {
+	if err == nil {
+		return nil
+	}
 	causes := make([]error, 0, len(err.Deferred)+1)
 	if err.Primary != nil {
 		causes = append(causes, err.Primary)

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -1,0 +1,119 @@
+package vm
+
+import (
+	"fmt"
+	"noxy-vm/internal/chunk"
+	"strings"
+)
+
+// SourceLocation identifies a Noxy source position associated with a runtime error.
+type SourceLocation struct {
+	File string
+	Line int
+}
+
+func (location SourceLocation) String() string {
+	return fmt.Sprintf("%s:line %d", location.File, location.Line)
+}
+
+// RuntimeError adds Noxy source context to an underlying runtime failure.
+type RuntimeError struct {
+	Location SourceLocation
+	Message  string
+	Cause    error
+}
+
+func (err *RuntimeError) Error() string {
+	prefix := fmt.Sprintf("[%s] %s", err.Location, err.Message)
+	return renderErrorCause(prefix, err.Cause)
+}
+
+func (err *RuntimeError) Unwrap() error {
+	return err.Cause
+}
+
+// DeferredError describes a failure from a call registered by defer.
+type DeferredError struct {
+	Registration SourceLocation
+	Cause        error
+}
+
+func (err DeferredError) Error() string {
+	prefix := fmt.Sprintf("defer registered at %s failed", err.Registration)
+	return renderErrorCause(prefix, err.Cause)
+}
+
+func (err DeferredError) Unwrap() error {
+	return err.Cause
+}
+
+// UnwindError keeps the original failure and each deferred failure in execution order.
+type UnwindError struct {
+	Primary  error
+	Deferred []DeferredError
+}
+
+func (err *UnwindError) Error() string {
+	if err == nil {
+		return "<nil>"
+	}
+
+	parts := make([]string, 0, len(err.Deferred)+1)
+	if err.Primary != nil {
+		parts = append(parts, err.Primary.Error())
+	}
+	for _, deferred := range err.Deferred {
+		parts = append(parts, deferred.Error())
+	}
+	if len(parts) == 0 {
+		return "runtime unwind failed"
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (err *UnwindError) Unwrap() []error {
+	causes := make([]error, 0, len(err.Deferred)+1)
+	if err.Primary != nil {
+		causes = append(causes, err.Primary)
+	}
+	for index := range err.Deferred {
+		causes = append(causes, &err.Deferred[index])
+	}
+	return causes
+}
+
+func sourceLocation(c *chunk.Chunk, ip int) SourceLocation {
+	location := SourceLocation{File: "?"}
+	if c == nil {
+		return location
+	}
+
+	location.File = c.FileName
+	if ip > 0 && ip <= len(c.Lines) {
+		location.Line = c.Lines[ip-1]
+	}
+	return location
+}
+
+func (vm *VM) runtimeErrorCause(c *chunk.Chunk, ip int, cause error, format string, args ...interface{}) error {
+	return &RuntimeError{
+		Location: sourceLocation(c, ip),
+		Message:  fmt.Sprintf(format, args...),
+		Cause:    cause,
+	}
+}
+
+func renderErrorCause(prefix string, cause error) string {
+	if cause == nil {
+		return prefix
+	}
+	causeText := cause.Error()
+	if !strings.Contains(causeText, "\n") {
+		return prefix + ": " + causeText
+	}
+	return prefix + ":\n" + indentError(causeText, "  ")
+}
+
+func indentError(text, indent string) string {
+	return indent + strings.ReplaceAll(text, "\n", "\n"+indent)
+}

--- a/internal/vm/runtime_errors_test.go
+++ b/internal/vm/runtime_errors_test.go
@@ -41,6 +41,22 @@ func TestUnwindErrorPreservesLIFOOrderAndNestedCause(t *testing.T) {
 	}
 }
 
+func TestNilUnwindErrorUnwrapIsSafe(t *testing.T) {
+	var unwind *UnwindError
+
+	t.Run("direct", func(t *testing.T) {
+		if causes := unwind.Unwrap(); causes != nil {
+			t.Fatalf("causes=%v, want nil", causes)
+		}
+	})
+
+	t.Run("errors Is", func(t *testing.T) {
+		if errors.Is(unwind, errors.New("sentinel")) {
+			t.Fatal("typed-nil unwind unexpectedly matched sentinel")
+		}
+	})
+}
+
 func TestNativeRuntimeErrorPreservesNativeCause(t *testing.T) {
 	sentinel := errors.New("native sentinel")
 	machine := New()

--- a/internal/vm/runtime_errors_test.go
+++ b/internal/vm/runtime_errors_test.go
@@ -1,0 +1,105 @@
+package vm
+
+import (
+	"errors"
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeErrorPreservesCause(t *testing.T) {
+	sentinel := errors.New("native sentinel")
+	err := &RuntimeError{
+		Location: SourceLocation{File: "main.nx", Line: 4},
+		Message:  "native failed",
+		Cause:    sentinel,
+	}
+
+	if !errors.Is(err, sentinel) || err.Error() != "[main.nx:line 4] native failed: native sentinel" {
+		t.Fatalf("error=%q unwrap=%v", err, errors.Is(err, sentinel))
+	}
+}
+
+func TestUnwindErrorPreservesLIFOOrderAndNestedCause(t *testing.T) {
+	original := errors.New("original")
+	nested := &UnwindError{Deferred: []DeferredError{{
+		Registration: SourceLocation{File: "cleanup.nx", Line: 9},
+		Cause:        errors.New("nested"),
+	}}}
+	err := &UnwindError{Primary: original, Deferred: []DeferredError{
+		{Registration: SourceLocation{File: "main.nx", Line: 8}, Cause: nested},
+		{Registration: SourceLocation{File: "main.nx", Line: 7}, Cause: errors.New("older")},
+	}}
+
+	if !errors.Is(err, original) {
+		t.Fatal("primary cause lost")
+	}
+	text := err.Error()
+	if strings.Index(text, "line 8") > strings.Index(text, "line 7") || strings.Count(text, "cleanup.nx:line 9") != 1 {
+		t.Fatalf("bad nested rendering:\n%s", text)
+	}
+}
+
+func TestNativeRuntimeErrorPreservesNativeCause(t *testing.T) {
+	sentinel := errors.New("native sentinel")
+	machine := New()
+	native := value.NewContextualNative("explode", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), sentinel
+	})
+	machine.push(native)
+	source := &chunk.Chunk{FileName: "native.nx", Lines: []int{17}}
+
+	ok, err := machine.callValue(native, 0, source, 1)
+	if ok || !errors.Is(err, sentinel) {
+		t.Fatalf("ok=%v errors.Is(err, sentinel)=%v", ok, errors.Is(err, sentinel))
+	}
+	if got, want := err.Error(), "[native.nx:line 17] native 'explode' failed: native sentinel"; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestNativeValidationErrorPreservesCause(t *testing.T) {
+	machine := New()
+	native := value.NewNativeWithSignature("needs_ref", value.NativeSignature{
+		Arity:      1,
+		Params:     []value.ParamInfo{{IsRef: true, TypeName: "ref int"}},
+		ReturnType: "void",
+	}, func([]value.Value) value.Value {
+		return value.NewNull()
+	})
+	machine.push(native)
+	machine.push(value.NewInt(1))
+
+	ok, err := machine.callValue(native, 1, &chunk.Chunk{FileName: "native.nx", Lines: []int{18}}, 1)
+	if ok || err == nil {
+		t.Fatalf("ok=%v error=%v, want native validation failure", ok, err)
+	}
+	var runtimeErr *RuntimeError
+	if !errors.As(err, &runtimeErr) || runtimeErr.Cause == nil {
+		t.Fatalf("error did not preserve validation cause: %T %[1]v", err)
+	}
+	if got, want := runtimeErr.Cause.Error(), "function 'needs_ref' argument 1: expected ref int, got int"; got != want {
+		t.Fatalf("cause=%q, want %q", got, want)
+	}
+}
+
+func TestImportRuntimeErrorPreservesModuleCause(t *testing.T) {
+	source := &chunk.Chunk{
+		Code:      []byte{byte(chunk.OP_IMPORT), 0},
+		Constants: []value.Value{value.NewString("missing_runtime_error_module")},
+		Lines:     []int{6, 6},
+		FileName:  "importer.nx",
+	}
+	err := New().Interpret(source)
+	if err == nil {
+		t.Fatal("missing import succeeded")
+	}
+	var runtimeErr *RuntimeError
+	if !errors.As(err, &runtimeErr) || runtimeErr.Cause == nil {
+		t.Fatalf("error did not preserve a structured import cause: %T %[1]v", err)
+	}
+	if got, want := err.Error(), "[importer.nx:line 6] failed to import module 'missing_runtime_error_module': module not found: missing_runtime_error_module"; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -1,0 +1,72 @@
+package vm
+
+import "noxy-vm/internal/value"
+
+type frameOutcome struct {
+	Result value.Value
+	Err    error
+}
+
+func (vm *VM) finishFrame(outcome frameOutcome) frameOutcome {
+	frame := vm.currentFrame
+	if frame == nil || vm.frameCount == 0 {
+		return outcome
+	}
+
+	for len(frame.Deferred) > 0 {
+		last := len(frame.Deferred) - 1
+		call := frame.Deferred[last]
+		frame.Deferred[last] = PreparedCall{}
+		frame.Deferred = frame.Deferred[:last]
+
+		if err := vm.invokePreparedCall(call); err != nil {
+			outcome.Err = appendDeferredError(outcome.Err, DeferredError{
+				Registration: call.Registration,
+				Cause:        err,
+			})
+		}
+	}
+
+	return vm.finalizeCurrentFrame(outcome)
+}
+
+func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
+	frame := vm.currentFrame
+	if frame == nil || vm.frameCount == 0 {
+		return outcome
+	}
+
+	ownedTop := vm.stackTop
+	for index := frame.StackBase; index < ownedTop; index++ {
+		vm.closeUpvalue(&vm.stack[index])
+		vm.stack[index] = value.Value{}
+	}
+
+	frameIndex := vm.frameCount - 1
+	vm.frames[frameIndex] = nil
+	vm.frameCount--
+	vm.stackTop = frame.StackBase
+
+	if vm.frameCount == 0 {
+		vm.currentFrame = nil
+		vm.stackTop = 0
+		return outcome
+	}
+
+	vm.currentFrame = vm.frames[vm.frameCount-1]
+	if outcome.Err == nil {
+		vm.push(outcome.Result)
+	}
+	return outcome
+}
+
+func appendDeferredError(primary error, deferred DeferredError) error {
+	if unwind, ok := primary.(*UnwindError); ok {
+		unwind.Deferred = append(unwind.Deferred, deferred)
+		return unwind
+	}
+	return &UnwindError{
+		Primary:  primary,
+		Deferred: []DeferredError{deferred},
+	}
+}

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -8,6 +8,17 @@ type frameOutcome struct {
 }
 
 func (vm *VM) finishFrame(outcome frameOutcome) frameOutcome {
+	return vm.finalizeCurrentFrame(outcome)
+}
+
+func (vm *VM) unwindTo(targetFrameCount int, outcome frameOutcome) frameOutcome {
+	for vm.frameCount > targetFrameCount {
+		outcome = vm.finalizeCurrentFrame(outcome)
+	}
+	return outcome
+}
+
+func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	frame := vm.currentFrame
 	if frame == nil || vm.frameCount == 0 {
 		return outcome
@@ -25,15 +36,6 @@ func (vm *VM) finishFrame(outcome frameOutcome) frameOutcome {
 				Cause:        err,
 			})
 		}
-	}
-
-	return vm.finalizeCurrentFrame(outcome)
-}
-
-func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
-	frame := vm.currentFrame
-	if frame == nil || vm.frameCount == 0 {
-		return outcome
 	}
 
 	ownedTop := vm.stackTop

--- a/internal/vm/unwind_test.go
+++ b/internal/vm/unwind_test.go
@@ -1,0 +1,132 @@
+package vm
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestDeferredCallsRunLIFOOnExplicitReturn(t *testing.T) {
+	machine := New()
+	var order []int64
+	machine.DefineNative("record", func(args []value.Value) value.Value {
+		order = append(order, args[0].AsInt)
+		return value.NewNull()
+	})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+	err := interpretVMSource(t, machine, `
+func work() -> int
+    defer record(1)
+    defer record(2)
+    return 7
+end
+test_report(work())`)
+	if err != nil || !slices.Equal(order, []int64{2, 1}) || !valuesEqual(captured, value.NewInt(7)) {
+		t.Fatalf("error=%v order=%v result=%v", err, order, captured)
+	}
+}
+
+func TestDeferredCallsRunOnImplicitAndScriptReturn(t *testing.T) {
+	cases := []struct {
+		source string
+		want   []int64
+	}{
+		{`func work() -> void
+    defer record(1)
+    record(0)
+end
+work()`, []int64{0, 1}},
+		{`defer record(1)
+defer record(2)
+record(0)`, []int64{0, 2, 1}},
+	}
+
+	for _, test := range cases {
+		machine := New()
+		var order []int64
+		machine.DefineNative("record", func(args []value.Value) value.Value {
+			order = append(order, args[0].AsInt)
+			return value.NewNull()
+		})
+		if err := interpretVMSource(t, machine, test.source); err != nil {
+			t.Fatalf("source=%q error=%v", test.source, err)
+		}
+		if !slices.Equal(order, test.want) {
+			t.Fatalf("source=%q order=%v want=%v", test.source, order, test.want)
+		}
+	}
+}
+
+func TestDeferredClosureReadsOwnerLocalBeforeUpvalueCloses(t *testing.T) {
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func work() -> void
+    let local: int = 42
+    func cleanup() -> void
+        test_report(local)
+    end
+    defer cleanup()
+end
+work()`)
+	if err != nil || !valuesEqual(captured, value.NewInt(42)) {
+		t.Fatalf("error=%v captured=%v, want 42", err, captured)
+	}
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil || machine.openUpvalues != nil {
+		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
+	}
+}
+
+func TestDeferredCallsRunAllAfterFailuresAndPreserveOrder(t *testing.T) {
+	machine := New()
+	firstFailure := errors.New("cleanup two failed")
+	secondFailure := errors.New("cleanup three failed")
+	var order []int64
+	machine.DefineContextualNative("cleanup", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
+		id := args[0].AsInt
+		order = append(order, id)
+		switch id {
+		case 2:
+			return value.NewNull(), firstFailure
+		case 3:
+			return value.NewNull(), secondFailure
+		default:
+			return value.NewNull(), nil
+		}
+	})
+
+	err := interpretVMSource(t, machine, `
+defer cleanup(1)
+defer cleanup(2)
+defer cleanup(3)`)
+	if !slices.Equal(order, []int64{3, 2, 1}) {
+		t.Fatalf("order=%v, want [3 2 1]", order)
+	}
+	var unwind *UnwindError
+	if !errors.As(err, &unwind) {
+		t.Fatalf("error=%T %v, want *UnwindError", err, err)
+	}
+	if unwind.Primary != nil || len(unwind.Deferred) != 2 {
+		t.Fatalf("unwind=%#v, want two deferred failures and no primary", unwind)
+	}
+	if !errors.Is(&unwind.Deferred[0], secondFailure) || !errors.Is(&unwind.Deferred[1], firstFailure) {
+		t.Fatalf("deferred causes=%v, want cleanup three then cleanup two", unwind.Deferred)
+	}
+	if unwind.Deferred[0].Registration.Line != 4 || unwind.Deferred[1].Registration.Line != 3 {
+		t.Fatalf("registration lines=%d,%d want 4,3", unwind.Deferred[0].Registration.Line, unwind.Deferred[1].Registration.Line)
+	}
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil {
+		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d", machine.frameCount, machine.currentFrame, machine.stackTop)
+	}
+}

--- a/internal/vm/unwind_test.go
+++ b/internal/vm/unwind_test.go
@@ -130,3 +130,136 @@ defer cleanup(3)`)
 		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d", machine.frameCount, machine.currentFrame, machine.stackTop)
 	}
 }
+
+func TestRuntimeErrorRunsAllDeferredCalls(t *testing.T) {
+	machine := New()
+	var order []int64
+	machine.DefineNative("record", func(args []value.Value) value.Value {
+		order = append(order, args[0].AsInt)
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func fail() -> void
+    defer record(1)
+    defer record(2)
+    let zero: int = 0
+    print(1 / zero)
+end
+fail()`)
+	if err == nil || !slices.Equal(order, []int64{2, 1}) {
+		t.Fatalf("error=%v order=%v", err, order)
+	}
+}
+
+func TestCleanupFailuresAggregateAndDoNotSkipOlderEntries(t *testing.T) {
+	machine := New()
+	first := errors.New("first cleanup")
+	second := errors.New("second cleanup")
+	var completed bool
+	machine.DefineContextualNative("fail_first", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), first
+	})
+	machine.DefineContextualNative("fail_second", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), second
+	})
+	machine.DefineNative("complete", func([]value.Value) value.Value {
+		completed = true
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, "defer complete()\ndefer fail_first()\ndefer fail_second()\n")
+	var unwind *UnwindError
+	if !errors.As(err, &unwind) || !errors.Is(err, first) || !errors.Is(err, second) || !completed || len(unwind.Deferred) != 2 {
+		t.Fatalf("error=%v unwind=%#v completed=%v", err, unwind, completed)
+	}
+	if !errors.Is(&unwind.Deferred[0], second) || !errors.Is(&unwind.Deferred[1], first) {
+		t.Fatalf("deferred=%v, want second then first", unwind.Deferred)
+	}
+}
+
+func TestNormalReturnCleanupFailureUnwindsCallers(t *testing.T) {
+	machine := New()
+	first := errors.New("first cleanup")
+	var completed bool
+	machine.DefineContextualNative("fail_first", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), first
+	})
+	machine.DefineNative("complete", func([]value.Value) value.Value {
+		completed = true
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func inner() -> void
+    defer fail_first()
+end
+func outer() -> void
+    defer complete()
+    inner()
+end
+outer()`)
+	if !errors.Is(err, first) || !completed {
+		t.Fatalf("error=%v completed=%v", err, completed)
+	}
+}
+
+func TestNestedCleanupFailurePreservesAggregate(t *testing.T) {
+	machine := New()
+	first := errors.New("first cleanup")
+	second := errors.New("second cleanup")
+	machine.DefineContextualNative("fail_first", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), first
+	})
+	machine.DefineContextualNative("fail_second", func(value.NativeContext, []value.Value) (value.Value, error) {
+		return value.NewNull(), second
+	})
+
+	err := interpretVMSource(t, machine, `
+func nested_cleanup() -> void
+    defer fail_second()
+    fail_first()
+end
+defer nested_cleanup()`)
+	var outer *UnwindError
+	if !errors.As(err, &outer) || outer.Primary != nil || len(outer.Deferred) != 1 {
+		t.Fatalf("error=%v outer=%#v", err, outer)
+	}
+	inner, ok := outer.Deferred[0].Cause.(*UnwindError)
+	if !ok || !errors.Is(inner.Primary, first) || len(inner.Deferred) != 1 || !errors.Is(&inner.Deferred[0], second) {
+		t.Fatalf("outer cause=%T %#v, want nested aggregate", outer.Deferred[0].Cause, outer.Deferred[0].Cause)
+	}
+}
+
+func TestVMReusableAfterRuntimeError(t *testing.T) {
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func fail() -> void
+    let local: int = 1
+    func cleanup() -> void
+        test_report(local)
+    end
+    defer cleanup()
+    let zero: int = 0
+    print(1 / zero)
+end
+fail()`)
+	if err == nil {
+		t.Fatal("runtime failure returned nil")
+	}
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.openUpvalues != nil {
+		t.Fatalf("dirty VM after error: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
+	}
+	if err := interpretVMSource(t, machine, "test_report(42)\n"); err != nil {
+		t.Fatal(err)
+	}
+	if !valuesEqual(captured, value.NewInt(42)) {
+		t.Fatalf("reuse result=%v", captured)
+	}
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -17,7 +17,8 @@ func (vm *VM) runtimeError(c *chunk.Chunk, ip int, format string, args ...interf
 type CallFrame struct {
 	Closure     *value.ObjClosure
 	IP          int
-	Slots       int // Offset in stack where this frame's locals start
+	StackBase   int // First stack slot owned by this frame
+	LocalBase   int // Offset in stack where this frame's locals start
 	Environment *value.GlobalEnvironment
 }
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -19,6 +19,7 @@ type CallFrame struct {
 	IP          int
 	StackBase   int // First stack slot owned by this frame
 	LocalBase   int // Offset in stack where this frame's locals start
+	Deferred    []PreparedCall
 	Environment *value.GlobalEnvironment
 }
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -11,16 +11,7 @@ const StackMax = 2048
 const FramesMax = 64
 
 func (vm *VM) runtimeError(c *chunk.Chunk, ip int, format string, args ...interface{}) error {
-	line := 0
-	file := "?"
-	if c != nil {
-		file = c.FileName
-		if ip > 0 && ip <= len(c.Lines) {
-			line = c.Lines[ip-1]
-		}
-	}
-	msg := fmt.Sprintf(format, args...)
-	return fmt.Errorf("[%s:line %d] %s", file, line, msg)
+	return vm.runtimeErrorCause(c, ip, nil, format, args...)
 }
 
 type CallFrame struct {

--- a/noxy_examples/defer_lifo.nx
+++ b/noxy_examples/defer_lifo.nx
@@ -1,0 +1,23 @@
+use sys select exit
+
+func assert(condition: bool, message: string) -> void
+    if !condition then
+        print("defer example: FAIL - " + message)
+        exit(1)
+    end
+end
+
+let order: string = ""
+
+func record(label: string) -> void
+    order = order + label
+end
+
+func cleanup_demo() -> void
+    defer record("1")
+    defer record("2")
+end
+
+cleanup_demo()
+assert(order == "21", "defer must execute in LIFO order")
+print("defer LIFO: " + order)

--- a/noxy_examples/defer_lifo.nx
+++ b/noxy_examples/defer_lifo.nx
@@ -1,3 +1,5 @@
+use io
+use sqlite
 use sys select exit
 
 func assert(condition: bool, message: string) -> void
@@ -8,6 +10,8 @@ func assert(condition: bool, message: string) -> void
 end
 
 let order: string = ""
+let file_path: string = "noxy_examples/.defer_lifo_resource.txt"
+let database_path: string = "noxy_examples/.defer_lifo_resource.sqlite"
 
 func record(label: string) -> void
     order = order + label
@@ -18,6 +22,40 @@ func cleanup_demo() -> void
     defer record("2")
 end
 
+func cleanup_sqlite() -> void
+    let db: sqlite.Database = sqlite.open(database_path)
+    assert(db.open, "SQLite database must open")
+    defer sqlite.close(db)
+
+    let create: sqlite.ExecResult = sqlite.exec(db, "CREATE TABLE cleanup_values (value INTEGER NOT NULL)")
+    assert(create.ok, "SQLite table must be created")
+
+    let statement: sqlite.Statement = sqlite.prepare(db, "INSERT INTO cleanup_values VALUES (?)")
+    assert(statement.handle > 0, "SQLite statement must prepare")
+    defer sqlite.finalize(statement)
+    sqlite.bind_int(statement, 1, 21)
+    let inserted: sqlite.ExecResult = sqlite.step_exec(statement)
+    assert(inserted.ok, "SQLite statement must execute")
+end
+
+func cleanup_resources() -> void
+    let file: io.File = io.open(file_path, "w")
+    assert(file.open, "file must open")
+    defer io.close(file)
+    io.write(file, "defer cleanup\n")
+
+    cleanup_sqlite()
+end
+
+if io.exists(file_path) then
+    assert(io.remove(file_path), "stale file must be removable")
+end
+if io.exists(database_path) then
+    assert(io.remove(database_path), "stale SQLite database must be removable")
+end
 cleanup_demo()
 assert(order == "21", "defer must execute in LIFO order")
+cleanup_resources()
+assert(io.remove(file_path), "deferred file close must allow removal")
+assert(io.remove(database_path), "deferred SQLite cleanup must allow removal")
 print("defer LIFO: " + order)

--- a/noxy_examples/defer_lifo.nx
+++ b/noxy_examples/defer_lifo.nx
@@ -56,6 +56,6 @@ end
 cleanup_demo()
 assert(order == "21", "defer must execute in LIFO order")
 cleanup_resources()
-assert(io.remove(file_path), "deferred file close must allow removal")
-assert(io.remove(database_path), "deferred SQLite cleanup must allow removal")
+assert(io.remove(file_path), "temporary file must be removable after cleanup frame")
+assert(io.remove(database_path), "temporary database must be removable after cleanup frame")
 print("defer LIFO: " + order)


### PR DESCRIPTION
## What

- adds Go-style call-only `defer` with immediate argument capture and per-frame LIFO execution
- centralizes bounded runtime unwind while preserving frames, stack, instruction pointer, upvalues, and caller boundaries
- preserves structured primary and cleanup errors, including failures during deferred cleanup
- covers modules, spawned routines, files, listeners, connected sockets, and SQLite statements/databases
- documents the language semantics and adds an executable file + SQLite example

## Why

Resolves point 10 from #17 by providing deterministic cleanup on normal returns and runtime errors without corrupting VM state.

## Validation

- `go test ./internal/... -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/vm -count=1`
- `go run cmd/noxy/main.go noxy_examples/defer_lifo.nx` -> `defer LIFO: 21`
- concurrent Noxy runner -> 158/158 passed

## Review

Independent review found no Critical or Important issues. One non-blocking diagnostic follow-up remains: a deferred native failure can include the synthetic location `[?:line 0]` in its nested rendered text; error identity, registration location, unwind order, and cleanup behavior remain correct.