### PR TITLE
feat(net): add portable network deadlines

### DIFF
--- a/.github/workflows/network-deadlines.yml
+++ b/.github/workflows/network-deadlines.yml
@@ -1,0 +1,25 @@
+name: Network deadlines
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  network-deadlines:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - run: go test ./internal/vm -run 'Test(ValidateNetworkTimeout|Network|NetSet|NetSelect|Socket|Listener|ReceiveSocket|SendSocket|CloseDoes|BufferedAccept|ConnectedSocket|ConcurrentNetSelect)' -count=1 -timeout=120s
+      - run: go test ./internal/... -count=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - `defer call(...)` with immediate argument capture and frame-level LIFO cleanup across functions, scripts, modules, loops, and spawned functions.
+- Portable positive TCP read, write, and accept timeouts through `net.settimeout`.
 
 ### Fixed
 
 - Normal returns and runtime failures now share safe frame unwinding, preserving primary errors while collecting observable cleanup failures.
+- `net.setblocking(sock, true)` now restores indefinite blocking, while the deprecated `false` branch remains a compatibility no-op until the network poller lands.
+- Temporary `net_select` deadlines now preserve the latest persistent timeout and buffered readiness without blocking concurrent close.
 
 ## [0.2.0] - 2026-08-13
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -756,6 +756,82 @@ Noxy comes with a comprehensive standard library. Available modules include:
 | `sqlite` | SQLite database support |
 | `rand` | Random number generation |
 
+### Network deadlines
+
+The `net` module supports portable blocking sockets with optional positive
+deadlines:
+
+```noxy
+net.settimeout(sock, 250)
+net.setblocking(sock, true)
+```
+
+`settimeout(sock, timeout_ms)` selects timed mode. `timeout_ms` must be a
+positive `int` whose conversion to Go `time.Duration` milliseconds does not
+overflow. Each `recv`, `send`, or listener `accept` starts with a fresh
+deadline, so time spent between configuration and the operation does not
+consume the operation's timeout.
+
+`setblocking(sock, true)` clears the persistent timeout and restores
+indefinite blocking, including I/O that is already pending. The compatibility
+call `setblocking(sock, false)` is deprecated and remains an unconditional
+no-op until true portable non-blocking I/O is implemented by the network
+poller. It does not inspect the socket and does not alter an existing timeout.
+An expired deadline is never used to simulate non-blocking behavior.
+
+The latest successfully completed `settimeout` or `setblocking(..., true)`
+call determines the persistent mode. A rejected call leaves that mode
+unchanged. Configuration belongs to the shared network resource, so related
+VMs observe the same mode.
+
+For effective configuration calls, a socket may be the existing map-backed
+`Socket` value or a typed `Socket` instance. The `fd` field must exist, be an
+exact `int`, fit the platform descriptor type without narrowing, resolve to a
+listener before a connected socket, and name an open resource. `fd` is
+authoritative; mutable `open`, `addr`, and `port` fields are not trusted.
+`settimeout` validates exact arity, timeout type and range, socket shape and
+descriptor, lookup, then open state. `setblocking` retains its compatibility
+behavior for malformed arity/type; only the exact `true` branch performs
+socket validation.
+
+`net.poll`/`net_select` retains its call-local timeout. While a read or accept
+probe is active, its absolute deadline is an upper bound: blocking mode or a
+longer persistent timeout cannot extend it, while a shorter persistent timeout
+may shorten it. Cleanup restores the latest persistent mode. A failure to
+install or restore a deadline is synchronous and produces no partial
+`SelectResult`; ordinary read/accept errors remain not-ready candidates.
+Read bytes or accepted connections consumed successfully are published before
+deadline restoration, so a restoration failure does not discard readiness.
+For one probe start instant `t`, the effective deadline is exactly:
+
+```text
+probe_bound = t + select_timeout
+effective = min(probe_bound, t + io_timeout), when io_timeout > 0
+effective = probe_bound, otherwise
+```
+
+The preservation guarantee above is specific to deadline-management failure.
+The existing ordinary `Read(n > 0, err != nil)` probe behavior remains
+unchanged and is reserved for the later network-poller work.
+
+Accepted and connected sockets explicitly clear prior deadlines before being
+registered and start in indefinite blocking mode; a listener timeout is not
+inherited. Failure to clear that initial deadline closes the connection and
+returns the existing `Socket{open:false}` result. Listener accept timeout also
+uses that existing result shape.
+
+Read and write expiry is reported as `"operation timed out"` using portable
+deadline-error classification. A receive that obtained bytes before an error
+remains successful with those bytes. A failed partial send reports `ok=false`
+and its actual transferred `count`. If a multi-step configuration cannot
+restore its exact prior absolute deadline snapshots after failure, the runtime
+marks the shared resource closed, detaches its OS handles and buffers, and
+closes them rather than leaving pending I/O in an unknown deadline state. The
+poisoned entry remains invalid in the shared registry until ordinary
+`net_close` removes the handle. If concurrent close invalidates a deadline
+transition, that close owns cleanup; the stale transition cannot commit,
+register, roll back, poison, or close the resource again.
+
 ---
 
 ## 13. Implementation Notes

