### PR TITLE
feat(vm): add supervised tasks

### DIFF
--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -642,6 +642,30 @@ let hex: string = hex_encode(data)  // "48656c6c6f"
 let back: bytes = hex_decode(hex)   // b"Hello"
 ```
 
+### Concurrency and Supervised Tasks
+
+`spawn(function, ...arguments)` starts a detached Noxy routine and immediately returns `null`. It exposes no handle and does not propagate the worker's result, runtime error, or panic to its caller. Its existing validation and asynchronous diagnostics remain compatible.
+
+`spawn_task(function, ...arguments)` instead validates a Noxy function or closure, arity, and parameter modes synchronously, launches it in a shared child VM, and returns an opaque task handle. Handles may be stored as `any`, passed, printed, and compared by identity, but cannot be constructed or inspected by Noxy code.
+
+`task_await(handle)` waits indefinitely. `task_await(handle, timeout_ms)` accepts a non-negative integer number of milliseconds; zero performs an immediate poll. Invalid handles or timeouts are synchronous runtime errors in the caller.
+
+Each successful await returns a fresh `map[string, any]` envelope:
+
+| Status | `value` | `error` |
+|---|---|---|
+| `"ok"` | The task's return value, including `null` for a void return | `null` |
+| `"error"` | `null` | A structured failure map |
+| `"timeout"` | `null` | `null` |
+
+For `"error"`, the failure map contains string fields `kind`, `message`, and `stack`. `kind` is `"runtime"` for a Noxy runtime error or `"panic"` for a recovered Go panic. Runtime stacks are Noxy stacks captured at the failure point; panic stacks are Go stacks. The panic boundary covers the supervised task's main goroutine only, not independent goroutines started by native code.
+
+Task completion is published exactly once and can be awaited consistently by multiple sequential or concurrent waiters. Each envelope and failure map is a fresh container, but an `"ok"` composite value preserves its original identity. Consequently, replay means the same terminal outcome and returned-value identity, not independent deep snapshots.
+
+Timeout is local and non-terminal: it does not cancel the worker, consume the result, or mutate the task. Completion is preferred whenever it is observably available at the deadline. A wait that returns `"timeout"` may therefore be followed by a later wait that returns `"ok"` or `"error"`.
+
+Supervised tasks share globals, module state, runtime resources, closure environments, and the VM configuration. Ordinary composite arguments retain Noxy's top-level shallow-copy semantics and `ref` arguments retain reference identity. Shared references, nested composites, returned composite values, and closure upvalues require explicit concurrency coordination.
+
 ---
 
 ## 10. Module System

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -109,7 +109,7 @@ Parameters declared with `ref` skip the shallow copy and access the caller's ori
 
 #### Concurrency and composite values
 
-Shared routines use synchronized global bindings, module state, maps, and runtime handle registries. An individual binding lookup/update or map operation is safe from the Go runtime's concurrent-map crash, but synchronization is not recursive and does not make a read-modify-write sequence atomic. Arrays, structs, and nested composite values may still share mutable identity because parameter copying remains shallow. Concurrent compound operations or nested composite mutation require coordination through channels or another explicit single-owner protocol.
+Shared routines use synchronized global bindings, module state, maps, and runtime handle registries. An individual binding lookup/update or map operation is safe from the Go runtime's concurrent-map crash, but synchronization is not recursive and does not make a read-modify-write sequence atomic. Normal calls and `spawn_task` use the shallow-copy parameter rules above. The legacy detached `spawn` is a compatibility exception and forwards argument values directly, preserving the top-level identity of mutable composites. Concurrent compound operations or mutation through any shared identity require coordination through channels or another explicit single-owner protocol.
 
 This runtime foundation does not change any public Noxy syntax, builtin signature, result shape, or shallow-copy rule.
 
@@ -644,7 +644,7 @@ let back: bytes = hex_decode(hex)   // b"Hello"
 
 ### Concurrency and Supervised Tasks
 
-`spawn(function, ...arguments)` starts a detached Noxy routine and immediately returns `null`. It exposes no handle and does not propagate the worker's result, runtime error, or panic to its caller. Its existing validation and asynchronous diagnostics remain compatible.
+`spawn(function, ...arguments)` starts a detached Noxy routine and immediately returns `null`. It exposes no handle and does not propagate the worker's result, runtime error, or panic to its caller. For compatibility, it also forwards arguments without the normal top-level shallow copy, so mutable composite arguments keep the same identity in caller and worker and require explicit coordination to avoid races. Its existing validation and asynchronous diagnostics remain compatible.
 
 `spawn_task(function, ...arguments)` instead validates a Noxy function or closure, arity, and parameter modes synchronously, launches it in a shared child VM, and returns an opaque task handle. Handles may be stored as `any`, passed, printed, and compared by identity, but cannot be constructed or inspected by Noxy code.
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -16,7 +16,7 @@ Individual global-binding and map operations are synchronized and do not crash t
 
 These guarantees do not make a sequence of operations atomic. For example, `counter = counter + 1` is still a separate read and write. Likewise, arrays, structs, and composite values nested inside a map or global binding are not recursively synchronized. Coordinate compound operations and mutation of nested composite values with channels (or another explicit single-owner protocol).
 
-Function arguments preserve Noxy's shallow-copy rules: the outer array, map, or struct is copied for an ordinary parameter, while nested composites remain shared. The synchronized runtime foundation does not turn that shallow copy into a deep copy.
+Normal function calls, including functions launched by `spawn_task`, preserve Noxy's shallow-copy rules: the outer array, map, or struct is copied for an ordinary parameter, while nested composites remain shared. The legacy detached `spawn` is a compatibility exception: it forwards its argument values directly, so mutable composites retain their top-level identity. Coordinate every concurrent access to those shared values explicitly; the synchronized runtime foundation neither deep-copies them nor prevents data races in compound mutations.
 
 This foundation does not change the behavior of existing concurrency primitives. It also underpins supervised tasks, described below, without changing detached `spawn`.
 
@@ -47,6 +47,7 @@ end
 - **Non-blocking**: `spawn` returns immediately.
 - **Concurrent**: The spawned function runs in parallel (on multi-core systems).
 - **Detached**: `spawn` returns `null`, exposes no handle, and never propagates a worker result or failure to its caller. Existing validation and worker diagnostics remain on standard output as `Runtime Error:`, `Thread Error:`, or `Thread Panic:` messages.
+- **Argument compatibility**: Unlike a normal call or `spawn_task`, legacy `spawn` forwards mutable arguments without a top-level shallow copy. Caller and worker therefore observe the same composite identity and must coordinate reads and writes to avoid races.
 
 ---
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -18,7 +18,7 @@ These guarantees do not make a sequence of operations atomic. For example, `coun
 
 Function arguments preserve Noxy's shallow-copy rules: the outer array, map, or struct is copied for an ordinary parameter, while nested composites remain shared. The synchronized runtime foundation does not turn that shallow copy into a deep copy.
 
-This foundation changes no public Noxy syntax, builtin signature, or result shape. Corrected `net_select` semantics and supervised `spawn`/task behavior are separate follow-up work.
+This foundation does not change the behavior of existing concurrency primitives. It also underpins supervised tasks, described below, without changing detached `spawn`.
 
 ---
 
@@ -46,7 +46,41 @@ end
 ### Key Characteristics
 - **Non-blocking**: `spawn` returns immediately.
 - **Concurrent**: The spawned function runs in parallel (on multi-core systems).