--- a/docs/superpowers/plans/2026-08-14-network-deadlines.md
+++ b/docs/superpowers/plans/2026-08-14-network-deadlines.md
@@ -1,0 +1,365 @@
+# Network Deadlines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add portable positive network timeouts and restoration of indefinite blocking while preserving the legacy `setblocking(false)` call until true non-blocking I/O lands with the platform poller.
+
+**Architecture:** Shared listener and socket resources store one validated `time.Duration`, where zero means indefinite blocking and positive means a fresh per-operation deadline. A dedicated `deadlineMu` serializes configuration and temporary `net_select` transitions without holding `stateMu` across external setters; a generation revalidation detects concurrent close. Direction locks continue to serialize I/O. The public API adds `net.settimeout`, `setblocking(true)` clears deadlines, and the deprecated `false` branch remains an unconditional no-op.
+
+**Tech Stack:** Go 1.24+, Go `net`, `time`, `errors`, and `os`; Noxy standard-library wrappers and VM tests.
+
+## Global Constraints
+
+- Support only indefinite blocking and positive portable timeouts in this subproject.
+- Never simulate non-blocking mode with an expired deadline.
+- Preserve `setblocking(false)` as an unconditional deprecated no-op, including for stale handles; true non-blocking belongs to `feat/network-poller`.
+- Preserve `Socket`, `NetResult`, `net_accept`, and `net_select` result shapes.
+- Keep timeout milliseconds as `int64` through overflow validation; never narrow through `int`.
+- Share configuration across related VMs and never hold `stateMu` or registry locks during external deadline setters, close, or blocking I/O.
+- Use lock order direction mutex, then `deadlineMu`, then short-lived `stateMu`; configuration starts at `deadlineMu`, and close never acquires `deadlineMu`.
+- The latest successfully linearized supported configuration wins for persistent state and pending ordinary I/O, but an active select deadline remains an upper bound that cannot be removed or extended.
+- If rollback cannot restore a known live deadline, fail closed and close the resource so pending I/O cannot hang.
+- Do not change ordinary `net_select` Read/Accept error handling; only new deadline-management failures are synchronous.
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `internal/vm/resources.go` | Shared listener/socket timeout state. |
+| `internal/vm/builtins_net.go` | Validation, configuration, deadline application/restoration, and error normalization. |
+| `internal/vm/builtins_net_test.go` | Real and controlled deadline, concurrency, partial-I/O, and select tests. |
+| `internal/vm/builtins_registry_test.go` | New contextual-native registry guard. |
+| `internal/stdlib/net.nx` | Typed `settimeout` wrapper. |
+| `docs/NOXY_LANGUAGE_SPEC.md` | Public contract and precedence. |
+| `CHANGELOG.md` | Release-facing summary. |
+| `.github/workflows/network-deadlines.yml` | Execute public deadline behavior on Windows and Unix. |
+
+---
+
+### Task 1: Shared timeout state and validation
+
+**Files:**
+- Modify: `internal/vm/resources.go`
+- Modify: `internal/vm/builtins_net.go`
+- Test: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Produces: `validateNetworkTimeout(milliseconds int64) (time.Duration, error)`.
+- Produces: internal `deadlineListener` combining `net.Listener` and `SetDeadline(time.Time) error`.
+- Produces: listener `deadlineMu`, `deadlineGeneration`, `ioTimeout`, `acceptProbeDeadline`, and `lastAcceptDeadline` state.
+- Produces: socket `deadlineMu`, `deadlineGeneration`, `ioTimeout`, `readProbeDeadline`, `lastReadDeadline`, and `lastWriteDeadline` state.
+- Produces: shared listener/socket handle resolution for configuration natives.
+
+- [ ] **Step 1: Write failing validation and shared-state tests**
+
+Table-test literal inputs `1`, `0`, `-1`, `math.MaxInt64/int64(time.Millisecond)`, and one greater than the maximum. Require exact conversion for safe positives and stable errors for the rest. Configure a socket through a child VM and observe the same field from its parent's shared registry. Verify that a real TCP listener satisfies `deadlineListener`; a controlled listener without `SetDeadline` is closed and `net_listen` returns the existing closed-socket result. Add handle extraction tests requiring `Type == VAL_OBJ`, non-nil `*ObjMap` or `*ObjInstance`, existing exact-`VAL_INT` `fd`, listener-first lookup, and the maximum/minimum platform `int`. Include typed nil map/instance objects. When `strconv.IntSize < 64`, also test representable `int64` values immediately outside the `int` range; on 64-bit, assert all `int64` values round-trip. Require only `fd` to affect lookup while mutated `open`, `addr`, and `port` are ignored. These tests catch panic paths, overflow, narrowing/wrap, invalid zero/negative input, VM-local state, and unvalidated listener capability.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```text
+go test ./internal/vm -run 'TestValidateNetworkTimeout|TestNetworkTimeoutStateIsShared' -count=1
+```
+
+Expected: FAIL because state and validation do not exist.
+
+- [ ] **Step 3: Add minimal state and validation**
+
+```go
+func validateNetworkTimeout(milliseconds int64) (time.Duration, error) {
+    if milliseconds <= 0 {
+        return 0, fmt.Errorf("network timeout must be positive")
+    }
+    const maximum = int64(math.MaxInt64) / int64(time.Millisecond)
+    if milliseconds > maximum {
+        return 0, fmt.Errorf("network timeout is too large")
+    }
+    return time.Duration(milliseconds) * time.Millisecond, nil
+}
+```
+
+Define:
+
+```go
+type deadlineListener interface {
+    net.Listener
+    SetDeadline(time.Time) error
+}
+```
+
+Store that interface in `ListenerResource` and validate the assertion before registration. Add a dedicated deadline-transition mutex, generation, timeout, active-probe, and last-successful-absolute-deadline fields to each resource. `stateMu` guards lifecycle and metadata but is never held across an external setter. Add one nil-safe parser: require `VAL_OBJ`, type-switch to non-nil `*ObjMap` or `*ObjInstance`, read an existing exact-integer `fd`, verify `int64(int(fd)) == fd`, then look up listener before socket. Ignore `open`, `addr`, and `port`. Effective configuration paths reject malformed, unknown, or closed handles rather than selecting descriptor zero.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+```text
+go test ./internal/vm -run 'TestValidateNetworkTimeout|TestNetworkTimeoutStateIsShared' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```text
+git add internal/vm/resources.go internal/vm/builtins_net.go internal/vm/builtins_net_test.go
+git commit -m "feat(net): add shared timeout state"
+```
+
+---
+
+### Task 2: Read and write deadline behavior
+
+**Files:**
+- Modify: `internal/vm/builtins_net.go`
+- Test: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Consumes: `SocketResource.ioTimeout`.
+- Produces: per-operation read/write deadline helpers.
+- Produces: deadline classification through `errors.Is(err, os.ErrDeadlineExceeded)`.
+
+- [ ] **Step 1: Write failing I/O tests**
+
+Use loopback TCP to prove a default read waits for later data and a positive read timeout returns within a generous bound. Use `net.Pipe` or a controlled `net.Conn` for deterministic blocked and partial writes. Require a partial receive plus deadline error to remain successful with its bytes; require a partial send to return `ok=false`, its actual count, and `"operation timed out"`. Add controlled `SetReadDeadline`/`SetWriteDeadline` failures.
+
+Seed `bufferedRead` and prove a fully satisfied receive performs no deadline call. For a larger receive, make deadline installation fail before additional I/O: require the buffered bytes as a successful partial result and no byte loss. Repeat with successful installation followed by a failing `Read`. Add a dialed controlled connection carrying a prior deadline; require `SetDeadline(time.Time{})` before registry insertion and close plus invalid-socket result when clearing fails.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```text
+go test ./internal/vm -run 'TestSocket(Read|Write)(Timeout|Deadline|Partial)|TestBlockingReadWaitsForData' -count=1
+```
+
+Expected: FAIL because stored deadlines are not applied.
+
+- [ ] **Step 3: Implement minimal I/O behavior**
+
+Within `readMu`/`writeMu`, acquire `deadlineMu`, briefly lock `stateMu` to validate lifecycle state, capture the connection and mode, and reserve a generation. Unlock `stateMu`, apply zero or `time.Now().Add(ioTimeout)`, then reacquire it to commit the last-installed absolute deadline only if the resource is still open and the generation remains current. Release `deadlineMu` before I/O. Close never waits for `deadlineMu`. Normalize only deadline errors:
+
+```go
+func networkErrorMessage(err error) string {
+    if errors.Is(err, os.ErrDeadlineExceeded) {
+        return "operation timed out"
+    }
+    return err.Error()
+}
+```
+
+Inspect buffered bytes before deadline application. Return a fully satisfied buffer without I/O. When more data is required, install the deadline before detaching the buffer; if installation or later Read fails after buffered bytes are available, consume and return them under the partial-read contract. Preserve EOF behavior and report the real byte count on partial send failures. Before registering a dialed connection, clear all deadlines explicitly; close and return the current invalid-socket result on failure.
+
+- [ ] **Step 4: Verify GREEN and existing lifecycle behavior**
+
+```text
+go test ./internal/vm -run 'TestSocket|TestBlockingRead|TestNetworkBuiltinsLoopbackLifecycle|TestNetSelectBufferIsSharedAcrossVMs' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```text
+git add internal/vm/builtins_net.go internal/vm/builtins_net_test.go
+git commit -m "feat(net): enforce read and write deadlines"
+```
+
+---
+
+### Task 3: Listener deadlines and select restoration
+
+**Files:**
+- Modify: `internal/vm/builtins_net.go`
+- Test: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Consumes: listener/socket timeout state.
+- Produces: `ListenerResource.acceptProbeDeadline` and `SocketResource.readProbeDeadline` absolute upper bounds.
+- Produces: exact last-installed absolute deadline snapshots for rollback.
+- Produces: directional live configuration with best-effort exact rollback and persistent commit only after all applications succeed.
+- Produces: select cleanup that restores the latest persistent mode or reports an open-resource failure.
+
+- [ ] **Step 1: Write failing listener and concurrency tests**
+
+Cover: timed `accept` returning the existing invalid-socket sentinel; accepted sockets starting with `ioTimeout == 0`; setting a timeout during pending Read/Write/Accept; and clearing a deadline during pending ordinary I/O with `setblocking(true)`. Start probes with persistent timeouts both shorter and longer than the select timeout and assert the exact `min` formula. Prove that concurrent clearing or a longer timeout cannot extend the immutable probe bound, a shorter timeout may shorten it, write configuration remains independent of a read probe, and cleanup restores the latest persistent mode.
+
+Split deadline-management failures into installation failure (no I/O attempted), restoration failure on an open resource (synchronous `net_select` error), and close during probe (skip restoration and report not ready). For both socket and listener, make readiness succeed and restoration fail; require the same candidate's byte/connection to be published before the error and available to the next call. If close wins after Accept, require the accepted connection to close and no buffer publication. Separately inject ordinary `Read` and `Accept` errors and require the current not-ready result plus continued processing of later candidates. Characterize ordinary `Read(n>0, err!=nil)` as unchanged and do not preserve its byte in this task. Use the Task 1 listener interface for ordering and loopback for visible behavior. Add doubles where read application succeeds and write application fails after mutation five seconds into a ten-second pending deadline; require rollback to the exact stored absolute instant, not `now+10s`. Cover successful rollback and repair by the next operation.
+
+When rollback itself fails, require fail-closed behavior for sockets and listeners: `closed` set under `stateMu`, buffers detached and cleared, OS resources closed after unlock, pending Read/Write/Accept/probe released, and an `errors.Join` containing application, rollback, and close failures. The poisoned handle remains registered but all later operations fail promptly until `net_close` removes it. Add a buffered accepted connection and assert it is also closed by listener poisoning.
+
+Run two controlled configurations concurrently and prove their persistent commits follow `deadlineMu` order while pending read/write effects occur at their individual setters. Stall each kind of deadline setter behind a controlled barrier, invoke close concurrently, and require close to mark/detach and call `Close` exactly once without waiting for the setter; release the barrier and require the stale generation to perform no commit, rollback, registration, poisoning, or second close. Race close against Read, Write, Accept, and configuration and require bounded completion without deadlock. In a multi-candidate select, make an earlier probe buffer readiness and a later deadline installation fail; require no `SelectResult`, no later probes, and retention of the earlier buffer. Repeat the later candidate with an ordinary I/O error and require continued processing instead of a synchronous error.
+
+Seed `bufferedAccept` and prove accept performs no listener deadline call. Hold `acceptMu` for delivery, observe the connection under `stateMu`, and keep it published while clearing its own deadline without `stateMu`. On success require revalidation of `!closed && bufferedAccept == connection`, atomic detach, then registration. On clearing failure require the same ownership revalidation followed by destructive detach, connection close outside the lock, invalid-socket sentinel, and an empty buffer. Add success and failure barrier tests where listener close wins during clearing: close owns the detached connection, accept returns the sentinel, no closed connection is registered, and no connection is closed twice. Do not mutate unrelated buffered state.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```text
+go test ./internal/vm -run 'TestListenerTimeout|TestAcceptedSocket|TestPendingNetwork|TestNetSelectRestores|TestConcurrentNetworkConfiguration' -count=1
+```
+
+Expected: FAIL because listener modes and non-stale restoration do not exist.
+
+- [ ] **Step 3: Implement linearized configuration/restoration**
+
+```go
+type deadlineListener interface {
+    net.Listener
+    SetDeadline(time.Time) error
+}
+```
+
+Serialize each transition with `deadlineMu`. Under `stateMu`, snapshot the exact last-successful absolute deadlines, validate the live resource, capture it, compute directional effective deadlines, and reserve a generation; then release `stateMu` before every setter. Reacquire `stateMu` after each setter and before commit. If close changed the generation, do not commit, roll back, poison, register, or close again. At probe start `t`, store `probeBound=t+selectTimeout` and install `min(probeBound, t+ioTimeout)` when persistent timeout is positive, otherwise the probe bound. When configuration runs during a read/accept probe, blocking or a longer timeout preserves that immutable upper bound and a shorter timeout uses the earlier instant. Apply socket read and write deadlines separately so a read probe never blocks write configuration. After each successful, still-current setter, record its exact absolute value. Store `ioTimeout` only after every required setter succeeds and generation revalidation passes; this store is the persistent-mode linearization point.
+
+On application failure while the generation is still owned, retain persistent state and best-effort reapply the exact absolute snapshots without `stateMu`, preserving a probe bound. Never derive rollback from `time.Now().Add(oldTimeout)`. If rollback succeeds, return the primary error and allow later reapplication to repair unknown live state. If rollback fails and the generation is still current, poison the resource under `stateMu`, increment the generation, clear/detach buffers, unlock both mutexes, close every captured OS resource, and return all application, rollback, and close errors with `errors.Join`. If close already invalidated the generation, it owns resource cleanup and the transition performs no second close. This fail-closed path is required because a pending operation may hold its direction mutex and cannot rely on later repair.
+
+Refactor select helpers to distinguish management from ordinary I/O errors. Installation/restoration failures use `(false, error)`; ordinary Read/Accept errors use `(false, nil)`. On a management error, stop later candidates and discard the `SelectResult`, retaining buffers from earlier probes. On ordinary errors, continue candidates, including the unchanged `n>0, err!=nil` path reserved for `feat/network-poller`. Record and install the probe with the reserve/apply/revalidate protocol before I/O. After successful readiness, acquire `deadlineMu`, publish the byte/connection under `stateMu`, and only then restore the latest persistent deadline without `stateMu`; a concurrent close invalidates the generation and owns buffer/resource cleanup. Restoration failure leaves that same buffer published when close did not win. For buffered accept delivery, hold `acceptMu`, observe but do not detach under `stateMu`, clear `connection.SetDeadline(time.Time{})` without `stateMu`, then reacquire it and detach only if the listener is open and still owns that exact connection. Close wins by detaching and closing; accept then returns the sentinel without registration or a second close.
+
+- [ ] **Step 4: Verify GREEN under repetition and race detector**
+
+```text
+go test ./internal/vm -run 'TestListenerTimeout|TestAcceptedSocket|TestPendingNetwork|TestNetSelect|TestConcurrentNetwork' -count=20
+go test -race ./internal/vm -run 'TestPendingNetwork|TestNetSelectRestores|TestConcurrentNetworkConfiguration' -count=1
+```
+
+Expected: PASS without races or stale restoration.
+
+- [ ] **Step 5: Commit**
+
+```text
+git add internal/vm/builtins_net.go internal/vm/builtins_net_test.go
+git commit -m "fix(net): preserve deadlines across select probes"
+```
+
+---
+
+### Task 4: Public native and typed wrapper
+
+**Files:**
+- Modify: `internal/vm/builtins_net.go`
+- Modify: `internal/vm/builtins_registry_test.go`
+- Modify: `internal/stdlib/net.nx`
+- Test: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Produces: `net_settimeout(socket, timeout_ms) -> void` and `net.settimeout(sock: Socket, timeout_ms: int) -> void`.
+- Changes: `net_setblocking(socket, true)` clears deadlines.
+- Preserves: `net_setblocking(socket, false)` returns without inspecting the socket or mutating state.
+
+- [ ] **Step 1: Write failing native/API tests**
+
+Invoke the natives against the normative decision tree and assert error precedence. `net_settimeout` must check: exact arity; exact `VAL_INT` timeout; positivity/overflow; first value `VAL_OBJ`; non-nil `ObjMap` or `ObjInstance`; existing exact-integer, platform-representable `fd`; listener lookup before socket; then open state. Include typed nil values and cases failing multiple conditions, requiring the earlier error without panic. `net_setblocking` must return silent `void` unless it has exactly two arguments and argument two is exactly bool; false returns before inspecting malformed, nil, missing, unknown, closed, or out-of-range handles; only exact true performs shared extraction/lookup and clears an open resource or errors. Also require no false-branch state change from blocking and timed modes. Add `net_settimeout` to registry and contextual-handler expectations. Compile and run a Noxy source snippet importing `net`, calling `settimeout(listener, 25)`, restoring blocking, and closing it.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```text
+go test ./internal/vm -run 'TestNetSetTimeout|TestNetSetBlocking|TestBuiltinRegistrySnapshot|TestStatefulBuiltinsUseContextualHandlers|TestNetTimeoutWrapper' -count=1
+```
+
+Expected: FAIL because the new API is absent and `net_setblocking` is unconditional.
+
+- [ ] **Step 3: Register natives and wrapper**
+
+Register `net_settimeout` contextually and implement the Task 4 test order exactly: arity, timeout type, safe timeout value, `VAL_OBJ`, non-nil supported object, exact/range-safe `fd`, listener-first registry lookup, then open state. Refactor `net_setblocking` in this order: return `void` unless there are exactly two arguments and argument two is exactly bool; return `void` immediately when false; only then run shared nil-safe extraction/lookup and configure zero duration for true.
+
+```noxy
+func settimeout(sock: Socket, timeout_ms: int) -> void
+    net_settimeout(sock, timeout_ms)
+end
+```
+
+- [ ] **Step 4: Verify GREEN and import/compiler compatibility**
+
+```text
+go test ./internal/vm -run 'TestNetSet|TestBuiltinRegistrySnapshot|TestStatefulBuiltinsUseContextualHandlers|TestNetTimeoutWrapper|TestNetworkBuiltinsLoopbackLifecycle' -count=1
+go test ./internal/compiler ./internal/parser -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```text
+git add internal/vm/builtins_net.go internal/vm/builtins_net_test.go internal/vm/builtins_registry_test.go internal/stdlib/net.nx
+git commit -m "feat(net): add portable socket timeouts"
+```
+
+---
+
+### Task 5: Documentation and full validation
+
+**Files:**
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `CHANGELOG.md`
+- Create: `.github/workflows/network-deadlines.yml`
+- Include: `docs/superpowers/specs/2026-08-14-network-deadlines-design.md`
+- Include: `docs/superpowers/plans/2026-08-14-network-deadlines.md`
+
+- [ ] **Step 1: Document the exact contract**
+
+Add “Network Deadlines” to the standard-library section. Include the precedence table, exact validation/error order, nil-safe `ObjMap`/`ObjInstance` forms, authoritative range-safe `fd` and listener-first lookup, positive/overflow limits specific to `net_settimeout`, per-operation refresh, persistent commit versus directional pending-I/O effects, shared-VM state, accept sentinel, accepted-socket non-inheritance, buffered and partial I/O, and normalized timeout error. Document publication before restoration, destructive buffered-accept removal on initialization failure, the exact probe `min` formula, absolute rollback snapshots, fail-closed rollback failure, skipped restoration after close, and the distinction between synchronous deadline-management errors and ordinary not-ready probe errors. Explicitly leave ordinary select `Read(n>0, err!=nil)` unchanged for `feat/network-poller`. Mark `setblocking(false)` as an unconditional deprecated no-op until that subproject; never describe it as non-blocking. Add concise Unreleased changelog entries.
+
+- [ ] **Step 2: Add Windows and Unix execution coverage**
+
+Create this workflow with the current Node 24-based major releases of the
+official checkout and Go setup actions:
+
+```yaml
+name: Network deadlines
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  network-deadlines:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - run: go test ./internal/vm -run 'Test(Socket|Listener|PendingNetwork|NetSelectRestores|ConcurrentNetwork|NetSet)' -count=1
+      - run: go test ./internal/... -count=1
+```
+
+The real-loopback suite must assert that a TCP listener supports deadline configuration and that a wrapped `os.ErrDeadlineExceeded` normalizes through `errors.Is`. Controlled doubles remain platform-independent.
+
+- [ ] **Step 3: Format and inspect the diff**
+
+```text
+gofmt -w internal/vm/resources.go internal/vm/builtins_net.go internal/vm/builtins_net_test.go internal/vm/builtins_registry_test.go
+git diff --check
+```
+
+Expected: formatting succeeds and `git diff --check` prints nothing.
+
+- [ ] **Step 4: Run required project validation**
+
+```text
+go test ./internal/...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Expected: all internal Go tests and all non-excluded Noxy examples pass.
+
+- [ ] **Step 5: Run final checks**
+
+```text
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Expected: every command exits zero without newly introduced warnings.
+
+- [ ] **Step 6: Commit**
+
+```text
+git add docs/NOXY_LANGUAGE_SPEC.md CHANGELOG.md .github/workflows/network-deadlines.yml docs/superpowers/specs/2026-08-14-network-deadlines-design.md docs/superpowers/plans/2026-08-14-network-deadlines.md
+git commit -m "docs(net): specify deadline precedence"
+```

--- a/docs/superpowers/specs/2026-08-14-network-deadlines-design.md
+++ b/docs/superpowers/specs/2026-08-14-network-deadlines-design.md
@@ -1,0 +1,405 @@
+# Network Deadlines Design
+
+## Goal and Scope
+
+Resolve point 4 from PR #17 through a portable, additive deadline API for TCP
+listeners and connected sockets. This subproject supports indefinite blocking
+and positive read/write/accept timeouts. True non-blocking I/O remains part of
+`feat/network-poller`, where Windows and Unix readiness implementations will
+be introduced together with corrected `net_select` semantics.
+
+This separation is required because Go's portable `net.Conn` API implements
+deadlines but does not expose a portable non-blocking operation. An expired
+deadline is not a non-blocking probe: it fails even when I/O is already ready.
+
+## Public API
+
+The additive public function follows the module's existing naming style:
+
+```noxy
+net.settimeout(sock, timeout_ms)
+```
+
+Its native entry point is `net_settimeout(Socket, int) -> void`. It configures
+one positive timeout for reads, writes, or listener `accept`. A timeout must be
+greater than zero and small enough to convert safely to `time.Duration`.
+
+Validation is normative:
+
+- `net_settimeout` validates in this exact order: exactly two arguments;
+  argument two is exactly `VAL_INT`; timeout is positive and within the safe
+  duration bound; argument one has `Type == VAL_OBJ`; its object is a non-nil
+  `*ObjMap` or non-nil `*ObjInstance`; its `fd` field exists, is exactly
+  `VAL_INT`, and round-trips through platform `int` without a value change;
+  the descriptor resolves to a listener first or connected socket second; and
+  the resource is open under `stateMu`. Every violation is a synchronous
+  runtime error and later checks do not run after an earlier failure;
+- `net_setblocking` returns silently unless it has exactly two arguments and
+  its second argument is exactly `bool`;
+- `net_setblocking(..., false)` returns before inspecting its first argument;
+- only `net_setblocking(..., true)` performs the same socket extraction,
+  descriptor, lookup, and open-state checks before clearing the timeout, with
+  failures producing a synchronous runtime error.
+
+The accepted socket representations are the existing non-nil `ObjMap` returned
+by network natives and non-nil `ObjInstance` used by typed Noxy values. Typed
+nil pointers are rejected before method or field access. In both forms, `fd`
+is the only authoritative field. User-mutable `open`, `addr`, and `port` fields
+are ignored. A descriptor outside the platform `int` range is rejected before
+lookup, so narrowing can never wrap to a valid handle. Lookup remains listener
+then socket, matching current `net_select`; odd/even handle allocation makes
+ordinary descriptors unambiguous.
+
+The existing function remains callable:
+
+```noxy
+net.setblocking(sock, blocking)
+```
+
+`setblocking(sock, true)` clears an active timeout and restores indefinite
+blocking. `setblocking(sock, false)` remains the exact compatibility no-op and
+is deprecated: it does not inspect or validate the socket, and it neither
+clears nor replaces an active timeout. This behavior is explicit so the
+runtime does not pretend that an expired deadline is true non-blocking I/O.
+The later network-poller subproject will give the `false` branch real
+readiness semantics without another API change.
+
+Separate read/write timeout setters are excluded: the existing network module
+is intentionally small, and current HTTP consumers use one timeout value.
+
+## Modes and Precedence
+
+Every listener and connected socket starts in indefinite blocking mode. The
+persistent state has two supported modes:
+
+| Successful call | Resulting mode |
+|---|---|
+| `settimeout(sock, n)`, `n > 0` | timed; each I/O operation gets a fresh `n` millisecond deadline |
+| `setblocking(sock, true)` | blocking; read, write, and accept deadlines are cleared |
+| `setblocking(sock, false)` | unchanged; deprecated compatibility behavior |
+
+Between supported configuration calls, the most recently linearized call
+wins. A rejected configuration never changes the prior persistent mode.
+
+`net_select` keeps its current call-local probe timeout in this subproject. Its
+absolute read or accept deadline is an upper bound while the probe is active:
+no configuration may remove or extend it. A concurrent positive timeout may
+shorten the live probe deadline, while `setblocking(true)` or a longer timeout
+changes persistent state immediately but leaves the probe bound intact. For a
+socket, write configuration is applied independently even while a read probe
+is active. When the probe finishes, it removes the active-probe marker and
+restores the latest persistent read or accept mode, not the mode captured at
+probe start. `net_select` never mutates persistent configuration.
+
+## Runtime Model and Linearization
+
+An internal `deadlineListener` interface extends `net.Listener` with
+`SetDeadline(time.Time) error`. `net_listen` validates this capability before
+registering a TCP listener; an implementation without it is closed and
+reported through the existing `Socket{open:false}` listen result.
+
+`ListenerResource` stores the `deadlineListener`, `ioTimeout`, the active
+accept-probe bound, the last successfully installed absolute accept deadline,
+a deadline-transition mutex, and a deadline generation. `SocketResource`
+stores the equivalent transition mutex and generation plus `ioTimeout`, the
+active read-probe bound, and the last successfully installed absolute read and
+write deadlines. Zero `ioTimeout` means indefinite blocking; only validated
+positive values mean timed mode. The absolute fields are exact rollback
+snapshots, not values reconstructed from the relative timeout.
+
+Public timeout milliseconds remain `int64` until validation against:
+
+```go
+timeoutMilliseconds > 0 &&
+timeoutMilliseconds <= int64(math.MaxInt64)/int64(time.Millisecond)
+```
+
+No conversion through platform-sized `int` is permitted on the new
+`net_settimeout` path. The existing narrowing and timeout coercion inside
+`net_select` belong to `feat/network-poller` and are deliberately unchanged.
+
+Deadline transitions are serialized by a dedicated `deadlineMu`, never by
+`stateMu`. No call to `SetReadDeadline`, `SetWriteDeadline`, `SetDeadline`, or
+`Close` occurs while `stateMu` is held. This is required because the interface
+contracts permit concurrent calls but do not promise that a setter returns
+promptly. Consequently, `net_close` never acquires `deadlineMu`: under
+`stateMu` it marks the resource closed, increments the deadline generation,
+detaches owned buffers and OS resources, then invokes `Close` after unlocking.
+It can therefore close the resource even when a deadline setter is stalled.
+
+The lock order is directional mutex (`readMu`, `writeMu`, or `acceptMu`), when
+applicable, then `deadlineMu`, then the short-lived `stateMu`. Configuration
+starts at `deadlineMu`; close uses only `stateMu`. Code never acquires
+`deadlineMu` while holding `stateMu`.
+
+Every deadline transition follows a reserve/apply/revalidate protocol:
+
+1. acquire `deadlineMu` and, under `stateMu`, validate the live resource,
+   snapshot the exact state needed for rollback, reserve the next generation,
+   and capture the underlying connection or listener;
+2. release `stateMu` and invoke the required setters while retaining only
+   `deadlineMu`;
+3. reacquire `stateMu` after each setter and before commit. Commit only if the
+   resource remains open and the reserved generation is still current;
+4. if close changed the generation, perform no persistent commit, rollback,
+   registration, or second close: close owns the detached resource lifecycle.
+
+Before each `Accept`, `Read`, or `Write`, the operation acquires its existing
+direction mutex and uses that protocol to install a fresh deadline derived
+from the current persistent mode. The direction mutex remains held across its
+I/O, but `deadlineMu`, `stateMu`, and registry locks do not. Every successful,
+still-current setter records its exact absolute value in the corresponding
+last-installed field.
+
+Configuration uses the same protocol and applies read and write deadlines
+separately. It stores the new persistent mode only after all required calls
+succeed and the generation revalidation confirms that close did not win. Go
+deadlines affect pending and future I/O, so changing the mode can shorten,
+extend, or clear an operation already waiting, except that it cannot remove or
+extend an active select bound.
+
+The persistent-mode linearization point is the `ioTimeout` store after all
+required setters succeed and the reserved generation is revalidated.
+Operations beginning after that store observe the new mode. Effects on
+already-pending read and write operations linearize at their individual setter
+calls and are not atomic across directions. A pending read may therefore
+observe a new deadline before a pending write; this is an explicit property of
+the underlying Go API, not a shared-state race.
+
+`SetReadDeadline`, `SetWriteDeadline`, and listener `SetDeadline` are not
+assumed to be transactional. Before configuration, the runtime snapshots the
+last successfully installed absolute deadlines. If an application step fails,
+configuration keeps the previous persistent mode and makes a best-effort
+rollback to those exact snapshots, including any active probe bound. It never
+reconstructs rollback as `time.Now().Add(oldTimeout)`, which could extend a
+pending operation. The configuration returns a synchronous error; if rollback
+also fails, both failures are preserved with `errors.Join`.
+
+A setter that returns an error may already have changed OS state, so the live
+deadline for that direction is considered unknown until a rollback, later
+operation, successful configuration, or probe cleanup installs a deadline
+successfully. Only persistent state is guaranteed unchanged. Each successful
+reapplication refreshes the last-installed absolute field and repairs the
+unknown live state.
+
+If any rollback step fails, later repair cannot be guaranteed because a
+pending operation may still hold its direction mutex indefinitely. If the
+transition still owns its generation, the runtime therefore fails closed:
+while holding `stateMu` it marks the resource closed, increments the
+generation, detaches and clears buffered state, and captures the underlying
+connection, listener, and any buffered accepted connection. After releasing
+`stateMu` and `deadlineMu`, it closes the captured resources to unblock pending
+I/O. If ordinary close already invalidated the generation, that close owns the
+lifecycle and the transition does not poison or close anything again. The
+synchronous error joins the original application failure, every rollback
+failure, and any close failure with `errors.Join`. A poisoned resource remains
+invalid in its shared registry until an ordinary `net_close` removes the
+handle; subsequent operations observe `closed` and cannot start new I/O.
+
+At probe start time `t`, the runtime computes the immutable upper bound and
+initial effective deadline as:
+
+```text
+probeBound = t + selectTimeout
+effective = min(probeBound, t + ioTimeout), when ioTimeout > 0
+effective = probeBound, otherwise
+```
+
+The marker always stores `probeBound`, even when the initial effective
+deadline is earlier. Configuration during the probe recomputes its directional
+effective value against that original bound. Probe cleanup removes the marker
+and installs zero or `time.Now().Add(latestTimeout)`.
+
+If initial installation fails, the probe clears its marker, performs no
+`Read` or `Accept`, and returns a synchronous error from `net_select`. If the
+resource closes during the probe, cleanup skips restoration and reports the
+candidate as not ready. If restoration fails while the resource remains open,
+`net_select` returns a synchronous error rather than a partial `SelectResult`;
+the next operation attempts repair before I/O.
+
+After a probe returns ordinary success (`Read` with `n > 0 && err == nil`, or
+`Accept` with a non-nil connection and `err == nil`), it locks `stateMu` and
+checks close state. If still open, it publishes the consumed byte or connection into
+`bufferedRead` or `bufferedAccept` before attempting deadline restoration. A
+restoration failure therefore returns a synchronous error while retaining the
+same candidate's readiness buffer for a later call. If close won, an accepted
+connection is closed and the candidate is not ready; bytes need not be
+retained after their owning socket has closed.
+
+Only deadline installation or restoration failures introduced by this feature
+are synchronous `net_select` errors. On such a management error,
+`net_select` stops processing later candidates and returns no `SelectResult`.
+Read bytes or accepted connections buffered by earlier successful probes
+remain buffered. Ordinary `Read` or `Accept` errors retain current behavior:
+that candidate is not ready and later candidates are still processed. This
+subproject does not otherwise change consumer-buffered or multiplexing
+semantics.
+
+The preservation guarantee is limited to deadline installation and
+restoration failures introduced by this feature. The current behavior for an
+ordinary select `Read` returning `n > 0` together with a non-nil error remains
+unchanged, even though a general `io.Reader` consumer may process those bytes.
+Correcting that polling behavior belongs to `feat/network-poller`.
+
+## Buffered Read and Accept Ordering
+
+Buffered readiness is examined before installing an operation deadline.
+
+- A `bufferedAccept` fully satisfies `net_accept`, so no listener deadline is
+  installed. `acceptMu` remains held for the entire delivery. Under `stateMu`,
+  `net_accept` observes the connection but leaves it published, then clears the
+  connection's own deadline without holding `stateMu`. It reacquires `stateMu`
+  and detaches only if the listener is still open and
+  `bufferedAccept == connection`. On success, the detached connection is owned
+  locally and registered. On clearing failure, the still-owned connection is
+  destructively detached and closed outside the lock. If listener close won,
+  it already detached and owns closing the connection; `net_accept` neither
+  registers nor closes it again and returns the existing invalid-socket
+  sentinel. A closed connection is never left inside the buffer.
+- A `bufferedRead` that fully satisfies `net_recv` is returned without a socket
+  read or deadline installation.
+- When additional reading is required, the deadline is installed before the
+  shared buffer is detached or mutated. If installation fails and buffered
+  bytes are already deliverable, those bytes are consumed and returned as a
+  successful partial receive under the existing partial-read contract. With
+  no buffered bytes, the deadline failure is returned as `NetResult{ok:false}`.
+- A later `Read` error after buffered bytes were detached also returns those
+  bytes as a successful partial receive.
+
+These rules prevent deadline-management failures from silently discarding a
+byte or accepted connection previously consumed by `net_select`.
+
+Configuration belongs to shared resources, so parent and child VMs observe the
+same mode. Registry locks are never held during network I/O.
+
+## Accept and Socket Inheritance
+
+A listener timeout bounds only `net_accept`. On expiry, `net_accept` preserves
+its existing return shape and yields `Socket(-1, "", 0, false)`; it cannot
+return a `NetResult` error string without a breaking API change.
+
+Every connection returned by `Accept` or `DialTimeout` has
+`SetDeadline(time.Time{})` applied before registration, then starts with zero
+absolute snapshots and indefinite blocking mode. An accepted connection does
+not inherit the listener timeout. If clearing the deadline fails, the
+connection is closed and the existing invalid-socket result is returned; a
+close failure cannot be represented by the current `Socket` shape and is not
+exposed. Callers configure a successfully returned socket explicitly when
+required.
+
+## Results and Errors
+
+The existing `Socket` and `NetResult` shapes remain unchanged.
+
+- A read or write deadline expiry is recognized with
+  `errors.Is(err, os.ErrDeadlineExceeded)` and reported as
+  `error="operation timed out"`; platform-specific error text is never used
+  for classification.
+- EOF remains `ok=true`, `count=0`, `error=""`.
+- A receive that transfers bytes before an error remains
+  `ok=true`, returns those bytes and their count, and leaves `error` empty.
+- A send that transfers bytes before an error returns `ok=false`, the actual
+  transferred count, and the normalized or underlying error. This lets the
+  caller resume at the correct offset without changing the result shape.
+- Other I/O failures retain their underlying error string.
+- Deadline-application failures during `recv` or `send` use `NetResult` with
+  `ok=false`; during `accept` they use the existing closed-socket sentinel.
+
+`net_settimeout` and the effective `net_setblocking(true)` configuration path
+produce synchronous runtime errors for malformed sockets, unknown or closed
+handles, deadline-application or rollback failure, non-positive timeouts, and
+overflow. The deprecated `net_setblocking(false)` preserves the prior native
+behavior exactly: it returns `void` without validating or changing anything.
+
+## Compatibility
+
+- Existing sockets remain blocking by default.
+- Existing `setblocking` calls retain their name, arguments, and `void` return
+  type. The valid `true` branch now restores blocking; malformed calls retain
+  the old silent return behavior because no effective branch can be selected.
+- `setblocking(false)`, including calls carrying stale or invalid socket
+  handles, remains an unconditional no-op and is now documented as deprecated.
+- `settimeout` is additive and uses the same `Socket` type.
+- `net_recv`, `net_send`, `net_accept`, and `net_select` retain their result
+  shapes.
+- `net_select` remains sequential and consumer-buffered until
+  `feat/network-poller`.
+
+## Testing
+
+Tests use real loopback TCP connections plus controlled `net.Conn` and
+`net.Listener` implementations where deterministic pending operations or
+deadline failures are required. Every goroutine has a bounded harness wait.
+The loopback and public deadline tests run in CI on both Windows and Unix;
+controlled contract tests run on every supported job.
+
+The test matrix proves:
+
+- default reads wait for later data;
+- positive read timeout waits for a bounded interval and returns the stable
+  timeout result;
+- positive write timeout bounds a blocked write and reports its actual partial
+  count;
+- listener timeout bounds `accept` and returns the existing invalid-socket
+  sentinel;
+- accepted sockets start blocking rather than inheriting the listener mode;
+- `setblocking(true)` clears a timeout for subsequent and pending I/O;
+- `setblocking(false)` performs no validation and leaves both blocking and
+  timed modes unchanged, including for stale handles;
+- the latest supported configuration call wins across related VMs;
+- configuration during pending read, write, and accept is observed;
+- persistent mode commits only after all directional setters succeed, while
+  already-pending directional effects may occur one setter at a time;
+- two concurrent configurations commit in `deadlineMu` order without exposing
+  a partially committed persistent mode;
+- an active `net_select` deadline cannot be removed or extended by concurrent
+  configuration, while a shorter timeout may shorten it;
+- a probe starting with a shorter persistent timeout uses that timeout, while
+  a longer persistent timeout remains capped by the select bound;
+- write configuration proceeds independently during an active read probe;
+- `net_select` restores the latest blocking or timed mode after readiness or
+  timeout, skips restoration after close, and reports installation or live
+  restoration failures synchronously;
+- `1`, the maximum safe timeout, `0`, negative values, and overflow are handled
+  without narrowing through `int`;
+- malformed, unknown, and closed handles fail as specified;
+- deadline errors are normalized with `errors.Is`, independent of operating
+  system text;
+- configuration doubles simulate partial OS mutation, primary failure,
+  exact successful absolute-deadline rollback and recovery on the next
+  operation without claiming live atomicity;
+- rollback failure poisons and closes listeners or sockets, unblocks pending
+  read/write/accept/probe operations, clears buffers, and cannot deadlock;
+- concurrent close with read, write, accept, and configuration terminates
+  without deadlock;
+- a deadline setter stalled behind a controlled barrier cannot prevent
+  `net_close` from marking, detaching, and closing its resource exactly once;
+- a later deadline-management failure yields no `SelectResult`, stops later
+  probes, and preserves data or connections buffered by earlier successful
+  candidates, while ordinary I/O errors remain not-ready candidates;
+- a restoration failure after successful readiness preserves the same
+  candidate's byte or accepted connection before returning the management
+  error;
+- fully buffered operations skip deadline installation, and partial buffered
+  reads preserve bytes when installation or subsequent I/O fails;
+- concurrent buffered-accept deadline clearing and listener close has one
+  lifecycle owner on both setter success and failure: no closed connection is
+  registered and no connection is closed twice;
+- connected and accepted sockets explicitly clear any inherited deadline
+  before registration, including controlled connections that start timed;
+- typed nil socket objects, invalid `fd` types/ranges, and listener-first
+  lookup are handled without panic;
+- ordinary select `Read(n>0, err!=nil)` behavior remains characterized but
+  unchanged for the later poller subproject;
+- deadline-application failures and partial I/O preserve their contracts;
+- wrapped deadline errors normalize correctly through `errors.Is`;
+- real TCP listeners implement the required deadline interface on Windows and
+  Unix CI jobs;
+- existing lifecycle, buffering, and concurrent-select tests remain green.
+
+The project validation is:
+
+```text
+go test ./internal/...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```