-- **Independent**: If a routine crashes (panics), it prints an error but (usually) doesn't kill the whole VM immediately (implementation details verify this).
+- **Detached**: `spawn` returns `null`, exposes no handle, and never propagates a worker result or failure to its caller. Existing validation and worker diagnostics remain on standard output as `Runtime Error:`, `Thread Error:`, or `Thread Panic:` messages.
+
+---
+
+## Supervised Tasks
+
+Use `spawn_task(function, ...arguments)` when the caller must observe a routine's result or failure. It validates the Noxy function or closure, its arity, and parameter modes before launch, then returns an opaque task handle. The handle can be stored behind `any`, passed around, printed, and compared by identity; its internal state is not directly accessible.
+
+```noxy
+let task: any = spawn_task(calculate, input)
+
+// Wait until the task finishes.
+let terminal: any = task_await(task)
+
+// Or wait for at most 500 milliseconds.
+let bounded: any = task_await(task, 500)
+```
+
+Invalid callables, arity, parameter modes, handles, and timeout values are synchronous runtime errors in the calling VM. The optional timeout is an integer number of milliseconds, must be non-negative, and may be zero for an immediate poll.
+
+Every `task_await` returns a new `map[string, any]` envelope with this contract:
+
+| Status | `value` | `error` |
+|---|---|---|
+| `"ok"` | The task's return value, including `null` for a void return | `null` |
+| `"error"` | `null` | A structured failure map |
+| `"timeout"` | `null` | `null` |
+
+An error map contains `kind`, `message`, and `stack`. `kind` is `"runtime"` for a Noxy runtime error and `"panic"` for a recovered internal Go panic. Runtime failures contain a Noxy call stack captured at the failure point; panic failures contain a Go stack. Panic recovery covers the task's main goroutine, not goroutines independently started by native code.
+
+A timeout is non-terminal: it never cancels the worker, consumes its outcome, or changes the task. If completion is observable at the deadline, completion wins over timeout. A later or repeated wait therefore observes the same terminal outcome. Envelopes and error maps are fresh on every wait so their mutation cannot alter the private outcome, while a successful composite `value` preserves its original identity rather than being deep-copied.
+
+Supervised tasks share global/module runtime state and use the normal parameter rules: ordinary composite parameters receive a top-level shallow copy, while `ref` parameters, nested composites, closure upvalues, and successful composite results can preserve shared identity. Coordinate concurrent access to shared references, arrays, maps, structs, and upvalues with channels or another explicit ownership protocol.
+
+The original `spawn` API remains detached for compatibility. Choose `spawn_task` only when the caller needs structured completion, replayable results, or failures it can inspect.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-14-supervised-tasks.md
+++ b/docs/superpowers/plans/2026-08-14-supervised-tasks.md
@@ -1,0 +1,603 @@
+# Supervised Tasks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add supervised Noxy tasks with opaque handles, repeatable result/error waits, non-terminal timeouts, structured worker failures, and panic recovery while preserving detached `spawn`.
+
+**Architecture:** `VAL_TASK` wraps a self-contained `ObjTask` whose private terminal outcome is published once and broadcast by closing `done`. A prepared-call boundary validates and copies arguments synchronously, while an explicit execution boundary receives the terminal return value from `run` without scraping the child stack. `spawn_task` publishes success, typed runtime failure, or recovered panic; `task_await` renders a fresh envelope and uses completion-biased timeout checks.
+
+**Tech Stack:** Go, Noxy bytecode VM, goroutines/channels, `sync.Once`, `time.Timer`, Go tests, and Noxy executable examples.
+
+## Global Constraints
+
+- Preserve all observable behavior of detached `spawn`, including immediate `null`, diagnostic text/destination, and non-propagation.
+- Add no syntax, opcode, public source-level `task` type, cancellation, restart strategy, or task registry.
+- `spawn_task` accepts only Noxy functions/closures and validates callable, arity, runtime argument types, and `ref` modes before starting a goroutine.
+- Non-`ref` task arguments use normal top-level shallow-copy semantics; `ref` arguments preserve reference identity.
+- Runtime-error stacks are captured at `runtimeError`, before frames can be unwound or cleared.
+- A terminal outcome is stored before `done` closes and is replayable to sequential and concurrent waiters.
+- Each wait returns a new envelope while its successful `value` preserves Noxy identity.
+- Timeout is local to one wait, never cancels or consumes the task, and completion wins if observable before the wait returns.
+- Run every production change through RED, GREEN, and focused regression tests before committing.
+
+## File Structure
+
+- Create `internal/value/task.go` and `task_test.go` for the opaque handle and single-publication state.
+- Create `internal/vm/runtime_errors.go` for failure-point Noxy stack capture.
+- Create `internal/vm/task_execution.go` and `task_execution_test.go` for call preparation and explicit results.
+- Create `internal/vm/builtins_tasks.go` and `builtins_tasks_test.go` for launch, wait, envelopes, panic recovery, and timeout.
+- Modify value/VM switches, builtin registration, executor `run` callers, registry tests, and detached-spawn characterization tests.
+- Update `docs/concurrency.md`, `docs/NOXY_LANGUAGE_SPEC.md`, and add `noxy_examples/supervised_tasks.nx`.
+
+---
+
+### Task 1: Opaque task value and single-publication primitive
+
+**Files:**
+- Create: `internal/value/task.go`
+- Create: `internal/value/task_test.go`
+- Modify: `internal/value/value.go`
+- Modify: `internal/vm/stack.go`
+- Modify: `internal/vm/call_validation.go`
+- Modify: `internal/vm/builtins_core.go`
+- Modify: `internal/vm/references.go`
+- Modify: `internal/vm/builtins_core_test.go`
+- Modify: `internal/vm/builtins_json_test.go`
+- Modify: `internal/vm/malformed_reference_test.go`
+
+**Interfaces:**
+- Produces: `value.NewTask() value.Value`
+- Produces: `(*value.ObjTask).Done() <-chan struct{}`
+- Produces: `(*value.ObjTask).Complete(value.TaskOutcome)`
+- Produces: `(*value.ObjTask).Outcome() value.TaskOutcome`
+- Produces: `value.TaskOutcome{Value value.Value, Failure *value.TaskFailure}`
+- Produces: `value.TaskFailure{Kind, Message, Stack string; Cause error}`
+
+- [ ] **Step 1: Write failing task-value tests**
+
+```go
+func TestTaskPublishesFirstOutcomeToEveryWaiter(t *testing.T) {
+    handle := NewTask()
+    task := handle.Obj.(*ObjTask)
+    seen := make(chan Value, 4)
+    for range 4 {
+        go func() {
+            <-task.Done()
+            seen <- task.Outcome().Value
+        }()
+    }
+    task.Complete(TaskOutcome{Value: NewInt(42)})
+    task.Complete(TaskOutcome{Value: NewInt(99)})
+    for range 4 {
+        got := <-seen
+        if got.Type != VAL_INT || got.AsInt != 42 {
+            t.Fatalf("outcome = %v, want 42", got)
+        }
+    }
+}
+
+func TestTaskHandleIsOpaqueAndStable(t *testing.T) {
+    handle := NewTask()
+    if handle.Type != VAL_TASK || handle.String() != "<task>" {
+        t.Fatalf("handle = %s (%v)", handle.String(), handle.Type)
+    }
+}
+```
+
+In VM tests, assert `valuesEqual(handle, handle)` is true while two separately
+created tasks are unequal, `fmt("%T", handle)` produces `"task"`, strict JSON
+returns `errJSONUnsupported`, and `validateReferencedValue` rejects a
+`VAL_TASK` with a nil or wrongly typed payload.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `go test ./internal/value -run TestTask -count=1`
+
+Expected: compilation fails because the task types and `VAL_TASK` do not exist.
+
+- [ ] **Step 3: Implement the minimal primitive**
+
+Append `VAL_TASK` after existing tags. Create `internal/value/task.go`:
+
+```go
+type TaskFailure struct {
+    Kind, Message, Stack string
+    Cause                error
+}
+type TaskOutcome struct {
+    Value   Value
+    Failure *TaskFailure
+}
+type ObjTask struct {
+    done chan struct{}
+    once sync.Once
+    mu sync.RWMutex
+    outcome TaskOutcome
+}
+func NewTask() Value {
+    return Value{Type: VAL_TASK, Obj: &ObjTask{done: make(chan struct{})}}
+}
+func (task *ObjTask) Done() <-chan struct{} { return task.done }
+func (task *ObjTask) Complete(outcome TaskOutcome) {
+    task.once.Do(func() {
+        task.mu.Lock()
+        task.outcome = outcome
+        task.mu.Unlock()
+        close(task.done)
+    })
+}
+func (task *ObjTask) Outcome() TaskOutcome {
+    task.mu.RLock()
+    defer task.mu.RUnlock()
+    return task.outcome
+}
+func (*ObjTask) String() string { return "<task>" }
+```
+
+Handle `VAL_TASK` in `Value.String`, `valuesEqual` (object identity), `runtimeValueMode` (`"task"`), `%T` (`"task"`), and `validateReferencedValue` (non-nil payload). Strict JSON continues rejecting the new tag through its default unsupported branch.
+
+- [ ] **Step 4: Run focused and race tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/value ./internal/vm -run 'TestTask|TestMalformedReference' -count=1
+go test -race ./internal/value -run TestTaskPublishesFirstOutcomeToEveryWaiter -count=1
+```
+
+Expected: PASS without race reports.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/value/task.go internal/value/task_test.go internal/value/value.go internal/vm/stack.go internal/vm/call_validation.go internal/vm/builtins_core.go internal/vm/references.go internal/vm/builtins_core_test.go internal/vm/builtins_json_test.go internal/vm/malformed_reference_test.go
+git commit -m "feat(value): add opaque task handles"
+```
+
+---
+
+### Task 2: Failure-point stack capture and explicit closure results
+
+**Files:**
+- Create: `internal/vm/runtime_errors.go`
+- Create: `internal/vm/task_execution.go`
+- Create: `internal/vm/task_execution_test.go`
+- Modify: `internal/vm/vm.go`
+- Modify: `internal/vm/executor.go`
+- Modify: `internal/vm/modules.go`
+- Modify: `internal/vm/builtins_concurrency.go`
+
+**Interfaces:**
+- Produces: `RuntimeError{Rendered, Stack string}` implementing `error`.
+- Produces: `preparedTaskCall{Callable value.Value, Closure *value.ObjClosure, Arguments []value.Value}`.
+- Produces: `(*VM).prepareTaskCall(value.Value, []value.Value) (preparedTaskCall, error)`.
+- Produces: `(*VM).executePreparedTaskCall(preparedTaskCall) (value.Value, error)`.
+- Changes: `(*VM).run(int, *value.Value) error`; a non-nil sink receives the terminal return before cleanup.
+
+- [ ] **Step 1: Write failing execution-boundary tests**
+
+```go
+func TestPreparedTaskCallReturnsExplicitResult(t *testing.T) {
+    machine := New()
+    if err := interpretVMSource(t, machine, `
+func worker(value: int) -> int
+    return value * 2
+end`); err != nil {
+        t.Fatal(err)
+    }
+    callable, _ := machine.GetGlobal("worker")
+    call, err := machine.prepareTaskCall(callable, []value.Value{value.NewInt(21)})
+    if err != nil {
+        t.Fatal(err)
+    }
+    child := NewWithShared(machine.shared, machine.Config)
+    got, err := child.executePreparedTaskCall(call)
+    if err != nil || got.Type != value.VAL_INT || got.AsInt != 42 {
+        t.Fatalf("result=%v err=%v", got, err)
+    }
+}
+
+func TestRuntimeErrorCapturesNoxyStackAtFailurePoint(t *testing.T) {
+    machine := New()
+    err := interpretVMSource(t, machine, `
+func inner() -> int
+    return 1 / 0
+end
+func outer() -> int
+    return inner()
+end
+outer()`)
+    var runtimeErr *RuntimeError
+    if !errors.As(err, &runtimeErr) {
+        t.Fatalf("error type = %T, want *RuntimeError", err)
+    }
+    if !strings.Contains(runtimeErr.Stack, "in inner") ||
+        !strings.Contains(runtimeErr.Stack, "in outer") {
+        t.Fatalf("stack = %q", runtimeErr.Stack)
+    }
+}
+```
+
+Add focused tests proving a normal array argument gets a different outer `ObjArray` with shared nested identity, a `ref` argument retains its `ObjRef` pointer, wrong arity/mode/type fails synchronously, and the child uses the caller configuration/environment.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `go test ./internal/vm -run 'TestPreparedTaskCall|TestRuntimeErrorCaptures' -count=1`
+
+Expected: compilation fails because the new boundary and error type do not exist.
+
+- [ ] **Step 3: Capture a typed stack inside `runtimeError`**
+
+Implement `runtime_errors.go`:
+
+```go
+type RuntimeError struct {
+    Rendered string
+    Stack    string
+}
+func (failure *RuntimeError) Error() string { return failure.Rendered }
+
+func (vm *VM) newRuntimeError(c *chunk.Chunk, ip int, message string) error {
+    file, line := runtimeLocation(c, ip)
+    return &RuntimeError{
+        Rendered: fmt.Sprintf("[%s:line %d] %s", file, line, message),
+        Stack:    vm.captureNoxyStack(c, ip),
+    }
+}
+```
+
+`captureNoxyStack` walks live frames newest-to-oldest, uses supplied `c`/`ip` for the active frame and saved `frame.IP` for callers, and emits `[%s:line %d] in %s`. Change the existing `VM.runtimeError` body to call `newRuntimeError`; preserve its rendered text exactly.
+
+- [ ] **Step 4: Implement preparation and explicit result delivery**
+
+`prepareTaskCall` normalizes `ObjFunction` into `ObjClosure`, rejects natives and malformed values, checks arity and `validateParameterModes`, validates complete `RuntimeType` parameters with `runtimeValueMatchesType`, and copies only non-`ref` arguments.
+
+Change `run` to accept `terminalResult *value.Value`. In terminal `OP_RETURN`, assign `result` to a non-nil sink before stack cleanup. Pass `nil` from `InterpretWithEnvironment`, module execution, and detached `spawn`.
+
+```go
+func (vm *VM) executePreparedTaskCall(call preparedTaskCall) (value.Value, error) {
+    result := value.NewNull()
+    vm.push(call.Callable)
+    for _, argument := range call.Arguments {
+        vm.push(argument)
+    }
+    frame := &CallFrame{
+        Closure: call.Closure, IP: 0, Slots: 0,
+        Environment: call.Closure.Environment,
+    }
+    vm.frames[0], vm.frameCount, vm.currentFrame = frame, 1, frame
+    if err := vm.run(1, &result); err != nil {
+        return value.NewNull(), err
+    }
+    return result, nil
+}
+```
+
+- [ ] **Step 5: Run focused and regression tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/vm -run 'TestPreparedTaskCall|TestRuntimeErrorCaptures|TestSpawn' -count=1
+go test ./internal/... -count=1
+```
+
+Expected: PASS with unchanged legacy error strings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/vm/runtime_errors.go internal/vm/task_execution.go internal/vm/task_execution_test.go internal/vm/vm.go internal/vm/executor.go internal/vm/modules.go internal/vm/builtins_concurrency.go
+git commit -m "refactor(vm): add task execution boundary"
+```
+
+---
+
+### Task 3: Supervised completion, failure replay, and panic recovery
+
+**Files:**
+- Create: `internal/vm/builtins_tasks.go`
+- Create: `internal/vm/builtins_tasks_test.go`
+- Modify: `internal/vm/builtins_concurrency.go`
+- Modify: `internal/vm/builtins_registry_test.go`
+
+**Interfaces:**
+- Produces builtin: `spawn_task(function, ...arguments) -> any`.
+- Produces initial builtin: `task_await(handle) -> map[string, any]`.
+- Consumes: `preparedTaskCall`, `executePreparedTaskCall`, `value.ObjTask`, and `RuntimeError`.
+
+- [ ] **Step 1: Write failing public behavior tests**
+
+```go
+func TestSpawnTaskReplaysSuccessfulResult(t *testing.T) {
+    got := captureVMSource(t, `
+func worker(value: int) -> int
+    return value * 2
+end
+let task: any = spawn_task(worker, 21)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first["status"] == "ok" && first["value"] == 42 &&
+    first["error"] == null && second["value"] == 42)`)
+    assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestSpawnTaskReplaysRuntimeFailure(t *testing.T) {
+    got := captureVMSource(t, `
+func worker() -> int
+    return 1 / 0
+end
+let task: any = spawn_task(worker)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first["status"] == "error" && first["value"] == null &&
+    first["error"]["kind"] == "runtime" &&
+    contains(first["error"]["message"], "division by zero") &&
+    first["error"]["stack"] == second["error"]["stack"])`)
+    assertBuiltinValue(t, got, value.NewBool(true))
+}
+```
+
+Register a `panic_now` native, spawn a Noxy worker that calls it, then assert both waits return `kind == "panic"`, message `"boom"`, non-empty stack, `value == null`, and consistent fields. Add void/null and composite-return identity cases.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `go test ./internal/vm -run TestSpawnTask -count=1`
+
+Expected: failure because `spawn_task` and `task_await` are not registered.
+
+- [ ] **Step 3: Implement launch, terminal publication, and envelopes**
+
+Register both builtins contextually from `defineConcurrencyBuiltins`. Validate/copy before creating the task. Launch a child from `NewWithShared(machine.shared, machine.Config)`.
+
+```go
+func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
+    defer func() {
+        if recovered := recover(); recovered != nil {
+            task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
+                Kind: "panic", Message: fmt.Sprint(recovered),
+                Stack: string(debug.Stack()),
+            }})
+        }
+    }()
+    result, err := vm.executePreparedTaskCall(call)
+    if err != nil {
+        stack := ""
+        var runtimeErr *RuntimeError
+        if errors.As(err, &runtimeErr) {
+            stack = runtimeErr.Stack
+        }
+        task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
+            Kind: "runtime", Message: err.Error(), Stack: stack, Cause: err,
+        }})
+        return
+    }
+    task.Complete(value.TaskOutcome{Value: result})
+}
+```
+
+The initial `task_await` accepts exactly one valid `VAL_TASK`, blocks on `Done()`, and renders a fresh `value.NewMapWithData` envelope. Success sets `error: null`; failure sets `value: null` and creates a fresh nested `{kind,message,stack}` map.
+
+- [ ] **Step 4: Update builtin registry guarantees**
+
+Insert `spawn_task` and `task_await` into the sorted snapshot and the contextual-handler list. Assert `Contextual != nil`, `Fn == nil`, and `IsCallable()`.
+
+- [ ] **Step 5: Run focused and race tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/vm -run 'TestSpawnTask|TestBuiltinRegistry|TestStatefulBuiltins' -count=1
+go test -race ./internal/vm -run TestSpawnTask -count=1
+```
+
+Expected: PASS; panic becomes data and does not escape the worker goroutine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/vm/builtins_tasks.go internal/vm/builtins_tasks_test.go internal/vm/builtins_concurrency.go internal/vm/builtins_registry_test.go
+git commit -m "feat(vm): add supervised task outcomes"
+```
+
+---
+
+### Task 4: Deterministic non-terminal timeout and concurrent waits
+
+**Files:**
+- Modify: `internal/vm/builtins_tasks.go`
+- Modify: `internal/vm/builtins_tasks_test.go`
+
+**Interfaces:**
+- Extends builtin: `task_await(handle, timeout_ms) -> map[string, any]`.
+- Zero is an immediate poll; positive is bounded; negative/non-integer/overflow is a synchronous caller error.
+
+- [ ] **Step 1: Write failing timeout and concurrency tests**
+
+Use a custom native blocked on a Go channel so completion is test-controlled:
+
+```go
+func TestTaskTimeoutDoesNotConsumeLaterSuccess(t *testing.T) {
+    gate := make(chan struct{})
+    machine := New()
+    machine.DefineNative("wait_for_gate", func([]value.Value) value.Value {
+        <-gate
+        return value.NewInt(42)
+    })
+    task := spawnCompiledTestTask(t, machine, `
+func worker() -> int
+    return wait_for_gate()
+end`, "worker")
+    timed := invokeTaskAwait(t, machine, task, value.NewInt(0))
+    requireTaskEnvelope(t, timed, "timeout", value.NewNull(), value.NewNull())
+    close(gate)
+    requireTaskOK(t, invokeTaskAwait(t, machine, task), value.NewInt(42))
+}
+```
+
+Add positive timeout, completed zero poll, negative/non-integer/overflow timeout, wrong arity, invalid and malformed handles. Start 16 concurrent waits, release one gate, and assert all receive `"ok"` and the same composite result identity. Add a controlled deadline-boundary test proving the final done recheck beats timeout.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `go test ./internal/vm -run 'TestTaskTimeout|TestTaskAwait|TestConcurrentTask' -count=1`
+
+Expected: FAIL because timeout and completion-biased logic are absent.
+
+- [ ] **Step 3: Implement validated completion-biased waiting**
+
+```go
+func awaitTask(task *value.ObjTask, timeout *int64) (bool, error) {
+    select {
+    case <-task.Done(): return true, nil
+    default:
+    }
+    if timeout == nil {
+        <-task.Done()
+        return true, nil
+    }
+    if *timeout < 0 {
+        return false, fmt.Errorf("task timeout must be non-negative")
+    }
+    if *timeout == 0 {
+        return false, nil
+    }
+    if *timeout > int64(math.MaxInt64)/int64(time.Millisecond) {
+        return false, fmt.Errorf("task timeout is too large")
+    }
+    timer := time.NewTimer(time.Duration(*timeout) * time.Millisecond)
+    defer timer.Stop()
+    select {
+    case <-task.Done():
+        return true, nil
+    case <-timer.C:
+        select {
+        case <-task.Done(): return true, nil
+        default: return false, nil
+        }
+    }
+}
+```
+
+Parse one or two `task_await` arguments before this helper. When incomplete, return a fresh `{"status":"timeout","value":null,"error":null}` and never modify the task.
+
+- [ ] **Step 4: Run focused and race tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/vm -run 'TestTaskTimeout|TestTaskAwait|TestConcurrentTask|TestSpawnTask' -count=1
+go test -race ./internal/vm -run 'TestTask|TestConcurrentTask|TestSpawnTask' -count=1
+```
+
+Expected: PASS without nondeterministic timeout or race reports.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/vm/builtins_tasks.go internal/vm/builtins_tasks_test.go
+git commit -m "feat(vm): add non-terminal task timeouts"
+```
+
+---
+
+### Task 5: Detached compatibility, documentation, example, and full validation
+
+**Files:**
+- Modify: `internal/vm/builtins_concurrency_test.go`
+- Modify: `docs/concurrency.md`
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Create: `noxy_examples/supervised_tasks.nx`
+
+**Interfaces:**
+- Documents both task APIs, the exact envelope table, timeout precedence, identity/replay, failure kinds, panic boundary, and detached compatibility.
+- Demonstrates success, runtime error, timeout followed by success, and repeated wait.
+
+- [ ] **Step 1: Add detached-spawn characterization before any refactor**
+
+Cover missing/invalid callable, wrong arity, immediate `null`, and no propagation. For asynchronous error/panic diagnostics, use a child copy of the Go test process and assert captured output and successful exit:
+
+```go
+func TestSpawnRemainsDetachedOnWorkerFailure(t *testing.T) {
+    command := exec.Command(os.Args[0], "-test.run=TestSpawnDetachedHelper")
+    command.Env = append(os.Environ(), "NOXY_SPAWN_HELPER=runtime-error")
+    output, err := command.CombinedOutput()
+    if err != nil {
+        t.Fatalf("helper exit: %v\n%s", err, output)
+    }
+    if !bytes.Contains(output, []byte("Thread Error:")) {
+        t.Fatalf("output = %q", output)
+    }
+}
+```
+
+`TestSpawnDetachedHelper` returns immediately unless the environment variable is set. Its Noxy worker uses a test-only native/channel handshake, then errors or calls a panic native. Add a second mode asserting `Thread Panic:`. Do not use arbitrary sleeps.
+
+- [ ] **Step 2: Run characterization and verify the baseline is GREEN**
+
+Run: `go test ./internal/vm -run 'TestSpawnRemains|TestSpawnDetachedHelper|TestSpawnWorker|TestSpawnUses' -count=1`
+
+Expected: PASS against legacy `spawn`. If not, adjust the characterization to the actual observable behavior before changing production code.
+
+- [ ] **Step 3: Add the executable example**
+
+Create `noxy_examples/supervised_tasks.nx`:
+
+```noxy
+func double(value: int) -> int
+    return value * 2
+end
+func fail() -> int
+    return 1 / 0
+end
+func delayed() -> string
+    time_sleep(25)
+    return "ready"
+end
+
+let success: any = spawn_task(double, 21)
+let first: any = task_await(success)
+let second: any = task_await(success)
+assert(first["status"] == "ok" && first["value"] == 42, "task success")
+assert(second["value"] == 42, "task replay")
+
+let failed: any = task_await(spawn_task(fail))
+assert(failed["status"] == "error", "task failure")
+assert(failed["error"]["kind"] == "runtime", "runtime kind")
+
+let slow: any = spawn_task(delayed)
+let timeout: any = task_await(slow, 0)
+assert(timeout["status"] == "timeout", "non-terminal timeout")
+let completed: any = task_await(slow)
+assert(completed["status"] == "ok" && completed["value"] == "ready", "later wait")
+print("supervised tasks: ok")
+```
+
+- [ ] **Step 4: Document the normative contract**
+
+Add “Supervised Tasks” to both documents. Copy the three-row envelope table from the design. State that completion is preferred at the deadline, timeout never cancels/consumes, envelopes are fresh, successful values preserve identity, runtime stacks are Noxy stacks, panic stacks are Go stacks, shared refs/upvalues need coordination, and `spawn` remains detached.
+
+- [ ] **Step 5: Format and run complete validation**
+
+```bash
+gofmt -w internal/value/task.go internal/value/task_test.go internal/vm/runtime_errors.go internal/vm/task_execution.go internal/vm/task_execution_test.go internal/vm/builtins_tasks.go internal/vm/builtins_tasks_test.go internal/vm/builtins_concurrency_test.go
+go test ./internal/... -count=1
+go test ./... -count=1
+go test -race ./internal/vm -count=1
+go vet ./...
+go build ./...
+go run cmd/noxy/main.go noxy_examples/supervised_tasks.nx
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Expected: every Go command exits 0; the example prints `supervised tasks: ok`; the concurrent runner reports all included examples passing.
+
+- [ ] **Step 6: Inspect and commit the completed feature**
+
+Run: `git diff --check && git status --short && git diff --stat`
+
+Expected: no whitespace errors and only planned files changed.
+
+```bash
+git add internal docs/concurrency.md docs/NOXY_LANGUAGE_SPEC.md noxy_examples/supervised_tasks.nx
+git commit -m "feat(vm): document supervised tasks"
+```

--- a/docs/superpowers/specs/2026-08-14-supervised-tasks-design.md
+++ b/docs/superpowers/specs/2026-08-14-supervised-tasks-design.md
@@ -1,0 +1,223 @@
+# Supervised Tasks Design
+
+**Date:** 2026-08-14
+
+**Status:** Approved for implementation planning
+
+## Goal
+
+Resolve point 3 from PR #17 by adding supervised tasks that expose a stable,
+opaque handle, replay a terminal result or failure to any number of waiters,
+support non-terminal timeouts, and recover internal panics. The existing
+detached `spawn` builtin remains compatible.
+
+## Public API
+
+The feature adds two dynamic builtins. It does not add syntax, opcodes, or a
+source-level `task` type.
+
+```noxy
+let task: any = spawn_task(worker, argument)
+
+// Wait indefinitely.
+let terminal: any = task_await(task)
+
+// Wait for at most 500 milliseconds.
+let bounded: any = task_await(task, 500)
+```
+
+`spawn_task(function, ...arguments)` accepts only Noxy functions and closures.
+It validates the callable, arity, and parameter modes before returning a
+handle. Invalid input is a synchronous runtime error in the calling VM and
+does not create a task.
+
+`task_await(handle)` waits until the task reaches a terminal state.
+`task_await(handle, timeout_ms)` waits for at most the supplied number of
+milliseconds. A zero timeout is an immediate poll. A negative timeout, a
+non-integer timeout, or an invalid handle is a synchronous runtime error in
+the calling VM.
+
+## Result Contract
+
+Every successful `task_await` call returns a fresh `map[string, any]` envelope
+with exactly the following semantic fields:
+
+| Status | `value` | `error` |
+|---|---|---|
+| `"ok"` | The task's return value, including `null` for a void return | `null` |
+| `"error"` | `null` | A structured failure map |
+| `"timeout"` | `null` | `null` |
+
+The failure map has these fields:
+
+| Field | Meaning |
+|---|---|
+| `kind` | `"runtime"` for a Noxy runtime error or `"panic"` for a recovered Go panic |
+| `message` | The original error or panic message |
+| `stack` | A Noxy stack captured at the failure point for runtime errors, or `debug.Stack()` for panics |
+
+The implementation retains the original Go error internally rather than only
+its rendered message. This preserves an integration seam for typed or
+aggregate unwind errors added later.
+
+## Opaque Handle and Terminal State
+
+The runtime adds `VAL_TASK` and `ObjTask`. Noxy code can store the value behind
+`any`, pass it around, print it as an opaque task handle, and compare handles
+by identity, but cannot construct or inspect `ObjTask` directly.
+
+An `ObjTask` owns:
+
+- a `done chan struct{}` used only as a completion broadcast;
+- a private immutable terminal outcome containing either a return value or a
+  failure;
+- a single-publication guard.
+
+The worker stores its complete terminal outcome before closing `done`. Closing
+the channel publishes the stored outcome to all current and future waiters.
+Publication happens exactly once even if panic recovery is involved.
+
+Each wait creates a new public envelope, so user mutation cannot corrupt the
+task's private terminal state. The returned `value` preserves the identity and
+normal return semantics of the original Noxy value. Multiple waits therefore
+mean the same outcome and the same returned-value identity, not independent
+deep snapshots. Shared arrays, maps, structs, references, and closure upvalues
+still require explicit concurrency coordination.
+
+## Task Execution Boundary
+
+Task execution uses a new internal closure execution entrypoint with an
+explicit `(value.Value, error)` result. It must not discover the result by
+peeking or popping incidental stack state after `run` returns. This entrypoint
+owns preparation of the child VM, frame setup, execution, and extraction of
+the terminal return value.
+
+The child VM shares the caller's `SharedState`, VM configuration, closure, and
+global environment. Before the goroutine starts, call arguments are validated
+with the normal callable contract. Non-`ref` parameters receive Noxy's normal
+top-level shallow copy; `ref` parameters preserve the supplied reference.
+
+This execution entrypoint is a stable seam for later runtime unwind work. It
+must continue returning the terminal value explicitly if unwind cleanup later
+clears the child stack.
+
+## Failure and Panic Handling
+
+A Noxy runtime error terminates only the supervised task. The worker captures
+the Noxy stack while its frames still describe the failure, before any unwind
+or cleanup can clear them, and publishes a `runtime` failure.
+
+The task goroutine has a top-level `recover`. A recovered panic becomes a
+`panic` failure and includes `debug.Stack()`. Recovery covers only the task's
+main goroutine. A native that starts unrelated goroutines owns their panic
+boundaries; `spawn_task` cannot recover panics in those goroutines.
+
+Every exit path publishes a terminal outcome and closes `done`, so a runtime
+error or recovered panic cannot leave waiters blocked forever.
+
+## Timeout Semantics
+
+Timeout is local to one `task_await` call. It does not cancel the task, consume
+its result, mutate its state, or prevent a later wait.
+
+Completion is preferred whenever it is observably available before
+`task_await` returns. The wait algorithm therefore:
+
+1. checks `done` before creating or considering a timeout;
+2. uses `time.NewTimer` for positive bounded waits;
+3. schedules `timer.Stop()` when the bounded wait returns;
+4. checks `done` again after the timer fires before returning `"timeout"`.
+
+This prevents a terminal task from randomly returning timeout when both the
+timer and `done` are ready, including zero-time polls. Millisecond conversion
+must reject values that overflow `time.Duration`.
+
+## Detached Spawn Compatibility
+
+The existing `spawn` builtin remains detached and retains its current public
+behavior:
+
+- it returns `null` immediately;
+- it does not expose a handle or propagate a worker result;
+- it prints its existing validation, runtime-error, and panic diagnostics to
+  the same destinations;
+- a worker failure does not become an error in the caller.
+
+`spawn_task` must not silently change `spawn` by routing the legacy builtin
+through stricter validation or argument-copy behavior. Shared low-level code
+is acceptable only where characterization tests prove the observable legacy
+behavior remains identical.
+
+## Alternatives Considered
+
+### Shared registry with numeric handles
+
+A runtime-wide task registry would allow integer handles, but introduces
+forgery, retention, eviction, and cleanup policy that this feature does not
+need. The object handle carries its own lifecycle and becomes collectible when
+Noxy code releases it.
+
+### Result channel as the handle
+
+A one-shot result channel fits the existing concurrency primitives but makes
+the first receive consume the result. Supporting repeated waits would require
+another cache layered over the channel, effectively recreating `ObjTask` with
+a less precise public contract.
+
+### Raising worker failures from `task_await`
+
+Propagating an awaited failure as a caller runtime error would terminate the
+caller because Noxy has no catch mechanism. A structured envelope lets the
+caller inspect and recover from task failures while preserving synchronous
+runtime errors for misuse of the task API itself.
+
+## Testing Strategy
+
+Implementation follows test-first development. VM tests cover:
+
+- successful primitive, composite, `null`, and void results;
+- repeated sequential waits and concurrent waiters;
+- preserved identity for returned composite values;
+- runtime failure message and Noxy stack capture;
+- recovered panic message and stack capture;
+- a timeout followed by a later successful wait;
+- zero-time polling before and after completion;
+- completion winning at the deadline boundary;
+- invalid callable, arity, parameter mode, handle, and timeout;
+- duration overflow rejection;
+- shared globals, module environment, runtime state, and VM configuration;
+- shallow-copy behavior for ordinary parameters and identity for `ref`;
+- task handle formatting, identity equality, reference validation, JSON
+  rejection, and runtime type reporting;
+- race-detector coverage for publication and multiple waiters.
+
+Characterization tests lock down detached `spawn` behavior for missing or
+invalid callables, wrong arity, immediate `null` return, diagnostic text and
+destination, runtime errors, panics, and absence of propagation to the caller.
+
+An executable Noxy example demonstrates success, failure, timeout followed by
+success, and repeated waits. The concurrency guide and language specification
+document the API and guarantees.
+
+## Out of Scope
+
+- task cancellation or forced interruption;
+- supervisor trees, restart strategies, or task groups;
+- result-retention registries or explicit handle disposal;
+- a public `task` type or generic `Task<T>`;
+- catching arbitrary runtime errors outside supervised tasks;
+- recovering panics from goroutines started independently by native code;
+- changing detached `spawn` behavior.
+
+## Validation
+
+The implementation must pass:
+
+```bash
+go test ./internal/...
+go test ./...
+go test -race ./internal/vm
+go vet ./...
+go build ./...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```

--- a/internal/value/task.go
+++ b/internal/value/task.go
@@ -23,6 +23,10 @@ func NewTask() Value {
 	return Value{Type: VAL_TASK, Obj: &ObjTask{done: make(chan struct{})}}
 }
 
+func (task *ObjTask) IsValid() bool {
+	return task != nil && task.done != nil
+}
+
 func (task *ObjTask) Done() <-chan struct{} { return task.done }
 
 func (task *ObjTask) Complete(outcome TaskOutcome) {

--- a/internal/value/task.go
+++ b/internal/value/task.go
@@ -1,0 +1,43 @@
+package value
+
+import "sync"
+
+type TaskFailure struct {
+	Kind, Message, Stack string
+	Cause                error
+}
+
+type TaskOutcome struct {
+	Value   Value
+	Failure *TaskFailure
+}
+
+type ObjTask struct {
+	done    chan struct{}
+	once    sync.Once
+	mu      sync.RWMutex
+	outcome TaskOutcome
+}
+
+func NewTask() Value {
+	return Value{Type: VAL_TASK, Obj: &ObjTask{done: make(chan struct{})}}
+}
+
+func (task *ObjTask) Done() <-chan struct{} { return task.done }
+
+func (task *ObjTask) Complete(outcome TaskOutcome) {
+	task.once.Do(func() {
+		task.mu.Lock()
+		task.outcome = outcome
+		task.mu.Unlock()
+		close(task.done)
+	})
+}
+
+func (task *ObjTask) Outcome() TaskOutcome {
+	task.mu.RLock()
+	defer task.mu.RUnlock()
+	return task.outcome
+}
+
+func (*ObjTask) String() string { return "<task>" }

--- a/internal/value/task_test.go
+++ b/internal/value/task_test.go
@@ -1,0 +1,30 @@
+package value
+
+import "testing"
+
+func TestTaskPublishesFirstOutcomeToEveryWaiter(t *testing.T) {
+	handle := NewTask()
+	task := handle.Obj.(*ObjTask)
+	seen := make(chan Value, 4)
+	for range 4 {
+		go func() {
+			<-task.Done()
+			seen <- task.Outcome().Value
+		}()
+	}
+	task.Complete(TaskOutcome{Value: NewInt(42)})
+	task.Complete(TaskOutcome{Value: NewInt(99)})
+	for range 4 {
+		got := <-seen
+		if got.Type != VAL_INT || got.AsInt != 42 {
+			t.Fatalf("outcome = %v, want 42", got)
+		}
+	}
+}
+
+func TestTaskHandleIsOpaqueAndStable(t *testing.T) {
+	handle := NewTask()
+	if handle.Type != VAL_TASK || handle.String() != "<task>" {
+		t.Fatalf("handle = %s (%v)", handle.String(), handle.Type)
+	}
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -143,9 +143,101 @@ type ObjFunction struct {
 }
 
 type ObjUpvalue struct {
-	Location *Value // Pointer to stack variable or Closed field
-	Closed   Value  // The closed value
-	Next     *ObjUpvalue
+	mu       sync.RWMutex
+	location *Value
+	closed   Value
+	next     *ObjUpvalue
+}
+
+func NewOpenUpvalue(location *Value, next *ObjUpvalue) *ObjUpvalue {
+	return &ObjUpvalue{location: location, next: next}
+}
+
+func (upvalue *ObjUpvalue) IsValid() bool {
+	if upvalue == nil {
+		return false
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	return upvalue.location != nil
+}
+
+func (upvalue *ObjUpvalue) PointsTo(location *Value) bool {
+	if upvalue == nil || location == nil {
+		return false
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	return upvalue.location == location
+}
+
+func (upvalue *ObjUpvalue) Load() (Value, bool) {
+	if upvalue == nil {
+		return Value{}, false
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	if upvalue.location == nil {
+		return Value{}, false
+	}
+	return *upvalue.location, true
+}
+
+func (upvalue *ObjUpvalue) Store(updated Value) bool {
+	if upvalue == nil {
+		return false
+	}
+	upvalue.mu.Lock()
+	defer upvalue.mu.Unlock()
+	if upvalue.location == nil {
+		return false
+	}
+	*upvalue.location = updated
+	return true
+}
+
+func (upvalue *ObjUpvalue) Close(location *Value) bool {
+	if upvalue == nil || location == nil {
+		return false
+	}
+	upvalue.mu.Lock()
+	defer upvalue.mu.Unlock()
+	if upvalue.location != location {
+		return false
+	}
+	upvalue.closed = *location
+	upvalue.location = &upvalue.closed
+	return true
+}
+
+func (upvalue *ObjUpvalue) Next() *ObjUpvalue {
+	if upvalue == nil {
+		return nil
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	return upvalue.next
+}
+
+func (upvalue *ObjUpvalue) SetNext(next *ObjUpvalue) {
+	if upvalue == nil {
+		return
+	}
+	upvalue.mu.Lock()
+	defer upvalue.mu.Unlock()
+	upvalue.next = next
+}
+
+func (upvalue *ObjUpvalue) LocationAddress() (string, bool) {
+	if upvalue == nil {
+		return "", false
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	if upvalue.location == nil {
+		return "", false
+	}
+	return fmt.Sprintf("%p", upvalue.location), true
 }
 
 type ObjClosure struct {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -21,6 +21,7 @@ const (
 	VAL_CHANNEL
 	VAL_WAITGROUP
 	VAL_REF
+	VAL_TASK
 )
 
 type Value struct {
@@ -421,6 +422,12 @@ func (v Value) String() string {
 			return "<invalid reference>"
 		}
 		return ref.String()
+	case VAL_TASK:
+		task, ok := v.Obj.(*ObjTask)
+		if !ok || task == nil {
+			return "<invalid task>"
+		}
+		return task.String()
 	default:
 		return "unknown"
 	}

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -8,6 +8,8 @@ import (
 )
 
 func (vm *VM) defineConcurrencyBuiltins() {
+	vm.defineTaskBuiltins()
+
 	// Concurrency Primitives
 	vm.DefineContextualNative("spawn", func(context value.NativeContext, args []value.Value) (value.Value, error) {
 		machine, err := nativeVM(context)

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -17,51 +17,29 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		if len(args) < 1 {
 			return value.NewNull(), nil
 		}
-		fnVal := args[0]
-		if fnVal.Type != value.VAL_FUNCTION {
-			// Only script functions are supported in spawn.
-			fmt.Println("Runtime Error: spawn expects a function")
+		call, err := machine.prepareTaskCall(args[0], args[1:])
+		if err != nil {
+			fmt.Printf("Runtime Error: spawn %v\n", err)
 			return value.NewNull(), nil
 		}
-
-		threadArgs := args[1:]
 
 		// Create new VM thread sharing state
 		threadVM := NewWithShared(machine.shared, machine.Config)
 
-		// Setup execution
-		var closure *value.ObjClosure
-		if cl, ok := fnVal.Obj.(*value.ObjClosure); ok {
-			closure = cl
-		} else if fn, ok := fnVal.Obj.(*value.ObjFunction); ok {
-			closure = &value.ObjClosure{Function: fn, Upvalues: []*value.ObjUpvalue{}, Environment: fn.Environment}
-		} else {
-			fmt.Println("Runtime Error: spawn expects a function or closure")
-			return value.NewNull(), nil
-		}
-
-		fnObj := closure.Function
-
-		// Check arity
-		if len(threadArgs) != fnObj.Arity {
-			fmt.Printf("Runtime Error: spawn expected %d args, got %d\n", fnObj.Arity, len(threadArgs))
-			return value.NewNull(), nil
-		}
-
 		// Push Function (Stack slot 0)
-		threadVM.push(fnVal)
+		threadVM.push(call.Callable)
 
 		// Push Args
-		for _, arg := range threadArgs {
+		for _, arg := range call.Arguments {
 			threadVM.push(arg)
 		}
 
 		// Create Frame
 		frame := &CallFrame{
-			Closure:     closure,
+			Closure:     call.Closure,
 			IP:          0,
 			Slots:       0,
-			Environment: closure.Environment,
+			Environment: call.Closure.Environment,
 		}
 
 		threadVM.frames[0] = frame
@@ -75,7 +53,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 					fmt.Printf("Thread Panic: %v\n%s", r, debug.Stack())
 				}
 			}()
-			err := threadVM.run(1) // Run until finished (frame 0 popped)
+			err := threadVM.run(1, nil) // Run until finished (frame 0 popped)
 			if err != nil {
 				fmt.Printf("Thread Error: %v\n", err)
 			}

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -17,29 +17,51 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		if len(args) < 1 {
 			return value.NewNull(), nil
 		}
-		call, err := machine.prepareTaskCall(args[0], args[1:])
-		if err != nil {
-			fmt.Printf("Runtime Error: spawn %v\n", err)
+		fnVal := args[0]
+		if fnVal.Type != value.VAL_FUNCTION {
+			// Only script functions are supported in spawn.
+			fmt.Println("Runtime Error: spawn expects a function")
 			return value.NewNull(), nil
 		}
+
+		threadArgs := args[1:]
 
 		// Create new VM thread sharing state
 		threadVM := NewWithShared(machine.shared, machine.Config)
 
+		// Setup execution
+		var closure *value.ObjClosure
+		if cl, ok := fnVal.Obj.(*value.ObjClosure); ok {
+			closure = cl
+		} else if fn, ok := fnVal.Obj.(*value.ObjFunction); ok {
+			closure = &value.ObjClosure{Function: fn, Upvalues: []*value.ObjUpvalue{}, Environment: fn.Environment}
+		} else {
+			fmt.Println("Runtime Error: spawn expects a function or closure")
+			return value.NewNull(), nil
+		}
+
+		fnObj := closure.Function
+
+		// Check arity
+		if len(threadArgs) != fnObj.Arity {
+			fmt.Printf("Runtime Error: spawn expected %d args, got %d\n", fnObj.Arity, len(threadArgs))
+			return value.NewNull(), nil
+		}
+
 		// Push Function (Stack slot 0)
-		threadVM.push(call.Callable)
+		threadVM.push(fnVal)
 
 		// Push Args
-		for _, arg := range call.Arguments {
+		for _, arg := range threadArgs {
 			threadVM.push(arg)
 		}
 
 		// Create Frame
 		frame := &CallFrame{
-			Closure:     call.Closure,
+			Closure:     closure,
 			IP:          0,
 			Slots:       0,
-			Environment: call.Closure.Environment,
+			Environment: closure.Environment,
 		}
 
 		threadVM.frames[0] = frame

--- a/internal/vm/builtins_concurrency_test.go
+++ b/internal/vm/builtins_concurrency_test.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -8,6 +10,30 @@ import (
 )
 
 const statefulBuiltinTimeout = 2 * time.Second
+
+func captureConcurrencyStdout(t *testing.T, operation func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stdout
+	os.Stdout = writer
+	defer func() { os.Stdout = previous }()
+
+	operation()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
+}
 
 func awaitBuiltinResult(t *testing.T, result <-chan value.Value, operation string) value.Value {
 	t.Helper()
@@ -146,4 +172,89 @@ test_report(chan_recv(channel))
 		t.Fatal("spawn did not complete")
 	}
 	assertBuiltinValue(t, captured, value.NewString("child"))
+}
+
+func TestSpawnPreservesLegacyDiagnosticsOnStdout(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(item: int)
+end`); err != nil {
+		t.Fatal(err)
+	}
+	worker, _ := machine.GetGlobal("worker")
+	spawn := requireBuiltin(t, machine, "spawn")
+
+	tests := []struct {
+		name string
+		args []value.Value
+		want string
+	}{
+		{name: "non-function", args: []value.Value{value.NewInt(1)}, want: "Runtime Error: spawn expects a function\n"},
+		{name: "arity", args: []value.Value{worker}, want: "Runtime Error: spawn expected 1 args, got 0\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := captureConcurrencyStdout(t, func() {
+				result, err := spawn.Invoke(machine, test.args)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertBuiltinValue(t, result, value.NewNull())
+			})
+			if got != test.want {
+				t.Fatalf("stdout = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSpawnLaunchesDetachedWorkerWithoutSynchronousTypeValidation(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(item: int, channel: any)
+    chan_send(channel, item)
+end`); err != nil {
+		t.Fatal(err)
+	}
+	worker, _ := machine.GetGlobal("worker")
+	channel := value.NewChannel(1)
+
+	result, err := requireBuiltin(t, machine, "spawn").Invoke(machine, []value.Value{
+		worker, value.NewString("legacy"), channel,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBuiltinValue(t, result, value.NewNull())
+	select {
+	case got := <-channel.Obj.(*value.ObjChannel).Chan:
+		assertBuiltinValue(t, got, value.NewString("legacy"))
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("legacy spawn did not launch worker with a runtime type mismatch")
+	}
+}
+
+func TestSpawnPassesMutableArgumentsWithoutCopying(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(item: any, channel: any)
+    chan_send(channel, item)
+end`); err != nil {
+		t.Fatal(err)
+	}
+	worker, _ := machine.GetGlobal("worker")
+	channel := value.NewChannel(1)
+	argument := value.NewArray([]value.Value{value.NewInt(1)})
+
+	if _, err := requireBuiltin(t, machine, "spawn").Invoke(machine, []value.Value{worker, argument, channel}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-channel.Obj.(*value.ObjChannel).Chan:
+		if got.Obj != argument.Obj {
+			t.Fatal("legacy spawn copied a mutable argument before launching the worker")
+		}
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("legacy spawn worker did not return its argument")
+	}
 }