--- a/internal/stdlib/net.nx
+++ b/internal/stdlib/net.nx
@@ -53,6 +53,10 @@ func setblocking(sock: Socket, blocking: bool) -> void
     net_setblocking(sock, blocking)
 end
 
+func settimeout(sock: Socket, timeout_ms: int) -> void
+    net_settimeout(sock, timeout_ms)
+end
+
 func socket_set() -> Socket[64]
     return net_socket_set()
 end

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -1,13 +1,345 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
+	"os"
 	"time"
 
 	"noxy-vm/internal/value"
 )
+
+type deadlineListener interface {
+	net.Listener
+	SetDeadline(time.Time) error
+}
+
+var networkDialTimeout = net.DialTimeout
+
+func validateNetworkTimeout(milliseconds int64) (time.Duration, error) {
+	if milliseconds <= 0 {
+		return 0, fmt.Errorf("network timeout must be positive")
+	}
+	const maximum = int64(math.MaxInt64) / int64(time.Millisecond)
+	if milliseconds > maximum {
+		return 0, fmt.Errorf("network timeout is too large")
+	}
+	return time.Duration(milliseconds) * time.Millisecond, nil
+}
+
+func networkSocketDescriptor(socket value.Value) (int, error) {
+	if socket.Type != value.VAL_OBJ {
+		return 0, fmt.Errorf("invalid socket")
+	}
+	var descriptor value.Value
+	var exists bool
+	switch object := socket.Obj.(type) {
+	case *value.ObjMap:
+		if object == nil {
+			return 0, fmt.Errorf("invalid socket")
+		}
+		descriptor, exists = object.Get("fd")
+	case *value.ObjInstance:
+		if object == nil {
+			return 0, fmt.Errorf("invalid socket")
+		}
+		descriptor, exists = object.Fields["fd"]
+	default:
+		return 0, fmt.Errorf("invalid socket")
+	}
+	if !exists || descriptor.Type != value.VAL_INT {
+		return 0, fmt.Errorf("invalid socket")
+	}
+	handle := int(descriptor.AsInt)
+	if int64(handle) != descriptor.AsInt {
+		return 0, fmt.Errorf("invalid socket")
+	}
+	return handle, nil
+}
+
+func effectiveNetworkDeadline(now time.Time, timeout time.Duration, probeBound time.Time) time.Time {
+	deadline := time.Time{}
+	if timeout > 0 {
+		deadline = now.Add(timeout)
+	}
+	if !probeBound.IsZero() && (deadline.IsZero() || probeBound.Before(deadline)) {
+		return probeBound
+	}
+	return deadline
+}
+
+func networkProbeDeadline(started time.Time, selectTimeout time.Duration, ioTimeout time.Duration) time.Time {
+	return effectiveNetworkDeadline(started, ioTimeout, started.Add(selectTimeout))
+}
+
+func configureSocketTimeout(resource *SocketResource, timeout time.Duration) error {
+	resource.deadlineMu.Lock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return fmt.Errorf("invalid socket")
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	connection := resource.connection
+	oldReadDeadline := resource.lastReadDeadline
+	oldWriteDeadline := resource.lastWriteDeadline
+	now := time.Now()
+	readDeadline := effectiveNetworkDeadline(now, timeout, resource.readProbeDeadline)
+	writeDeadline := effectiveNetworkDeadline(now, timeout, time.Time{})
+	resource.stateMu.Unlock()
+
+	readErr := connection.SetReadDeadline(readDeadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return net.ErrClosed
+	}
+	if readErr == nil {
+		resource.lastReadDeadline = readDeadline
+	}
+	resource.stateMu.Unlock()
+	if readErr != nil {
+		rollbackErr := connection.SetReadDeadline(oldReadDeadline)
+		resource.stateMu.Lock()
+		if resource.closed || resource.deadlineGeneration != generation {
+			resource.stateMu.Unlock()
+			resource.deadlineMu.Unlock()
+			return errors.Join(readErr, rollbackErr, net.ErrClosed)
+		}
+		if rollbackErr == nil {
+			resource.lastReadDeadline = oldReadDeadline
+			resource.stateMu.Unlock()
+			resource.deadlineMu.Unlock()
+			return readErr
+		}
+		resource.closed = true
+		resource.deadlineGeneration++
+		resource.connection = nil
+		resource.bufferedRead = nil
+		resource.readProbeDeadline = time.Time{}
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		closeErr := connection.Close()
+		return errors.Join(readErr, rollbackErr, closeErr)
+	}
+
+	writeErr := connection.SetWriteDeadline(writeDeadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return net.ErrClosed
+	}
+	if writeErr == nil {
+		resource.lastWriteDeadline = writeDeadline
+		resource.ioTimeout = timeout
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return nil
+	}
+	resource.stateMu.Unlock()
+	readRollbackErr := connection.SetReadDeadline(oldReadDeadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return errors.Join(writeErr, readRollbackErr, net.ErrClosed)
+	}
+	resource.stateMu.Unlock()
+	writeRollbackErr := connection.SetWriteDeadline(oldWriteDeadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return errors.Join(writeErr, readRollbackErr, writeRollbackErr, net.ErrClosed)
+	}
+	if readRollbackErr == nil && writeRollbackErr == nil {
+		resource.lastReadDeadline = oldReadDeadline
+		resource.lastWriteDeadline = oldWriteDeadline
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return writeErr
+	}
+	resource.closed = true
+	resource.deadlineGeneration++
+	resource.connection = nil
+	resource.bufferedRead = nil
+	resource.readProbeDeadline = time.Time{}
+	resource.stateMu.Unlock()
+	resource.deadlineMu.Unlock()
+	closeErr := connection.Close()
+	return errors.Join(writeErr, readRollbackErr, writeRollbackErr, closeErr)
+}
+
+func configureListenerTimeout(resource *ListenerResource, timeout time.Duration) error {
+	resource.deadlineMu.Lock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener == nil {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return fmt.Errorf("invalid socket")
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	listener := resource.listener
+	oldDeadline := resource.lastAcceptDeadline
+	deadline := effectiveNetworkDeadline(time.Now(), timeout, resource.acceptProbeDeadline)
+	resource.stateMu.Unlock()
+
+	applicationErr := listener.SetDeadline(deadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return net.ErrClosed
+	}
+	if applicationErr == nil {
+		resource.lastAcceptDeadline = deadline
+		resource.ioTimeout = timeout
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return nil
+	}
+	resource.stateMu.Unlock()
+
+	rollbackErr := listener.SetDeadline(oldDeadline)
+	resource.stateMu.Lock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return errors.Join(applicationErr, rollbackErr, net.ErrClosed)
+	}
+	if rollbackErr == nil {
+		resource.lastAcceptDeadline = oldDeadline
+		resource.stateMu.Unlock()
+		resource.deadlineMu.Unlock()
+		return applicationErr
+	}
+	resource.closed = true
+	resource.deadlineGeneration++
+	resource.listener = nil
+	buffered := resource.bufferedAccept
+	resource.bufferedAccept = nil
+	resource.acceptProbeDeadline = time.Time{}
+	resource.stateMu.Unlock()
+	resource.deadlineMu.Unlock()
+	listenerCloseErr := listener.Close()
+	var bufferedCloseErr error
+	if buffered != nil {
+		bufferedCloseErr = buffered.Close()
+	}
+	return errors.Join(applicationErr, rollbackErr, listenerCloseErr, bufferedCloseErr)
+}
+
+func configureNetworkTimeout(machine *VM, socket value.Value, timeout time.Duration) error {
+	handle, err := networkSocketDescriptor(socket)
+	if err != nil {
+		return err
+	}
+	if listener, exists := machine.shared.Listeners.get(handle); exists {
+		return configureListenerTimeout(listener, timeout)
+	}
+	if connection, exists := machine.shared.Sockets.get(handle); exists {
+		return configureSocketTimeout(connection, timeout)
+	}
+	return fmt.Errorf("invalid socket")
+}
+
+func networkErrorMessage(err error) string {
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return "operation timed out"
+	}
+	return err.Error()
+}
+
+func prepareSocketRead(resource *SocketResource) (net.Conn, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return nil, fmt.Errorf("invalid socket")
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	connection := resource.connection
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, resource.readProbeDeadline)
+	resource.stateMu.Unlock()
+
+	if err := connection.SetReadDeadline(deadline); err != nil {
+		return nil, err
+	}
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return nil, net.ErrClosed
+	}
+	resource.lastReadDeadline = deadline
+	return connection, nil
+}
+
+func prepareSocketWrite(resource *SocketResource) (net.Conn, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return nil, fmt.Errorf("invalid socket")
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	connection := resource.connection
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
+	resource.stateMu.Unlock()
+
+	if err := connection.SetWriteDeadline(deadline); err != nil {
+		return nil, err
+	}
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return nil, net.ErrClosed
+	}
+	resource.lastWriteDeadline = deadline
+	return connection, nil
+}
+
+func prepareListenerAccept(resource *ListenerResource) (deadlineListener, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener == nil {
+		resource.stateMu.Unlock()
+		return nil, fmt.Errorf("invalid socket")
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	listener := resource.listener
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, resource.acceptProbeDeadline)
+	resource.stateMu.Unlock()
+
+	if err := listener.SetDeadline(deadline); err != nil {
+		return nil, err
+	}
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return nil, net.ErrClosed
+	}
+	resource.lastAcceptDeadline = deadline
+	return listener, nil
+}
 
 func socketValue(fd int, address string, port int, open bool) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
@@ -61,13 +393,44 @@ func acceptConnection(resource *ListenerResource) (net.Conn, error) {
 	}
 	if resource.bufferedAccept != nil {
 		connection := resource.bufferedAccept
+		resource.stateMu.Unlock()
+		clearErr := connection.SetDeadline(time.Time{})
+
+		resource.stateMu.Lock()
+		if resource.closed || resource.bufferedAccept != connection {
+			resource.stateMu.Unlock()
+			return nil, net.ErrClosed
+		}
 		resource.bufferedAccept = nil
 		resource.stateMu.Unlock()
+		if clearErr != nil {
+			_ = connection.Close()
+			return nil, clearErr
+		}
 		return connection, nil
 	}
-	listener := resource.listener
 	resource.stateMu.Unlock()
-	return listener.Accept()
+
+	listener, err := prepareListenerAccept(resource)
+	if err != nil {
+		return nil, err
+	}
+	connection, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if err := connection.SetDeadline(time.Time{}); err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	resource.stateMu.Lock()
+	closed := resource.closed || resource.listener != listener
+	resource.stateMu.Unlock()
+	if closed {
+		_ = connection.Close()
+		return nil, net.ErrClosed
+	}
+	return connection, nil
 }
 
 func receiveSocket(resource *SocketResource, size int) value.Value {
@@ -79,8 +442,36 @@ func receiveSocket(resource *SocketResource, size int) value.Value {
 		resource.stateMu.Unlock()
 		return netResult(false, "", 0, "invalid socket")
 	}
-	connection := resource.connection
-	buffered := resource.bufferedRead
+	if size <= 0 {
+		resource.stateMu.Unlock()
+		return netResult(true, "", 0, "")
+	}
+	if len(resource.bufferedRead) >= size {
+		data := append([]byte(nil), resource.bufferedRead[:size]...)
+		resource.bufferedRead = resource.bufferedRead[size:]
+		resource.stateMu.Unlock()
+		return netResult(true, string(data), len(data), "")
+	}
+	resource.stateMu.Unlock()
+
+	connection, deadlineErr := prepareSocketRead(resource)
+	if deadlineErr != nil {
+		resource.stateMu.Lock()
+		buffered := append([]byte(nil), resource.bufferedRead...)
+		resource.bufferedRead = nil
+		resource.stateMu.Unlock()
+		if len(buffered) != 0 {
+			return netResult(true, string(buffered), len(buffered), "")
+		}
+		return netResult(false, "", 0, networkErrorMessage(deadlineErr))
+	}
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection != connection {
+		resource.stateMu.Unlock()
+		return netResult(false, "", 0, "invalid socket")
+	}
+	buffered := append([]byte(nil), resource.bufferedRead...)
 	resource.bufferedRead = nil
 	resource.stateMu.Unlock()
 
@@ -95,11 +486,11 @@ func receiveSocket(resource *SocketResource, size int) value.Value {
 		if additional > 0 {
 			read += additional
 		}
-		if readErr != nil && read == 0 && additional == 0 {
+		if readErr != nil && read == 0 {
 			if readErr == io.EOF {
 				return netResult(true, "", 0, "")
 			}
-			return netResult(false, "", 0, readErr.Error())
+			return netResult(false, "", 0, networkErrorMessage(readErr))
 		}
 	}
 	return netResult(true, string(buffer[:read]), read, "")
@@ -109,91 +500,224 @@ func sendSocket(resource *SocketResource, data string) value.Value {
 	resource.writeMu.Lock()
 	defer resource.writeMu.Unlock()
 
-	resource.stateMu.Lock()
-	if resource.closed || resource.connection == nil {
-		resource.stateMu.Unlock()
-		return netResult(false, "", 0, "invalid socket")
+	connection, deadlineErr := prepareSocketWrite(resource)
+	if deadlineErr != nil {
+		return netResult(false, "", 0, networkErrorMessage(deadlineErr))
 	}
-	connection := resource.connection
-	resource.stateMu.Unlock()
 
 	written, writeErr := connection.Write([]byte(data))
 	if writeErr != nil {
-		return netResult(false, "", 0, writeErr.Error())
+		return netResult(false, "", written, networkErrorMessage(writeErr))
 	}
 	return netResult(true, "", written, "")
 }
 
-func selectListener(resource *ListenerResource, timeout time.Duration) bool {
+func beginListenerProbe(resource *ListenerResource, timeout time.Duration) (deadlineListener, bool, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener == nil {
+		resource.stateMu.Unlock()
+		return nil, true, nil
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	listener := resource.listener
+	started := time.Now()
+	probeBound := started.Add(timeout)
+	resource.acceptProbeDeadline = probeBound
+	deadline := networkProbeDeadline(started, timeout, resource.ioTimeout)
+	resource.stateMu.Unlock()
+
+	setterErr := listener.SetDeadline(deadline)
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return nil, true, nil
+	}
+	if setterErr != nil {
+		resource.acceptProbeDeadline = time.Time{}
+		return nil, false, setterErr
+	}
+	resource.lastAcceptDeadline = deadline
+	return listener, false, nil
+}
+
+func finishListenerProbe(resource *ListenerResource, listener deadlineListener, connection net.Conn) (bool, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.listener != listener {
+		resource.stateMu.Unlock()
+		if connection != nil {
+			_ = connection.Close()
+		}
+		return true, nil
+	}
+	if connection != nil {
+		resource.bufferedAccept = connection
+	}
+	resource.acceptProbeDeadline = time.Time{}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
+	resource.stateMu.Unlock()
+
+	setterErr := listener.SetDeadline(deadline)
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return true, nil
+	}
+	if setterErr != nil {
+		return false, setterErr
+	}
+	resource.lastAcceptDeadline = deadline
+	return false, nil
+}
+
+func selectListener(resource *ListenerResource, timeout time.Duration) (bool, error) {
 	resource.acceptMu.Lock()
 	defer resource.acceptMu.Unlock()
 
 	resource.stateMu.Lock()
 	if resource.closed || resource.listener == nil {
 		resource.stateMu.Unlock()
-		return false
+		return false, nil
 	}
 	if resource.bufferedAccept != nil {
 		resource.stateMu.Unlock()
-		return true
+		return true, nil
 	}
-	listener := resource.listener
 	resource.stateMu.Unlock()
 
-	tcpListener, ok := listener.(*net.TCPListener)
-	if !ok {
-		return false
+	listener, closed, err := beginListenerProbe(resource, timeout)
+	if err != nil {
+		return false, err
 	}
-	_ = tcpListener.SetDeadline(time.Now().Add(timeout))
+	if closed {
+		return false, nil
+	}
 	connection, acceptErr := listener.Accept()
-	_ = tcpListener.SetDeadline(time.Time{})
-	if acceptErr != nil {
-		return false
+	ordinarySuccess := acceptErr == nil && connection != nil
+	closed, restoreErr := finishListenerProbe(resource, listener, func() net.Conn {
+		if ordinarySuccess {
+			return connection
+		}
+		return nil
+	}())
+	if restoreErr != nil {
+		return false, restoreErr
 	}
-
-	resource.stateMu.Lock()
-	if resource.closed {
-		resource.stateMu.Unlock()
-		_ = connection.Close()
-		return false
+	if closed || !ordinarySuccess {
+		return false, nil
 	}
-	resource.bufferedAccept = connection
-	resource.stateMu.Unlock()
-	return true
+	return true, nil
 }
 
-func selectSocket(resource *SocketResource, timeout time.Duration) bool {
+func beginSocketProbe(resource *SocketResource, timeout time.Duration) (net.Conn, bool, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection == nil {
+		resource.stateMu.Unlock()
+		return nil, true, nil
+	}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	connection := resource.connection
+	started := time.Now()
+	probeBound := started.Add(timeout)
+	resource.readProbeDeadline = probeBound
+	deadline := networkProbeDeadline(started, timeout, resource.ioTimeout)
+	resource.stateMu.Unlock()
+
+	setterErr := connection.SetReadDeadline(deadline)
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return nil, true, nil
+	}
+	if setterErr != nil {
+		resource.readProbeDeadline = time.Time{}
+		return nil, false, setterErr
+	}
+	resource.lastReadDeadline = deadline
+	return connection, false, nil
+}
+
+func finishSocketProbe(resource *SocketResource, connection net.Conn, ready []byte) (bool, error) {
+	resource.deadlineMu.Lock()
+	defer resource.deadlineMu.Unlock()
+
+	resource.stateMu.Lock()
+	if resource.closed || resource.connection != connection {
+		resource.stateMu.Unlock()
+		return true, nil
+	}
+	if len(ready) != 0 {
+		resource.bufferedRead = append(resource.bufferedRead, ready...)
+	}
+	resource.readProbeDeadline = time.Time{}
+	resource.deadlineGeneration++
+	generation := resource.deadlineGeneration
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
+	resource.stateMu.Unlock()
+
+	setterErr := connection.SetReadDeadline(deadline)
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	if resource.closed || resource.deadlineGeneration != generation {
+		return true, nil
+	}
+	if setterErr != nil {
+		return false, setterErr
+	}
+	resource.lastReadDeadline = deadline
+	return false, nil
+}
+
+func selectSocket(resource *SocketResource, timeout time.Duration) (bool, error) {
 	resource.readMu.Lock()
 	defer resource.readMu.Unlock()
 
 	resource.stateMu.Lock()
 	if resource.closed || resource.connection == nil {
 		resource.stateMu.Unlock()
-		return false
+		return false, nil
 	}
 	if len(resource.bufferedRead) != 0 {
 		resource.stateMu.Unlock()
-		return true
+		return true, nil
 	}
-	connection := resource.connection
 	resource.stateMu.Unlock()
 
-	_ = connection.SetReadDeadline(time.Now().Add(timeout))
+	connection, closed, err := beginSocketProbe(resource, timeout)
+	if err != nil {
+		return false, err
+	}
+	if closed {
+		return false, nil
+	}
 	buffer := make([]byte, 1)
 	read, readErr := connection.Read(buffer)
-	_ = connection.SetReadDeadline(time.Time{})
-	if readErr != nil || read == 0 {
-		return false
+	ordinarySuccess := readErr == nil && read > 0
+	closed, restoreErr := finishSocketProbe(resource, connection, func() []byte {
+		if ordinarySuccess {
+			return buffer[:read]
+		}
+		return nil
+	}())
+	if restoreErr != nil {
+		return false, restoreErr
 	}
-
-	resource.stateMu.Lock()
-	if resource.closed {
-		resource.stateMu.Unlock()
-		return false
+	if closed || !ordinarySuccess {
+		return false, nil
 	}
-	resource.bufferedRead = buffer[:read]
-	resource.stateMu.Unlock()
-	return true
+	return true, nil
 }
 
 func closeListener(resource *ListenerResource) {
@@ -203,7 +727,10 @@ func closeListener(resource *ListenerResource) {
 		return
 	}
 	resource.closed = true
+	resource.deadlineGeneration++
 	listener := resource.listener
+	resource.listener = nil
+	resource.acceptProbeDeadline = time.Time{}
 	buffered := resource.bufferedAccept
 	resource.bufferedAccept = nil
 	resource.stateMu.Unlock()
@@ -222,7 +749,10 @@ func closeSocket(resource *SocketResource) {
 		return
 	}
 	resource.closed = true
+	resource.deadlineGeneration++
 	connection := resource.connection
+	resource.connection = nil
+	resource.readProbeDeadline = time.Time{}
 	resource.bufferedRead = nil
 	resource.stateMu.Unlock()
 	if connection != nil {
@@ -245,7 +775,12 @@ func (vm *VM) defineNetworkBuiltins() {
 		if listenErr != nil {
 			return socketValue(-1, host, port, false), nil
 		}
-		handle := machine.shared.Listeners.add(&ListenerResource{listener: listener})
+		configuredListener, ok := listener.(deadlineListener)
+		if !ok {
+			_ = listener.Close()
+			return socketValue(-1, host, port, false), nil
+		}
+		handle := machine.shared.Listeners.add(&ListenerResource{listener: configuredListener})
 		return socketValue(handle, host, port, true), nil
 	})
 
@@ -287,8 +822,12 @@ func (vm *VM) defineNetworkBuiltins() {
 		}
 		host := args[0].String()
 		port := int(args[1].AsInt)
-		connection, connectErr := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 5*time.Second)
+		connection, connectErr := networkDialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 5*time.Second)
 		if connectErr != nil {
+			return socketValue(-1, host, port, false), nil
+		}
+		if err := connection.SetDeadline(time.Time{}); err != nil {
+			_ = connection.Close()
 			return socketValue(-1, host, port, false), nil
 		}
 		handle := machine.shared.Sockets.add(&SocketResource{connection: connection})
@@ -371,7 +910,35 @@ func (vm *VM) defineNetworkBuiltins() {
 	})
 
 	vm.DefineContextualNative("net_setblocking", func(context value.NativeContext, args []value.Value) (value.Value, error) {
-		if _, err := nativeVM(context); err != nil {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) != 2 || args[1].Type != value.VAL_BOOL || !args[1].AsBool {
+			return value.NewNull(), nil
+		}
+		if err := configureNetworkTimeout(machine, args[0], 0); err != nil {
+			return value.NewNull(), err
+		}
+		return value.NewNull(), nil
+	})
+
+	vm.DefineContextualNative("net_settimeout", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) != 2 {
+			return value.NewNull(), fmt.Errorf("net_settimeout expects exactly 2 arguments")
+		}
+		if args[1].Type != value.VAL_INT {
+			return value.NewNull(), fmt.Errorf("network timeout must be an int")
+		}
+		timeout, err := validateNetworkTimeout(args[1].AsInt)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if err := configureNetworkTimeout(machine, args[0], timeout); err != nil {
 			return value.NewNull(), err
 		}
 		return value.NewNull(), nil
@@ -410,10 +977,14 @@ func (vm *VM) defineNetworkBuiltins() {
 					continue
 				}
 				ready := false
+				var probeErr error
 				if listener, exists := machine.shared.Listeners.get(int(handle)); exists {
-					ready = selectListener(listener, timeout)
+					ready, probeErr = selectListener(listener, timeout)
 				} else if socket, exists := machine.shared.Sockets.get(int(handle)); exists {
-					ready = selectSocket(socket, timeout)
+					ready, probeErr = selectSocket(socket, timeout)
+				}
+				if probeErr != nil {
+					return value.NewNull(), probeErr
 				}
 				if ready {
 					readyRead = append(readyRead, candidate)

--- a/internal/vm/builtins_net_deadlines_test.go
+++ b/internal/vm/builtins_net_deadlines_test.go
@@ -1,0 +1,1458 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"noxy-vm/internal/stdlib"
+	"noxy-vm/internal/value"
+)
+
+type controlledDeadlineConn struct {
+	net.Conn
+	mu             sync.Mutex
+	readDeadlines  []time.Time
+	writeDeadlines []time.Time
+	deadlines      []time.Time
+	closeCount     int
+	readFn         func([]byte) (int, error)
+	writeFn        func([]byte) (int, error)
+	setDeadlineFn  func(time.Time) error
+	setReadFn      func(time.Time) error
+	setWriteFn     func(time.Time) error
+}
+
+type controlledDeadlineListener struct {
+	net.Listener
+	mu         sync.Mutex
+	deadlines  []time.Time
+	closeCount int
+	acceptFn   func() (net.Conn, error)
+	setFn      func(time.Time) error
+}
+
+func (listener *controlledDeadlineListener) Accept() (net.Conn, error) {
+	if listener.acceptFn != nil {
+		return listener.acceptFn()
+	}
+	return listener.Listener.Accept()
+}
+
+func (listener *controlledDeadlineListener) SetDeadline(deadline time.Time) error {
+	listener.mu.Lock()
+	listener.deadlines = append(listener.deadlines, deadline)
+	listener.mu.Unlock()
+	if listener.setFn != nil {
+		return listener.setFn(deadline)
+	}
+	return listener.Listener.(deadlineListener).SetDeadline(deadline)
+}
+
+func (listener *controlledDeadlineListener) Close() error {
+	listener.mu.Lock()
+	listener.closeCount++
+	listener.mu.Unlock()
+	return listener.Listener.Close()
+}
+
+func (listener *controlledDeadlineListener) closes() int {
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+	return listener.closeCount
+}
+
+func (connection *controlledDeadlineConn) Read(buffer []byte) (int, error) {
+	if connection.readFn != nil {
+		return connection.readFn(buffer)
+	}
+	return connection.Conn.Read(buffer)
+}
+
+func (connection *controlledDeadlineConn) Write(buffer []byte) (int, error) {
+	if connection.writeFn != nil {
+		return connection.writeFn(buffer)
+	}
+	return connection.Conn.Write(buffer)
+}
+
+func (connection *controlledDeadlineConn) SetReadDeadline(deadline time.Time) error {
+	connection.mu.Lock()
+	connection.readDeadlines = append(connection.readDeadlines, deadline)
+	connection.mu.Unlock()
+	if connection.setReadFn != nil {
+		return connection.setReadFn(deadline)
+	}
+	return connection.Conn.SetReadDeadline(deadline)
+}
+
+func (connection *controlledDeadlineConn) SetDeadline(deadline time.Time) error {
+	connection.mu.Lock()
+	connection.deadlines = append(connection.deadlines, deadline)
+	connection.mu.Unlock()
+	if connection.setDeadlineFn != nil {
+		return connection.setDeadlineFn(deadline)
+	}
+	return connection.Conn.SetDeadline(deadline)
+}
+
+func (connection *controlledDeadlineConn) SetWriteDeadline(deadline time.Time) error {
+	connection.mu.Lock()
+	connection.writeDeadlines = append(connection.writeDeadlines, deadline)
+	connection.mu.Unlock()
+	if connection.setWriteFn != nil {
+		return connection.setWriteFn(deadline)
+	}
+	return connection.Conn.SetWriteDeadline(deadline)
+}
+
+func (connection *controlledDeadlineConn) readDeadlineCount() int {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return len(connection.readDeadlines)
+}
+
+func (connection *controlledDeadlineConn) Close() error {
+	connection.mu.Lock()
+	connection.closeCount++
+	connection.mu.Unlock()
+	return connection.Conn.Close()
+}
+
+func (connection *controlledDeadlineConn) closes() int {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return connection.closeCount
+}
+
+func invokeBuiltin(t *testing.T, machine *VM, name string, args ...value.Value) (value.Value, error) {
+	t.Helper()
+	return requireBuiltin(t, machine, name).Invoke(machine, args)
+}
+
+func TestValidateNetworkTimeout(t *testing.T) {
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	tests := []struct {
+		name         string
+		milliseconds int64
+		want         time.Duration
+		wantError    string
+	}{
+		{name: "one millisecond", milliseconds: 1, want: time.Millisecond},
+		{name: "maximum", milliseconds: maximum, want: time.Duration(maximum) * time.Millisecond},
+		{name: "zero", milliseconds: 0, wantError: "network timeout must be positive"},
+		{name: "negative", milliseconds: -1, wantError: "network timeout must be positive"},
+		{name: "overflow", milliseconds: maximum + 1, wantError: "network timeout is too large"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := validateNetworkTimeout(test.milliseconds)
+			if test.wantError != "" {
+				if err == nil || err.Error() != test.wantError {
+					t.Fatalf("error=%v, want %q", err, test.wantError)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("duration=%v, error=%v, want %v", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestNetworkTimeoutStateIsShared(t *testing.T) {
+	parent := New()
+	child := NewWithShared(parent.shared, parent.Config)
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	resource := &SocketResource{connection: connection}
+	handle := parent.shared.Sockets.add(resource)
+	t.Cleanup(func() { parent.shared.Sockets.remove(handle) })
+	socket := socketValue(handle, "pipe", 0, true)
+
+	result, err := invokeBuiltin(t, child, "net_settimeout", socket, value.NewInt(25))
+	if err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	assertBuiltinValue(t, result, value.NewNull())
+
+	resource.stateMu.Lock()
+	got := resource.ioTimeout
+	resource.stateMu.Unlock()
+	if got != 25*time.Millisecond {
+		t.Fatalf("shared ioTimeout=%v, want 25ms", got)
+	}
+}
+
+func TestNetSetTimeoutRejectsInvalidValuesBeforeSocketLookup(t *testing.T) {
+	machine := New()
+	malformedSocket := value.NewString("not a socket")
+
+	tests := []struct {
+		name    string
+		args    []value.Value
+		message string
+	}{
+		{name: "arity", args: []value.Value{malformedSocket}, message: "net_settimeout expects exactly 2 arguments"},
+		{name: "timeout type", args: []value.Value{malformedSocket, value.NewString("1")}, message: "network timeout must be an int"},
+		{name: "timeout value", args: []value.Value{malformedSocket, value.NewInt(0)}, message: "network timeout must be positive"},
+		{name: "socket type", args: []value.Value{malformedSocket, value.NewInt(1)}, message: "invalid socket"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := invokeBuiltin(t, machine, "net_settimeout", test.args...)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("error=%v, want substring %q", err, test.message)
+			}
+		})
+	}
+}
+
+func TestNetSetBlockingFalseIsCompatibilityNoOp(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	resource := &SocketResource{connection: connection, ioTimeout: 40 * time.Millisecond}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+
+	for _, socket := range []value.Value{
+		socketValue(handle, "pipe", 0, true),
+		value.NewString("malformed"),
+		socketValue(handle+1000, "stale", 0, false),
+	} {
+		result, err := invokeBuiltin(t, machine, "net_setblocking", socket, value.NewBool(false))
+		if err != nil {
+			t.Fatalf("net_setblocking(false): %v", err)
+		}
+		assertBuiltinValue(t, result, value.NewNull())
+	}
+
+	resource.stateMu.Lock()
+	got := resource.ioTimeout
+	resource.stateMu.Unlock()
+	if got != 40*time.Millisecond {
+		t.Fatalf("ioTimeout=%v, want unchanged 40ms", got)
+	}
+}
+
+func TestSocketReadTimeoutIsRefreshedPerOperation(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	resource := &SocketResource{connection: connection}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	socket := socketValue(handle, "pipe", 0, true)
+
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", socket, value.NewInt(30)); err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	time.Sleep(45 * time.Millisecond)
+	started := time.Now()
+	result := receiveSocket(resource, 1)
+	elapsed := time.Since(started)
+
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, result, "error"), value.NewString("operation timed out"))
+	if elapsed < 15*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("receive elapsed=%v, want a freshly bounded operation", elapsed)
+	}
+}
+
+func TestReceiveSocketInstallsDeadlineBeforeRead(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		readFn: func([]byte) (int, error) {
+			return 0, io.EOF
+		},
+	}
+	resource := &SocketResource{connection: controlled, ioTimeout: 50 * time.Millisecond}
+	result := receiveSocket(resource, 1)
+
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
+	if controlled.readDeadlineCount() != 1 {
+		t.Fatalf("read deadline calls=%d, want 1", controlled.readDeadlineCount())
+	}
+}
+
+func TestReceiveSocketFullyBufferedSkipsDeadlineSetter(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			return errors.New("unexpected deadline setter")
+		},
+	}
+	resource := &SocketResource{
+		connection:   controlled,
+		bufferedRead: []byte("x"),
+		ioTimeout:    50 * time.Millisecond,
+	}
+	result := receiveSocket(resource, 1)
+
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes("x"))
+	if controlled.readDeadlineCount() != 0 {
+		t.Fatalf("read deadline calls=%d, want 0", controlled.readDeadlineCount())
+	}
+}
+
+func TestSendSocketReportsPartialTimeout(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		writeFn: func([]byte) (int, error) {
+			return 2, fmt.Errorf("wrapped: %w", os.ErrDeadlineExceeded)
+		},
+	}
+	resource := &SocketResource{connection: controlled, ioTimeout: 50 * time.Millisecond}
+	result := sendSocket(resource, "data")
+
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, result, "count"), value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, result, "error"), value.NewString("operation timed out"))
+}
+
+func TestNetworkErrorMessageUsesErrorsIs(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", os.ErrDeadlineExceeded)
+	if got := networkErrorMessage(err); got != "operation timed out" {
+		t.Fatalf("message=%q, want operation timed out", got)
+	}
+}
+
+func TestListenerAcceptTimeoutIsRefreshedPerOperation(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", listener, value.NewInt(30)); err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	time.Sleep(45 * time.Millisecond)
+	started := time.Now()
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	elapsed := time.Since(started)
+
+	assertBuiltinValue(t, builtinMapField(t, accepted, "open"), value.NewBool(false))
+	if elapsed < 15*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("accept elapsed=%v, want a freshly bounded operation", elapsed)
+	}
+}
+
+func TestCloseDoesNotWaitForBlockedDeadlineSetter(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	setterEntered := make(chan struct{})
+	releaseSetter := make(chan struct{})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			close(setterEntered)
+			<-releaseSetter
+			return nil
+		},
+	}
+	resource := &SocketResource{connection: controlled}
+	configured := make(chan error, 1)
+	go func() { configured <- configureSocketTimeout(resource, 20*time.Millisecond) }()
+	select {
+	case <-setterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("deadline setter was not entered")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		closeSocket(resource)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("close waited for deadline setter")
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	}
+
+	close(releaseSetter)
+	select {
+	case err := <-configured:
+		if !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("configuration error=%v, want net.ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("configuration did not finish after setter release")
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls after stale setter=%d, want 1", controlled.closes())
+	}
+}
+
+func TestBufferedAcceptCloseWinsDuringDeadlineClear(t *testing.T) {
+	for _, setterError := range []error{nil, errors.New("clear failed")} {
+		name := "setter success"
+		if setterError != nil {
+			name = "setter failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			deadlineCapable := listener.(deadlineListener)
+			connection, peer := net.Pipe()
+			t.Cleanup(func() { _ = peer.Close() })
+			setterEntered := make(chan struct{})
+			releaseSetter := make(chan struct{})
+			controlled := &controlledDeadlineConn{
+				Conn: connection,
+				setDeadlineFn: func(time.Time) error {
+					close(setterEntered)
+					<-releaseSetter
+					return setterError
+				},
+			}
+			resource := &ListenerResource{listener: deadlineCapable, bufferedAccept: controlled}
+			t.Cleanup(func() {
+				_ = listener.Close()
+				_ = connection.Close()
+			})
+			accepted := make(chan struct {
+				connection net.Conn
+				err        error
+			}, 1)
+			go func() {
+				connection, err := acceptConnection(resource)
+				accepted <- struct {
+					connection net.Conn
+					err        error
+				}{connection: connection, err: err}
+			}()
+			select {
+			case <-setterEntered:
+			case <-time.After(time.Second):
+				t.Fatal("accepted connection deadline clear was not entered")
+			}
+
+			closeListener(resource)
+			if controlled.closes() != 1 {
+				t.Fatalf("close calls=%d, want listener close ownership", controlled.closes())
+			}
+			close(releaseSetter)
+			select {
+			case result := <-accepted:
+				if result.connection != nil || result.err == nil {
+					t.Fatalf("accept=(%v, %v), want nil connection and error", result.connection, result.err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("accept did not finish")
+			}
+			if controlled.closes() != 1 {
+				t.Fatalf("close calls after accept=%d, want 1", controlled.closes())
+			}
+		})
+	}
+}
+
+func TestNetSelectRestoresPersistentSocketDeadline(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		readFn: func(buffer []byte) (int, error) {
+			buffer[0] = 'x'
+			return 1, nil
+		},
+	}
+	resource := &SocketResource{connection: controlled, ioTimeout: 100 * time.Millisecond}
+	started := time.Now()
+	ready, err := selectSocket(resource, 10*time.Millisecond)
+	if err != nil || !ready {
+		t.Fatalf("selectSocket=(%v, %v), want ready", ready, err)
+	}
+
+	controlled.mu.Lock()
+	deadlines := append([]time.Time(nil), controlled.readDeadlines...)
+	controlled.mu.Unlock()
+	if len(deadlines) != 2 {
+		t.Fatalf("read deadline calls=%d, want probe and restoration", len(deadlines))
+	}
+	if deadlines[0].Before(started.Add(5*time.Millisecond)) || deadlines[0].After(started.Add(50*time.Millisecond)) {
+		t.Fatalf("probe deadline=%v, want select bound", deadlines[0])
+	}
+	if deadlines[1].IsZero() || !deadlines[1].After(deadlines[0]) {
+		t.Fatalf("restored deadline=%v, want fresh persistent deadline after %v", deadlines[1], deadlines[0])
+	}
+	resource.stateMu.Lock()
+	buffered := string(resource.bufferedRead)
+	resource.stateMu.Unlock()
+	if buffered != "x" {
+		t.Fatalf("buffered read=%q, want x", buffered)
+	}
+}
+
+func TestNetSelectRestorationFailureKeepsReadyByte(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	restoreFailure := errors.New("restore failed")
+	setterCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		readFn: func(buffer []byte) (int, error) {
+			buffer[0] = 'x'
+			return 1, nil
+		},
+		setReadFn: func(time.Time) error {
+			setterCalls++
+			if setterCalls == 2 {
+				return restoreFailure
+			}
+			return nil
+		},
+	}
+	resource := &SocketResource{connection: controlled, ioTimeout: 100 * time.Millisecond}
+	ready, err := selectSocket(resource, 10*time.Millisecond)
+	if ready || !errors.Is(err, restoreFailure) {
+		t.Fatalf("selectSocket=(%v, %v), want restoration failure", ready, err)
+	}
+	resource.stateMu.Lock()
+	buffered := string(resource.bufferedRead)
+	resource.stateMu.Unlock()
+	if buffered != "x" {
+		t.Fatalf("buffered read=%q, want x after restoration failure", buffered)
+	}
+}
+
+func TestSocketConfigurationRollsBackExactDeadlines(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	writeFailure := errors.New("write deadline failed")
+	writeCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setWriteFn: func(time.Time) error {
+			writeCalls++
+			if writeCalls == 1 {
+				return writeFailure
+			}
+			return nil
+		},
+	}
+	oldRead := time.Now().Add(2 * time.Second).Round(0)
+	oldWrite := time.Now().Add(3 * time.Second).Round(0)
+	resource := &SocketResource{
+		connection:        controlled,
+		ioTimeout:         10 * time.Second,
+		lastReadDeadline:  oldRead,
+		lastWriteDeadline: oldWrite,
+	}
+	err := configureSocketTimeout(resource, 5*time.Second)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("configuration error=%v, want write failure", err)
+	}
+
+	controlled.mu.Lock()
+	readDeadlines := append([]time.Time(nil), controlled.readDeadlines...)
+	writeDeadlines := append([]time.Time(nil), controlled.writeDeadlines...)
+	controlled.mu.Unlock()
+	if len(readDeadlines) != 2 || !readDeadlines[1].Equal(oldRead) {
+		t.Fatalf("read rollback=%v, want exact %v", readDeadlines, oldRead)
+	}
+	if len(writeDeadlines) != 2 || !writeDeadlines[1].Equal(oldWrite) {
+		t.Fatalf("write rollback=%v, want exact %v", writeDeadlines, oldWrite)
+	}
+	resource.stateMu.Lock()
+	timeout := resource.ioTimeout
+	resource.stateMu.Unlock()
+	if timeout != 10*time.Second {
+		t.Fatalf("ioTimeout=%v, want unchanged 10s", timeout)
+	}
+}
+
+func TestSocketRollbackFailurePoisonsAndCloses(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	applicationFailure := errors.New("write deadline failed")
+	rollbackFailure := errors.New("read rollback failed")
+	readCalls := 0
+	writeCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			readCalls++
+			if readCalls == 2 {
+				return rollbackFailure
+			}
+			return nil
+		},
+		setWriteFn: func(time.Time) error {
+			writeCalls++
+			if writeCalls == 1 {
+				return applicationFailure
+			}
+			return nil
+		},
+	}
+	resource := &SocketResource{
+		connection:        controlled,
+		ioTimeout:         10 * time.Second,
+		lastReadDeadline:  time.Now().Add(2 * time.Second),
+		lastWriteDeadline: time.Now().Add(3 * time.Second),
+		bufferedRead:      []byte("x"),
+	}
+	err := configureSocketTimeout(resource, 5*time.Second)
+	if !errors.Is(err, applicationFailure) || !errors.Is(err, rollbackFailure) {
+		t.Fatalf("configuration error=%v, want application and rollback failures", err)
+	}
+	resource.stateMu.Lock()
+	closed := resource.closed
+	underlying := resource.connection
+	buffered := len(resource.bufferedRead)
+	resource.stateMu.Unlock()
+	if !closed || underlying != nil || buffered != 0 {
+		t.Fatalf("poisoned state: closed=%v connection=%v buffered=%d", closed, underlying, buffered)
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	}
+}
+
+func TestListenerConfigurationRollsBackExactDeadline(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = underlying.Close() })
+	applicationFailure := errors.New("accept deadline failed")
+	setterCalls := 0
+	controlled := &controlledDeadlineListener{
+		Listener: underlying,
+		setFn: func(time.Time) error {
+			setterCalls++
+			if setterCalls == 1 {
+				return applicationFailure
+			}
+			return nil
+		},
+	}
+	oldDeadline := time.Now().Add(2 * time.Second).Round(0)
+	resource := &ListenerResource{
+		listener:           controlled,
+		ioTimeout:          10 * time.Second,
+		lastAcceptDeadline: oldDeadline,
+	}
+	err = configureListenerTimeout(resource, 5*time.Second)
+	if !errors.Is(err, applicationFailure) {
+		t.Fatalf("configuration error=%v, want application failure", err)
+	}
+	controlled.mu.Lock()
+	deadlines := append([]time.Time(nil), controlled.deadlines...)
+	controlled.mu.Unlock()
+	if len(deadlines) != 2 || !deadlines[1].Equal(oldDeadline) {
+		t.Fatalf("listener rollback=%v, want exact %v", deadlines, oldDeadline)
+	}
+}
+
+func TestListenerRollbackFailurePoisonsOwnedResources(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	applicationFailure := errors.New("accept deadline failed")
+	rollbackFailure := errors.New("accept rollback failed")
+	setterCalls := 0
+	controlledListener := &controlledDeadlineListener{
+		Listener: underlying,
+		setFn: func(time.Time) error {
+			setterCalls++
+			if setterCalls == 1 {
+				return applicationFailure
+			}
+			return rollbackFailure
+		},
+	}
+	accepted, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
+	resource := &ListenerResource{
+		listener:           controlledListener,
+		bufferedAccept:     controlledAccepted,
+		ioTimeout:          10 * time.Second,
+		lastAcceptDeadline: time.Now().Add(2 * time.Second),
+	}
+	err = configureListenerTimeout(resource, 5*time.Second)
+	if !errors.Is(err, applicationFailure) || !errors.Is(err, rollbackFailure) {
+		t.Fatalf("configuration error=%v, want application and rollback failures", err)
+	}
+	resource.stateMu.Lock()
+	closed := resource.closed
+	listener := resource.listener
+	buffered := resource.bufferedAccept
+	resource.stateMu.Unlock()
+	if !closed || listener != nil || buffered != nil {
+		t.Fatalf("poisoned listener: closed=%v listener=%v buffered=%v", closed, listener, buffered)
+	}
+	if controlledListener.closes() != 1 || controlledAccepted.closes() != 1 {
+		t.Fatalf("close calls: listener=%d accepted=%d, want 1 each", controlledListener.closes(), controlledAccepted.closes())
+	}
+}
+
+func TestNetTimeoutWrapper(t *testing.T) {
+	machine := NewWithConfig(VMConfig{RootPath: "."})
+	content, err := stdlib.FS.ReadFile("net.nx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	module, err := machine.loadResolvedModule(resolvedModule{
+		Key:     moduleKey{Root: "embedded", Name: "net"},
+		Name:    "net",
+		Kind:    resolvedEmbeddedModule,
+		Content: string(content),
+	})
+	if err != nil {
+		t.Fatalf("load embedded net module: %v", err)
+	}
+	mapping := requireBuiltinMap(t, module)
+	exported, exists := mapping.Get("settimeout")
+	if !exists || exported.Type != value.VAL_FUNCTION {
+		t.Fatalf("net.settimeout export=%v, exists=%v", exported, exists)
+	}
+}
+
+func TestConnectedSocketClearsDeadlineBeforeRegistration(t *testing.T) {
+	originalDial := networkDialTimeout
+	t.Cleanup(func() { networkDialTimeout = originalDial })
+
+	for _, clearErr := range []error{nil, errors.New("clear failed")} {
+		name := "success"
+		if clearErr != nil {
+			name = "clear failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			machine := New()
+			connection, peer := net.Pipe()
+			t.Cleanup(func() { _ = peer.Close() })
+			controlled := &controlledDeadlineConn{
+				Conn: connection,
+				setDeadlineFn: func(time.Time) error {
+					return clearErr
+				},
+			}
+			networkDialTimeout = func(string, string, time.Duration) (net.Conn, error) {
+				return controlled, nil
+			}
+
+			result := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("example.test"), value.NewInt(80))
+			controlled.mu.Lock()
+			deadlines := append([]time.Time(nil), controlled.deadlines...)
+			controlled.mu.Unlock()
+			if len(deadlines) != 1 || !deadlines[0].IsZero() {
+				t.Fatalf("connection deadlines=%v, want one zero clear", deadlines)
+			}
+			if clearErr == nil {
+				assertBuiltinValue(t, builtinMapField(t, result, "open"), value.NewBool(true))
+				callBuiltinWithinBound(t, machine, "net_close", result)
+				return
+			}
+			assertBuiltinValue(t, builtinMapField(t, result, "open"), value.NewBool(false))
+			if len(machine.shared.Sockets.snapshot()) != 0 {
+				t.Fatal("connection with failed deadline clear was registered")
+			}
+			if controlled.closes() != 1 {
+				t.Fatalf("close calls=%d, want 1", controlled.closes())
+			}
+		})
+	}
+}
+
+func TestPendingReadObservesTimeoutConfiguration(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	readEntered := make(chan struct{})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		readFn: func(buffer []byte) (int, error) {
+			close(readEntered)
+			return connection.Read(buffer)
+		},
+	}
+	resource := &SocketResource{connection: controlled}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	result := make(chan value.Value, 1)
+	go func() { result <- receiveSocket(resource, 1) }()
+	select {
+	case <-readEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pending read did not start")
+	}
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", socketValue(handle, "pipe", 0, true), value.NewInt(25)); err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	select {
+	case got := <-result:
+		assertBuiltinValue(t, builtinMapField(t, got, "error"), value.NewString("operation timed out"))
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pending read did not observe configured timeout")
+	}
+}
+
+func TestPendingReadObservesBlockingConfiguration(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	readEntered := make(chan struct{})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		readFn: func(buffer []byte) (int, error) {
+			close(readEntered)
+			return connection.Read(buffer)
+		},
+	}
+	resource := &SocketResource{connection: controlled, ioTimeout: 30 * time.Millisecond}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	socket := socketValue(handle, "pipe", 0, true)
+	result := make(chan value.Value, 1)
+	go func() { result <- receiveSocket(resource, 1) }()
+	select {
+	case <-readEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pending read did not start")
+	}
+	if _, err := invokeBuiltin(t, machine, "net_setblocking", socket, value.NewBool(true)); err != nil {
+		t.Fatalf("net_setblocking(true): %v", err)
+	}
+	time.Sleep(45 * time.Millisecond)
+	if _, err := peer.Write([]byte("x")); err != nil {
+		t.Fatalf("write after clearing deadline: %v", err)
+	}
+	select {
+	case got := <-result:
+		assertBuiltinValue(t, builtinMapField(t, got, "data"), value.NewBytes("x"))
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pending read was not restored to blocking")
+	}
+}
+
+func TestNetSetTimeoutAcceptsTypedSocketAndRejectsTypedNil(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	resource := &SocketResource{connection: connection}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	definition := &value.ObjStruct{Name: "Socket", Fields: []string{"fd", "addr", "port", "open"}}
+	instance := value.NewInstance(definition)
+	instance.Obj.(*value.ObjInstance).Fields["fd"] = value.NewInt(int64(handle))
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", instance, value.NewInt(10)); err != nil {
+		t.Fatalf("typed socket: %v", err)
+	}
+
+	invalid := []value.Value{
+		{Type: value.VAL_OBJ, Obj: (*value.ObjMap)(nil)},
+		{Type: value.VAL_OBJ, Obj: (*value.ObjInstance)(nil)},
+		value.NewMap(),
+		value.NewMapWithData(map[string]value.Value{"fd": value.NewString("1")}),
+	}
+	for _, socket := range invalid {
+		if _, err := invokeBuiltin(t, machine, "net_settimeout", socket, value.NewInt(10)); err == nil || !strings.Contains(err.Error(), "invalid socket") {
+			t.Fatalf("invalid socket %#v produced error %v", socket, err)
+		}
+	}
+}
+
+func TestNetworkProbeDeadlineUsesOneStartInstant(t *testing.T) {
+	started := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		selectTimeout time.Duration
+		ioTimeout     time.Duration
+		want          time.Time
+	}{
+		{name: "persistent shorter", selectTimeout: 10 * time.Millisecond, ioTimeout: 9 * time.Millisecond, want: started.Add(9 * time.Millisecond)},
+		{name: "select shorter", selectTimeout: 9 * time.Millisecond, ioTimeout: 10 * time.Millisecond, want: started.Add(9 * time.Millisecond)},
+		{name: "blocking mode", selectTimeout: 9 * time.Millisecond, ioTimeout: 0, want: started.Add(9 * time.Millisecond)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := networkProbeDeadline(started, test.selectTimeout, test.ioTimeout); !got.Equal(test.want) {
+				t.Fatalf("deadline=%v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSocketRollbackStopsWhenCloseInvalidatesGeneration(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	applicationFailure := errors.New("write deadline failed")
+	readRollbackEntered := make(chan struct{})
+	releaseReadRollback := make(chan struct{})
+	readCalls := 0
+	writeCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			readCalls++
+			if readCalls == 2 {
+				close(readRollbackEntered)
+				<-releaseReadRollback
+			}
+			return nil
+		},
+		setWriteFn: func(time.Time) error {
+			writeCalls++
+			if writeCalls == 1 {
+				return applicationFailure
+			}
+			return nil
+		},
+	}
+	resource := &SocketResource{
+		connection:        controlled,
+		lastReadDeadline:  time.Now().Add(time.Second),
+		lastWriteDeadline: time.Now().Add(2 * time.Second),
+	}
+	configured := make(chan error, 1)
+	go func() { configured <- configureSocketTimeout(resource, 5*time.Second) }()
+	select {
+	case <-readRollbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("read rollback did not start")
+	}
+	closeSocket(resource)
+	close(releaseReadRollback)
+	select {
+	case err := <-configured:
+		if !errors.Is(err, net.ErrClosed) || !errors.Is(err, applicationFailure) {
+			t.Fatalf("configuration error=%v, want application failure and net.ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("configuration did not finish")
+	}
+	if writeCalls != 1 {
+		t.Fatalf("write deadline calls=%d, want no write rollback after stale generation", writeCalls)
+	}
+}
+
+func TestBlockedWriteIsBoundedByTimeout(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	resource := &SocketResource{connection: connection, ioTimeout: 25 * time.Millisecond}
+	started := time.Now()
+	result := sendSocket(resource, "x")
+	elapsed := time.Since(started)
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, result, "error"), value.NewString("operation timed out"))
+	if elapsed < 10*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("write elapsed=%v, want bounded wait", elapsed)
+	}
+}
+
+func TestPendingWriteObservesTimeoutConfiguration(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	writeEntered := make(chan struct{})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		writeFn: func(buffer []byte) (int, error) {
+			close(writeEntered)
+			return connection.Write(buffer)
+		},
+	}
+	resource := &SocketResource{connection: controlled}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	result := make(chan value.Value, 1)
+	go func() { result <- sendSocket(resource, "x") }()
+	select {
+	case <-writeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pending write did not start")
+	}
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", socketValue(handle, "pipe", 0, true), value.NewInt(25)); err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	select {
+	case got := <-result:
+		assertBuiltinValue(t, builtinMapField(t, got, "error"), value.NewString("operation timed out"))
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pending write did not observe configured timeout")
+	}
+}
+
+func TestPendingAcceptObservesTimeoutConfiguration(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptEntered := make(chan struct{})
+	controlled := &controlledDeadlineListener{Listener: underlying}
+	controlled.acceptFn = func() (net.Conn, error) {
+		close(acceptEntered)
+		return underlying.Accept()
+	}
+	resource := &ListenerResource{listener: controlled}
+	t.Cleanup(func() { closeListener(resource) })
+	result := make(chan error, 1)
+	go func() {
+		_, err := acceptConnection(resource)
+		result <- err
+	}()
+	select {
+	case <-acceptEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pending accept did not start")
+	}
+	if err := configureListenerTimeout(resource, 25*time.Millisecond); err != nil {
+		t.Fatalf("configure listener: %v", err)
+	}
+	select {
+	case err := <-result:
+		if err == nil || !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("accept error=%v, want deadline exceeded", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pending accept did not observe configured timeout")
+	}
+}
+
+func TestAcceptedSocketDoesNotInheritListenerTimeout(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	listenerHandle := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerResource, exists := machine.shared.Listeners.get(listenerHandle)
+	if !exists {
+		t.Fatal("listener not registered")
+	}
+	listenerResource.stateMu.Lock()
+	address := listenerResource.listener.Addr().(*net.TCPAddr)
+	listenerResource.stateMu.Unlock()
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", listener, value.NewInt(100)); err != nil {
+		t.Fatalf("net_settimeout: %v", err)
+	}
+	client := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("127.0.0.1"), value.NewInt(int64(address.Port)))
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	t.Cleanup(func() {
+		callBuiltinWithinBound(t, machine, "net_close", client)
+		callBuiltinWithinBound(t, machine, "net_close", accepted)
+	})
+	_, acceptedResource := requireSocketResource(t, machine, accepted)
+	acceptedResource.stateMu.Lock()
+	timeout := acceptedResource.ioTimeout
+	readDeadline := acceptedResource.lastReadDeadline
+	writeDeadline := acceptedResource.lastWriteDeadline
+	acceptedResource.stateMu.Unlock()
+	if timeout != 0 || !readDeadline.IsZero() || !writeDeadline.IsZero() {
+		t.Fatalf("accepted mode: timeout=%v read=%v write=%v, want blocking", timeout, readDeadline, writeDeadline)
+	}
+}
+
+func TestPartialBufferedReadSurvivesDeadlineInstallationFailure(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			return errors.New("deadline install failed")
+		},
+	}
+	resource := &SocketResource{connection: controlled, bufferedRead: []byte("x"), ioTimeout: 20 * time.Millisecond}
+	result := receiveSocket(resource, 2)
+	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, result, "count"), value.NewInt(1))
+}
+
+func TestConcurrentTimeoutConfigurationsCommitInDeadlineOrder(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	readCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			readCalls++
+			if readCalls == 1 {
+				close(firstEntered)
+				<-releaseFirst
+			}
+			return nil
+		},
+	}
+	resource := &SocketResource{connection: controlled}
+	first := make(chan error, 1)
+	second := make(chan error, 1)
+	go func() { first <- configureSocketTimeout(resource, 10*time.Millisecond) }()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first configuration did not start")
+	}
+	go func() { second <- configureSocketTimeout(resource, 20*time.Millisecond) }()
+	close(releaseFirst)
+	if err := <-first; err != nil {
+		t.Fatalf("first configuration: %v", err)
+	}
+	if err := <-second; err != nil {
+		t.Fatalf("second configuration: %v", err)
+	}
+	resource.stateMu.Lock()
+	timeout := resource.ioTimeout
+	resource.stateMu.Unlock()
+	if timeout != 20*time.Millisecond {
+		t.Fatalf("ioTimeout=%v, want second configuration 20ms", timeout)
+	}
+}
+
+func TestListenerSelectRestorationFailureKeepsAcceptedConnection(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	restoreFailure := errors.New("listener restore failed")
+	setterCalls := 0
+	controlled := &controlledDeadlineListener{
+		Listener: underlying,
+		acceptFn: func() (net.Conn, error) {
+			return accepted, nil
+		},
+		setFn: func(time.Time) error {
+			setterCalls++
+			if setterCalls == 2 {
+				return restoreFailure
+			}
+			return nil
+		},
+	}
+	resource := &ListenerResource{listener: controlled, ioTimeout: 100 * time.Millisecond}
+	t.Cleanup(func() { closeListener(resource) })
+	ready, err := selectListener(resource, 10*time.Millisecond)
+	if ready || !errors.Is(err, restoreFailure) {
+		t.Fatalf("selectListener=(%v, %v), want restoration failure", ready, err)
+	}
+	resource.stateMu.Lock()
+	buffered := resource.bufferedAccept
+	resource.stateMu.Unlock()
+	if buffered != accepted {
+		t.Fatalf("buffered accept=%v, want accepted connection", buffered)
+	}
+}
+
+func TestNetSelectManagementFailureStopsLaterCandidatesAndKeepsEarlierBuffer(t *testing.T) {
+	machine := New()
+	makeControlled := func(readFn func([]byte) (int, error), setReadFn func(time.Time) error) (*SocketResource, value.Value, *controlledDeadlineConn) {
+		connection, peer := net.Pipe()
+		t.Cleanup(func() {
+			_ = connection.Close()
+			_ = peer.Close()
+		})
+		controlled := &controlledDeadlineConn{Conn: connection, readFn: readFn, setReadFn: setReadFn}
+		resource := &SocketResource{connection: controlled}
+		handle := machine.shared.Sockets.add(resource)
+		t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+		return resource, socketValue(handle, "pipe", 0, true), controlled
+	}
+	first, firstValue, _ := makeControlled(func(buffer []byte) (int, error) {
+		buffer[0] = 'a'
+		return 1, nil
+	}, nil)
+	managementFailure := errors.New("probe install failed")
+	_, secondValue, _ := makeControlled(nil, func(time.Time) error { return managementFailure })
+	thirdReads := 0
+	_, thirdValue, _ := makeControlled(func([]byte) (int, error) {
+		thirdReads++
+		return 0, io.EOF
+	}, nil)
+
+	_, err := invokeBuiltin(t, machine, "net_select",
+		value.NewArray([]value.Value{firstValue, secondValue, thirdValue}),
+		value.NewArray(nil), value.NewArray(nil), value.NewInt(10))
+	if !errors.Is(err, managementFailure) {
+		t.Fatalf("net_select error=%v, want management failure", err)
+	}
+	first.stateMu.Lock()
+	buffered := string(first.bufferedRead)
+	first.stateMu.Unlock()
+	if buffered != "a" {
+		t.Fatalf("earlier buffer=%q, want a", buffered)
+	}
+	if thirdReads != 0 {
+		t.Fatalf("later candidate reads=%d, want 0", thirdReads)
+	}
+}
+
+func TestNetSetTimeoutUsesListenerFirstAndRejectsClosedHandle(t *testing.T) {
+	machine := New()
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlledListener := &controlledDeadlineListener{Listener: underlying}
+	listenerResource := &ListenerResource{listener: controlledListener}
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	controlledSocket := &controlledDeadlineConn{Conn: connection}
+	socketResource := &SocketResource{connection: controlledSocket}
+	const handle = 77
+	machine.shared.Listeners.mu.Lock()
+	machine.shared.Listeners.items[handle] = listenerResource
+	machine.shared.Listeners.mu.Unlock()
+	machine.shared.Sockets.mu.Lock()
+	machine.shared.Sockets.items[handle] = socketResource
+	machine.shared.Sockets.mu.Unlock()
+	t.Cleanup(func() {
+		machine.shared.Listeners.remove(handle)
+		machine.shared.Sockets.remove(handle)
+		closeListener(listenerResource)
+		closeSocket(socketResource)
+	})
+	socket := socketValue(handle, "ambiguous", 0, true)
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", socket, value.NewInt(10)); err != nil {
+		t.Fatalf("listener-first configuration: %v", err)
+	}
+	listenerResource.stateMu.Lock()
+	listenerTimeout := listenerResource.ioTimeout
+	listenerResource.stateMu.Unlock()
+	socketResource.stateMu.Lock()
+	socketTimeout := socketResource.ioTimeout
+	socketResource.stateMu.Unlock()
+	if listenerTimeout != 10*time.Millisecond || socketTimeout != 0 {
+		t.Fatalf("timeouts listener=%v socket=%v, want listener-first", listenerTimeout, socketTimeout)
+	}
+
+	closeListener(listenerResource)
+	if _, err := invokeBuiltin(t, machine, "net_settimeout", socket, value.NewInt(10)); err == nil || !strings.Contains(err.Error(), "invalid socket") {
+		t.Fatalf("closed listener error=%v, want invalid socket", err)
+	}
+}
+
+func TestCloseDoesNotWaitForBlockedWriteDeadlineSetter(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	setterEntered := make(chan struct{})
+	releaseSetter := make(chan struct{})
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setWriteFn: func(time.Time) error {
+			close(setterEntered)
+			<-releaseSetter
+			return nil
+		},
+	}
+	resource := &SocketResource{connection: controlled}
+	configured := make(chan error, 1)
+	go func() { configured <- configureSocketTimeout(resource, 20*time.Millisecond) }()
+	select {
+	case <-setterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("write deadline setter was not entered")
+	}
+	closed := make(chan struct{})
+	go func() {
+		closeSocket(resource)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("close waited for write deadline setter")
+	}
+	close(releaseSetter)
+	if err := <-configured; !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("configuration error=%v, want net.ErrClosed", err)
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	}
+}
+
+func TestCloseDoesNotWaitForBlockedListenerDeadlineSetter(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	setterEntered := make(chan struct{})
+	releaseSetter := make(chan struct{})
+	controlled := &controlledDeadlineListener{
+		Listener: underlying,
+		setFn: func(time.Time) error {
+			close(setterEntered)
+			<-releaseSetter
+			return nil
+		},
+	}
+	resource := &ListenerResource{listener: controlled}
+	configured := make(chan error, 1)
+	go func() { configured <- configureListenerTimeout(resource, 20*time.Millisecond) }()
+	select {
+	case <-setterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("listener deadline setter was not entered")
+	}
+	closed := make(chan struct{})
+	go func() {
+		closeListener(resource)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("close waited for listener deadline setter")
+	}
+	close(releaseSetter)
+	if err := <-configured; !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("configuration error=%v, want net.ErrClosed", err)
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	}
+}
+
+func TestActiveSocketProbeBoundsConcurrentConfiguration(t *testing.T) {
+	tests := []struct {
+		name              string
+		configuredTimeout time.Duration
+		wantAgainstProbe  string
+		wantRestoredZero  bool
+	}{
+		{name: "longer timeout cannot extend", configuredTimeout: 200 * time.Millisecond, wantAgainstProbe: "equal"},
+		{name: "shorter timeout may shorten", configuredTimeout: 20 * time.Millisecond, wantAgainstProbe: "before"},
+		{name: "blocking cannot remove", configuredTimeout: 0, wantAgainstProbe: "equal", wantRestoredZero: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			connection, peer := net.Pipe()
+			t.Cleanup(func() {
+				_ = connection.Close()
+				_ = peer.Close()
+			})
+			readEntered := make(chan struct{})
+			releaseRead := make(chan struct{})
+			controlled := &controlledDeadlineConn{
+				Conn: connection,
+				readFn: func(buffer []byte) (int, error) {
+					close(readEntered)
+					<-releaseRead
+					buffer[0] = 'x'
+					return 1, nil
+				},
+			}
+			resource := &SocketResource{connection: controlled}
+			selected := make(chan error, 1)
+			go func() {
+				ready, err := selectSocket(resource, 100*time.Millisecond)
+				if err == nil && !ready {
+					err = errors.New("probe was not ready")
+				}
+				selected <- err
+			}()
+			select {
+			case <-readEntered:
+			case <-time.After(time.Second):
+				t.Fatal("probe read did not start")
+			}
+			if err := configureSocketTimeout(resource, test.configuredTimeout); err != nil {
+				t.Fatalf("concurrent configuration: %v", err)
+			}
+			controlled.mu.Lock()
+			installed := append([]time.Time(nil), controlled.readDeadlines...)
+			controlled.mu.Unlock()
+			if len(installed) != 2 {
+				t.Fatalf("deadlines before cleanup=%v, want probe and configuration", installed)
+			}
+			switch test.wantAgainstProbe {
+			case "equal":
+				if !installed[1].Equal(installed[0]) {
+					t.Fatalf("configured deadline=%v, want probe bound %v", installed[1], installed[0])
+				}
+			case "before":
+				if !installed[1].Before(installed[0]) {
+					t.Fatalf("configured deadline=%v, want before probe bound %v", installed[1], installed[0])
+				}
+			}
+			close(releaseRead)
+			if err := <-selected; err != nil {
+				t.Fatalf("selectSocket: %v", err)
+			}
+			controlled.mu.Lock()
+			restored := controlled.readDeadlines[len(controlled.readDeadlines)-1]
+			controlled.mu.Unlock()
+			if restored.IsZero() != test.wantRestoredZero {
+				t.Fatalf("restored deadline=%v, want zero=%v", restored, test.wantRestoredZero)
+			}
+			if !test.wantRestoredZero && restored.Before(installed[1]) {
+				t.Fatalf("restored deadline=%v, want no earlier than %v", restored, installed[1])
+			}
+		})
+	}
+}

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -21,7 +21,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"io_remove", "io_stat", "io_write", "io_write_result", "iprint", "json_dumps",
 		"json_dumps_result", "json_loads", "json_parse", "keys", "length", "make_chan",
 		"make_wg", "net_accept", "net_close", "net_connect", "net_listen",