--- a/internal/vm/builtins_concurrency_test.go
+++ b/internal/vm/builtins_concurrency_test.go
@@ -1,8 +1,11 @@
 package vm
 
 import (
+	"bufio"
+	"bytes"
 	"io"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -256,5 +259,143 @@ end`); err != nil {
 		}
 	case <-time.After(statefulBuiltinTimeout):
 		t.Fatal("legacy spawn worker did not return its argument")
+	}
+}
+
+func TestSpawnRemainsDetachedAndReturnsNullImmediately(t *testing.T) {
+	machine := New()
+	spawn := requireBuiltin(t, machine, "spawn")
+
+	missingOutput := captureConcurrencyStdout(t, func() {
+		result, err := spawn.Invoke(machine, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBuiltinValue(t, result, value.NewNull())
+	})
+	if missingOutput != "" {
+		t.Fatalf("missing callable stdout = %q, want empty", missingOutput)
+	}
+
+	if err := interpretVMSource(t, machine, `
+func worker(channel: any)
+    chan_send(channel, "finished")
+end`); err != nil {
+		t.Fatal(err)
+	}
+	worker, _ := machine.GetGlobal("worker")
+	channel := value.NewChannel(1)
+	result, err := spawn.Invoke(machine, []value.Value{worker, channel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBuiltinValue(t, result, value.NewNull())
+	select {
+	case got := <-channel.Obj.(*value.ObjChannel).Chan:
+		assertBuiltinValue(t, got, value.NewString("finished"))
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("legacy spawn worker did not finish")
+	}
+}
+
+func TestSpawnRemainsDetachedOnWorkerFailure(t *testing.T) {
+	tests := []struct {
+		mode       string
+		diagnostic string
+	}{
+		{mode: "runtime-error", diagnostic: "Thread Error:"},
+		{mode: "panic", diagnostic: "Thread Panic:"},
+	}
+	for _, test := range tests {
+		t.Run(test.mode, func(t *testing.T) {
+			command := exec.Command(os.Args[0], "-test.run=^TestSpawnDetachedHelper$")
+			command.Env = append(os.Environ(), "NOXY_SPAWN_HELPER="+test.mode)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("helper exit: %v\n%s", err, output)
+			}
+			if !bytes.Contains(output, []byte(test.diagnostic)) {
+				t.Fatalf("output = %q, want %q", output, test.diagnostic)
+			}
+		})
+	}
+}
+
+func TestSpawnDetachedHelper(t *testing.T) {
+	mode := os.Getenv("NOXY_SPAWN_HELPER")
+	if mode == "" {
+		return
+	}
+	if mode != "runtime-error" && mode != "panic" {
+		t.Fatalf("unknown helper mode %q", mode)
+	}
+
+	machine := New()
+	workerReady := make(chan struct{})
+	machine.DefineNative("test_spawn_ready", func([]value.Value) value.Value {
+		close(workerReady)
+		return value.NewNull()
+	})
+	if mode == "panic" {
+		machine.DefineNative("test_spawn_failure", func([]value.Value) value.Value {
+			panic("detached panic")
+		})
+	}
+
+	source := `
+func worker()
+    test_spawn_ready()
+    let zero: int = 0
+    let failed: int = 1 / zero
+end`
+	if mode == "panic" {
+		source = `
+func worker()
+    test_spawn_ready()
+    test_spawn_failure()
+end`
+	}
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatal(err)
+	}
+	worker, _ := machine.GetGlobal("worker")
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stdout
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = previous
+		_ = writer.Close()
+		_ = reader.Close()
+	}()
+
+	result, err := requireBuiltin(t, machine, "spawn").Invoke(machine, []value.Value{worker})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBuiltinValue(t, result, value.NewNull())
+	select {
+	case <-workerReady:
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("detached worker did not start")
+	}
+
+	diagnostic := make(chan string, 1)
+	go func() {
+		line, _ := bufio.NewReader(reader).ReadString('\n')
+		diagnostic <- line
+	}()
+	var line string
+	select {
+	case line = <-diagnostic:
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("detached worker did not emit a diagnostic")
+	}
+	os.Stdout = previous
+	if _, err := io.WriteString(previous, line); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/vm/builtins_core.go
+++ b/internal/vm/builtins_core.go
@@ -323,6 +323,8 @@ func (vm *VM) defineCoreBuiltins() {
 						typeName = "function"
 					case value.VAL_NATIVE:
 						typeName = "function"
+					case value.VAL_TASK:
+						typeName = "task"
 					case value.VAL_OBJ:
 						// Determine specific object type
 						if _, ok := val.Obj.(*value.ObjArray); ok {

--- a/internal/vm/builtins_core_test.go
+++ b/internal/vm/builtins_core_test.go
@@ -147,3 +147,16 @@ func TestFmtBuiltin(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskHandleIdentityAndFormat(t *testing.T) {
+	machine := New()
+	handle := value.NewTask()
+	if !valuesEqual(handle, handle) {
+		t.Fatal("task handle is not equal to itself")
+	}
+	if valuesEqual(handle, value.NewTask()) {
+		t.Fatal("distinct task handles compare equal")
+	}
+	got := callBuiltin(t, machine, "fmt", value.NewString("%T"), handle)
+	assertBuiltinValue(t, got, value.NewString("task"))
+}

--- a/internal/vm/builtins_json_test.go
+++ b/internal/vm/builtins_json_test.go
@@ -72,6 +72,12 @@ func TestStrictJSONValToGoRejectsNonJSONValues(t *testing.T) {
 	}
 }
 
+func TestStrictJSONValToGoRejectsTaskHandle(t *testing.T) {
+	if _, err := strictJSONValToGo(value.NewTask()); err != errJSONUnsupported {
+		t.Fatalf("task conversion error = %v, want %v", err, errJSONUnsupported)
+	}
+}
+
 func TestStrictJSONValToGoRejectsInvalidUTF8Strings(t *testing.T) {
 	invalidValue := value.NewString(string([]byte{0xff}))
 	invalidKey := value.NewMap()

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -22,7 +22,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"json_dumps_result", "json_loads", "json_parse", "keys", "length", "make_chan",
 		"make_wg", "net_accept", "net_close", "net_connect", "net_listen",
 		"net_recv", "net_select", "net_send", "net_setblocking", "ord",
-		"pop", "print", "slice", "spawn", "sqlite_bind_float",
+		"pop", "print", "slice", "spawn", "spawn_task", "sqlite_bind_float",
 		"sqlite_bind_int", "sqlite_bind_text", "sqlite_close", "sqlite_exec",
 		"sqlite_exec_params", "sqlite_finalize", "sqlite_open",
 		"sqlite_prepare", "sqlite_query", "sqlite_reset", "sqlite_step_exec",
@@ -35,7 +35,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"strings_starts_with", "strings_substring", "strings_to_lower",
 		"strings_to_upper", "strings_trim", "sys_argv", "sys_exec",
 		"sys_exec_output", "sys_exit", "sys_getcwd", "sys_getenv",
-		"sys_load_plugin", "sys_os", "sys_setenv", "sys_sleep",
+		"sys_load_plugin", "sys_os", "sys_setenv", "sys_sleep", "task_await",
 		"time_add_days", "time_add_seconds", "time_after", "time_before",
 		"time_days_in_month", "time_diff", "time_diff_duration", "time_format",
 		"time_format_custom", "time_format_date", "time_format_time",
@@ -115,7 +115,7 @@ func TestBuiltinNativeSignatures(t *testing.T) {
 func TestStatefulBuiltinsUseContextualHandlers(t *testing.T) {
 	machine := New()
 	for _, name := range []string{
-		"spawn", "delete", "append", "pop", "json_loads", "sys_load_plugin",
+		"spawn", "spawn_task", "task_await", "delete", "append", "pop", "json_loads", "sys_load_plugin",
 		"io_open", "net_listen", "sqlite_open",
 	} {
 		native := requireBuiltin(t, machine, name)

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -1,0 +1,102 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+
+	"noxy-vm/internal/value"
+)
+
+func (vm *VM) defineTaskBuiltins() {
+	vm.DefineContextualNative("spawn_task", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 1 {
+			return value.NewNull(), fmt.Errorf("spawn_task expects a function")
+		}
+
+		call, err := machine.prepareTaskCall(args[0], args[1:])
+		if err != nil {
+			return value.NewNull(), err
+		}
+
+		handle := value.NewTask()
+		task := handle.Obj.(*value.ObjTask)
+		worker := NewWithShared(machine.shared, machine.Config)
+		go worker.startSupervisedTask(task, call)
+		return handle, nil
+	})
+
+	vm.DefineContextualNative("task_await", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		if _, err := nativeVM(context); err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) != 1 {
+			return value.NewNull(), fmt.Errorf("task_await expects exactly 1 argument, got %d", len(args))
+		}
+		if args[0].Type != value.VAL_TASK {
+			return value.NewNull(), fmt.Errorf("task_await expects a task handle")
+		}
+		task, ok := args[0].Obj.(*value.ObjTask)
+		if !ok || task == nil {
+			return value.NewNull(), fmt.Errorf("task_await received a malformed task handle")
+		}
+
+		<-task.Done()
+		return taskOutcomeEnvelope(task.Outcome()), nil
+	})
+}
+
+func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
+				Kind:    "panic",
+				Message: fmt.Sprint(recovered),
+				Stack:   string(debug.Stack()),
+			}})
+		}
+	}()
+
+	result, err := vm.executePreparedTaskCall(call)
+	if err != nil {
+		stack := ""
+		var runtimeErr *RuntimeError
+		if errors.As(err, &runtimeErr) {
+			stack = runtimeErr.Stack
+		}
+		task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
+			Kind:    "runtime",
+			Message: err.Error(),
+			Stack:   stack,
+			Cause:   err,
+		}})
+		return
+	}
+
+	task.Complete(value.TaskOutcome{Value: result})
+}
+
+func taskOutcomeEnvelope(outcome value.TaskOutcome) value.Value {
+	if outcome.Failure == nil {
+		return value.NewMapWithData(map[string]value.Value{
+			"status": value.NewString("ok"),
+			"value":  outcome.Value,
+			"error":  value.NewNull(),
+		})
+	}
+
+	failure := outcome.Failure
+	return value.NewMapWithData(map[string]value.Value{
+		"status": value.NewString("error"),
+		"value":  value.NewNull(),
+		"error": value.NewMapWithData(map[string]value.Value{
+			"kind":    value.NewString(failure.Kind),
+			"message": value.NewString(failure.Message),
+			"stack":   value.NewString(failure.Stack),
+		}),
+	})
+}

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -3,7 +3,9 @@ package vm
 import (
 	"errors"
 	"fmt"
+	"math"
 	"runtime/debug"
+	"time"
 
 	"noxy-vm/internal/value"
 )
@@ -34,8 +36,8 @@ func (vm *VM) defineTaskBuiltins() {
 		if _, err := nativeVM(context); err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) != 1 {
-			return value.NewNull(), fmt.Errorf("task_await expects exactly 1 argument, got %d", len(args))
+		if len(args) < 1 || len(args) > 2 {
+			return value.NewNull(), fmt.Errorf("task_await expects 1 or 2 arguments, got %d", len(args))
 		}
 		if args[0].Type != value.VAL_TASK {
 			return value.NewNull(), fmt.Errorf("task_await expects a task handle")
@@ -45,9 +47,76 @@ func (vm *VM) defineTaskBuiltins() {
 			return value.NewNull(), fmt.Errorf("task_await received a malformed task handle")
 		}
 
-		<-task.Done()
+		var timeout *int64
+		if len(args) == 2 {
+			if args[1].Type != value.VAL_INT {
+				return value.NewNull(), fmt.Errorf("task_await timeout must be an integer")
+			}
+			timeoutValue := args[1].AsInt
+			timeout = &timeoutValue
+		}
+
+		completed, err := awaitTask(task, timeout)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if !completed {
+			return taskTimeoutEnvelope(), nil
+		}
 		return taskOutcomeEnvelope(task.Outcome()), nil
 	})
+}
+
+func awaitTask(task *value.ObjTask, timeout *int64) (bool, error) {
+	if timeout != nil {
+		if *timeout < 0 {
+			return false, fmt.Errorf("task timeout must be non-negative")
+		}
+		if *timeout > int64(math.MaxInt64)/int64(time.Millisecond) {
+			return false, fmt.Errorf("task timeout is too large")
+		}
+	}
+
+	select {
+	case <-task.Done():
+		return true, nil
+	default:
+	}
+
+	if timeout == nil {
+		<-task.Done()
+		return true, nil
+	}
+	if *timeout == 0 {
+		return false, nil
+	}
+
+	timer := time.NewTimer(time.Duration(*timeout) * time.Millisecond)
+	defer stopAndDrainTaskTimer(timer)
+	return awaitTaskUntilDeadline(task, timer.C), nil
+}
+
+func awaitTaskUntilDeadline(task *value.ObjTask, deadline <-chan time.Time) bool {
+	select {
+	case <-task.Done():
+		return true
+	case <-deadline:
+		select {
+		case <-task.Done():
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+func stopAndDrainTaskTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
@@ -98,5 +167,13 @@ func taskOutcomeEnvelope(outcome value.TaskOutcome) value.Value {
 			"message": value.NewString(failure.Message),
 			"stack":   value.NewString(failure.Stack),
 		}),
+	})
+}
+
+func taskTimeoutEnvelope() value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"status": value.NewString("timeout"),
+		"value":  value.NewNull(),
+		"error":  value.NewNull(),
 	})
 }

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -43,7 +43,7 @@ func (vm *VM) defineTaskBuiltins() {
 			return value.NewNull(), fmt.Errorf("task_await expects a task handle")
 		}
 		task, ok := args[0].Obj.(*value.ObjTask)
-		if !ok || task == nil {
+		if !ok || !task.IsValid() {
 			return value.NewNull(), fmt.Errorf("task_await received a malformed task handle")
 		}
 

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"runtime/debug"
@@ -132,15 +131,10 @@ func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
 
 	result, err := vm.executePreparedTaskCall(call)
 	if err != nil {
-		stack := ""
-		var runtimeErr *RuntimeError
-		if errors.As(err, &runtimeErr) {
-			stack = runtimeErr.Stack
-		}
 		task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
 			Kind:    "runtime",
 			Message: err.Error(),
-			Stack:   stack,
+			Stack:   deepestRuntimeStack(err),
 			Cause:   err,
 		}})
 		return

--- a/internal/vm/builtins_tasks_test.go
+++ b/internal/vm/builtins_tasks_test.go
@@ -1,10 +1,68 @@
 package vm
 
 import (
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"noxy-vm/internal/value"
 )
+
+func spawnCompiledTestTask(t *testing.T, machine *VM, source, functionName string) value.Value {
+	t.Helper()
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("compile task source: %v", err)
+	}
+	callable, ok := machine.GetGlobal(functionName)
+	if !ok {
+		t.Fatalf("task function %q is not defined", functionName)
+	}
+	handle, err := requireBuiltin(t, machine, "spawn_task").Invoke(machine, []value.Value{callable})
+	if err != nil {
+		t.Fatalf("spawn_task: %v", err)
+	}
+	return handle
+}
+
+func invokeTaskAwait(machine *VM, args ...value.Value) (value.Value, error) {
+	builtin, ok := machine.GetGlobal("task_await")
+	if !ok {
+		return value.NewNull(), nil
+	}
+	return builtin.Obj.(*value.ObjNative).Invoke(machine, args)
+}
+
+func taskEnvelopeField(t *testing.T, envelope value.Value, name string) value.Value {
+	t.Helper()
+	mapping, ok := envelope.Obj.(*value.ObjMap)
+	if envelope.Type != value.VAL_OBJ || !ok || mapping == nil {
+		t.Fatalf("task envelope = %#v, want map", envelope)
+	}
+	field, ok := mapping.Get(name)
+	if !ok {
+		t.Fatalf("task envelope has no %q field", name)
+	}
+	return field
+}
+
+func requireTaskEnvelope(t *testing.T, envelope value.Value, status string, result, failure value.Value) {
+	t.Helper()
+	if got := taskEnvelopeField(t, envelope, "status"); !valuesEqual(got, value.NewString(status)) {
+		t.Fatalf("task status = %v, want %q", got, status)
+	}
+	if got := taskEnvelopeField(t, envelope, "value"); !valuesEqual(got, result) {
+		t.Fatalf("task value = %v, want %v", got, result)
+	}
+	if got := taskEnvelopeField(t, envelope, "error"); !valuesEqual(got, failure) {
+		t.Fatalf("task error = %v, want %v", got, failure)
+	}
+}
+
+func requireTaskOK(t *testing.T, envelope, result value.Value) {
+	t.Helper()
+	requireTaskEnvelope(t, envelope, "ok", result, value.NewNull())
+}
 
 func TestSpawnTaskReplaysSuccessfulResult(t *testing.T) {
 	got := captureVMSource(t, `
@@ -85,4 +143,175 @@ let second: any = task_await(task)
 test_report(first != second && first["value"] == second["value"] && first["error"] == null && second["error"] == null)
 `)
 	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestTaskTimeoutZeroPollDoesNotConsumeLaterSuccess(t *testing.T) {
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	machine := New()
+	machine.DefineNative("wait_for_gate", func([]value.Value) value.Value {
+		entered <- struct{}{}
+		<-gate
+		return value.NewInt(42)
+	})
+	task := spawnCompiledTestTask(t, machine, `
+func worker() -> int
+    return wait_for_gate()
+end`, "worker")
+	<-entered
+
+	timed, err := invokeTaskAwait(machine, task, value.NewInt(0))
+	if err != nil {
+		t.Fatalf("zero poll: %v", err)
+	}
+	requireTaskEnvelope(t, timed, "timeout", value.NewNull(), value.NewNull())
+
+	close(gate)
+	completed, err := invokeTaskAwait(machine, task)
+	if err != nil {
+		t.Fatalf("later wait: %v", err)
+	}
+	requireTaskOK(t, completed, value.NewInt(42))
+}
+
+func TestTaskTimeoutPositiveWaitIsBoundedAndNonTerminal(t *testing.T) {
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	machine := New()
+	machine.DefineNative("wait_for_gate", func([]value.Value) value.Value {
+		entered <- struct{}{}
+		<-gate
+		return value.NewInt(7)
+	})
+	task := spawnCompiledTestTask(t, machine, `
+func worker() -> int
+    return wait_for_gate()
+end`, "worker")
+	<-entered
+
+	timed, err := invokeTaskAwait(machine, task, value.NewInt(1))
+	if err != nil {
+		t.Fatalf("positive timeout: %v", err)
+	}
+	requireTaskEnvelope(t, timed, "timeout", value.NewNull(), value.NewNull())
+
+	close(gate)
+	completed, err := invokeTaskAwait(machine, task, value.NewInt(1000))
+	if err != nil {
+		t.Fatalf("later bounded wait: %v", err)
+	}
+	requireTaskOK(t, completed, value.NewInt(7))
+}
+
+func TestTaskAwaitCompletedTaskWinsZeroPoll(t *testing.T) {
+	machine := New()
+	handle := value.NewTask()
+	handle.Obj.(*value.ObjTask).Complete(value.TaskOutcome{Value: value.NewInt(9)})
+
+	got, err := invokeTaskAwait(machine, handle, value.NewInt(0))
+	if err != nil {
+		t.Fatalf("completed poll: %v", err)
+	}
+	requireTaskOK(t, got, value.NewInt(9))
+}
+
+func TestTaskAwaitRejectsInvalidArguments(t *testing.T) {
+	machine := New()
+	handle := value.NewTask()
+	completedHandle := value.NewTask()
+	completedHandle.Obj.(*value.ObjTask).Complete(value.TaskOutcome{Value: value.NewInt(1)})
+	overflow := int64((1<<63-1)/int64(time.Millisecond) + 1)
+	tests := []struct {
+		name string
+		args []value.Value
+		want string
+	}{
+		{name: "no arguments", want: "1 or 2 arguments"},
+		{name: "too many arguments", args: []value.Value{handle, value.NewInt(0), value.NewInt(0)}, want: "1 or 2 arguments"},
+		{name: "invalid handle", args: []value.Value{value.NewInt(1)}, want: "task handle"},
+		{name: "malformed nil handle", args: []value.Value{{Type: value.VAL_TASK, Obj: (*value.ObjTask)(nil)}}, want: "malformed task handle"},
+		{name: "malformed handle object", args: []value.Value{{Type: value.VAL_TASK, Obj: "not a task"}}, want: "malformed task handle"},
+		{name: "negative timeout", args: []value.Value{handle, value.NewInt(-1)}, want: "non-negative"},
+		{name: "negative timeout on completed task", args: []value.Value{completedHandle, value.NewInt(-1)}, want: "non-negative"},
+		{name: "non-integer timeout", args: []value.Value{handle, value.NewFloat(1)}, want: "integer"},
+		{name: "overflow timeout", args: []value.Value{handle, value.NewInt(overflow)}, want: "too large"},
+		{name: "overflow timeout on completed task", args: []value.Value{completedHandle, value.NewInt(overflow)}, want: "too large"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := invokeTaskAwait(machine, test.args...)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestConcurrentTaskWaitersReplayCompositeIdentity(t *testing.T) {
+	const waiterCount = 16
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	composite := value.NewArray([]value.Value{value.NewInt(1), value.NewInt(2), value.NewInt(3)})
+	machine := New()
+	machine.DefineNative("wait_for_gate", func([]value.Value) value.Value {
+		entered <- struct{}{}
+		<-gate
+		return composite
+	})
+	task := spawnCompiledTestTask(t, machine, `
+func worker() -> any
+    return wait_for_gate()
+end`, "worker")
+	<-entered
+
+	type waitResult struct {
+		envelope value.Value
+		err      error
+	}
+	started := make(chan struct{}, waiterCount)
+	results := make(chan waitResult, waiterCount)
+	var waiters sync.WaitGroup
+	waiters.Add(waiterCount)
+	for range waiterCount {
+		go func() {
+			defer waiters.Done()
+			started <- struct{}{}
+			envelope, err := invokeTaskAwait(machine, task)
+			results <- waitResult{envelope: envelope, err: err}
+		}()
+	}
+	for range waiterCount {
+		<-started
+	}
+	close(gate)
+	waiters.Wait()
+	close(results)
+
+	seenEnvelopes := make(map[any]struct{}, waiterCount)
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("concurrent wait: %v", result.err)
+		}
+		requireTaskOK(t, result.envelope, composite)
+		if got := taskEnvelopeField(t, result.envelope, "value"); got.Obj != composite.Obj {
+			t.Fatalf("result identity = %p, want %p", got.Obj, composite.Obj)
+		}
+		if _, duplicate := seenEnvelopes[result.envelope.Obj]; duplicate {
+			t.Fatal("concurrent waits reused an envelope")
+		}
+		seenEnvelopes[result.envelope.Obj] = struct{}{}
+	}
+}
+
+func TestTaskAwaitCompletionWinsAtDeadlineBoundary(t *testing.T) {
+	for range 256 {
+		handle := value.NewTask()
+		task := handle.Obj.(*value.ObjTask)
+		deadline := make(chan time.Time, 1)
+		deadline <- time.Time{}
+		task.Complete(value.TaskOutcome{Value: value.NewInt(1)})
+		if !awaitTaskUntilDeadline(task, deadline) {
+			t.Fatal("ready task lost to ready deadline")
+		}
+	}
 }

--- a/internal/vm/builtins_tasks_test.go
+++ b/internal/vm/builtins_tasks_test.go
@@ -145,6 +145,56 @@ test_report(first != second && first["value"] == second["value"] && first["error
 	assertBuiltinValue(t, got, value.NewBool(true))
 }
 
+func TestSpawnTaskSynchronizesCapturedLocalHandoff(t *testing.T) {
+	got := captureVMSource(t, `
+func launch(value: int) -> any
+    let captured: int = value
+    func worker() -> int
+        return captured
+    end
+    return spawn_task(worker)
+end
+
+let iteration: int = 0
+let valid: bool = true
+while iteration < 1000 do
+    let outcome: any = task_await(launch(iteration))
+    if outcome["status"] != "ok" || outcome["value"] != iteration then
+        valid = false
+    end
+    iteration = iteration + 1
+end
+test_report(valid)
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestSpawnTaskSynchronizesCapturedReferenceHandoff(t *testing.T) {
+	got := captureVMSource(t, `
+func launch(value: int) -> any
+    let captured: int = value
+    func worker() -> int
+        let pointer: ref int = ref captured
+        *pointer = pointer + 1
+        return captured
+    end
+    return spawn_task(worker)
+end
+
+let iteration: int = 0
+let valid: bool = true
+while iteration < 1000 do
+    let outcome: any = task_await(launch(iteration))
+    if outcome["status"] != "ok" || outcome["value"] != iteration + 1 then
+        valid = false
+    end
+    iteration = iteration + 1
+end
+test_report(valid)
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
 func TestTaskTimeoutZeroPollDoesNotConsumeLaterSuccess(t *testing.T) {
 	gate := make(chan struct{})
 	entered := make(chan struct{}, 1)
@@ -231,6 +281,7 @@ func TestTaskAwaitRejectsInvalidArguments(t *testing.T) {
 		{name: "invalid handle", args: []value.Value{value.NewInt(1)}, want: "task handle"},
 		{name: "malformed nil handle", args: []value.Value{{Type: value.VAL_TASK, Obj: (*value.ObjTask)(nil)}}, want: "malformed task handle"},
 		{name: "malformed handle object", args: []value.Value{{Type: value.VAL_TASK, Obj: "not a task"}}, want: "malformed task handle"},
+		{name: "zero-value handle", args: []value.Value{{Type: value.VAL_TASK, Obj: &value.ObjTask{}}, value.NewInt(0)}, want: "malformed task handle"},
 		{name: "negative timeout", args: []value.Value{handle, value.NewInt(-1)}, want: "non-negative"},
 		{name: "negative timeout on completed task", args: []value.Value{completedHandle, value.NewInt(-1)}, want: "non-negative"},
 		{name: "non-integer timeout", args: []value.Value{handle, value.NewFloat(1)}, want: "integer"},

--- a/internal/vm/builtins_tasks_test.go
+++ b/internal/vm/builtins_tasks_test.go
@@ -1,0 +1,88 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestSpawnTaskReplaysSuccessfulResult(t *testing.T) {
+	got := captureVMSource(t, `
+func worker(value: int) -> int
+    return value * 2
+end
+let task: any = spawn_task(worker, 21)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first["status"] == "ok" && first["value"] == 42 && first["error"] == null && second["value"] == 42)
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestSpawnTaskReplaysRuntimeFailure(t *testing.T) {
+	got := captureVMSource(t, `
+func worker() -> int
+    return 1 / 0
+end
+let task: any = spawn_task(worker)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first["status"] == "error" && first["value"] == null && first["error"]["kind"] == "runtime" && strings_contains(first["error"]["message"], "division by zero") && length(first["error"]["stack"]) > 0 && first["error"]["stack"] == second["error"]["stack"])
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestSpawnTaskRecoversAndReplaysNativePanic(t *testing.T) {
+	machine := New()
+	machine.DefineNative("panic_now", func([]value.Value) value.Value {
+		panic("boom")
+	})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+
+	err := interpretVMSource(t, machine, `
+func worker()
+    panic_now()
+end
+let task: any = spawn_task(worker)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first["status"] == "error" && first["value"] == null && first["error"]["kind"] == "panic" && first["error"]["message"] == "boom" && length(first["error"]["stack"]) > 0 && first["error"]["kind"] == second["error"]["kind"] && first["error"]["message"] == second["error"]["message"] && first["error"]["stack"] == second["error"]["stack"])
+`)
+	if err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	assertBuiltinValue(t, captured, value.NewBool(true))
+}
+
+func TestSpawnTaskPreservesNullAndVoidResults(t *testing.T) {
+	got := captureVMSource(t, `
+func void_worker() -> void
+end
+func null_worker() -> any
+    return null
+end
+let void_result: any = task_await(spawn_task(void_worker))
+let null_result: any = task_await(spawn_task(null_worker))
+test_report(void_result["status"] == "ok" && void_result["value"] == null && void_result["error"] == null && null_result["status"] == "ok" && null_result["value"] == null && null_result["error"] == null)
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+func TestSpawnTaskReplaysCompositeIdentityInFreshEnvelopes(t *testing.T) {
+	got := captureVMSource(t, `
+func worker() -> int[]
+    return [1, 2, 3]
+end
+let task: any = spawn_task(worker)
+let first: any = task_await(task)
+let second: any = task_await(task)
+test_report(first != second && first["value"] == second["value"] && first["error"] == null && second["error"] == null)
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}

--- a/internal/vm/builtins_tasks_test.go
+++ b/internal/vm/builtins_tasks_test.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -426,5 +428,71 @@ end`, "worker")
 	stack := taskEnvelopeField(t, failure, "stack")
 	if stack.Type != value.VAL_OBJ || stack.Obj.(string) == "" {
 		t.Fatal("deferred cleanup failure lost its Noxy stack")
+	}
+}
+
+func TestSpawnTaskPreservesDeepModuleFailureStack(t *testing.T) {
+	root := t.TempDir()
+	moduleSource := `
+func nested_failure() -> int
+    return 1 / 0
+end
+nested_failure()
+`
+	if err := os.WriteFile(filepath.Join(root, "broken_task.nx"), []byte(moduleSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	machine := NewWithConfig(VMConfig{RootPath: root})
+	task := spawnCompiledTestTask(t, machine, `
+func worker() -> int
+    use broken_task
+    return 1
+end`, "worker")
+	envelope, err := invokeTaskAwait(machine, task)
+	if err != nil {
+		t.Fatalf("task_await: %v", err)
+	}
+	failure := taskEnvelopeField(t, envelope, "error")
+	stack := taskEnvelopeField(t, failure, "stack")
+	if stack.Type != value.VAL_OBJ {
+		t.Fatalf("stack = %v, want string", stack)
+	}
+	stackText := stack.Obj.(string)
+	if !strings.Contains(stackText, "in nested_failure") || !strings.Contains(stackText, "in worker") {
+		t.Fatalf("stack = %q, want module failure and worker frames", stackText)
+	}
+}
+
+func TestSpawnTaskDeferredHeadroomFailureHasNoxyStack(t *testing.T) {
+	machine := New()
+	machine.DefineNative("headroom_cleanup", func([]value.Value) value.Value {
+		return value.NewNull()
+	})
+	machine.DefineContextualNative("fill_task_stack", func(context value.NativeContext, _ []value.Value) (value.Value, error) {
+		worker, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		worker.stackTop = StackMax
+		return value.NewNull(), nil
+	})
+
+	task := spawnCompiledTestTask(t, machine, `
+func worker() -> void
+    defer headroom_cleanup(1)
+    fill_task_stack()
+end`, "worker")
+	envelope, err := invokeTaskAwait(machine, task)
+	if err != nil {
+		t.Fatalf("task_await: %v", err)
+	}
+	if got := taskEnvelopeField(t, envelope, "status"); !valuesEqual(got, value.NewString("error")) {
+		t.Fatalf("status = %v, want error", got)
+	}
+	failure := taskEnvelopeField(t, envelope, "error")
+	stack := taskEnvelopeField(t, failure, "stack")
+	if stack.Type != value.VAL_OBJ || !strings.Contains(stack.Obj.(string), "in worker") {
+		t.Fatalf("stack = %v, want worker frame", stack)
 	}
 }

--- a/internal/vm/call_validation.go
+++ b/internal/vm/call_validation.go
@@ -29,6 +29,8 @@ func runtimeValueMode(v value.Value) string {
 		return "waitgroup"
 	case value.VAL_REF:
 		return "ref"
+	case value.VAL_TASK:
+		return "task"
 	default:
 		return "unknown"
 	}

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -105,7 +105,7 @@ func (vm *VM) copyPreparedArguments(args []value.Value, params []value.ParamInfo
 func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 	base := vm.stackTop
 	if base < 0 || base >= len(vm.stack) || len(call.Arguments) > len(vm.stack)-base-1 {
-		return fmt.Errorf("stack overflow while invoking deferred call")
+		return vm.runtimeErrorAtCurrentFrame("stack overflow while invoking deferred call")
 	}
 	temporaryTop := base
 	defer func() {

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -40,10 +40,10 @@ func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.Global
 	vm.frames[0] = frame
 	vm.frameCount = 1
 	vm.currentFrame = frame
-	return vm.run(1)
+	return vm.run(1, nil)
 }
 
-func (vm *VM) run(minFrameCount int) error {
+func (vm *VM) run(minFrameCount int, terminalResult *value.Value) error {
 	// Cache current frame values for speed
 	frame := vm.currentFrame
 	c := frame.Closure.Function.Chunk.(*chunk.Chunk)
@@ -913,6 +913,10 @@ func (vm *VM) run(minFrameCount int) error {
 			// 1. Pop result
 			result := vm.pop()
 			calleeFrame := vm.currentFrame
+			terminal := vm.frameCount-1 < minFrameCount
+			if terminal && terminalResult != nil {
+				*terminalResult = result
+			}
 
 			// 2. Clear the stack range used by the function (args + locals)
 			// This is CRITICAL for GC. We must nullify the references.
@@ -934,7 +938,7 @@ func (vm *VM) run(minFrameCount int) error {
 			}
 
 			// 5. Return from run() if we drop below call depth
-			if vm.frameCount < minFrameCount {
+			if terminal {
 				// We are exiting the run loop.
 				// We need to place result at the location expected by the caller.
 				// The caller expects the function and args to be consumed, and result pushed.
@@ -1002,7 +1006,7 @@ func (vm *VM) run(minFrameCount int) error {
 			mod, err := vm.loadModule(moduleName)
 			if err != nil {
 				context := vm.runtimeError(c, ip, "failed to import module '%s'", moduleName)
-				return fmt.Errorf("%v: %w", context, err)
+				return fmt.Errorf("%w: %w", context, err)
 			}
 			vm.push(mod)
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -157,7 +157,11 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) error {
 					// For global references, display the name as the address proxy.
 					addrStr = fmt.Sprintf("<global %s>", ref.Name)
 				case value.REF_UPVALUE:
-					addrStr = fmt.Sprintf("%p", ref.Upvalue.Location)
+					address, ok := ref.Upvalue.LocationAddress()
+					if !ok {
+						return vm.runtimeError(c, ip, "invalid upvalue reference")
+					}
+					addrStr = address
 				case value.REF_PROPERTY:
 					containerAddr := fmt.Sprintf("%p", ref.Container.Obj)
 					addrStr = fmt.Sprintf("<prop %s of %s>", ref.Name, containerAddr)
@@ -895,13 +899,18 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) error {
 		case chunk.OP_GET_UPVALUE:
 			slot := c.Code[ip]
 			ip++
-			val := *frame.Closure.Upvalues[slot].Location
+			val, ok := frame.Closure.Upvalues[slot].Load()
+			if !ok {
+				return vm.runtimeError(c, ip, "invalid upvalue")
+			}
 			vm.push(val)
 
 		case chunk.OP_SET_UPVALUE:
 			slot := c.Code[ip]
 			ip++
-			*frame.Closure.Upvalues[slot].Location = vm.peek(0)
+			if !frame.Closure.Upvalues[slot].Store(vm.peek(0)) {
+				return vm.runtimeError(c, ip, "invalid upvalue")
+			}
 
 		case chunk.OP_CLOSE_UPVALUE:
 			vm.closeUpvalue(&vm.stack[vm.stackTop-1])

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -245,6 +245,7 @@ func TestMalformedReferenceRejectsTaskPayload(t *testing.T) {
 	}{
 		{name: "nil", stored: value.Value{Type: value.VAL_TASK}},
 		{name: "wrong type", stored: value.Value{Type: value.VAL_TASK, Obj: "not a task"}},
+		{name: "zero value", stored: value.Value{Type: value.VAL_TASK, Obj: &value.ObjTask{}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/vm/malformed_reference_test.go
+++ b/internal/vm/malformed_reference_test.go
@@ -224,6 +224,7 @@ func TestReferencesToTypedNilObjectsAreRuntimeErrors(t *testing.T) {
 		{name: "bytes", stored: value.Value{Type: value.VAL_BYTES, Obj: (*string)(nil)}},
 		{name: "channel", stored: value.Value{Type: value.VAL_CHANNEL, Obj: (*value.ObjChannel)(nil)}},
 		{name: "waitgroup", stored: value.Value{Type: value.VAL_WAITGROUP, Obj: (*value.ObjWaitGroup)(nil)}},
+		{name: "task", stored: value.Value{Type: value.VAL_TASK, Obj: (*value.ObjTask)(nil)}},
 		{name: "reference", stored: value.Value{Type: value.VAL_REF, Obj: (*value.ObjRef)(nil)}},
 	}
 	for _, tt := range tests {
@@ -232,6 +233,23 @@ func TestReferencesToTypedNilObjectsAreRuntimeErrors(t *testing.T) {
 			input := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
 			if _, err := New().resolveReferenceValue(input); err == nil {
 				t.Fatal("typed-nil referenced object resolved without runtime error")
+			}
+		})
+	}
+}
+
+func TestMalformedReferenceRejectsTaskPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		stored value.Value
+	}{
+		{name: "nil", stored: value.Value{Type: value.VAL_TASK}},
+		{name: "wrong type", stored: value.Value{Type: value.VAL_TASK, Obj: "not a task"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateReferencedValue(tt.stored); err == nil {
+				t.Fatal("malformed task payload was accepted")
 			}
 		})
 	}

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -202,7 +202,7 @@ func (vm *VM) compileAndRunModule(source resolvedModule, content string) (value.
 		return value.NewNull(), callErr
 	}
 	startFrameCount := vm.frameCount
-	if err := vm.run(startFrameCount); err != nil {
+	if err := vm.run(startFrameCount, nil); err != nil {
 		return value.NewNull(), err
 	}
 	vm.pop()

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -26,7 +26,7 @@ type referenceSetter func(value.Value)
 func validateReferencedValue(stored value.Value) error {
 	switch stored.Type {
 	case value.VAL_OBJ, value.VAL_FUNCTION, value.VAL_NATIVE, value.VAL_BYTES,
-		value.VAL_CHANNEL, value.VAL_WAITGROUP, value.VAL_REF:
+		value.VAL_CHANNEL, value.VAL_WAITGROUP, value.VAL_REF, value.VAL_TASK:
 		// These tags require a concrete payload in Obj.
 	default:
 		return nil
@@ -38,6 +38,11 @@ func validateReferencedValue(stored value.Value) error {
 	switch object.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 		if object.IsNil() {
+			return fmt.Errorf("invalid referenced object")
+		}
+	}
+	if stored.Type == value.VAL_TASK {
+		if _, ok := stored.Obj.(*value.ObjTask); !ok {
 			return fmt.Errorf("invalid referenced object")
 		}
 	}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -42,7 +42,8 @@ func validateReferencedValue(stored value.Value) error {
 		}
 	}
 	if stored.Type == value.VAL_TASK {
-		if _, ok := stored.Obj.(*value.ObjTask); !ok {
+		task, ok := stored.Obj.(*value.ObjTask)
+		if !ok || !task.IsValid() {
 			return fmt.Errorf("invalid referenced object")
 		}
 	}
@@ -83,10 +84,11 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 		}
 		return stored, true, func(updated value.Value) { ref.GlobalOwner.SetLocal(ref.Name, updated) }, nil
 	case value.REF_UPVALUE:
-		if ref.Upvalue == nil || ref.Upvalue.Location == nil {
+		stored, ok := ref.Upvalue.Load()
+		if !ok {
 			return value.Value{}, false, nil, fmt.Errorf("invalid upvalue reference")
 		}
-		return *ref.Upvalue.Location, true, func(updated value.Value) { *ref.Upvalue.Location = updated }, nil
+		return stored, true, func(updated value.Value) { ref.Upvalue.Store(updated) }, nil
 	case value.REF_PTR:
 		if ref.Ptr == nil {
 			return value.Value{}, false, nil, fmt.Errorf("invalid pointer reference")

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -120,13 +120,53 @@ func (vm *VM) captureNoxyStack(activeChunk *chunk.Chunk, activeIP int) string {
 	return strings.Join(frames, "\n")
 }
 
+func deepestRuntimeStack(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	current := ""
+	if runtimeErr, ok := err.(*RuntimeError); ok {
+		current = runtimeErr.Stack
+	}
+
+	switch wrapped := err.(type) {
+	case interface{ Unwrap() []error }:
+		for _, cause := range wrapped.Unwrap() {
+			if stack := deepestRuntimeStack(cause); stack != "" {
+				return stack
+			}
+		}
+	case interface{ Unwrap() error }:
+		if stack := deepestRuntimeStack(wrapped.Unwrap()); stack != "" {
+			return stack
+		}
+	}
+
+	return current
+}
+
 func (vm *VM) runtimeErrorCause(c *chunk.Chunk, ip int, cause error, format string, args ...interface{}) error {
+	stack := vm.captureNoxyStack(c, ip)
+	if causeStack := deepestRuntimeStack(cause); causeStack != "" {
+		stack = causeStack
+	}
 	return &RuntimeError{
 		Location: sourceLocation(c, ip),
 		Message:  fmt.Sprintf(format, args...),
 		Cause:    cause,
-		Stack:    vm.captureNoxyStack(c, ip),
+		Stack:    stack,
 	}
+}
+
+func (vm *VM) runtimeErrorAtCurrentFrame(format string, args ...interface{}) error {
+	var activeChunk *chunk.Chunk
+	activeIP := 0
+	if frame := vm.currentFrame; frame != nil && frame.Closure != nil && frame.Closure.Function != nil {
+		activeChunk, _ = frame.Closure.Function.Chunk.(*chunk.Chunk)
+		activeIP = frame.IP
+	}
+	return vm.runtimeErrorCause(activeChunk, activeIP, nil, format, args...)
 }
 
 func renderErrorCause(prefix string, cause error) string {

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -1,0 +1,56 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+
+	"noxy-vm/internal/chunk"
+)
+
+type RuntimeError struct {
+	Rendered string
+	Stack    string
+}
+
+func (failure *RuntimeError) Error() string {
+	return failure.Rendered
+}
+
+func runtimeLocation(c *chunk.Chunk, ip int) (string, int) {
+	file := "?"
+	line := 0
+	if c != nil {
+		file = c.FileName
+		if ip > 0 && ip <= len(c.Lines) {
+			line = c.Lines[ip-1]
+		}
+	}
+	return file, line
+}
+
+func (vm *VM) captureNoxyStack(activeChunk *chunk.Chunk, activeIP int) string {
+	frames := make([]string, 0, vm.frameCount)
+	for i := vm.frameCount - 1; i >= 0; i-- {
+		frame := vm.frames[i]
+		if frame == nil || frame.Closure == nil || frame.Closure.Function == nil {
+			continue
+		}
+		c, _ := frame.Closure.Function.Chunk.(*chunk.Chunk)
+		ip := frame.IP
+		if i == vm.frameCount-1 {
+			c = activeChunk
+			ip = activeIP
+		}
+		file, line := runtimeLocation(c, ip)
+		frames = append(frames, fmt.Sprintf("[%s:line %d] in %s", file, line, frame.Closure.Function.Name))
+	}
+	return strings.Join(frames, "\n")
+}
+
+func (vm *VM) newRuntimeError(c *chunk.Chunk, ip int, message string) error {
+	file, line := runtimeLocation(c, ip)
+	return &RuntimeError{
+		Rendered: fmt.Sprintf("[%s:line %d] %s", file, line, message),
+		Stack:    vm.captureNoxyStack(c, ip),
+	}
+}

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -27,6 +27,8 @@ func valuesEqual(a, b value.Value) bool {
 			return a.Obj == b.Obj // Simple pointer/string comparison
 		case value.VAL_BYTES:
 			return a.Obj.(string) == b.Obj.(string)
+		case value.VAL_TASK:
+			return a.Obj == b.Obj
 		default:
 			return false
 		}

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -77,19 +77,16 @@ func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 	upvalue := vm.openUpvalues
 
 	// Walk list
-	for upvalue != nil && upvalue.Location != local {
+	for upvalue != nil && !upvalue.PointsTo(local) {
 		// prevUpvalue = upvalue
-		upvalue = upvalue.Next
+		upvalue = upvalue.Next()
 	}
 
-	if upvalue != nil && upvalue.Location == local {
+	if upvalue != nil {
 		return upvalue
 	}
 
-	createdUpvalue := &value.ObjUpvalue{
-		Location: local,
-		Next:     vm.openUpvalues,
-	}
+	createdUpvalue := value.NewOpenUpvalue(local, vm.openUpvalues)
 	vm.openUpvalues = createdUpvalue
 
 	return createdUpvalue
@@ -100,18 +97,16 @@ func (vm *VM) closeUpvalue(slot *value.Value) {
 	curr := vm.openUpvalues
 
 	for curr != nil {
-		if curr.Location == slot {
-			curr.Closed = *slot          // Copy value to heap
-			curr.Location = &curr.Closed // Point to heap
-
+		if curr.Close(slot) {
+			next := curr.Next()
 			if prev == nil {
-				vm.openUpvalues = curr.Next
+				vm.openUpvalues = next
 			} else {
-				prev.Next = curr.Next
+				prev.SetNext(next)
 			}
 			return
 		}
 		prev = curr
-		curr = curr.Next
+		curr = curr.Next()
 	}
 }

--- a/internal/vm/stack_characterization_test.go
+++ b/internal/vm/stack_characterization_test.go
@@ -89,14 +89,22 @@ func TestUpvalueCaptureAndClose(t *testing.T) {
 
 	machine.closeUpvalue(slot)
 	machine.stack[0] = value.NewInt(42)
-	if got := first.Location; got != &first.Closed {
-		t.Fatal("closed upvalue does not point to its closed value")
+	if first.PointsTo(slot) {
+		t.Fatal("closed upvalue still points to its former stack slot")
 	}
-	if got := first.Closed; !valuesEqual(got, value.NewInt(7)) {
-		t.Fatalf("closed value=%v, want 7", got)
+	got, ok := first.Load()
+	if !ok || !valuesEqual(got, value.NewInt(7)) {
+		t.Fatalf("closed value=%v valid=%v, want 7", got, ok)
 	}
-	if got := *first.Location; !valuesEqual(got, value.NewInt(7)) {
-		t.Fatalf("closed location value=%v, want 7", got)
+	if !first.Store(value.NewInt(9)) {
+		t.Fatal("closed upvalue rejected a store")
+	}
+	got, ok = first.Load()
+	if !ok || !valuesEqual(got, value.NewInt(9)) {
+		t.Fatalf("stored closed value=%v valid=%v, want 9", got, ok)
+	}
+	if got := machine.stack[0]; !valuesEqual(got, value.NewInt(42)) {
+		t.Fatalf("closed upvalue store mutated former stack slot: %v", got)
 	}
 	if machine.openUpvalues != nil {
 		t.Fatal("closed upvalue remained in the open list")

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -43,7 +43,7 @@ func (vm *VM) prepareTaskCall(callable value.Value, arguments []value.Value) (pr
 		return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
 	}
 	for _, upvalue := range closure.Upvalues {
-		if upvalue == nil || upvalue.Location == nil {
+		if !upvalue.IsValid() {
 			return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
 		}
 	}

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -1,0 +1,98 @@
+package vm
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+type preparedTaskCall struct {
+	Callable  value.Value
+	Closure   *value.ObjClosure
+	Arguments []value.Value
+}
+
+func (vm *VM) prepareTaskCall(callable value.Value, arguments []value.Value) (preparedTaskCall, error) {
+	if callable.Type != value.VAL_FUNCTION {
+		return preparedTaskCall{}, fmt.Errorf("task expects a script function")
+	}
+
+	var closure *value.ObjClosure
+	switch object := callable.Obj.(type) {
+	case *value.ObjClosure:
+		closure = object
+	case *value.ObjFunction:
+		if object != nil && object.UpvalueCount == 0 {
+			closure = &value.ObjClosure{
+				Function:    object,
+				Upvalues:    []*value.ObjUpvalue{},
+				Environment: object.Environment,
+			}
+			callable = value.Value{Type: value.VAL_FUNCTION, Obj: closure}
+		}
+	default:
+		return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
+	}
+	if closure == nil || closure.Function == nil || closure.Environment == nil {
+		return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
+	}
+	function := closure.Function
+	code, ok := function.Chunk.(*chunk.Chunk)
+	if !ok || code == nil || function.Arity < 0 || len(function.Params) != function.Arity || len(closure.Upvalues) != function.UpvalueCount {
+		return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
+	}
+	for _, upvalue := range closure.Upvalues {
+		if upvalue == nil || upvalue.Location == nil {
+			return preparedTaskCall{}, fmt.Errorf("task received a malformed function value")
+		}
+	}
+
+	if len(arguments) != function.Arity {
+		return preparedTaskCall{}, fmt.Errorf("expected %d arguments but got %d", function.Arity, len(arguments))
+	}
+	if err := validateParameterModes(function.Name, function.Params, arguments); err != nil {
+		return preparedTaskCall{}, err
+	}
+	if schema := function.RuntimeType; schema != nil && schema.Kind == value.TYPE_CALLABLE && len(schema.Params) == len(arguments) {
+		for i, expected := range schema.Params {
+			if !runtimeTypeComplete(expected, make(map[*value.RuntimeTypeInfo]bool)) {
+				continue
+			}
+			if !vm.runtimeValueMatchesType(arguments[i], expected) {
+				return preparedTaskCall{}, fmt.Errorf("function '%s' argument %d: expected %s, got %s", function.Name, i+1, expected.String(), runtimeValueMode(arguments[i]))
+			}
+		}
+	}
+
+	preparedArguments := make([]value.Value, len(arguments))
+	copy(preparedArguments, arguments)
+	for i, parameter := range function.Params {
+		if i >= len(preparedArguments) {
+			break
+		}
+		if !parameter.IsRef {
+			preparedArguments[i] = vm.copyValue(preparedArguments[i])
+		}
+	}
+	return preparedTaskCall{Callable: callable, Closure: closure, Arguments: preparedArguments}, nil
+}
+
+func (vm *VM) executePreparedTaskCall(call preparedTaskCall) (value.Value, error) {
+	result := value.NewNull()
+	vm.push(call.Callable)
+	for _, argument := range call.Arguments {
+		vm.push(argument)
+	}
+	frame := &CallFrame{
+		Closure:     call.Closure,
+		IP:          0,
+		Slots:       0,
+		Environment: call.Closure.Environment,
+	}
+	vm.frames[0], vm.frameCount, vm.currentFrame = frame, 1, frame
+	if err := vm.run(1, &result); err != nil {
+		return value.NewNull(), err
+	}
+	return result, nil
+}

--- a/internal/vm/task_execution_test.go
+++ b/internal/vm/task_execution_test.go
@@ -1,0 +1,253 @@
+package vm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+func TestPreparedTaskCallReturnsExplicitResult(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(value: int) -> int
+    return value * 2
+end`); err != nil {
+		t.Fatal(err)
+	}
+	callable, _ := machine.GetGlobal("worker")
+	call, err := machine.prepareTaskCall(callable, []value.Value{value.NewInt(21)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := NewWithShared(machine.shared, machine.Config)
+	got, err := child.executePreparedTaskCall(call)
+	if err != nil || got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("result=%v err=%v", got, err)
+	}
+}
+
+func TestRuntimeErrorCapturesNoxyStackAtFailurePoint(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func inner() -> int
+    return 1 / 0
+end
+func outer() -> int
+    return inner()
+end
+outer()`)
+	var runtimeErr *RuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error type = %T, want *RuntimeError", err)
+	}
+	if !strings.Contains(runtimeErr.Stack, "in inner") ||
+		!strings.Contains(runtimeErr.Stack, "in outer") {
+		t.Fatalf("stack = %q", runtimeErr.Stack)
+	}
+	if runtimeErr.Error() != runtimeErr.Rendered {
+		t.Fatalf("Error() = %q, Rendered = %q", runtimeErr.Error(), runtimeErr.Rendered)
+	}
+}
+
+func TestRuntimeErrorRemainsTypedThroughImportFailure(t *testing.T) {
+	machine := NewWithConfig(VMConfig{RootPath: t.TempDir()})
+	err := interpretVMSource(t, machine, "use missing_task_test_module")
+	var runtimeErr *RuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error type chain = %T, want *RuntimeError: %v", err, err)
+	}
+	if !strings.Contains(runtimeErr.Stack, "in script") {
+		t.Fatalf("stack = %q", runtimeErr.Stack)
+	}
+}
+
+func TestPreparedTaskCallCopiesOnlyOuterArrayForValueParameter(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(values: int[][]) -> int
+    return 0
+end`); err != nil {
+		t.Fatal(err)
+	}
+	callable, _ := machine.GetGlobal("worker")
+	nested := value.NewArray([]value.Value{value.NewInt(7)})
+	outer := value.NewArray([]value.Value{nested})
+
+	call, err := machine.prepareTaskCall(callable, []value.Value{outer})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotOuter := call.Arguments[0].Obj.(*value.ObjArray)
+	wantOuter := outer.Obj.(*value.ObjArray)
+	if gotOuter == wantOuter {
+		t.Fatal("value parameter reused the outer ObjArray")
+	}
+	if gotOuter.Elements[0].Obj != nested.Obj {
+		t.Fatal("value parameter deep-copied nested array identity")
+	}
+}
+
+func TestPreparedTaskCallRetainsReferenceIdentity(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(target: ref int) -> int
+    return target
+end`); err != nil {
+		t.Fatal(err)
+	}
+	callable, _ := machine.GetGlobal("worker")
+	stored := value.NewInt(9)
+	ref := &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}
+	argument := value.Value{Type: value.VAL_REF, Obj: ref}
+
+	call, err := machine.prepareTaskCall(callable, []value.Value{argument})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if call.Arguments[0].Obj != ref {
+		t.Fatal("ref parameter did not retain its ObjRef pointer")
+	}
+}
+
+func TestPreparedTaskCallRejectsInvalidCallsSynchronously(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func by_value(item: int) -> int
+    return item
+end
+func by_ref(item: ref int) -> int
+    return item
+end`); err != nil {
+		t.Fatal(err)
+	}
+	byValue, _ := machine.GetGlobal("by_value")
+	byRef, _ := machine.GetGlobal("by_ref")
+	stored := value.NewInt(1)
+	reference := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_PTR, Ptr: &stored}}
+
+	tests := []struct {
+		name     string
+		callable value.Value
+		args     []value.Value
+		want     string
+	}{
+		{name: "native", callable: value.NewNative("native", func([]value.Value) value.Value { return value.NewNull() }), want: "script function"},
+		{name: "malformed", callable: value.Value{Type: value.VAL_FUNCTION, Obj: "not a function"}, want: "malformed"},
+		{name: "wrong arity", callable: byValue, want: "expected 1 arguments but got 0"},
+		{name: "wrong mode", callable: byValue, args: []value.Value{reference}, want: "expected int, got ref"},
+		{name: "wrong type", callable: byValue, args: []value.Value{value.NewString("wrong")}, want: "expected int, got object"},
+		{name: "ref mode", callable: byRef, args: []value.Value{value.NewInt(1)}, want: "expected ref int, got int"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := machine.prepareTaskCall(test.callable, test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestPreparedTaskCallRejectsMalformedCallableMetadata(t *testing.T) {
+	machine := New()
+	validChunk := chunk.New()
+	var nilChunk *chunk.Chunk
+
+	tests := []struct {
+		name     string
+		callable value.Value
+	}{
+		{
+			name: "typed nil chunk",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjFunction{
+				Name: "worker", Chunk: nilChunk, Environment: machine.shared.Root,
+			}},
+		},
+		{
+			name: "parameter count mismatch",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjFunction{
+				Name: "worker", Arity: 1, Chunk: validChunk, Environment: machine.shared.Root,
+			}},
+		},
+		{
+			name: "raw function requiring upvalues",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjFunction{
+				Name: "worker", UpvalueCount: 1, Chunk: validChunk, Environment: machine.shared.Root,
+			}},
+		},
+		{
+			name: "closure upvalue count mismatch",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjClosure{
+				Function:    &value.ObjFunction{Name: "worker", UpvalueCount: 1, Chunk: validChunk, Environment: machine.shared.Root},
+				Environment: machine.shared.Root,
+			}},
+		},
+		{
+			name: "nil closure upvalue",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjClosure{
+				Function:    &value.ObjFunction{Name: "worker", UpvalueCount: 1, Chunk: validChunk, Environment: machine.shared.Root},
+				Upvalues:    []*value.ObjUpvalue{nil},
+				Environment: machine.shared.Root,
+			}},
+		},
+		{
+			name: "nil closure upvalue location",
+			callable: value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjClosure{
+				Function:    &value.ObjFunction{Name: "worker", UpvalueCount: 1, Chunk: validChunk, Environment: machine.shared.Root},
+				Upvalues:    []*value.ObjUpvalue{{}},
+				Environment: machine.shared.Root,
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := machine.prepareTaskCall(test.callable, nil)
+			if err == nil || !strings.Contains(err.Error(), "malformed") {
+				t.Fatalf("error = %v, want malformed callable rejection", err)
+			}
+		})
+	}
+}
+
+func TestPreparedTaskCallChildUsesCallerConfigurationAndClosureEnvironment(t *testing.T) {
+	machine := NewWithConfig(VMConfig{RootPath: "caller-root"})
+	observedRoot := ""
+	machine.DefineContextualNative("task_test_config", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		child, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		observedRoot = child.Config.RootPath
+		return value.NewInt(2), nil
+	})
+	environment := value.NewGlobalEnvironment(machine.shared.Root)
+	if err := machine.InterpretWithEnvironment(compileVMSource(t, `
+let offset: int = 40
+func worker() -> int
+    return offset + task_test_config()
+end`), environment); err != nil {
+		t.Fatal(err)
+	}
+	callable, ok := environment.GetLocal("worker")
+	if !ok {
+		t.Fatal("worker was not bound in the custom environment")
+	}
+	call, err := machine.prepareTaskCall(callable, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := NewWithShared(machine.shared, machine.Config)
+	got, err := child.executePreparedTaskCall(call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != value.VAL_INT || got.AsInt != 42 {
+		t.Fatalf("result = %v, want 42", got)
+	}
+	if observedRoot != "caller-root" {
+		t.Fatalf("child root = %q, want caller-root", observedRoot)
+	}
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -11,16 +11,7 @@ const StackMax = 2048
 const FramesMax = 64
 
 func (vm *VM) runtimeError(c *chunk.Chunk, ip int, format string, args ...interface{}) error {
-	line := 0
-	file := "?"
-	if c != nil {
-		file = c.FileName
-		if ip > 0 && ip <= len(c.Lines) {
-			line = c.Lines[ip-1]
-		}
-	}
-	msg := fmt.Sprintf(format, args...)
-	return fmt.Errorf("[%s:line %d] %s", file, line, msg)
+	return vm.newRuntimeError(c, ip, fmt.Sprintf(format, args...))
 }
 
 type CallFrame struct {

--- a/noxy_examples/supervised_tasks.nx
+++ b/noxy_examples/supervised_tasks.nx
@@ -1,0 +1,39 @@
+use sys select exit
+
+func assert(condition: bool, message: string) -> void
+    if !condition then
+        print("supervised tasks: FAIL - " + message)
+        exit(1)
+    end
+end
+
+func double(value: int) -> int
+    return value * 2
+end
+
+func fail() -> int
+    return 1 / 0
+end
+
+func delayed() -> string
+    time_sleep(25)
+    return "ready"
+end
+
+let success: any = spawn_task(double, 21)
+let first: any = task_await(success)
+let second: any = task_await(success)
+assert(first["status"] == "ok" && first["value"] == 42, "task success")
+assert(second["status"] == "ok" && second["value"] == 42, "task replay")
+
+let failed: any = task_await(spawn_task(fail))
+assert(failed["status"] == "error", "task failure")
+assert(failed["error"]["kind"] == "runtime", "runtime kind")
+
+let slow: any = spawn_task(delayed)
+let timeout: any = task_await(slow, 0)
+assert(timeout["status"] == "timeout", "non-terminal timeout")
+let completed: any = task_await(slow)
+assert(completed["status"] == "ok" && completed["value"] == "ready", "later wait")
+
+print("supervised tasks: ok")

--- a/noxy_examples/supervised_tasks.nx
+++ b/noxy_examples/supervised_tasks.nx
@@ -15,8 +15,8 @@ func fail() -> int
     return 1 / 0
 end
 
-func delayed() -> string
-    time_sleep(25)
+func delayed(gate: any) -> string
+    chan_recv(gate)
     return "ready"
 end
 
@@ -30,9 +30,11 @@ let failed: any = task_await(spawn_task(fail))
 assert(failed["status"] == "error", "task failure")
 assert(failed["error"]["kind"] == "runtime", "runtime kind")
 
-let slow: any = spawn_task(delayed)
+let gate: any = make_chan(0)
+let slow: any = spawn_task(delayed, gate)
 let timeout: any = task_await(slow, 0)
 assert(timeout["status"] == "timeout", "non-terminal timeout")
+chan_send(gate, true)
 let completed: any = task_await(slow)
 assert(completed["status"] == "ok" && completed["value"] == "ready", "later wait")
 


### PR DESCRIPTION
## Summary

- add `spawn_task(function, ...arguments)` with an opaque, identity-based task handle
- add replayable `task_await(handle[, timeout_ms])` result envelopes for success, structured runtime failures, recovered panics, and non-terminal timeouts
- support consistent sequential and concurrent waits while preserving composite result identity
- synchronize captured upvalue handoff between parent and worker VMs
- preserve the existing detached `spawn` behavior for compatibility
- document supervised tasks and add an executable example

## Why

This implements the supervised-task gap described in item 3 of #17. Callers can now observe concurrent work without changing the behavior of existing detached routines.

## Validation

- `go test ./internal/... -count=1`
- `go test ./... -count=1`
- `go test -race ./internal/vm -count=1`
- `go vet ./...`
- `go build ./...`
- `go run cmd/noxy/main.go noxy_examples/supervised_tasks.nx`
- `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx` — 158/158 passing