-		"net_recv", "net_select", "net_send", "net_setblocking", "ord",
+		"net_recv", "net_select", "net_send", "net_setblocking", "net_settimeout", "ord",
 		"pop", "print", "slice", "spawn", "spawn_task", "sqlite_bind_float",
 		"sqlite_bind_int", "sqlite_bind_text", "sqlite_close", "sqlite_exec",
 		"sqlite_exec_params", "sqlite_finalize", "sqlite_open",
@@ -116,7 +116,7 @@ func TestStatefulBuiltinsUseContextualHandlers(t *testing.T) {
 	machine := New()
 	for _, name := range []string{
 		"spawn", "spawn_task", "task_await", "delete", "append", "pop", "json_loads", "sys_load_plugin",
-		"io_open", "net_listen", "sqlite_open",
+		"io_open", "net_listen", "net_settimeout", "sqlite_open",
 	} {
 		native := requireBuiltin(t, machine, name)
 		if native.Contextual == nil || native.Fn != nil || !native.IsCallable() {

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"noxy-vm/internal/value"
 )
@@ -98,20 +99,31 @@ func (resource *FileResource) close() error {
 }
 
 type ListenerResource struct {
-	stateMu        sync.Mutex
-	acceptMu       sync.Mutex
-	listener       net.Listener
-	bufferedAccept net.Conn
-	closed         bool
+	stateMu             sync.Mutex
+	deadlineMu          sync.Mutex
+	acceptMu            sync.Mutex
+	listener            deadlineListener
+	bufferedAccept      net.Conn
+	ioTimeout           time.Duration
+	acceptProbeDeadline time.Time
+	lastAcceptDeadline  time.Time
+	deadlineGeneration  uint64
+	closed              bool
 }
 
 type SocketResource struct {
-	stateMu      sync.Mutex
-	readMu       sync.Mutex
-	writeMu      sync.Mutex
-	connection   net.Conn
-	bufferedRead []byte
-	closed       bool
+	stateMu            sync.Mutex
+	deadlineMu         sync.Mutex
+	readMu             sync.Mutex
+	writeMu            sync.Mutex
+	connection         net.Conn
+	bufferedRead       []byte
+	ioTimeout          time.Duration
+	readProbeDeadline  time.Time
+	lastReadDeadline   time.Time
+	lastWriteDeadline  time.Time
+	deadlineGeneration uint64
+	closed             bool
 }
 
 type DatabaseResource struct {


### PR DESCRIPTION
## What changed

- add `net.settimeout(sock, timeout_ms)` for positive per-operation read, write, and accept deadlines
- make `net.setblocking(sock, true)` restore indefinite blocking
- preserve `net.setblocking(sock, false)` as the deprecated compatibility no-op until the network poller lands
- define deadline precedence with active `net_select` probes
- serialize deadline transitions with a dedicated mutex and generation revalidation, without holding lifecycle locks across external setters
- linearize buffered accept ownership against concurrent close
- preserve readiness before deadline restoration and normalize portable timeout errors
- add exact rollback and fail-closed behavior when live deadlines cannot be restored
- document the language contract and add Windows/Unix CI coverage

## Why

PR #17 identified that `net_setblocking` was ineffective and that read/write deadlines and the precedence between blocking, non-blocking, and timeout were undefined. Go exposes portable deadlines but not a portable true non-blocking socket operation, so this change adds a compatible deadline API while explicitly deferring real non-blocking behavior to `feat/network-poller`.

## Impact

Existing sockets remain blocking by default. Existing `setblocking(false)` calls keep their current no-op behavior. Applications can opt into bounded network operations with `net.settimeout` and return to indefinite blocking with `setblocking(true)`. Public `Socket`, `NetResult`, accept, and select result shapes remain unchanged.

## Validation

- `go test ./...`
- `go test -race ./internal/vm -count=1 -timeout=300s`
- `go vet ./...`
- `go build ./...`
- `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx` — 159/159 passed
- independent implementation review and follow-up: Ready
