### PR TITLE
feat(net): add portable non-consuming network poller

### DIFF
--- a/.github/workflows/network-deadlines.yml
+++ b/.github/workflows/network-deadlines.yml
@@ -1,4 +1,4 @@
-name: Network deadlines
+name: Network semantics
 
 on:
   pull_request:
@@ -9,7 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  network-deadlines:
+  network-semantics:
+    name: Runtime semantics (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -21,5 +22,36 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test ./internal/vm -run 'Test(ValidateNetworkTimeout|Network|NetSet|NetSelect|Socket|Listener|ReceiveSocket|SendSocket|CloseDoes|BufferedAccept|ConnectedSocket|ConcurrentNetSelect)' -count=1 -timeout=120s
+      - run: go test ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=120s
+      # The Go race detector supports the hosted linux/amd64 and windows/amd64 toolchains.
+      - run: go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s
       - run: go test ./internal/... -count=1
+
+  cross-build:
+    name: Production cross-build (${{ matrix.goos }}/${{ matrix.goarch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: amd64
+          - goos: freebsd
+            goarch: amd64
+    runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      CGO_ENABLED: 0
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      # Poller sources also compile for dragonfly/amd64, netbsd/amd64,
+      # openbsd/amd64, solaris/amd64, and aix/ppc64. Full-repository builds
+      # for those targets currently fail earlier in modernc SQLite/libc, so
+      # they must not be presented as green production cross-build gates.
+      - run: go build ./...

--- a/.github/workflows/network-deadlines.yml
+++ b/.github/workflows/network-deadlines.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=120s
+      - run: go test ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=120s
       # The Go race detector supports the hosted linux/amd64 and windows/amd64 toolchains.
-      - run: go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s
+      - run: go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s
       - run: go test ./internal/... -count=1
 
   cross-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Normal returns and runtime failures now share safe frame unwinding, preserving primary errors while collecting observable cleanup failures.
 - `net.setblocking(sock, true)` now restores indefinite blocking, while the deprecated `false` branch remains a compatibility no-op.
 - `net.poll`/`net_select` now reports non-consuming readiness through independent 64-entry read, write, and error sets, with immediate zero-time polls, one global positive timeout, portable EOF/hangup projection, and concurrent-close wakeups that omit detached resources.
+- `net.listen(host, 0)` now returns the operating-system-assigned port in `Socket.port`, allowing collision-free loopback listeners.
 
 ## [0.2.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 ### Fixed
 
 - Normal returns and runtime failures now share safe frame unwinding, preserving primary errors while collecting observable cleanup failures.
-- `net.setblocking(sock, true)` now restores indefinite blocking, while the deprecated `false` branch remains a compatibility no-op until the network poller lands.
-- Temporary `net_select` deadlines now preserve the latest persistent timeout and buffered readiness without blocking concurrent close.
+- `net.setblocking(sock, true)` now restores indefinite blocking, while the deprecated `false` branch remains a compatibility no-op.
+- `net.poll`/`net_select` now reports non-consuming readiness through independent 64-entry read, write, and error sets, with immediate zero-time polls, one global positive timeout, portable EOF/hangup projection, and concurrent-close wakeups that omit detached resources.
 
 ## [0.2.0] - 2026-08-13
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -758,6 +758,10 @@ Noxy comes with a comprehensive standard library. Available modules include:
 
 ### Network sockets
 
+`net.listen(host, 0)` asks the operating system to choose an available port.
+On success, the returned `Socket.port` is that assigned non-zero port, so it
+can be passed directly to `net.connect` without inspecting native resources.
+
 #### Persistent I/O deadlines
 
 The `net` module supports portable blocking sockets with optional positive

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -756,7 +756,9 @@ Noxy comes with a comprehensive standard library. Available modules include:
 | `sqlite` | SQLite database support |
 | `rand` | Random number generation |
 
-### Network deadlines
+### Network sockets
+
+#### Persistent I/O deadlines
 
 The `net` module supports portable blocking sockets with optional positive
 deadlines:
@@ -775,9 +777,9 @@ consume the operation's timeout.
 `setblocking(sock, true)` clears the persistent timeout and restores
 indefinite blocking, including I/O that is already pending. The compatibility
 call `setblocking(sock, false)` is deprecated and remains an unconditional
-no-op until true portable non-blocking I/O is implemented by the network
-poller. It does not inspect the socket and does not alter an existing timeout.
-An expired deadline is never used to simulate non-blocking behavior.
+no-op. Poll readiness does not depend on this compatibility call. It does not
+inspect the socket or alter an existing timeout, and an expired deadline is
+never used to simulate non-blocking behavior.
 
 The latest successfully completed `settimeout` or `setblocking(..., true)`
 call determines the persistent mode. A rejected call leaves that mode
@@ -794,25 +796,59 @@ descriptor, lookup, then open state. `setblocking` retains its compatibility
 behavior for malformed arity/type; only the exact `true` branch performs
 socket validation.
 
-`net.poll`/`net_select` retains its call-local timeout. While a read or accept
-probe is active, its absolute deadline is an upper bound: blocking mode or a
-longer persistent timeout cannot extend it, while a shorter persistent timeout
-may shorten it. Cleanup restores the latest persistent mode. A failure to
-install or restore a deadline is synchronous and produces no partial
-`SelectResult`; ordinary read/accept errors remain not-ready candidates.
-Read bytes or accepted connections consumed successfully are published before
-deadline restoration, so a restoration failure does not discard readiness.
-For one probe start instant `t`, the effective deadline is exactly:
+#### Non-consuming readiness polling
 
-```text
-probe_bound = t + select_timeout
-effective = min(probe_bound, t + io_timeout), when io_timeout > 0
-effective = probe_bound, otherwise
-```
+`net.poll(read, write, error, timeout_ms)` (the public wrapper for
+`net_select`) observes readiness without performing I/O. The three input sets
+are independent fixed arrays with 64 entries each. For each set, only entries
+0 through 63 are considered. The corresponding output is another 64-entry
+array in stable input order; unused output entries are null. Duplicate socket
+occurrences are retained as separate output occurrences. `read_count`,
+`write_count`, and `error_count` are the exact numbers of values copied to
+their respective outputs, not the number of distinct resources.
 
-The preservation guarantee above is specific to deadline-management failure.
-The existing ordinary `Read(n > 0, err != nil)` probe behavior remains
-unchanged and is reserved for the later network-poller work.
+`timeout_ms` must be an `int` representable as Go `time.Duration`
+milliseconds. A negative value is an error. Zero performs one immediate poll.
+A positive value supplies one global wall-clock bound for the whole operation,
+including every candidate in all three sets; it is not a per-socket or
+per-set timeout. Poll may return earlier when readiness or a local concurrent
+close is observed. With no live candidates, a positive poll waits for the same
+global bound and returns empty sets.
+
+Poll is strictly observational. It does not call `Read` or `Accept`, peek at
+payload bytes, query or clear `SO_ERROR`, or install, clear, or restore a
+socket deadline. It therefore neither consumes bytes nor accepts a pending
+connection, and it does not mutate the persistent mode established by
+`settimeout` or `setblocking(..., true)`.
+
+For a connected socket, ordinary payload data is read readiness only. An
+orderly EOF is always readable. Explicit native hangup, error, or invalid
+descriptor events satisfy every set in which that connected socket was
+requested. Payload data may coexist with EOF, hangup, or error readiness; poll
+must not discard it, and a later `socket_recv` can still consume the pending
+bytes. Out-of-band or urgent data is outside the `net.poll` API and has no
+separate readiness category.
+
+A listening socket with a pending connection has normal read readiness only.
+A listener terminal event satisfies requested read and error sets, but a
+listener is never returned in the write set. Poll never calls `Accept`, so a
+pending connection remains available to a later explicit `net.accept`.
+
+Closing a requested socket or listener concurrently in the same runtime wakes
+a blocked positive poll. The detached resource is revalidated and omitted
+from every output set; stale descriptor reuse cannot make the old resource
+ready.
+
+Windows and Linux receive runtime verification. The poller backend has compile
+support for Windows and for `aix`, `darwin`, `dragonfly`, `freebsd`, `linux`,
+`netbsd`, `openbsd`, and `solaris`; this is compile support, not a claim of
+runtime verification on those Unix targets. Full-repository cross-build gates
+currently cover `linux/amd64`, `darwin/amd64`, and `freebsd/amd64`; existing
+SQLite dependencies prevent full-repository builds for the other listed Unix
+targets even though the poller backend itself compiles there. On any platform
+outside the Windows/Unix build-tag list, polling a live resource fails with
+`network polling is not supported on this platform`; no consuming fallback is
+used.
 
 Accepted and connected sockets explicitly clear prior deadlines before being
 registered and start in indefinite blocking mode; a listener timeout is not

--- a/docs/superpowers/plans/2026-08-14-network-poller.md
+++ b/docs/superpowers/plans/2026-08-14-network-poller.md
@@ -18,6 +18,9 @@
 - Keep `net.setblocking(sock, false)` as a deprecated no-op.
 - Keep `deadlineGeneration` exclusive to deadline transitions; do not add `lifetimeGeneration`.
 - Preserve the lock order `deadlineMu -> stateMu`; signal poll waiters and close OS resources outside both locks.
+- Attribute every `SyscallConn`/`RawConn.Control` failure to the exact registration and acquisition stage before deciding whether concurrent local close suppresses it.
+- Keep listener write-only registrations subscribed to local-close wake-up without placing their descriptors in the native poll set.
+- Cap each native blocking chunk at one second so a failed wake signal cannot hold `RawConn.Control` references—and therefore resource close—for an unbounded interval.
 - Treat Windows and Linux as runtime-verified. Treat AIX, Darwin, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, and Solaris as compile-supported until their integration tests run on those systems.
 - Use strict red-green-refactor for each behavior and leave unrelated worktree changes untouched.
 
@@ -31,6 +34,7 @@
 - `internal/vm/network_poller_test.go` — platform-independent contract, ordering, timeout, descriptor-lifetime, close-classification, and fake-backend tests.
 - `internal/vm/network_poller_windows.go` — Winsock wake sockets, `WSAPoll` ABI, and Windows event normalization.
 - `internal/vm/network_poller_windows_test.go` — Windows ABI, wake, immediate, listener, and error-path tests.
+- `internal/vm/network_poller_linux_test.go` — Linux `POLLRDHUP`, reset/pending-error, and half-close integration tests.
 - `internal/vm/network_poller_unix.go` — Unix socketpair wake and `unix.Poll` backend.
 - `internal/vm/network_poller_unix_test.go` — Unix wake, immediate, descriptor, and event tests.
 - `internal/vm/network_poller_rdhup.go` — Linux/FreeBSD `POLLRDHUP` terminal mask.
@@ -250,13 +254,14 @@ type fakePlatformWake struct {
 	closes int
 	closed bool
 	afterClose bool
+	signalErr error
 }
 func (*fakePlatformWake) descriptor() uintptr { return 99 }
 func (wake *fakePlatformWake) signal() error {
 	wake.mu.Lock(); defer wake.mu.Unlock()
 	if wake.closed { wake.afterClose = true }
 	wake.signals++
-	return nil
+	return wake.signalErr
 }
 func (wake *fakePlatformWake) close() error {
 	wake.mu.Lock(); defer wake.mu.Unlock()
@@ -285,9 +290,19 @@ func TestNetworkWakeSerializesSignalAndClose(t *testing.T) {
 }
 ```
 
+Add `TestNetworkWakeSignalFailureRemainsClosable`: make `signalErr` non-nil, require `Signal` to return it without transitioning to `signaled`, then require `Close` to close the platform exactly once and every later `Signal` to be a no-op. Platform-specific tasks add retry behavior for interruptible writes; the common state machine must not hide a real signaling failure.
+
 - [ ] **Step 2: Write failing resource broadcast/detach tests**
 
-Register two distinct wake objects in one `SocketResource`, call `closeSocket`, and require both to be signaled, the connection to be closed, the waiter map cleared, and a second close to do nothing. Repeat for `ListenerResource`. Add a rollback-failure test that reaches the existing fail-closed branch and requires the registered wake to be signaled before the controlled connection's `Close` method begins.
+Register two distinct wake objects in one `SocketResource`, call `closeSocket`, and require both to be signaled, the connection to be closed, the waiter map cleared, and a second close to do nothing. Repeat for `ListenerResource`.
+
+Cover the three existing fail-closed transitions independently:
+
+1. initial socket `SetReadDeadline` failure plus failed read rollback (`builtins_net.go:122` before refactoring);
+2. socket `SetWriteDeadline` failure plus at least one failed read/write rollback (`builtins_net.go:170`);
+3. listener `SetDeadline` failure plus failed rollback (`builtins_net.go:226`).
+
+For each, require detach, broadcast to every waiter before the controlled `Close` begins, exactly one underlying close, cleared waiter ownership, and `errors.Join` containing application, rollback, signal, and close failures that were injected for that case.
 
 Run RED:
 
@@ -366,7 +381,7 @@ Implement finish functions that call every `Signal`, then close detached resourc
 
 - [ ] **Step 5: Route normal close and every poison branch through detach**
 
-Replace direct `closed = true` transitions in both rollback-failure branches and in `closeSocket`/`closeListener`. For a poison path already holding `deadlineMu` and `stateMu`:
+Replace direct `closed = true` transitions in all three rollback-failure branches and in `closeSocket`/`closeListener`. For a poison path already holding `deadlineMu` and `stateMu`:
 
 ```go
 detached, _ := detachSocketLocked(resource)
@@ -376,12 +391,12 @@ detachErr := finishSocketDetach(detached)
 return errors.Join(applicationErr, rollbackErr, detachErr)
 ```
 
-Use the listener equivalent and preserve buffered accepted-connection cleanup until Task 6 removes that field. Normal close ignores the returned finish error, matching current public behavior.
+Use the listener equivalent and preserve buffered accepted-connection cleanup until Task 6 removes that field. Normal close ignores the returned finish error, matching current public behavior. The poller itself must surface its operation-local wake cleanup error synchronously and return no partial `SelectResult`; Task 3 tests that rule.
 
 - [ ] **Step 6: Run focused GREEN and race tests**
 
 ```powershell
-go test ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|Test(Socket|Listener)Rollback|TestCloseDoes' -count=20
+go test ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|Test(SocketRead|SocketWrite|Listener)RollbackPoison|TestCloseDoes' -count=20
 go test -race ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|TestCloseDoes' -count=1
 ```
 
@@ -419,9 +434,13 @@ Define a fake platform that records one descriptor array and scripted wait outco
 - backend failure returns an error instead of a partial result;
 - no valid candidates call the injected sleeper for positive timeout and return immediately for zero;
 - timeout zero calls `wait` once with zero;
-- positive timeouts use one absolute deadline, ceil a sub-millisecond remainder, and clamp chunks to `math.MaxInt32`;
+- positive timeouts use one absolute deadline, ceil a sub-millisecond remainder, and cap every native chunk at one second;
 - scripted Unix-style interruption retries only a positive timeout;
-- a signaled local-close wake returns promptly with the closed resource omitted.
+- a signaled local-close wake returns promptly with the closed resource omitted;
+- a listener requested only for write is registered for wake-up but contributes no native descriptor, waits for the positive timeout, and remains absent from write output;
+- a listener requested for error contributes a native descriptor with zero normal event flags so terminal flags remain observable;
+- closing unrelated registration A cannot suppress a `SyscallConn` or `Control` error attributed to still-open registration B;
+- operation-local wake close failure returns a synchronous error and no partial `SelectResult`.
 
 The fake returns events indexed to registrations, not candidates:
 
@@ -445,7 +464,7 @@ type fakeNetworkPlatform struct {
 
 Wrap two real loopback TCP connections with a `syscall.Conn` wrapper whose `RawConn.Control` increments an atomic active count only for the callback duration. In the fake platform's `wait`, require `active == 2`. This test must fail if descriptor numbers are copied before entering all callbacks.
 
-Also script close at `SyscallConn` acquisition and at each nested `Control` boundary. Revalidation must classify a detached resource as local close; the same error on an unchanged open resource must be returned synchronously.
+Also script close at `SyscallConn` acquisition and at each nested `Control` boundary. Revalidation must classify a detached resource as local close only when it is the registration attributed by the acquisition error; the same error on an unchanged open resource must be returned synchronously. Add the adversarial case where A closes while B's `Control` returns an invariant error: B's error must win and no result is returned.
 
 Run RED:
 
@@ -483,7 +502,9 @@ type networkPoller struct {
 
 type networkRegistration struct {
 	handle int
-	interests networkInterest
+	requested networkInterest
+	nativeInterests networkInterest
+	pollable bool
 	listener *ListenerResource
 	socket *SocketResource
 	attached any
@@ -494,28 +515,61 @@ type networkOccurrence struct {
 	candidate value.Value
 	registration *networkRegistration
 }
+
+type networkAcquisitionStage uint8
+const (
+	networkAcquireSyscallConn networkAcquisitionStage = iota
+	networkAcquireControl
+)
+
+type networkAcquisitionError struct {
+	registration *networkRegistration
+	stage networkAcquisitionStage
+	callbackEntered bool
+	err error
+}
+
+func (failure *networkAcquisitionError) Error() string { return failure.err.Error() }
+func (failure *networkAcquisitionError) Unwrap() error { return failure.err }
 ```
 
-Use three occurrence slices plus an ordered unique-registration slice. Group by authoritative integer handle after listener-first lookup. Invalid candidate extraction is skipped. Attach one wake to each unique open resource under its `stateMu`, capture the exact connection/listener, then obtain `SyscallConn` from the captured value.
+Use three occurrence slices plus an ordered unique-registration slice. Group by authoritative integer handle after listener-first lookup. Invalid candidate extraction is skipped. Attach one wake to each unique open resource under its `stateMu`, capture the exact connection/listener, then obtain `SyscallConn` from the captured value. Wrap each `SyscallConn` failure immediately in `networkAcquisitionError` with that registration and stage.
+
+For sockets, `nativeInterests` equals the union of requested interests and `pollable=true`, including error-only sockets. For listeners, remove writable from `nativeInterests`; set `pollable=true` only when read or error was requested. Thus a write-only listener stays in the waiter set but never enters `poll`/`WSAPoll`, while an error-only listener remains pollable with zero requested normal-event bits.
 
 - [ ] **Step 4: Retain every descriptor inside nested callbacks**
 
-Implement recursion with the native wait only at the innermost callback:
+Build a separate `pollRegistrations` slice containing only `pollable` registrations. Implement recursion over that slice, with the native wait only at the innermost callback:
 
 ```go
-func withNetworkDescriptors(registrations []*networkRegistration, pollfds []networkPollFD, index int, wait func([]networkPollFD) (networkPollBatch, error)) (batch networkPollBatch, err error) {
-	if index == len(registrations) { return wait(pollfds) }
+func withNetworkDescriptors(registrations []*networkRegistration, pollfds []networkPollFD, index int, wait func([]networkPollFD) (networkPollBatch, error)) (batch networkPollBatch, failure *networkAcquisitionError, err error) {
+	if index == len(registrations) {
+		batch, err = wait(pollfds)
+		return batch, nil, err
+	}
 	registration := registrations[index]
+	callbackEntered := false
 	controlErr := registration.raw.Control(func(fd uintptr) {
-		pollfds[index] = networkPollFD{descriptor: fd, interests: registration.interests, listener: registration.listener != nil}
-		batch, err = withNetworkDescriptors(registrations, pollfds, index+1, wait)
+		callbackEntered = true
+		pollfds[index] = networkPollFD{descriptor: fd, interests: registration.nativeInterests, listener: registration.listener != nil}
+		batch, failure, err = withNetworkDescriptors(registrations, pollfds, index+1, wait)
 	})
-	if err == nil && controlErr != nil { err = controlErr }
-	return batch, err
+	if failure != nil || err != nil { return batch, failure, err }
+	if controlErr != nil {
+		return batch, &networkAcquisitionError{
+			registration: registration,
+			stage: networkAcquireControl,
+			callbackEntered: callbackEntered,
+			err: controlErr,
+		}, nil
+	}
+	return batch, nil, nil
 }
 ```
 
-Do not execute another native wait after any local-close wake or acquisition failure. Always unregister from every resource, then call synchronized `wake.Close`, before returning.
+Never replace a deeper failure with an outer `Control` error. On `networkAcquisitionError`, revalidate only `failure.registration`: suppress it as local close only if that exact registry identity/attachment is detached or closed; otherwise return the wrapped error synchronously even if some unrelated registration changed concurrently.
+
+Do not execute another native wait after any local-close wake or acquisition failure. Always unregister from every resource, then call synchronized `wake.Close`, before returning. Join backend/acquisition/cleanup errors and return no `SelectResult` whenever any non-local operation or wake-close error remains.
 
 - [ ] **Step 5: Implement remaining-time calculation**
 
@@ -524,20 +578,20 @@ Use one deadline from `poller.now()` and this conversion:
 ```go
 func networkPollMilliseconds(remaining time.Duration) int32 {
 	if remaining <= 0 { return 0 }
+	if remaining > time.Second { remaining = time.Second }
 	milliseconds := remaining / time.Millisecond
 	if remaining%time.Millisecond != 0 { milliseconds++ }
-	if milliseconds > time.Duration(math.MaxInt32) { return math.MaxInt32 }
 	return int32(milliseconds)
 }
 ```
 
-Using quotient and remainder avoids overflowing `time.Duration` while rounding a near-maximum positive duration upward.
+Using quotient and remainder avoids overflowing `time.Duration` while rounding a near-maximum positive duration upward. The one-second safety chunk is below the signed 32-bit platform limit and guarantees that a failed wake signal releases nested `RawConn.Control` references within a bounded interval; it does not restart or extend the absolute operation deadline.
 
-For timeout zero with valid registrations, invoke the backend exactly once. For positive timeout, repeat only for an interrupted result, a completed `MaxInt32` chunk, or a non-local spurious wake while `poller.now().Before(deadline)`. Empty inputs call the injected sleeper only for a positive duration.
+For timeout zero with pollable registrations, invoke the backend exactly once. For positive timeout, repeat only for an interrupted result, a completed safety chunk, or a non-local spurious wake while `poller.now().Before(deadline)`. Empty inputs with no registered resources call the injected sleeper only for a positive duration. A write-only listener is not an empty input: wait on the operation wake descriptor so local close remains observable, but never pass the listener descriptor to the backend.
 
 - [ ] **Step 6: Revalidate and reconstruct public outputs**
 
-Under the relevant `stateMu`, require registry identity, `!closed`, and the exact captured attachment. Drop a locally closed registration. Apply listener filtering (`write` always removed; terminal/error keeps read and error) and scan each occurrence list in input order to call `selectResult`.
+Under the relevant `stateMu`, require registry identity, `!closed`, and the exact captured attachment. Drop a locally closed registration. As a defensive invariant, remove listener write again during reconstruction; terminal/error keeps listener read and error. Scan each occurrence list in input order to call `selectResult`.
 
 - [ ] **Step 7: Run GREEN, stress, and race checks**
 
@@ -601,7 +655,9 @@ Add a table for `POLLRDNORM`, `POLLWRNORM`, `POLLHUP`, `POLLERR`, and `POLLNVAL`
 
 - [ ] **Step 2: Write failing wake lifecycle integration tests**
 
-Create the real platform wake, assert its descriptor is accepted by a zero-time `WSAPoll`, signal it twice through the common `networkWake`, and require the wait to return `woke=true`. Race `Signal` and `Close` 100 times and require no Winsock call after handle close, panic, or leaked handle.
+Create the real platform wake, assert its descriptor is accepted by a zero-time `WSAPoll`, signal it twice through the common `networkWake`, and require the wait to return `woke=true`. Race `Signal` and `Close` 100 times and require no Winsock call after handle close or panic.
+
+Put socket creation and close behind a `windowsNetworkOps` value owned by the backend. In a deterministic fake, count every successfully created handle and every close, inject failure after each setup stage, and require exact balance. Keep the real race test for behavior, but do not use process-wide handle counts as a leak oracle.
 
 Add an injectable `callWSAPoll`/`callWSAGetLastError` pair and require a scripted `SOCKET_ERROR` to return the exact WSA error rather than the `LazyProc.Call` last-error value.
 
@@ -657,7 +713,20 @@ Wrap both procedure calls in package variables for deterministic error-path test
 
 - [ ] **Step 4: Implement operation-local non-blocking UDP wake sockets**
 
-Create a reader with `windows.Socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`, bind to `127.0.0.1:0`, obtain its `*windows.SockaddrInet4` through `windows.Getsockname`, and create a writer socket. Convert both handles to `syscall.Handle` and call `syscall.SetNonblock(handle, true)`. On any setup failure, close every handle already created with `windows.Closesocket` and return `errors.Join`.
+Define the exact injectable operation boundary:
+
+```go
+type windowsNetworkOps struct {
+	socket func(int, int, int) (windows.Handle, error)
+	bind func(windows.Handle, windows.Sockaddr) error
+	getsockname func(windows.Handle) (windows.Sockaddr, error)
+	setNonblock func(windows.Handle, bool) error
+	sendto func(windows.Handle, []byte, int, windows.Sockaddr) error
+	closeSocket func(windows.Handle) error
+}
+```
+
+The production `setNonblock` wrapper converts `windows.Handle` to `syscall.Handle` and calls `syscall.SetNonblock`. Create a reader with `windows.Socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`, bind to `127.0.0.1:0`, obtain its `*windows.SockaddrInet4` through `windows.Getsockname`, and create a writer socket. Set both handles non-blocking. On any setup failure, close every handle already created through the injected operation and return `errors.Join`.
 
 Implement the platform wake:
 
@@ -666,16 +735,17 @@ type windowsNetworkWake struct {
 	reader windows.Handle
 	writer windows.Handle
 	address *windows.SockaddrInet4
+	ops windowsNetworkOps
 }
 
 func (wake *windowsNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
 func (wake *windowsNetworkWake) signal() error {
-	err := windows.Sendto(wake.writer, []byte{1}, 0, wake.address)
+	err := wake.ops.sendto(wake.writer, []byte{1}, 0, wake.address)
 	if errors.Is(err, windows.WSAEWOULDBLOCK) { return nil }
 	return err
 }
 func (wake *windowsNetworkWake) close() error {
-	return errors.Join(windows.Closesocket(wake.writer), windows.Closesocket(wake.reader))
+	return errors.Join(wake.ops.closeSocket(wake.writer), wake.ops.closeSocket(wake.reader))
 }
 ```
 
@@ -683,16 +753,18 @@ The common `networkWake` guarantees at most one successful signal and serializes
 
 - [ ] **Step 5: Implement one `WSAPoll` call and normalize events**
 
-Prepend the wake reader with `pollRDNORM`, convert every common descriptor without narrowing, request only `pollRDNORM` and/or `pollWRNORM`, and allow zero requested flags for error-only interests. After the call:
+Prepend the wake reader with `pollRDNORM`, convert every common descriptor without narrowing, request only `pollRDNORM` and/or `pollWRNORM`, and allow zero requested flags for error-only interests. The common layer has already excluded listener write-only registrations; assert that such a listener never reaches this function with `pollWRNORM`. After the call:
 
 - wake `pollRDNORM|pollHUP|pollERR|pollNVAL` sets `batch.woke=true`;
 - `pollRDNORM` maps to read;
 - `pollWRNORM` maps to write;
 - `pollHUP|pollERR|pollNVAL` maps to read, write, and error;
-- listener write filtering remains common-layer responsibility;
+- listener write filtering remains a defensive common-layer invariant before and after the backend;
 - result event order remains aligned with the input descriptors after removing the prepended wake entry.
 
 Return `systemNetworkPlatform()` with `interrupted=false` for every Windows result; do not invent a `WSAEINTR` retry.
+
+Add a Windows loopback reset test: obtain the peer `*net.TCPConn`, call `SetLinger(0)`, close it to generate RST, and poll the other socket in read/write/error with a one-second global timeout. Require prompt readiness including `error_count == 1`, then call `net_recv` and require a non-timeout connection error. This proves `WSAPoll` observation did not consume or clear the pending error.
 
 - [ ] **Step 6: Promote `x/sys` and run Windows GREEN/race tests**
 
@@ -720,6 +792,7 @@ git commit -m "feat(net): add Windows WSAPoll backend"
 **Files:**
 - Create: `internal/vm/network_poller_unix.go`
 - Create: `internal/vm/network_poller_unix_test.go`
+- Create: `internal/vm/network_poller_linux_test.go`
 - Create: `internal/vm/network_poller_rdhup.go`
 - Create: `internal/vm/network_poller_no_rdhup.go`
 - Create: `internal/vm/network_poller_unsupported.go`
@@ -737,9 +810,9 @@ Create tests under the exact supported tag:
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 ```
 
-Test literal normalization for `POLLIN`, `POLLOUT`, `POLLHUP`, `POLLERR`, and `POLLNVAL`; verify that requested interests never include `POLLPRI`. On Linux/FreeBSD, a separate tagged test requires `POLLRDHUP` to normalize as read, write, and error. On other Unix targets, require the extension mask to be zero.
+Test literal normalization for `POLLIN`, `POLLOUT`, `POLLHUP`, `POLLERR`, and `POLLNVAL`; verify that requested interests never include `POLLPRI`. On Linux/FreeBSD, a separate tagged test requires `POLLRDHUP` both in the requested native mask for every pollable socket—including error-only—and normalized as read, write, and error. It must not be requested for listeners. On other Unix targets, require the extension mask to be zero.
 
-Use the real socketpair wake to prove a zero-time wait is empty before signal and `woke=true` after signal. Race common `Signal`/`Close` and assert idempotent cleanup.
+Use the real socketpair wake to prove a zero-time wait is empty before signal and `woke=true` after signal. Race common `Signal`/`Close` and assert idempotent cleanup. Put `Socketpair`, `Write`, and `Close` behind a `unixNetworkOps` value owned by the backend; inject failure at every setup stage and require the number of successfully created descriptors to equal the number closed, rather than using a noisy process-wide FD count.
 
 Run RED on Linux CI or an available Linux environment:
 
@@ -751,18 +824,31 @@ Expected: build failure because the Unix backend does not exist.
 
 - [ ] **Step 2: Implement the non-blocking Unix socketpair wake**
 
-In `network_poller_unix.go`, create `unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)`, call `unix.SetNonblock` on both descriptors, and close both on partial failure. Implement:
+In `network_poller_unix.go`, define injected operations and create `unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)`, call `unix.SetNonblock` on both descriptors, and close both on partial failure:
 
 ```go
-type unixNetworkWake struct { reader, writer int }
+type unixNetworkOps struct {
+	socketpair func(int, int, int) ([2]int, error)
+	setNonblock func(int, bool) error
+	write func(int, []byte) (int, error)
+	close func(int) error
+}
+
+type unixNetworkWake struct {
+	reader, writer int
+	ops unixNetworkOps
+}
 func (wake *unixNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
 func (wake *unixNetworkWake) signal() error {
-	_, err := unix.Write(wake.writer, []byte{1})
-	if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) { return nil }
-	return err
+	for {
+		_, err := wake.ops.write(wake.writer, []byte{1})
+		if errors.Is(err, unix.EINTR) { continue }
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) { return nil }
+		return err
+	}
 }
 func (wake *unixNetworkWake) close() error {
-	return errors.Join(unix.Close(wake.writer), unix.Close(wake.reader))
+	return errors.Join(wake.ops.close(wake.writer), wake.ops.close(wake.reader))
 }
 ```
 
@@ -770,7 +856,7 @@ The common lifecycle ensures the same numeric descriptor is never signaled after
 
 - [ ] **Step 3: Implement `unix.Poll` with exact descriptor checks**
 
-Reject a raw descriptor that cannot round-trip through `int32` before building `unix.PollFd`. Prepend the wake reader with `POLLIN`. Map interests to `POLLIN` and `POLLOUT`; error-only registrations use zero requested events because `POLLERR`, `POLLHUP`, and `POLLNVAL` are returned independently.
+Reject a raw descriptor that cannot round-trip through `int32` before building `unix.PollFd`. Prepend the wake reader with `POLLIN`. Map interests to `POLLIN` and `POLLOUT`; error-only registrations use zero normal requested events because `POLLERR`, `POLLHUP`, and `POLLNVAL` are returned independently. For every non-listener pollable socket, OR `networkPollReadHangup` into `PollFd.Events`, including error-only sockets; `POLLRDHUP` is not one of the unconditional result flags and must be explicitly requested on Linux/FreeBSD.
 
 On `errors.Is(err, unix.EINTR)`, return `networkPollBatch{interrupted:true}` with no error. Normalize:
 
@@ -805,6 +891,8 @@ const networkPollReadHangup int16 = 0
 
 Do not reference `POLLRDHUP` from the common Unix file, because it is not defined uniformly.
 
+In `network_poller_linux_test.go`, add two real TCP tests. First, call `CloseWrite` on one peer and require the other endpoint's raw poll result to include `POLLRDHUP`, with public read/error outputs populated when requested. Second, call `SetLinger(0)` and close a peer to generate RST; require public read/write/error readiness within one second, followed by `net_recv` returning a non-timeout connection error. The receive assertion proves poll did not clear the pending socket error.
+
 - [ ] **Step 5: Add the unsupported backend**
 
 Use the complement build tag:
@@ -820,8 +908,8 @@ Return a platform whose wake factory and wait both return `fmt.Errorf("network p
 On Linux:
 
 ```bash
-go test ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup' -count=20
-go test -race ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup' -count=1
+go test ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup|TestLinuxNetworkPoll' -count=20
+go test -race ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup|TestLinuxNetworkPoll' -count=1
 ```
 
 From PowerShell or CI, compile production code for the full matrix:
@@ -833,12 +921,21 @@ $targets = @(
   @{OS='netbsd'; Arch='amd64'}, @{OS='openbsd'; Arch='amd64'},
   @{OS='solaris'; Arch='amd64'}, @{OS='aix'; Arch='ppc64'}
 )
-foreach ($target in $targets) {
-  $env:GOOS=$target.OS; $env:GOARCH=$target.Arch; go build ./...
-  if ($LASTEXITCODE -ne 0) { throw "cross-build failed for $($target.OS)/$($target.Arch)" }
+$crossBuildFailure = $null
+try {
+  foreach ($target in $targets) {
+    $env:GOOS=$target.OS; $env:GOARCH=$target.Arch; go build ./...
+    if ($LASTEXITCODE -ne 0) { throw "cross-build failed for $($target.OS)/$($target.Arch)" }
+  }
+} catch {
+  $crossBuildFailure = $_
+} finally {
+  Remove-Item Env:GOOS -ErrorAction SilentlyContinue
+  Remove-Item Env:GOARCH -ErrorAction SilentlyContinue
+  go build ./...
+  if ($LASTEXITCODE -ne 0) { throw "native build failed after cross-build matrix" }
 }
-Remove-Item Env:GOOS -ErrorAction SilentlyContinue
-Remove-Item Env:GOARCH -ErrorAction SilentlyContinue
+if ($null -ne $crossBuildFailure) { throw $crossBuildFailure }
 ```
 
 Expected: all builds succeed. Runtime claims remain limited to Windows/Linux.
@@ -846,7 +943,7 @@ Expected: all builds succeed. Runtime claims remain limited to Windows/Linux.
 - [ ] **Step 7: Commit the Unix and fallback backends**
 
 ```powershell
-git add internal/vm/network_poller_unix.go internal/vm/network_poller_unix_test.go internal/vm/network_poller_rdhup.go internal/vm/network_poller_no_rdhup.go internal/vm/network_poller_unsupported.go
+git add internal/vm/network_poller_unix.go internal/vm/network_poller_unix_test.go internal/vm/network_poller_linux_test.go internal/vm/network_poller_rdhup.go internal/vm/network_poller_no_rdhup.go internal/vm/network_poller_unsupported.go
 git commit -m "feat(net): add Unix poll backend"
 ```
 
@@ -881,7 +978,8 @@ In `builtins_net_deadlines_test.go`:
 
 - snapshot a controlled socket's last read/write deadlines, call `net_select`, and require no setter invocation and no deadline change;
 - start a positive-timeout poll on one socket and one listener, close each from another goroutine, and require prompt completion without reporting the locally closed handle;
-- force both existing rollback-poison paths and require an already blocked poll to wake before the controlled connection/listener `Close` returns;
+- force each of the three existing rollback-poison paths—initial socket read application/rollback failure, socket write application/rollback failure, and listener application/rollback failure—and require an already blocked poll to wake before the controlled connection/listener `Close` returns;
+- inject a permanent wake signal failure while a poll holds nested `RawConn.Control` references; require the close path to finish within two safety chunks, proving the one-second native chunk cap provides bounded fallback progress;
 - replace `TestReceiveSocketFullyBufferedSkipsDeadlineSetter` with `TestReceiveSocketZeroSizeSkipsDeadlineSetter`.
 
 Run RED:
@@ -1023,6 +1121,8 @@ Add named tests with explicit assertions:
 - ordinary readable data alone never populates the error set.
 
 Do not make a cross-platform integration assertion that graceful EOF must appear in the error set: that depends on an explicit `HUP`/`RDHUP` indication, while EOF-as-readable is the portable guarantee.
+
+The Windows test from Task 4 and Linux test from Task 5 provide deterministic pending-error coverage with TCP RST. Both must require the socket in the public error output and then observe the still-pending connection error through `net_recv`; this is not satisfied by merely injecting a fake `POLLERR` mask. Other compile-supported Unix targets keep the portable EOF assertions until they have runtime runners.
 
 - [ ] **Step 4: Exercise concurrent close and concurrent polls**
 

--- a/docs/superpowers/plans/2026-08-14-network-poller.md
+++ b/docs/superpowers/plans/2026-08-14-network-poller.md
@@ -1,0 +1,1180 @@
+# Portable Network Poller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Noxy's sequential consuming `net_select` probes with a portable, non-consuming, globally timed read/write/error multiplexer on Windows and supported Unix systems.
+
+**Architecture:** A common poller resolves and deduplicates Noxy resources, owns timeout/revalidation/result semantics, and retains every descriptor inside nested `syscall.RawConn.Control` callbacks. Build-tagged Windows and Unix backends provide the native wait and an operation-local wake handle; resource close uses a two-phase detach that signals every registered poll before closing the OS handle.
+
+**Tech Stack:** Go 1.24 language level, Go toolchain 1.24.11+, `net`, `syscall.RawConn`, `golang.org/x/sys/unix`, `golang.org/x/sys/windows`, Winsock `WSAPoll`, Go tests/race detector, Noxy integration examples.
+
+## Global Constraints
+
+- Preserve `net.poll(read: Socket[64], write: Socket[64], err: Socket[64], timeout: int) -> SelectResult` and its six result fields.
+- `timeout < 0` is an error, `timeout == 0` is immediate, and positive timeout bounds the complete call.
+- Polling must never read, peek, accept, call `SO_ERROR`, or change a persistent deadline.
+- Consider only the first 64 elements of each input and make every count equal the number of copied output values.
+- Preserve order and duplicate occurrences independently in read, write, and error outputs.
+- Keep `net.setblocking(sock, false)` as a deprecated no-op.
+- Keep `deadlineGeneration` exclusive to deadline transitions; do not add `lifetimeGeneration`.
+- Preserve the lock order `deadlineMu -> stateMu`; signal poll waiters and close OS resources outside both locks.
+- Treat Windows and Linux as runtime-verified. Treat AIX, Darwin, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, and Solaris as compile-supported until their integration tests run on those systems.
+- Use strict red-green-refactor for each behavior and leave unrelated worktree changes untouched.
+
+---
+
+## Planned File Structure
+
+### New files
+
+- `internal/vm/network_poller.go` — public argument contract, common event model, wake lifecycle, candidate aggregation, nested descriptor retention, timeout loop, revalidation, and result construction.
+- `internal/vm/network_poller_test.go` — platform-independent contract, ordering, timeout, descriptor-lifetime, close-classification, and fake-backend tests.
+- `internal/vm/network_poller_windows.go` — Winsock wake sockets, `WSAPoll` ABI, and Windows event normalization.
+- `internal/vm/network_poller_windows_test.go` — Windows ABI, wake, immediate, listener, and error-path tests.
+- `internal/vm/network_poller_unix.go` — Unix socketpair wake and `unix.Poll` backend.
+- `internal/vm/network_poller_unix_test.go` — Unix wake, immediate, descriptor, and event tests.
+- `internal/vm/network_poller_rdhup.go` — Linux/FreeBSD `POLLRDHUP` terminal mask.
+- `internal/vm/network_poller_no_rdhup.go` — zero terminal-extension mask for other compile-supported Unix targets.
+- `internal/vm/network_poller_unsupported.go` — stable unsupported-platform backend.
+- `internal/vm/network_poller_integration_test.go` — real TCP non-consumption, read/write/EOF, global timeout, deadline independence, and concurrent-close tests.
+- `noxy_examples/network_poller.nx` — public Noxy poll lifecycle demonstration.
+
+### Modified files
+
+- `internal/vm/resources.go` — resource waiter sets and two-phase detach payloads.
+- `internal/vm/builtins_net.go` — centralized detach, simplified receive/accept/deadlines, removal of consuming probes, and new builtin dispatch.
+- `internal/vm/builtins_net_test.go` — replace shared-buffer assertions with non-consuming readiness assertions.
+- `internal/vm/builtins_net_deadlines_test.go` — remove obsolete probe/deadline-restoration cases and retain persistent-I/O guarantees.
+- `internal/vm/architecture_test.go` — forbid reintroduction of consuming poll buffers/probe helpers.
+- `go.mod`, `go.sum` — promote `golang.org/x/sys` to a direct dependency.
+- `.github/workflows/network-deadlines.yml` — Windows/Linux runtime matrix and Unix cross-build matrix.
+- `docs/NOXY_LANGUAGE_SPEC.md`, `CHANGELOG.md` — final public semantics and compatibility notes.
+
+---
+
+### Task 1: Establish the pure public contract and fixed result shape
+
+**Files:**
+- Create: `internal/vm/network_poller.go`
+- Create: `internal/vm/network_poller_test.go`
+- Modify: `internal/vm/builtins_net.go:362-381,947-994`
+
+**Interfaces:**
+- Produces: `networkInterest`, `networkEvent`, `validateNetworkPollArguments`, `boundedNetworkCandidates`, and `selectResult(read, write, errors []value.Value)`.
+- Preserves: the existing `SelectResult` map fields and 64-element arrays.
+
+- [ ] **Step 1: Write failing validation and result tests**
+
+Add table-driven tests with literal expectations:
+
+```go
+func TestValidateNetworkPollArguments(t *testing.T) {
+	empty := value.NewArray(nil)
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	tests := []struct {
+		name string
+		args []value.Value
+		want time.Duration
+		wantError string
+	}{
+		{"zero", []value.Value{empty, empty, empty, value.NewInt(0)}, 0, ""},
+		{"positive", []value.Value{empty, empty, empty, value.NewInt(25)}, 25 * time.Millisecond, ""},
+		{"negative", []value.Value{empty, empty, empty, value.NewInt(-1)}, 0, "network poll timeout must be non-negative"},
+		{"overflow", []value.Value{empty, empty, empty, value.NewInt(maximum + 1)}, 0, "network poll timeout is too large"},
+		{"wrong arity", []value.Value{empty}, 0, "net_select expects exactly 4 arguments"},
+		{"wrong set", []value.Value{value.NewNull(), empty, empty, value.NewInt(0)}, 0, "net_select read, write, and error arguments must be arrays"},
+		{"wrong timeout", []value.Value{empty, empty, empty, value.NewString("0")}, 0, "network poll timeout must be an int"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, got, err := validateNetworkPollArguments(test.args)
+			if test.wantError != "" {
+				if err == nil || err.Error() != test.wantError { t.Fatalf("error=%v want=%q", err, test.wantError) }
+				return
+			}
+			if err != nil || got != test.want { t.Fatalf("timeout=%v error=%v want=%v", got, err, test.want) }
+		})
+	}
+}
+
+func TestSelectResultPadsTruncatesAndCountsCopiedValues(t *testing.T) {
+	values := make([]value.Value, 65)
+	for i := range values { values[i] = socketValue(i+1, "test", 0, true) }
+	result := selectResult(values, values[:2], values[:1])
+	mapping := requireBuiltinMap(t, result)
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "read_count"), value.NewInt(64))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "write_count"), value.NewInt(2))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "error_count"), value.NewInt(1))
+	read := requireTestMapValue(t, mapping, "read").Obj.(*value.ObjArray)
+	if len(read.Elements) != 64 { t.Fatalf("read length=%d", len(read.Elements)) }
+}
+```
+
+- [ ] **Step 2: Run RED and confirm the missing contract**
+
+Run:
+
+```powershell
+go test ./internal/vm -run 'TestValidateNetworkPollArguments|TestSelectResultPadsTruncates' -count=1
+```
+
+Expected: build failure because the new helper/signature does not exist.
+
+- [ ] **Step 3: Add the common event types and exact argument validation**
+
+Create the beginning of `network_poller.go`:
+
+```go
+package vm
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"noxy-vm/internal/value"
+)
+
+const networkSetCapacity = 64
+
+type networkInterest uint8
+const (
+	networkReadable networkInterest = 1 << iota
+	networkWritable
+	networkErrorInterest
+)
+
+type networkEvent uint8
+const (
+	networkReadReady networkEvent = 1 << iota
+	networkWriteReady
+	networkErrorReady
+)
+
+func validateNetworkPollArguments(args []value.Value) ([3]*value.ObjArray, time.Duration, error) {
+	var sets [3]*value.ObjArray
+	if len(args) != 4 {
+		return sets, 0, fmt.Errorf("net_select expects exactly 4 arguments")
+	}
+	for index := 0; index < 3; index++ {
+		array, ok := args[index].Obj.(*value.ObjArray)
+		if args[index].Type != value.VAL_OBJ || !ok || array == nil {
+			return sets, 0, fmt.Errorf("net_select read, write, and error arguments must be arrays")
+		}
+		sets[index] = array
+	}
+	if args[3].Type != value.VAL_INT {
+		return sets, 0, fmt.Errorf("network poll timeout must be an int")
+	}
+	milliseconds := args[3].AsInt
+	if milliseconds < 0 {
+		return sets, 0, fmt.Errorf("network poll timeout must be non-negative")
+	}
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	if milliseconds > maximum {
+		return sets, 0, fmt.Errorf("network poll timeout is too large")
+	}
+	return sets, time.Duration(milliseconds) * time.Millisecond, nil
+}
+
+func boundedNetworkCandidates(array *value.ObjArray) []value.Value {
+	if len(array.Elements) <= networkSetCapacity { return array.Elements }
+	return array.Elements[:networkSetCapacity]
+}
+```
+
+- [ ] **Step 4: Generalize `selectResult` without changing its shape**
+
+Move it into `network_poller.go` and implement a literal 64-slot builder:
+
+```go
+func fixedNetworkSet(ready []value.Value) value.Value {
+	elements := make([]value.Value, networkSetCapacity)
+	for i := range elements { elements[i] = value.NewNull() }
+	copy(elements, ready[:min(len(ready), networkSetCapacity)])
+	return value.NewArray(elements)
+}
+
+func selectResult(read, write, errors []value.Value) value.Value {
+	read = read[:min(len(read), networkSetCapacity)]
+	write = write[:min(len(write), networkSetCapacity)]
+	errors = errors[:min(len(errors), networkSetCapacity)]
+	return value.NewMapWithData(map[string]value.Value{
+		"read": fixedNetworkSet(read), "read_count": value.NewInt(int64(len(read))),
+		"write": fixedNetworkSet(write), "write_count": value.NewInt(int64(len(write))),
+		"error": fixedNetworkSet(errors), "error_count": value.NewInt(int64(len(errors))),
+	})
+}
+```
+
+Temporarily change the old builtin return to `selectResult(readyRead, nil, nil)` so the package remains green until Task 6 replaces its body.
+
+- [ ] **Step 5: Run GREEN and the existing network tests**
+
+```powershell
+go test ./internal/vm -run 'TestValidateNetworkPollArguments|TestSelectResultPadsTruncates|TestNetworkBuiltinsLoopbackLifecycle' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the pure contract**
+
+```powershell
+git add internal/vm/network_poller.go internal/vm/network_poller_test.go internal/vm/builtins_net.go
+git commit -m "feat(net): define network poll contract"
+```
+
+---
+
+### Task 2: Add synchronized wake lifecycle and two-phase resource detach
+
+**Files:**
+- Modify: `internal/vm/network_poller.go`
+- Modify: `internal/vm/network_poller_test.go`
+- Modify: `internal/vm/resources.go:96-126`
+- Modify: `internal/vm/builtins_net.go:78-241,723-760`
+- Modify: `internal/vm/builtins_net_deadlines_test.go`
+
+**Interfaces:**
+- Produces: `platformNetworkWake`, `networkWake`, `detachSocketLocked`, `detachListenerLocked`, `finishSocketDetach`, and `finishListenerDetach`.
+- Preserves: idempotent `closeSocket`/`closeListener`, deadline lock order, and joined rollback/close errors.
+
+- [ ] **Step 1: Write failing wake serialization tests**
+
+Use a real fake whose methods detect calls after close rather than asserting on a mock invocation:
+
+```go
+type fakePlatformWake struct {
+	mu sync.Mutex
+	signals int
+	closes int
+	closed bool
+	afterClose bool
+}
+func (*fakePlatformWake) descriptor() uintptr { return 99 }
+func (wake *fakePlatformWake) signal() error {
+	wake.mu.Lock(); defer wake.mu.Unlock()
+	if wake.closed { wake.afterClose = true }
+	wake.signals++
+	return nil
+}
+func (wake *fakePlatformWake) close() error {
+	wake.mu.Lock(); defer wake.mu.Unlock()
+	wake.closed = true
+	wake.closes++
+	return nil
+}
+
+func TestNetworkWakeSerializesSignalAndClose(t *testing.T) {
+	raw := &fakePlatformWake{}
+	wake := newNetworkWake(raw)
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		workers.Add(1)
+		go func() { defer workers.Done(); <-start; _ = wake.Signal() }()
+	}
+	workers.Add(1)
+	go func() { defer workers.Done(); <-start; _ = wake.Close() }()
+	close(start)
+	workers.Wait()
+	_ = wake.Signal()
+	raw.mu.Lock(); defer raw.mu.Unlock()
+	if raw.afterClose { t.Fatal("platform signal ran after platform close") }
+	if raw.signals > 1 || raw.closes != 1 { t.Fatalf("signals=%d closes=%d", raw.signals, raw.closes) }
+}
+```
+
+- [ ] **Step 2: Write failing resource broadcast/detach tests**
+
+Register two distinct wake objects in one `SocketResource`, call `closeSocket`, and require both to be signaled, the connection to be closed, the waiter map cleared, and a second close to do nothing. Repeat for `ListenerResource`. Add a rollback-failure test that reaches the existing fail-closed branch and requires the registered wake to be signaled before the controlled connection's `Close` method begins.
+
+Run RED:
+
+```powershell
+go test ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|TestSocketRollbackFailurePoisons' -count=1
+```
+
+Expected: build failure because wake and detach APIs do not exist.
+
+- [ ] **Step 3: Implement the common wake state machine**
+
+Add to `network_poller.go`:
+
+```go
+type platformNetworkWake interface {
+	descriptor() uintptr
+	signal() error
+	close() error
+}
+
+type networkWakeState uint8
+const (
+	networkWakeOpen networkWakeState = iota
+	networkWakeSignaled
+	networkWakeClosed
+)
+
+type networkWake struct {
+	mu sync.Mutex
+	state networkWakeState
+	platform platformNetworkWake
+}
+
+func newNetworkWake(platform platformNetworkWake) *networkWake {
+	return &networkWake{platform: platform}
+}
+
+func (wake *networkWake) Signal() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	if wake.state != networkWakeOpen { return nil }
+	if err := wake.platform.signal(); err != nil { return err }
+	wake.state = networkWakeSignaled
+	return nil
+}
+
+func (wake *networkWake) Close() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	if wake.state == networkWakeClosed { return nil }
+	wake.state = networkWakeClosed
+	return wake.platform.close()
+}
+```
+
+`descriptor()` is read only while the operation owns the wake and before `Close`; expose it through a small locked helper if the race detector reports an access conflict.
+
+- [ ] **Step 4: Add waiter ownership and locked detach payloads**
+
+Extend both network resources with `pollWaiters map[*networkWake]struct{}`. Add payloads in `resources.go`:
+
+```go
+type detachedSocket struct { connection net.Conn; waiters []*networkWake }
+type detachedListener struct { listener deadlineListener; buffered net.Conn; waiters []*networkWake }
+
+func takeNetworkWaiters(waiters map[*networkWake]struct{}) []*networkWake {
+	result := make([]*networkWake, 0, len(waiters))
+	for waiter := range waiters { result = append(result, waiter) }
+	return result
+}
+```
+
+Implement `detachSocketLocked` and `detachListenerLocked` with the exact rule: caller already holds `stateMu`; set `closed`, increment `deadlineGeneration`, detach handles/buffers, snapshot and nil the waiter map, and return `(payload, true)`. Return `(_, false)` when already closed.
+
+Implement finish functions that call every `Signal`, then close detached resources, and return `errors.Join` of signal/close failures. They never acquire `stateMu` or `deadlineMu`.
+
+- [ ] **Step 5: Route normal close and every poison branch through detach**
+
+Replace direct `closed = true` transitions in both rollback-failure branches and in `closeSocket`/`closeListener`. For a poison path already holding `deadlineMu` and `stateMu`:
+
+```go
+detached, _ := detachSocketLocked(resource)
+resource.stateMu.Unlock()
+resource.deadlineMu.Unlock()
+detachErr := finishSocketDetach(detached)
+return errors.Join(applicationErr, rollbackErr, detachErr)
+```
+
+Use the listener equivalent and preserve buffered accepted-connection cleanup until Task 6 removes that field. Normal close ignores the returned finish error, matching current public behavior.
+
+- [ ] **Step 6: Run focused GREEN and race tests**
+
+```powershell
+go test ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|Test(Socket|Listener)Rollback|TestCloseDoes' -count=20
+go test -race ./internal/vm -run 'TestNetworkWake|Test(Socket|Listener)DetachWakes|TestCloseDoes' -count=1
+```
+
+Expected: PASS with no post-close platform call, double close, deadlock, or race.
+
+- [ ] **Step 7: Commit lifecycle ownership**
+
+```powershell
+git add internal/vm/network_poller.go internal/vm/network_poller_test.go internal/vm/resources.go internal/vm/builtins_net.go internal/vm/builtins_net_deadlines_test.go
+git commit -m "refactor(net): centralize poll-aware resource close"
+```
+
+---
+
+### Task 3: Implement candidate aggregation, stable descriptors, and global timing
+
+**Files:**
+- Modify: `internal/vm/network_poller.go`
+- Modify: `internal/vm/network_poller_test.go`
+
+**Interfaces:**
+- Consumes: `networkWake`, shared listener/socket registries, and `networkSocketDescriptor`.
+- Produces: `networkPlatform`, `networkPoller`, `networkRegistration`, `networkPollFD`, `networkPollBatch`, and `(*networkPoller).Poll`.
+
+- [ ] **Step 1: Write failing fake-backend contract tests**
+
+Define a fake platform that records one descriptor array and scripted wait outcomes. Cover these separate behaviors:
+
+- read/write/error occurrences preserve order and duplicates while one resource is registered once;
+- only the first 64 input values participate;
+- a listener's normal write event is suppressed;
+- listener terminal event populates requested read and error;
+- generic read does not populate error;
+- terminal/error/invalid events can populate all requested socket sets;
+- backend failure returns an error instead of a partial result;
+- no valid candidates call the injected sleeper for positive timeout and return immediately for zero;
+- timeout zero calls `wait` once with zero;
+- positive timeouts use one absolute deadline, ceil a sub-millisecond remainder, and clamp chunks to `math.MaxInt32`;
+- scripted Unix-style interruption retries only a positive timeout;
+- a signaled local-close wake returns promptly with the closed resource omitted.
+
+The fake returns events indexed to registrations, not candidates:
+
+```go
+type networkPollBatch struct {
+	events []networkEvent
+	woke bool
+	interrupted bool
+}
+
+type fakeNetworkPlatform struct {
+	wake platformNetworkWake
+	waits []networkPollBatch
+	timeouts []int32
+	descriptors [][]networkPollFD
+	err error
+}
+```
+
+- [ ] **Step 2: Write a failing nested-`Control` lifetime test**
+
+Wrap two real loopback TCP connections with a `syscall.Conn` wrapper whose `RawConn.Control` increments an atomic active count only for the callback duration. In the fake platform's `wait`, require `active == 2`. This test must fail if descriptor numbers are copied before entering all callbacks.
+
+Also script close at `SyscallConn` acquisition and at each nested `Control` boundary. Revalidation must classify a detached resource as local close; the same error on an unchanged open resource must be returned synchronously.
+
+Run RED:
+
+```powershell
+go test ./internal/vm -run 'TestNetworkPoller|TestNetworkDescriptorsRemainControlled|TestNetworkControlCloseClassification' -count=1
+```
+
+- [ ] **Step 3: Define the backend boundary and registration model**
+
+Add these exact common types:
+
+```go
+type networkPollFD struct {
+	descriptor uintptr
+	interests networkInterest
+	listener bool
+}
+
+type networkPollBatch struct {
+	events []networkEvent
+	woke bool
+	interrupted bool
+}
+
+type networkPlatform struct {
+	newWake func() (platformNetworkWake, error)
+	wait func([]networkPollFD, uintptr, int32) (networkPollBatch, error)
+}
+
+type networkPoller struct {
+	platform networkPlatform
+	now func() time.Time
+	sleep func(time.Duration)
+}
+
+type networkRegistration struct {
+	handle int
+	interests networkInterest
+	listener *ListenerResource
+	socket *SocketResource
+	attached any
+	raw syscall.RawConn
+}
+
+type networkOccurrence struct {
+	candidate value.Value
+	registration *networkRegistration
+}
+```
+
+Use three occurrence slices plus an ordered unique-registration slice. Group by authoritative integer handle after listener-first lookup. Invalid candidate extraction is skipped. Attach one wake to each unique open resource under its `stateMu`, capture the exact connection/listener, then obtain `SyscallConn` from the captured value.
+
+- [ ] **Step 4: Retain every descriptor inside nested callbacks**
+
+Implement recursion with the native wait only at the innermost callback:
+
+```go
+func withNetworkDescriptors(registrations []*networkRegistration, pollfds []networkPollFD, index int, wait func([]networkPollFD) (networkPollBatch, error)) (batch networkPollBatch, err error) {
+	if index == len(registrations) { return wait(pollfds) }
+	registration := registrations[index]
+	controlErr := registration.raw.Control(func(fd uintptr) {
+		pollfds[index] = networkPollFD{descriptor: fd, interests: registration.interests, listener: registration.listener != nil}
+		batch, err = withNetworkDescriptors(registrations, pollfds, index+1, wait)
+	})
+	if err == nil && controlErr != nil { err = controlErr }
+	return batch, err
+}
+```
+
+Do not execute another native wait after any local-close wake or acquisition failure. Always unregister from every resource, then call synchronized `wake.Close`, before returning.
+
+- [ ] **Step 5: Implement remaining-time calculation**
+
+Use one deadline from `poller.now()` and this conversion:
+
+```go
+func networkPollMilliseconds(remaining time.Duration) int32 {
+	if remaining <= 0 { return 0 }
+	milliseconds := remaining / time.Millisecond
+	if remaining%time.Millisecond != 0 { milliseconds++ }
+	if milliseconds > time.Duration(math.MaxInt32) { return math.MaxInt32 }
+	return int32(milliseconds)
+}
+```
+
+Using quotient and remainder avoids overflowing `time.Duration` while rounding a near-maximum positive duration upward.
+
+For timeout zero with valid registrations, invoke the backend exactly once. For positive timeout, repeat only for an interrupted result, a completed `MaxInt32` chunk, or a non-local spurious wake while `poller.now().Before(deadline)`. Empty inputs call the injected sleeper only for a positive duration.
+
+- [ ] **Step 6: Revalidate and reconstruct public outputs**
+
+Under the relevant `stateMu`, require registry identity, `!closed`, and the exact captured attachment. Drop a locally closed registration. Apply listener filtering (`write` always removed; terminal/error keeps read and error) and scan each occurrence list in input order to call `selectResult`.
+
+- [ ] **Step 7: Run GREEN, stress, and race checks**
+
+```powershell
+go test ./internal/vm -run 'TestNetworkPoller|TestNetworkDescriptorsRemainControlled|TestNetworkControlCloseClassification' -count=20
+go test -race ./internal/vm -run 'TestNetworkPoller|TestNetworkDescriptorsRemainControlled|TestNetworkControlCloseClassification' -count=1
+```
+
+Expected: PASS; fake wait sees all raw controls active, timeouts never restart, and waiter maps are empty after every return.
+
+- [ ] **Step 8: Commit the common multiplexer**
+
+```powershell
+git add internal/vm/network_poller.go internal/vm/network_poller_test.go
+git commit -m "feat(net): add common readiness multiplexer"
+```
+
+---
+
+### Task 4: Implement and verify the Windows `WSAPoll` backend
+
+**Files:**
+- Create: `internal/vm/network_poller_windows.go`
+- Create: `internal/vm/network_poller_windows_test.go`
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+**Interfaces:**
+- Consumes: `networkPlatform`, `networkPollFD`, `networkPollBatch`, `platformNetworkWake`.
+- Produces on Windows: `systemNetworkPlatform() networkPlatform`.
+
+- [ ] **Step 1: Write failing ABI and event-mask tests**
+
+Create a Windows-tagged test file (`//go:build windows`) that requires:
+
+```go
+func TestWSAPollFDLayout(t *testing.T) {
+	var descriptor wsaPollFD
+	if unsafe.Offsetof(descriptor.Events) != unsafe.Sizeof(uintptr(0)) {
+		t.Fatalf("events offset=%d", unsafe.Offsetof(descriptor.Events))
+	}
+	if unsafe.Offsetof(descriptor.Revents) != unsafe.Sizeof(uintptr(0))+2 {
+		t.Fatalf("revents offset=%d", unsafe.Offsetof(descriptor.Revents))
+	}
+}
+
+func TestWindowsPollInterestNeverRequestsPOLLPRI(t *testing.T) {
+	got := windowsPollEvents(networkReadable | networkWritable | networkErrorInterest)
+	if got&pollPRI != 0 { t.Fatalf("events=%#x include POLLPRI", got) }
+	if got != pollRDNORM|pollWRNORM { t.Fatalf("events=%#x", got) }
+}
+
+func TestWindowsPollNormalizesTerminalEvents(t *testing.T) {
+	got := normalizeWindowsPollEvents(pollHUP | pollERR)
+	want := networkReadReady | networkWriteReady | networkErrorReady
+	if got != want { t.Fatalf("events=%#x want=%#x", got, want) }
+}
+```
+
+Add a table for `POLLRDNORM`, `POLLWRNORM`, `POLLHUP`, `POLLERR`, and `POLLNVAL`. Do not include `POLLRDBAND` or `POLLPRI` in the public mapping.
+
+- [ ] **Step 2: Write failing wake lifecycle integration tests**
+
+Create the real platform wake, assert its descriptor is accepted by a zero-time `WSAPoll`, signal it twice through the common `networkWake`, and require the wait to return `woke=true`. Race `Signal` and `Close` 100 times and require no Winsock call after handle close, panic, or leaked handle.
+
+Add an injectable `callWSAPoll`/`callWSAGetLastError` pair and require a scripted `SOCKET_ERROR` to return the exact WSA error rather than the `LazyProc.Call` last-error value.
+
+Run RED:
+
+```powershell
+go test ./internal/vm -run 'TestWSAPoll|TestWindowsPoll|TestWindowsWake' -count=1
+```
+
+Expected: build failure because the Windows backend does not exist.
+
+- [ ] **Step 3: Define the Winsock ABI and explicit error retrieval**
+
+Implement the Windows file with:
+
+```go
+//go:build windows
+
+package vm
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type wsaPollFD struct {
+	FD uintptr
+	Events int16
+	Revents int16
+}
+
+const (
+	pollRDNORM int16 = 0x0100
+	pollWRNORM int16 = 0x0010
+	pollERR int16 = 0x0001
+	pollHUP int16 = 0x0002
+	pollNVAL int16 = 0x0004
+	pollPRI int16 = 0x0400
+	socketError int32 = -1
+)
+
+var (
+	ws2 = windows.NewLazySystemDLL("Ws2_32.dll")
+	procWSAPoll = ws2.NewProc("WSAPoll")
+	procWSAGetLastError = ws2.NewProc("WSAGetLastError")
+)
+```
+
+Wrap both procedure calls in package variables for deterministic error-path tests. Detect failure with `int32(result) == socketError`; call `WSAGetLastError` explicitly and return `syscall.Errno(code)`.
+
+- [ ] **Step 4: Implement operation-local non-blocking UDP wake sockets**
+
+Create a reader with `windows.Socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`, bind to `127.0.0.1:0`, obtain its `*windows.SockaddrInet4` through `windows.Getsockname`, and create a writer socket. Convert both handles to `syscall.Handle` and call `syscall.SetNonblock(handle, true)`. On any setup failure, close every handle already created with `windows.Closesocket` and return `errors.Join`.
+
+Implement the platform wake:
+
+```go
+type windowsNetworkWake struct {
+	reader windows.Handle
+	writer windows.Handle
+	address *windows.SockaddrInet4
+}
+
+func (wake *windowsNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
+func (wake *windowsNetworkWake) signal() error {
+	err := windows.Sendto(wake.writer, []byte{1}, 0, wake.address)
+	if errors.Is(err, windows.WSAEWOULDBLOCK) { return nil }
+	return err
+}
+func (wake *windowsNetworkWake) close() error {
+	return errors.Join(windows.Closesocket(wake.writer), windows.Closesocket(wake.reader))
+}
+```
+
+The common `networkWake` guarantees at most one successful signal and serializes close.
+
+- [ ] **Step 5: Implement one `WSAPoll` call and normalize events**
+
+Prepend the wake reader with `pollRDNORM`, convert every common descriptor without narrowing, request only `pollRDNORM` and/or `pollWRNORM`, and allow zero requested flags for error-only interests. After the call:
+
+- wake `pollRDNORM|pollHUP|pollERR|pollNVAL` sets `batch.woke=true`;
+- `pollRDNORM` maps to read;
+- `pollWRNORM` maps to write;
+- `pollHUP|pollERR|pollNVAL` maps to read, write, and error;
+- listener write filtering remains common-layer responsibility;
+- result event order remains aligned with the input descriptors after removing the prepended wake entry.
+
+Return `systemNetworkPlatform()` with `interrupted=false` for every Windows result; do not invent a `WSAEINTR` retry.
+
+- [ ] **Step 6: Promote `x/sys` and run Windows GREEN/race tests**
+
+Move `golang.org/x/sys v0.40.0` from the indirect block to the direct `require` block through:
+
+```powershell
+go mod tidy
+go test ./internal/vm -run 'TestWSAPoll|TestWindowsPoll|TestWindowsWake' -count=20
+go test -race ./internal/vm -run 'TestWSAPoll|TestWindowsPoll|TestWindowsWake' -count=1
+```
+
+Expected: PASS on Windows without `WSAEINVAL`, blocked signal, or handle race.
+
+- [ ] **Step 7: Commit the Windows backend**
+
+```powershell
+git add internal/vm/network_poller_windows.go internal/vm/network_poller_windows_test.go go.mod go.sum
+git commit -m "feat(net): add Windows WSAPoll backend"
+```
+
+---
+
+### Task 5: Implement and cross-verify the Unix `poll` backend
+
+**Files:**
+- Create: `internal/vm/network_poller_unix.go`
+- Create: `internal/vm/network_poller_unix_test.go`
+- Create: `internal/vm/network_poller_rdhup.go`
+- Create: `internal/vm/network_poller_no_rdhup.go`
+- Create: `internal/vm/network_poller_unsupported.go`
+
+**Interfaces:**
+- Consumes: the common backend types from Task 3.
+- Produces on compile-supported Unix: `systemNetworkPlatform() networkPlatform` using `unix.Poll`.
+- Produces elsewhere: a stable unsupported-platform backend with the same symbol.
+
+- [ ] **Step 1: Write failing Unix-tagged backend tests**
+
+Create tests under the exact supported tag:
+
+```go
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+```
+
+Test literal normalization for `POLLIN`, `POLLOUT`, `POLLHUP`, `POLLERR`, and `POLLNVAL`; verify that requested interests never include `POLLPRI`. On Linux/FreeBSD, a separate tagged test requires `POLLRDHUP` to normalize as read, write, and error. On other Unix targets, require the extension mask to be zero.
+
+Use the real socketpair wake to prove a zero-time wait is empty before signal and `woke=true` after signal. Race common `Signal`/`Close` and assert idempotent cleanup.
+
+Run RED on Linux CI or an available Linux environment:
+
+```bash
+go test ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup' -count=1
+```
+
+Expected: build failure because the Unix backend does not exist.
+
+- [ ] **Step 2: Implement the non-blocking Unix socketpair wake**
+
+In `network_poller_unix.go`, create `unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)`, call `unix.SetNonblock` on both descriptors, and close both on partial failure. Implement:
+
+```go
+type unixNetworkWake struct { reader, writer int }
+func (wake *unixNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
+func (wake *unixNetworkWake) signal() error {
+	_, err := unix.Write(wake.writer, []byte{1})
+	if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) { return nil }
+	return err
+}
+func (wake *unixNetworkWake) close() error {
+	return errors.Join(unix.Close(wake.writer), unix.Close(wake.reader))
+}
+```
+
+The common lifecycle ensures the same numeric descriptor is never signaled after close.
+
+- [ ] **Step 3: Implement `unix.Poll` with exact descriptor checks**
+
+Reject a raw descriptor that cannot round-trip through `int32` before building `unix.PollFd`. Prepend the wake reader with `POLLIN`. Map interests to `POLLIN` and `POLLOUT`; error-only registrations use zero requested events because `POLLERR`, `POLLHUP`, and `POLLNVAL` are returned independently.
+
+On `errors.Is(err, unix.EINTR)`, return `networkPollBatch{interrupted:true}` with no error. Normalize:
+
+```go
+if revents&unix.POLLIN != 0 { event |= networkReadReady }
+if revents&unix.POLLOUT != 0 { event |= networkWriteReady }
+if revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL|networkPollReadHangup) != 0 {
+	event |= networkReadReady | networkWriteReady | networkErrorReady
+}
+```
+
+Never request or publish `POLLPRI`.
+
+- [ ] **Step 4: Split the terminal extension by build tag**
+
+`network_poller_rdhup.go`:
+
+```go
+//go:build linux || freebsd
+package vm
+import "golang.org/x/sys/unix"
+const networkPollReadHangup int16 = unix.POLLRDHUP
+```
+
+`network_poller_no_rdhup.go`:
+
+```go
+//go:build aix || darwin || dragonfly || netbsd || openbsd || solaris
+package vm
+const networkPollReadHangup int16 = 0
+```
+
+Do not reference `POLLRDHUP` from the common Unix file, because it is not defined uniformly.
+
+- [ ] **Step 5: Add the unsupported backend**
+
+Use the complement build tag:
+
+```go
+//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+```
+
+Return a platform whose wake factory and wait both return `fmt.Errorf("network polling is not supported on this platform")`. This keeps builds explicit instead of restoring a consuming fallback.
+
+- [ ] **Step 6: Run Linux GREEN and cross-build every advertised target**
+
+On Linux:
+
+```bash
+go test ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup' -count=20
+go test -race ./internal/vm -run 'TestUnixPoll|TestUnixWake|TestUnixReadHangup' -count=1
+```
+
+From PowerShell or CI, compile production code for the full matrix:
+
+```powershell
+$targets = @(
+  @{OS='linux'; Arch='amd64'}, @{OS='darwin'; Arch='amd64'},
+  @{OS='dragonfly'; Arch='amd64'}, @{OS='freebsd'; Arch='amd64'},
+  @{OS='netbsd'; Arch='amd64'}, @{OS='openbsd'; Arch='amd64'},
+  @{OS='solaris'; Arch='amd64'}, @{OS='aix'; Arch='ppc64'}
+)
+foreach ($target in $targets) {
+  $env:GOOS=$target.OS; $env:GOARCH=$target.Arch; go build ./...
+  if ($LASTEXITCODE -ne 0) { throw "cross-build failed for $($target.OS)/$($target.Arch)" }
+}
+Remove-Item Env:GOOS -ErrorAction SilentlyContinue
+Remove-Item Env:GOARCH -ErrorAction SilentlyContinue
+```
+
+Expected: all builds succeed. Runtime claims remain limited to Windows/Linux.
+
+- [ ] **Step 7: Commit the Unix and fallback backends**
+
+```powershell
+git add internal/vm/network_poller_unix.go internal/vm/network_poller_unix_test.go internal/vm/network_poller_rdhup.go internal/vm/network_poller_no_rdhup.go internal/vm/network_poller_unsupported.go
+git commit -m "feat(net): add Unix poll backend"
+```
+
+---
+
+### Task 6: Wire the builtin and remove every consuming probe
+
+**Files:**
+- Modify: `internal/vm/builtins_net.go`
+- Modify: `internal/vm/resources.go`
+- Modify: `internal/vm/builtins_net_test.go`
+- Modify: `internal/vm/builtins_net_deadlines_test.go`
+- Modify: `internal/vm/architecture_test.go`
+
+**Interfaces:**
+- Consumes: `systemNetworkPlatform()` and `(*networkPoller).Poll`.
+- Removes: `beginSocketProbe`, `finishSocketProbe`, `selectSocket`, `beginListenerProbe`, `finishListenerProbe`, `selectListener`, probe deadlines, and consumer buffers.
+- Preserves: ordinary `net_recv`, `net_accept`, persistent timeout behavior, and fail-closed rollback semantics.
+
+- [ ] **Step 1: Replace buffer-oriented tests with failing non-consumption tests**
+
+In `builtins_net_test.go`, replace `TestNetSelectBufferIsSharedAcrossVMs` with two real loopback tests:
+
+1. Send `"xy"`, poll the accepted socket twice with `timeout=0`, assert both calls report it readable, then call `net_recv(..., 2)` from a VM sharing the same runtime and require exactly `"xy"`.
+2. Establish a pending client connection, poll the listener twice with `timeout=0`, require it readable both times, then accept exactly once and prove the accepted connection works.
+
+Add direct builtin validation tests for wrong arity, wrong set types, wrong timeout type, negative timeout, and overflow. Require a synchronous error and no partial `SelectResult`.
+
+- [ ] **Step 2: Add failing deadline-independence and close-wakeup tests**
+
+In `builtins_net_deadlines_test.go`:
+
+- snapshot a controlled socket's last read/write deadlines, call `net_select`, and require no setter invocation and no deadline change;
+- start a positive-timeout poll on one socket and one listener, close each from another goroutine, and require prompt completion without reporting the locally closed handle;
+- force both existing rollback-poison paths and require an already blocked poll to wake before the controlled connection/listener `Close` returns;
+- replace `TestReceiveSocketFullyBufferedSkipsDeadlineSetter` with `TestReceiveSocketZeroSizeSkipsDeadlineSetter`.
+
+Run RED:
+
+```powershell
+go test ./internal/vm -run 'TestNetSelectDoesNotConsume|TestNetSelectDoesNotAccept|TestNetSelectDoesNotMutateDeadline|TestNetSelectCloseWakes|TestNetSelectValidates' -count=1
+```
+
+Expected: the repeated poll or deadline assertions fail against the old consuming implementation.
+
+- [ ] **Step 3: Install one production poller and dispatch `net_select` to it**
+
+Add an immutable package-level poller initialized from the platform factory:
+
+```go
+var defaultNetworkPoller = networkPoller{
+	platform: systemNetworkPlatform(),
+	now:      time.Now,
+	sleep:    time.Sleep,
+}
+```
+
+Replace the complete `net_select` body with `defaultNetworkPoller.Poll(context.VM, args)`; `Poll` performs the strict validation from Task 1 before resolving any resource. Do not retain the old one-millisecond minimum or sequential candidate loop.
+
+- [ ] **Step 4: Delete consumer buffers and probe deadline machinery**
+
+Remove from `SocketResource`:
+
+```text
+bufferedRead
+readProbeDeadline
+```
+
+Remove from `ListenerResource`:
+
+```text
+bufferedAccept
+acceptProbeDeadline
+```
+
+Delete all six probe helpers and every branch that publishes or consumes their buffers. Simplify the ordinary-I/O deadline helper to:
+
+```go
+func effectiveNetworkDeadline(now time.Time, timeout time.Duration) time.Time {
+	if timeout > 0 { return now.Add(timeout) }
+	return time.Time{}
+}
+```
+
+Update `acceptConnection`, `receiveSocket`, and their rollback tests to use only persistent I/O configuration. Keep the zero-sized receive fast path and preserve `io.EOF` as a successful zero-byte `NetResult` under the existing receive contract.
+
+- [ ] **Step 5: Add an architecture guard against regression**
+
+Extend `architecture_test.go` with an AST/source guard that fails if `ListenerResource` or `SocketResource` regains any of these fields:
+
+```text
+bufferedAccept, bufferedRead, acceptProbeDeadline, readProbeDeadline
+```
+
+Also forbid these function declarations:
+
+```text
+beginListenerProbe, finishListenerProbe, selectListener,
+beginSocketProbe, finishSocketProbe, selectSocket
+```
+
+The guard makes a future consuming fallback an explicit reviewed design change.
+
+- [ ] **Step 6: Remove obsolete probe tests by name, not coverage**
+
+Delete the old cases whose contract no longer exists:
+
+```text
+TestBufferedAcceptCloseWinsDuringDeadlineClear
+TestNetSelectRestoresPersistentSocketDeadline
+TestNetSelectRestorationFailureKeepsReadyByte
+TestNetworkProbeDeadlineUsesOneStartInstant
+TestPartialBufferedReadSurvivesDeadlineInstallationFailure
+TestListenerSelectRestorationFailureKeepsAcceptedConnection
+TestNetSelectManagementFailureStopsLaterCandidatesAndKeepsEarlierBuffer
+TestActiveSocketProbeBoundsConcurrentConfiguration
+```
+
+Retain their still-relevant close, rollback, persistent timeout, and synchronization assertions in the new non-consuming tests from Step 2.
+
+- [ ] **Step 7: Run focused GREEN and race tests**
+
+```powershell
+go test ./internal/vm -run 'TestNetSelect|TestNetworkPoller|TestNetworkWake|Test(Socket|Listener).*(Deadline|Rollback|Detach)|TestReceiveSocketZeroSize|TestNetworkArchitecture' -count=1
+go test -race ./internal/vm -run 'TestNetSelect|TestNetworkPoller|TestNetworkWake|Test(Socket|Listener)Detach' -count=1
+```
+
+Expected: PASS with no reads, accepts, deadline mutations, leaked waiters, deadlocks, or races.
+
+- [ ] **Step 8: Commit the builtin cutover**
+
+```powershell
+git add internal/vm/builtins_net.go internal/vm/resources.go internal/vm/builtins_net_test.go internal/vm/builtins_net_deadlines_test.go internal/vm/architecture_test.go
+git commit -m "feat(net): replace consuming select with readiness poll"
+```
+
+---
+
+### Task 7: Prove the public semantics with real TCP integration tests
+
+**Files:**
+- Create: `internal/vm/network_poller_integration_test.go`
+- Modify: `internal/vm/builtins_net_test.go`
+
+**Interfaces:**
+- Exercises: the registered builtin, real shared resources, OS readiness, EOF/hangup, data plus terminal state, and close wakeups.
+- Separates: portable guarantees from platform-specific observations.
+
+- [ ] **Step 1: Add the real-loopback readiness matrix**
+
+Use `setupAcceptedLoopback` and the public builtin helpers. Add independent tests for:
+
+- repeated read polls preserve exact unread bytes;
+- repeated listener polls preserve the pending accept;
+- a connected client requested in the write set is reported writable;
+- the same socket occurring twice in one set is returned twice in the same order;
+- the same socket requested in read/write/error is independently copied to every matching output;
+- candidates after index 63 are ignored and all result arrays remain exactly 64 elements;
+- a zero-time empty poll returns within a conservative 100 ms test bound;
+- a positive empty poll does not return materially early.
+
+- [ ] **Step 2: Test one global timeout instead of per-candidate delay**
+
+Create several connected but idle sockets, request all in the read set, and poll for 80 ms. Require elapsed time to remain near one timeout (for example 60-400 ms under CI), not `N * timeout`. Repeat with three empty sets to prove the no-descriptor path obeys the same global bound.
+
+- [ ] **Step 3: Specify EOF, half-close, hangup, and coexisting data**
+
+Add named tests with explicit assertions:
+
+- after an orderly peer close, a socket requested only for read is reported readable and the following `net_recv` returns the existing EOF-shaped successful zero-byte result;
+- after TCP half-close where supported by the test helper, read is reported; error is asserted only when the backend exposes an explicit terminal bit;
+- if the peer writes `"tail"` and then closes, read readiness remains present and `net_recv` returns `"tail"` before the later EOF result;
+- when a terminal/error event is observed by a platform-specific backend test, it populates every requested read/write/error occurrence;
+- ordinary readable data alone never populates the error set.
+
+Do not make a cross-platform integration assertion that graceful EOF must appear in the error set: that depends on an explicit `HUP`/`RDHUP` indication, while EOF-as-readable is the portable guarantee.
+
+- [ ] **Step 4: Exercise concurrent close and concurrent polls**
+
+Start a long poll, close a requested socket/listener, and require the call to wake promptly with the locally closed resource omitted. Start several polls over the same open socket, send one byte, require every poll to observe readiness, then consume the byte once. Repeat these tests under `-race` and at least 20 iterations.
+
+- [ ] **Step 5: Run the integration suite on the current OS**
+
+```powershell
+go test ./internal/vm -run 'TestNetworkPollIntegration|TestNetSelectDoesNot' -count=20
+go test -race ./internal/vm -run 'TestNetworkPollIntegration|TestConcurrentNetSelect' -count=1
+```
+
+Expected: PASS without flaky ordering assumptions or per-candidate timeout multiplication.
+
+- [ ] **Step 6: Commit integration coverage**
+
+```powershell
+git add internal/vm/network_poller_integration_test.go internal/vm/builtins_net_test.go
+git commit -m "test(net): cover portable poll semantics"
+```
+
+---
+
+### Task 8: Document the contract, add a Noxy example, and harden CI
+
+**Files:**
+- Create: `noxy_examples/network_poller.nx`
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `CHANGELOG.md`
+- Modify: `.github/workflows/network-deadlines.yml`
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Add the executable Noxy example**
+
+Create a bounded loopback example using `net.listen`, `net.connect`, `net.accept`, `net.socket_set`, and `net.poll`. It must:
+
+- put the listener in the read set and show `timeout=0` before and after the connection;
+- poll the connected socket in the write set;
+- send `"poll-data"`, poll the server socket twice in the read set without receiving between calls, then receive and assert the exact bytes/count;
+- close every socket on success and every explicit failure branch;
+- use a short positive timeout and assertions so the integration runner never waits indefinitely.
+
+Follow the repository's fixed-array syntax (`set[0] = socket`) and avoid `setblocking(false)`, because readiness no longer depends on that deprecated no-op.
+
+- [ ] **Step 2: Replace the transitional language-spec text**
+
+In the networking section of `NOXY_LANGUAGE_SPEC.md`, document all of the following as normative behavior:
+
+- three independent 64-entry read/write/error input and output sets;
+- first-64 truncation, stable order, duplicate occurrences, and copied-value counts;
+- strict timeout semantics (`<0` error, `0` immediate, `>0` one global wall-clock bound);
+- no `Read`, `Accept`, peek, `SO_ERROR`, or persistent deadline mutation;
+- ordinary data is read-only readiness; EOF is always readable; explicit hangup/error/invalid events satisfy every requested set;
+- listener pending accept is normal read only; listener terminal state satisfies requested read/error and never write;
+- data may coexist with EOF/hangup/error and must remain consumable after poll;
+- local concurrent close wakes a blocked poll and omits the detached resource;
+- OOB/urgent data is outside this API;
+- Windows/Linux runtime verification, listed Unix compile support, and unsupported-platform error behavior;
+- `net.setblocking(sock, false)` remains a deprecated no-op.
+
+Remove the earlier statement that `net_select` is sequential or consumer-buffered.
+
+- [ ] **Step 3: Record the user-visible change and dependency ownership**
+
+Add a `CHANGELOG.md` entry for non-consuming readiness, the three sets, immediate/global timeout semantics, portable EOF/hangup behavior, and concurrent-close wakeup. Confirm that `golang.org/x/sys` remains a direct dependency after the Windows and Unix backends are present, then run:
+
+```powershell
+go mod tidy
+```
+
+Inspect `go.mod`/`go.sum` and keep only dependency changes caused by the new direct Unix/Windows backends.
+
+- [ ] **Step 4: Expand the existing network workflow**
+
+Keep the workflow filename but rename its displayed job scope from deadlines-only to network semantics. Its runtime matrix must run the focused poll/deadline tests on `ubuntu-latest` and `windows-latest`, including `go test -race` on both if the hosted Windows toolchain supports it; otherwise retain race on Linux and document the Windows limitation in the workflow comment.
+
+Add a cross-build job for:
+
+```text
+linux/amd64, darwin/amd64, dragonfly/amd64, freebsd/amd64,
+netbsd/amd64, openbsd/amd64, solaris/amd64, aix/ppc64
+```
+
+Cross-build production packages with `go build ./...`; do not claim runtime verification for those targets.
+
+- [ ] **Step 5: Run docs/example/workflow verification**
+
+```powershell
+go run cmd/noxy/main.go noxy_examples/network_poller.nx
+go test ./internal/vm -run 'TestNetwork|TestNetSelect' -count=1
+go build ./...
+```
+
+Expected: the example exits successfully and focused Go tests pass.
+
+- [ ] **Step 6: Commit documentation and CI**
+
+```powershell
+git add noxy_examples/network_poller.nx docs/NOXY_LANGUAGE_SPEC.md CHANGELOG.md .github/workflows/network-deadlines.yml go.mod go.sum
+git commit -m "docs(net): specify portable poll readiness"
+```
+
+---
+
+### Task 9: Perform final cross-platform verification and review the diff
+
+**Files:**
+- Verify all files changed by Tasks 1-8.
+
+- [ ] **Step 1: Format and prove no generated drift**
+
+```powershell
+gofmt -w internal/vm/network_poller*.go internal/vm/resources.go internal/vm/builtins_net.go internal/vm/builtins_net_test.go internal/vm/builtins_net_deadlines_test.go internal/vm/architecture_test.go
+git diff --check
+```
+
+- [ ] **Step 2: Run the repository-required gates**
+
+```powershell
+go test ./internal/...
+go test ./...
+go vet ./...
+go build ./...
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Expected: every command exits zero. If the integration runner reports a pre-existing excluded or environment-only failure, preserve its full output and distinguish it from this change instead of weakening coverage.
+
+- [ ] **Step 3: Run concurrency and repetition gates**
+
+```powershell
+go test -race ./internal/vm -run 'TestNetwork|TestNetSelect|TestConcurrentNetSelect' -count=1
+go test ./internal/vm -run 'TestNetworkPollIntegration|TestNetSelectCloseWakes' -count=50
+```
+
+Expected: PASS with no races or intermittent timeouts.
+
+- [ ] **Step 4: Cross-build all compile-supported targets**
+
+Use the Task 5 matrix and restore `GOOS`/`GOARCH` afterward. Run a final native `go build ./...` after restoration to ensure the current environment was not left cross-configured.
+
+- [ ] **Step 5: Audit the implementation against the spec**
+
+```powershell
+rg -n 'buffered(Read|Accept)|ProbeDeadline|begin(Socket|Listener)Probe|select(Socket|Listener)|SO_ERROR|MSG_PEEK|POLLPRI|POLLRDBAND' internal/vm
+git diff --stat HEAD~8..HEAD
+git status --short
+```
+
+Expected: the first search finds only intentional negative architecture tests/comments, the diff contains no unrelated files, and the worktree is clean.
+
+- [ ] **Step 6: Request an independent code review**
+
+Use `superpowers:requesting-code-review` against the implementation range. Require the reviewer to check the approved spec specifically for descriptor lifetime, wake/close serialization, EOF versus explicit hangup, listener write suppression, duplicate ordering, global timeout math, and Windows ABI correctness. Address technically validated findings with `superpowers:receiving-code-review`, rerun the affected gates, and only then report completion.

--- a/docs/superpowers/specs/2026-08-14-network-poller-design.md
+++ b/docs/superpowers/specs/2026-08-14-network-poller-design.md
@@ -1,0 +1,385 @@
+# Network Poller Design
+
+## Purpose
+
+Replace the current sequential, consuming `net_select` probes with a real
+socket-readiness multiplexer. The implementation resolves roadmap points 5–8
+from PR #17 while preserving the public `net.poll` result shape and the
+deadline behavior delivered by PR #20.
+
+Go's `net` package and runtime poller provide the behavioral reference:
+network operations may be used concurrently, deadlines apply to pending and
+future I/O, close wakes blocked operations, and readiness means that the next
+operation can finish without waiting rather than that it must succeed.
+
+## Goals
+
+- Detect socket and listener readiness without calling `Read` or `Accept`.
+- Make `timeout_ms == 0` a genuinely immediate poll.
+- Apply one timeout to the complete multiplexing operation rather than once per
+  candidate.
+- Implement read, write, and error result sets.
+- Provide explicit Windows and Unix backends behind one common contract.
+- Preserve safe concurrent close, shared runtime ownership, and persistent
+  network deadlines.
+- Define EOF, hangup, pending-error, duplicate, and overlapping-event behavior.
+
+## Non-goals
+
+- Do not change the `net.poll` Noxy signature or `SelectResult` fields.
+- Do not add UDP sockets, asynchronous connect, edge-triggered polling, or a
+  persistent event-loop API.
+- Do not make poll plus subsequent I/O atomic.
+- Do not implement true non-blocking mode for `net.setblocking(sock, false)`;
+  that deprecated branch remains a no-op.
+- Do not expose platform event constants to Noxy.
+- Do not treat an expired persistent I/O deadline as operating-system socket
+  readiness.
+
+## Public Contract
+
+The API remains:
+
+```noxy
+func poll(read: Socket[64], write: Socket[64], err: Socket[64], timeout: int) -> SelectResult
+```
+
+The native validates exactly four arguments, requires three arrays and an
+exact integer timeout, and rejects invalid timeout conversion before touching
+network resources. A negative timeout is invalid. Zero performs an immediate
+poll. A positive value is the maximum duration in milliseconds for the whole
+call. Values whose millisecond conversion exceeds Go's `time.Duration` range
+are invalid.
+
+Each result array remains 64 elements long and is padded with `null`. Each
+count is the number of non-null entries in its corresponding result array.
+Invalid, malformed, unknown, or already-closed candidate values are ignored,
+matching the existing candidate behavior. A valid resource may occur in more
+than one input set and may be reported in more than one output set.
+
+An empty union of valid candidates returns immediately for timeout zero. For a
+positive timeout it waits until the global timeout expires, then returns empty
+sets.
+
+Polling never:
+
+- reads or peeks at application bytes;
+- accepts a connection;
+- calls `getsockopt(SO_ERROR)` or otherwise clears a pending error;
+- calls any `SetDeadline` method;
+- changes the resource's persistent timeout mode.
+
+Readiness is an advisory snapshot. Another Noxy routine or Go goroutine may
+perform I/O or close the resource before the caller acts on the result.
+
+## Event Semantics
+
+The common layer normalizes platform events as follows:
+
+| Native condition | Connected socket `read` | Connected socket `write` | `error` |
+|---|---:|---:|---:|
+| Normal data readable | yes | no | no |
+| Normal data writable | no | yes | no |
+| Hangup/EOF | yes | yes | yes |
+| Pending socket error | yes | yes | yes |
+| Invalid native descriptor | yes | yes | yes |
+| Priority/OOB exceptional condition | no | no | yes |
+
+For a listener, normal read readiness means an `Accept` can complete without
+waiting. A listener is never returned as normally writable. Listener error,
+hangup, or invalid-descriptor events are returned only in the error set, even
+if the listener was also supplied in read or write.
+
+Hangup and error wake requested read and write interests because the next
+operation will complete immediately, even if it completes with EOF or an
+error. They also appear in the public error set when that resource was supplied
+there. The error set therefore represents terminal, error, invalid-descriptor,
+or exceptional readiness; it is not the narrow Berkeley `exceptfds` contract.
+
+EOF keeps the existing Noxy receive result:
+
+```text
+NetResult{ok: true, count: 0, data: "", error: ""}
+```
+
+Readable data and hangup may coexist. In that case the socket can appear in
+both read and error, and `net_recv` returns available bytes before a later
+receive observes EOF. The poller does not consume either the bytes or the
+pending terminal/error condition.
+
+## Candidate and Result Ordering
+
+The common layer resolves candidates using the current authoritative `fd`
+field rules and listener-first registry lookup. It creates one native
+registration per unique resource and combines all requested interests.
+
+For result construction, each input set is scanned in its original order.
+Every ready occurrence is copied to the corresponding output, including
+duplicate occurrences. Consequently:
+
+- native registration is deduplicated for efficiency;
+- public order and multiplicity remain compatible with the existing loop;
+- one socket may occur in read, write, and error simultaneously;
+- no result count can exceed 64.
+
+## Common Poller Boundary
+
+`internal/vm/network_poller.go` owns the platform-independent model:
+
+```go
+type networkInterest uint8
+
+const (
+	networkReadable networkInterest = 1 << iota
+	networkWritable
+	networkExceptional
+)
+
+type networkEvent uint8
+
+const (
+	networkReadReady networkEvent = 1 << iota
+	networkWriteReady
+	networkErrorReady
+)
+```
+
+An internal registration contains the Noxy handle, exact resource pointer,
+exact listener or connection pointer, raw connection, requested interests, and
+resource kind. Platform code receives only raw socket descriptors and interest
+masks and returns normalized native flags. It does not access VM registries or
+Noxy values.
+
+The builtin flow is:
+
+1. Validate arguments and timeout.
+2. Resolve input occurrences and build unique registrations.
+3. Create one operation-local wake-up object.
+4. Register that wake-up with every unique resource under its `stateMu`.
+5. Acquire stable raw-descriptor references and invoke one platform wait.
+6. Release raw references and unregister the wake-up.
+7. Revalidate every reported registration.
+8. Reconstruct read, write, and error outputs in input order.
+
+Backend failure is synchronous and returns no partial `SelectResult`.
+
+## Descriptor Lifetime
+
+`syscall.RawConn.Control` guarantees that its descriptor remains valid only
+during its callback. The implementation therefore performs the native wait
+inside nested `Control` callbacks: each callback retains one descriptor while
+the next is acquired, and the innermost callback invokes the backend with all
+descriptors stable. The operation-local wake socket or pipe remains owned and
+open until the wait and cleanup finish.
+
+Copying descriptor numbers outside `Control` and relying only on post-wait
+revalidation is forbidden because the operating system could reuse a closed
+descriptor number for another socket before polling starts.
+
+The resources do not need a separate lifetime generation. Their `closed`
+transition is monotonic, the stored connection/listener is never replaced, and
+Noxy registry handles are allocated monotonically. Revalidation requires all
+of the following:
+
+- the registry handle still resolves to the exact resource pointer;
+- `closed` is false;
+- the exact connection or listener pointer is still attached;
+- the reported registration belongs to the current poll operation.
+
+## Concurrent Close and Wake-up
+
+Each poll call owns a distinct wake-up object and registers it in a waiter set
+on every observed resource. Signaling is idempotent and non-blocking. This
+provides broadcast behavior when multiple poll calls observe the same socket.
+
+Every path that permanently closes or poisons a listener or socket uses one
+central detach transition:
+
+1. Lock `stateMu`.
+2. If already closed, return without another close.
+3. Mark `closed = true` and detach the OS connection/listener and obsolete
+   probe buffers.
+4. Snapshot and clear the poll waiter set.
+5. Unlock `stateMu`.
+6. Signal every waiter.
+7. Close detached OS resources outside the lock.
+
+Signaling precedes the OS close because close may wait for outstanding
+`RawConn.Control` references. The wake event causes the native wait to return,
+the callbacks to release those references, and close to finish. A local close
+that wakes a poll is omitted from all result sets after revalidation; the poll
+returns promptly rather than waiting out the remaining timeout.
+
+Deadline configuration remains independent. It neither invalidates poll
+registrations nor wakes a poll. Existing `deadlineGeneration` continues to
+belong only to deadline transitions.
+
+## Global Timeout
+
+The common layer records one monotonic start instant and, for positive values,
+one absolute end instant. Every backend retry or timeout chunk is computed from
+the remaining duration. No path restarts the original timeout.
+
+Windows accepts a signed 32-bit millisecond timeout, so longer durations are
+split into bounded chunks. The same common chunking rule is used on Unix for
+consistent behavior. Unix `EINTR` and the equivalent Windows interruption are
+handled as follows:
+
+- for a positive timeout, retry with the remaining duration;
+- for timeout zero, return an empty result immediately;
+- once the absolute end instant is reached, return an empty result.
+
+An unrelated spurious wake or platform wake event may cause the common layer
+to revalidate and retry with the remaining duration. A wake caused by local
+close returns promptly after omitting the closed resource.
+
+## Platform Backends
+
+### Unix
+
+`internal/vm/network_poller_unix.go` uses `golang.org/x/sys/unix.Poll` and an
+operation-local non-blocking pipe or socketpair for wake-up. Explicit build
+tags cover only Unix targets where `unix.Poll` and the chosen wake primitive
+are available. The backend maps `POLLIN`, `POLLOUT`, `POLLPRI`, `POLLHUP`,
+`POLLERR`, and `POLLNVAL` into common flags.
+
+The initial target list is AIX, Darwin, DragonFly BSD, FreeBSD, Linux, NetBSD,
+OpenBSD, and Solaris. Any target that lacks a required primitive uses the
+unsupported backend until it has a tested implementation.
+
+### Windows
+
+`internal/vm/network_poller_windows.go` defines the ABI-compatible
+`WSAPOLLFD` structure and calls `WSAPoll` from `Ws2_32.dll`. The maximum union
+is 192 unique candidate occurrences before deduplication, well within the
+`ULONG` count accepted by `WSAPoll`.
+
+The wake-up is an operation-local UDP loopback reader/writer pair because
+`WSAPoll` can wait only on Winsock sockets. Signaling writes at most one
+datagram per operation. The backend maps `POLLRDNORM`, `POLLWRNORM`,
+`POLLRDBAND`, `POLLHUP`, `POLLERR`, and `POLLNVAL` into common flags.
+
+The historical `WSAPoll` asynchronous-connect caveat does not affect this
+feature: Noxy's current `net_connect` is synchronous and only successfully
+connected sockets are registered.
+
+### Unsupported targets
+
+`internal/vm/network_poller_unsupported.go` compiles everywhere not covered by
+the Windows or supported-Unix tags and returns a stable "network polling is not
+supported on this platform" error. This is preferable to a sequential or
+consuming fallback with different semantics.
+
+## Interaction with Existing Deadlines
+
+The new poller never takes `readMu`, `writeMu`, `acceptMu`, or `deadlineMu` and
+never modifies a deadline. `net.settimeout` continues to control only
+`net_recv`, `net_send`, and `net_accept`. `net.setblocking(sock, true)` still
+clears persistent I/O deadlines. The deprecated false branch remains a no-op.
+
+The old probe-specific state becomes obsolete and is removed:
+
+- `SocketResource.bufferedRead`;
+- `ListenerResource.bufferedAccept`;
+- `SocketResource.readProbeDeadline`;
+- `ListenerResource.acceptProbeDeadline`;
+- `beginSocketProbe`, `finishSocketProbe`, and `selectSocket`;
+- `beginListenerProbe`, `finishListenerProbe`, and `selectListener`.
+
+Receive and accept no longer consult poller buffers. Persistent deadline
+application and rollback retain their existing fail-closed behavior, but every
+fail-closed path must use the centralized detach-and-wake transition.
+
+## Error Handling
+
+- Invalid public argument shape or timeout produces a synchronous native error.
+- Invalid candidate elements are ignored.
+- Failure to obtain `SyscallConn` for a registered production TCP resource is
+  a synchronous backend error.
+- Platform poll failure is synchronous and yields no partial result.
+- A resource closed concurrently is omitted, not reported as a platform error.
+- Native error and hangup flags remain observable; the poller does not inspect
+  or clear their underlying socket error.
+- Wake-up saturation is prevented by idempotent one-signal state.
+
+## Testing Strategy
+
+Development follows red-green-refactor. Tests are divided by responsibility.
+
+### Common unit tests
+
+A fake backend verifies:
+
+- timeout zero is passed as zero and returns immediately;
+- one positive global timeout is not multiplied by candidate count;
+- interrupted and chunked waits use only the remaining duration;
+- negative, wrong-type, and overflowing timeouts fail before polling;
+- read, write, error, hangup, invalid, and exceptional masks normalize exactly;
+- listener write readiness is suppressed;
+- order and duplicate occurrences are preserved;
+- one resource can occur in all three outputs;
+- malformed, unknown, and closed candidates are ignored;
+- backend error returns no partial result;
+- empty-set timing behavior.
+
+### Lifetime and concurrency tests
+
+Controlled TCP resources and barriers verify:
+
+- descriptors remain inside `RawConn.Control` during the backend wait;
+- close signals every poll watching the resource;
+- close does not deadlock behind descriptor references;
+- a closed resource is omitted after wake-up;
+- unrelated deadline configuration does not invalidate or wake poll;
+- concurrent polls and close are race-free;
+- poisoning through deadline rollback failure also wakes pollers.
+
+### Real loopback integration
+
+Platform tests use real TCP listeners and connections to verify:
+
+- listener accept readiness without accepting;
+- readable data remains fully available after repeated polls;
+- timeout zero with no data is immediate;
+- write readiness is populated;
+- graceful half-close/EOF behavior;
+- data plus hangup coexistence;
+- reset/pending-error reporting where the platform makes it deterministic;
+- global timeout with multiple non-ready sockets;
+- concurrent close unblocks a positive-timeout poll.
+
+Tests that require native descriptors do not use `net.Pipe`. Existing deadline
+tests based on consuming probes are removed or rewritten around the preserved
+persistent-deadline contract.
+
+### Platform verification
+
+- Run unit, integration, race, vet, and Noxy example suites on Windows.
+- Run unit, integration, and race suites on Linux CI.
+- Cross-build the affected packages for every supported Unix build tag.
+- Keep platform normalization tests independent of host-only event timing.
+
+## Documentation
+
+`docs/NOXY_LANGUAGE_SPEC.md` will replace the consuming-probe deadline section
+with the public contract above. It will explicitly document timeout modes,
+global timing, all three sets, duplicate/order behavior, EOF, hangup, pending
+errors, data coexistence, local close, readiness races, and deadline
+independence.
+
+`CHANGELOG.md` will record the non-consuming poller, true zero-time polling,
+global timeout, write/error sets, and platform-specific backends. An executable
+Noxy example will exercise immediate timeout, listener readiness, write
+readiness, data preservation, and EOF.
+
+## Compatibility
+
+Valid existing programs keep the same signature and result structure. Read
+polling no longer consumes and buffers a byte or accepts and buffers a
+connection. Timeout zero becomes immediate, positive timeout becomes global,
+and write/error fields become meaningful. Programs that accidentally depended
+on one millisecond minimum delay or sequential per-candidate waiting receive
+the intended corrected behavior.
+
+The implementation changes no language syntax, bytecode, compiler types,
+handle format, persistent timeout API, or detached/supervised task behavior.

--- a/docs/superpowers/specs/2026-08-14-network-poller-design.md
+++ b/docs/superpowers/specs/2026-08-14-network-poller-design.md
@@ -51,11 +51,12 @@ poll. A positive value is the maximum duration in milliseconds for the whole
 call. Values whose millisecond conversion exceeds Go's `time.Duration` range
 are invalid.
 
-Each result array remains 64 elements long and is padded with `null`. Each
-count is the number of non-null entries in its corresponding result array.
-Invalid, malformed, unknown, or already-closed candidate values are ignored,
-matching the existing candidate behavior. A valid resource may occur in more
-than one input set and may be reported in more than one output set.
+Only the first 64 elements of each input array participate in polling. Each
+result array remains 64 elements long and is padded with `null`. Each count is
+exactly the number of non-null entries copied into its corresponding result
+array. Invalid, malformed, unknown, or already-closed candidate values are
+ignored, matching the existing candidate behavior. A valid resource may occur
+in more than one input set and may be reported in more than one output set.
 
 An empty union of valid candidates returns immediately for timeout zero. For a
 positive timeout it waits until the global timeout expires, then returns empty
@@ -78,23 +79,26 @@ The common layer normalizes platform events as follows:
 
 | Native condition | Connected socket `read` | Connected socket `write` | `error` |
 |---|---:|---:|---:|
-| Normal data readable | yes | no | no |
-| Normal data writable | no | yes | no |
-| Hangup/EOF | yes | yes | yes |
-| Pending socket error | yes | yes | yes |
-| Invalid native descriptor | yes | yes | yes |
-| Priority/OOB exceptional condition | no | no | yes |
+| Normal read readiness, including indistinguishable EOF | yes | no | no |
+| Normal write readiness | no | yes | no |
+| Explicit hangup/terminal flag | yes | yes | yes |
+| Pending socket error flag | yes | yes | yes |
+| Invalid native descriptor flag | yes | yes | yes |
 
 For a listener, normal read readiness means an `Accept` can complete without
 waiting. A listener is never returned as normally writable. Listener error,
-hangup, or invalid-descriptor events are returned only in the error set, even
-if the listener was also supplied in read or write.
+hangup, or invalid-descriptor events make it read-ready when it was requested
+in read, because `Accept` will finish immediately, and error-ready when it was
+requested in error. They never make a listener write-ready.
 
-Hangup and error wake requested read and write interests because the next
-operation will complete immediately, even if it completes with EOF or an
-error. They also appear in the public error set when that resource was supplied
-there. The error set therefore represents terminal, error, invalid-descriptor,
-or exceptional readiness; it is not the narrow Berkeley `exceptfds` contract.
+An explicit hangup or error flag wakes requested read and write interests
+because the next operation will complete immediately, even if it completes
+with EOF or an error. It also appears in the public error set when that resource
+was supplied there. The error set therefore represents terminal, error, or
+invalid-descriptor readiness; it is not the narrow Berkeley `exceptfds`
+contract. Priority/OOB events are not requested or exposed because Noxy has no
+operation that consumes OOB data and would otherwise leave the condition
+continuously ready.
 
 EOF keeps the existing Noxy receive result:
 
@@ -102,10 +106,16 @@ EOF keeps the existing Noxy receive result:
 NetResult{ok: true, count: 0, data: "", error: ""}
 ```
 
-Readable data and hangup may coexist. In that case the socket can appear in
-both read and error, and `net_recv` returns available bytes before a later
-receive observes EOF. The poller does not consume either the bytes or the
-pending terminal/error condition.
+EOF is always observable as read readiness, but it is reported in error only
+when the backend supplies a distinct hangup or terminal flag. Some platforms
+report only generic read readiness, which cannot distinguish queued data from
+EOF without a prohibited peek. The public contract therefore does not promise
+that every EOF appears in error.
+
+Readable data and an explicit terminal flag may coexist. In that case the
+socket can appear in both read and error, and `net_recv` returns available bytes
+before a later receive observes EOF. The poller does not consume either the
+bytes or the pending terminal/error condition.
 
 ## Candidate and Result Ordering
 
@@ -113,14 +123,15 @@ The common layer resolves candidates using the current authoritative `fd`
 field rules and listener-first registry lookup. It creates one native
 registration per unique resource and combines all requested interests.
 
-For result construction, each input set is scanned in its original order.
-Every ready occurrence is copied to the corresponding output, including
-duplicate occurrences. Consequently:
+For result construction, the first 64 elements of each input set are scanned
+in their original order. Every ready occurrence is copied to the corresponding
+output, including duplicate occurrences. Consequently:
 
 - native registration is deduplicated for efficiency;
 - public order and multiplicity remain compatible with the existing loop;
 - one socket may occur in read, write, and error simultaneously;
-- no result count can exceed 64.
+- at most 192 candidate occurrences and 192 unique resources can be considered;
+- no result count can exceed 64 or exceed the number of values copied.
 
 ## Common Poller Boundary
 
@@ -132,7 +143,7 @@ type networkInterest uint8
 const (
 	networkReadable networkInterest = 1 << iota
 	networkWritable
-	networkExceptional
+	networkErrorInterest
 )
 
 type networkEvent uint8
@@ -157,9 +168,10 @@ The builtin flow is:
 3. Create one operation-local wake-up object.
 4. Register that wake-up with every unique resource under its `stateMu`.
 5. Acquire stable raw-descriptor references and invoke one platform wait.
-6. Release raw references and unregister the wake-up.
-7. Revalidate every reported registration.
-8. Reconstruct read, write, and error outputs in input order.
+6. Release raw references and unregister the wake-up from every resource.
+7. Close the wake-up through its synchronized lifecycle.
+8. Revalidate every reported registration.
+9. Reconstruct read, write, and error outputs in input order.
 
 Backend failure is synchronous and returns no partial `SelectResult`.
 
@@ -175,6 +187,13 @@ open until the wait and cleanup finish.
 Copying descriptor numbers outside `Control` and relying only on post-wait
 revalidation is forbidden because the operating system could reuse a closed
 descriptor number for another socket before polling starts.
+
+If obtaining `SyscallConn` or entering a nested `Control` callback fails, the
+common layer revalidates that registration before classifying the failure. If
+the registry entry, attachment, or `closed` state changed, the failure is a
+concurrent local close: cleanup runs and the poll returns promptly with that
+resource omitted. It is a synchronous backend error only when the exact
+resource remains registered, attached, and open.
 
 The resources do not need a separate lifetime generation. Their `closed`
 transition is monotonic, the stored connection/listener is never replaced, and
@@ -192,17 +211,34 @@ Each poll call owns a distinct wake-up object and registers it in a waiter set
 on every observed resource. Signaling is idempotent and non-blocking. This
 provides broadcast behavior when multiple poll calls observe the same socket.
 
-Every path that permanently closes or poisons a listener or socket uses one
-central detach transition:
+The wake-up object serializes `Signal` and `Close` with its own mutex and has
+the monotonic states `open`, `signaled`, and `closed`. `Signal` holds that mutex;
+it writes at most one non-blocking wake token only from `open`, transitions to
+`signaled`, and performs no handle operation after `closed`. `Close` holds the
+same mutex, transitions any non-closed state to `closed`, and then closes the
+backend handles. Thus a close path may retain a waiter pointer after removing
+it from a resource without racing a reused wake descriptor: either its signal
+finishes before `Close`, or it observes `closed` and becomes a no-op.
 
-1. Lock `stateMu`.
+Every path that permanently closes or poisons a listener or socket uses a
+two-phase central detach transition. `detachSocketLocked` and
+`detachListenerLocked` require `stateMu` to be held and never acquire it
+internally. They return the detached OS resources and waiter snapshot to the
+caller:
+
+1. The caller locks `stateMu`, possibly while already holding `deadlineMu`.
 2. If already closed, return without another close.
-3. Mark `closed = true` and detach the OS connection/listener and obsolete
-   probe buffers.
+3. Mark `closed = true`, detach the OS connection/listener, and clear
+   operation-specific state.
 4. Snapshot and clear the poll waiter set.
-5. Unlock `stateMu`.
-6. Signal every waiter.
-7. Close detached OS resources outside the lock.
+5. Return the detached state and unlock `stateMu`.
+6. Release `deadlineMu` if the caller held it.
+7. Signal every waiter through the synchronized wake lifecycle.
+8. Close detached OS resources outside both locks.
+
+This preserves the existing `deadlineMu` then `stateMu` acquisition order and
+prevents self-deadlock in fail-closed deadline rollback paths. No detach helper
+that acquires `stateMu` is called from code that may already hold `stateMu`.
 
 Signaling precedes the OS close because close may wait for outstanding
 `RawConn.Control` references. The wake event causes the native wait to return,
@@ -222,11 +258,21 @@ the remaining duration. No path restarts the original timeout.
 
 Windows accepts a signed 32-bit millisecond timeout, so longer durations are
 split into bounded chunks. The same common chunking rule is used on Unix for
-consistent behavior. Unix `EINTR` and the equivalent Windows interruption are
-handled as follows:
+consistent behavior. A positive remaining duration is converted to
+milliseconds by rounding up, then clamped to `math.MaxInt32`; a positive
+sub-millisecond remainder therefore waits for one millisecond instead of
+becoming a busy zero-time probe.
 
-- for a positive timeout, retry with the remaining duration;
-- for timeout zero, return an empty result immediately;
+When at least one valid candidate exists, timeout zero performs exactly one
+native non-blocking wait. A Unix `EINTR` during that wait produces an immediate
+empty result. For positive timeouts, Unix `EINTR` is retried with the remaining
+duration. No Windows error is treated as retryable unless the Windows backend
+has an explicit documented and tested mapping for it. After a timeout chunk,
+interruption, or unrelated wake, the common layer checks the absolute deadline
+before deciding whether to wait again:
+
+- while positive time remains, retry with the rounded-up remainder;
+- for timeout zero, never issue a second native wait;
 - once the absolute end instant is reached, return an empty result.
 
 An unrelated spurious wake or platform wake event may cause the common layer
@@ -238,26 +284,40 @@ close returns promptly after omitting the closed resource.
 ### Unix
 
 `internal/vm/network_poller_unix.go` uses `golang.org/x/sys/unix.Poll` and an
-operation-local non-blocking pipe or socketpair for wake-up. Explicit build
-tags cover only Unix targets where `unix.Poll` and the chosen wake primitive
-are available. The backend maps `POLLIN`, `POLLOUT`, `POLLPRI`, `POLLHUP`,
-`POLLERR`, and `POLLNVAL` into common flags.
+operation-local non-blocking pipe or socketpair for wake-up. A full wake buffer
+is treated as already signaled. Explicit build tags cover only Unix targets
+where `unix.Poll` and the chosen wake primitive are available. The common Unix
+backend maps `POLLIN`, `POLLOUT`, `POLLHUP`, `POLLERR`, and `POLLNVAL` into
+common flags and never requests `POLLPRI`.
 
-The initial target list is AIX, Darwin, DragonFly BSD, FreeBSD, Linux, NetBSD,
-OpenBSD, and Solaris. Any target that lacks a required primitive uses the
-unsupported backend until it has a tested implementation.
+Linux and FreeBSD add `POLLRDHUP` through a build-tagged terminal-mask file.
+Other Unix backends report EOF in error only when their poll result contains a
+distinct `POLLHUP` or `POLLERR`; generic `POLLIN` remains read-only.
+
+The initial compile-supported target list is AIX, Darwin, DragonFly BSD,
+FreeBSD, Linux, NetBSD, OpenBSD, and Solaris. Linux is the initially verified
+Unix platform. A compile-supported target is not documented as having verified
+identical terminal-event behavior until real integration tests run there. Any
+target that lacks a required primitive uses the unsupported backend.
 
 ### Windows
 
 `internal/vm/network_poller_windows.go` defines the ABI-compatible
-`WSAPOLLFD` structure and calls `WSAPoll` from `Ws2_32.dll`. The maximum union
-is 192 unique candidate occurrences before deduplication, well within the
-`ULONG` count accepted by `WSAPoll`.
+`WSAPOLLFD` structure and calls `WSAPoll` from `Ws2_32.dll`. The maximum input
+is 192 candidate occurrences and at most 192 unique resources before native
+registration, well within the `ULONG` count accepted by `WSAPoll`.
 
 The wake-up is an operation-local UDP loopback reader/writer pair because
-`WSAPoll` can wait only on Winsock sockets. Signaling writes at most one
-datagram per operation. The backend maps `POLLRDNORM`, `POLLWRNORM`,
-`POLLRDBAND`, `POLLHUP`, `POLLERR`, and `POLLNVAL` into common flags.
+`WSAPoll` can wait only on Winsock sockets. Its signaling socket is configured
+non-blocking at the Winsock level; signaling sends at most one datagram and
+treats `WSAEWOULDBLOCK` as already signaled. `Signal` and handle teardown use
+the synchronized lifecycle defined above.
+
+The backend requests `POLLRDNORM` and `POLLWRNORM`, never `POLLPRI`, and maps
+`POLLRDNORM`, `POLLWRNORM`, `POLLHUP`, `POLLERR`, and `POLLNVAL` into common
+flags. A `SOCKET_ERROR` return is detected explicitly and classified with
+`WSAGetLastError`. Error-only interest sets and listener registrations use the
+same normalized masks and listener filtering as the common layer.
 
 The historical `WSAPoll` asynchronous-connect caveat does not affect this
 feature: Noxy's current `net_connect` is synchronous and only successfully
@@ -294,7 +354,8 @@ fail-closed path must use the centralized detach-and-wake transition.
 
 - Invalid public argument shape or timeout produces a synchronous native error.
 - Invalid candidate elements are ignored.
-- Failure to obtain `SyscallConn` for a registered production TCP resource is
+- Failure to obtain `SyscallConn` or enter `RawConn.Control` is revalidated: a
+  concurrent detach is omitted, while failure on an unchanged open resource is
   a synchronous backend error.
 - Platform poll failure is synchronous and yields no partial result.
 - A resource closed concurrently is omitted, not reported as a platform error.
@@ -313,14 +374,24 @@ A fake backend verifies:
 - timeout zero is passed as zero and returns immediately;
 - one positive global timeout is not multiplied by candidate count;
 - interrupted and chunked waits use only the remaining duration;
+- a positive sub-millisecond remainder rounds up to one millisecond;
 - negative, wrong-type, and overflowing timeouts fail before polling;
-- read, write, error, hangup, invalid, and exceptional masks normalize exactly;
-- listener write readiness is suppressed;
+- normal read, normal write, explicit terminal, error, and invalid masks
+  normalize exactly;
+- generic read readiness does not promise EOF in error;
+- listener terminal readiness enters requested read and error while normal
+  listener write readiness is suppressed;
+- only the first 64 input elements participate and counts equal copied values;
 - order and duplicate occurrences are preserved;
 - one resource can occur in all three outputs;
 - malformed, unknown, and closed candidates are ignored;
 - backend error returns no partial result;
 - empty-set timing behavior.
+
+Windows-specific unit tests also verify `WSAPOLLFD` layout, `SOCKET_ERROR` plus
+`WSAGetLastError` classification, absence of `POLLPRI`, error-only interests,
+listener filtering, non-blocking wake saturation, and synchronized wake
+teardown.
 
 ### Lifetime and concurrency tests
 
@@ -330,6 +401,10 @@ Controlled TCP resources and barriers verify:
 - close signals every poll watching the resource;
 - close does not deadlock behind descriptor references;
 - a closed resource is omitted after wake-up;
+- `Signal` racing `Close` never touches a closed or reused wake descriptor;
+- normal readiness and timeout racing local close do not leak wake handles;
+- close at each `SyscallConn` and nested `Control` acquisition boundary is
+  classified as local close rather than backend failure;
 - unrelated deadline configuration does not invalidate or wake poll;
 - concurrent polls and close are race-free;
 - poisoning through deadline rollback failure also wakes pollers.
@@ -343,7 +418,8 @@ Platform tests use real TCP listeners and connections to verify:
 - timeout zero with no data is immediate;
 - write readiness is populated;
 - graceful half-close/EOF behavior;
-- data plus hangup coexistence;
+- EOF remains read-ready when no distinct terminal flag is available;
+- data plus an explicit terminal flag coexist where the platform reports both;
 - reset/pending-error reporting where the platform makes it deterministic;
 - global timeout with multiple non-ready sockets;
 - concurrent close unblocks a positive-timeout poll.
@@ -354,9 +430,11 @@ persistent-deadline contract.
 
 ### Platform verification
 
-- Run unit, integration, race, vet, and Noxy example suites on Windows.
-- Run unit, integration, and race suites on Linux CI.
-- Cross-build the affected packages for every supported Unix build tag.
+- Run unit, integration, race, vet, and Noxy example suites on Windows, which
+  is a verified platform.
+- Run unit, integration, and race suites on Linux CI, which is the verified
+  Unix platform.
+- Cross-build the affected packages for every compile-supported Unix build tag.
 - Keep platform normalization tests independent of host-only event timing.
 
 ## Documentation
@@ -379,7 +457,13 @@ polling no longer consumes and buffers a byte or accepts and buffers a
 connection. Timeout zero becomes immediate, positive timeout becomes global,
 and write/error fields become meaningful. Programs that accidentally depended
 on one millisecond minimum delay or sequential per-candidate waiting receive
-the intended corrected behavior.
+the intended corrected behavior. A positive-timeout call with no valid
+candidates now waits until its timeout instead of returning immediately.
+
+The native also deliberately hardens invalid direct calls: it requires exactly
+four arguments with three arrays and one integer, whereas the old native
+ignored extra arguments and returned `null` for too few. Statically valid Noxy
+calls already satisfy the stricter contract.
 
 The implementation changes no language syntax, bytecode, compiler types,
 handle format, persistent timeout API, or detached/supervised task behavior.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.24.0
 
 toolchain go1.24.11
 
-require modernc.org/sqlite v1.42.1
+require (
+	golang.org/x/sys v0.40.0
+	modernc.org/sqlite v1.42.1
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -12,9 +15,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	modernc.org/libc v1.66.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
-golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b h1:M2rDM6z3Fhozi9O7NWsxAkg/yqS/lQJ6PmkyIV3YP+o=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=
 golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
@@ -19,8 +17,6 @@ golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
 golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=

--- a/internal/stdlib/net.nx
+++ b/internal/stdlib/net.nx
@@ -62,5 +62,29 @@ func socket_set() -> Socket[64]
 end
 
 func poll(read: Socket[64], write: Socket[64], err: Socket[64], timeout: int) -> SelectResult
-    return net_select(read, write, err, timeout)
+    let raw: any = net_select(read, write, err, timeout)
+    let ready_read: Socket[64] = socket_set()
+    let ready_write: Socket[64] = socket_set()
+    let ready_error: Socket[64] = socket_set()
+
+    let i: int = 0
+    while i < raw.read_count do
+        let sock: any = raw.read[i]
+        ready_read[i] = Socket(sock.fd, sock.addr, sock.port, sock.open)
+        i = i + 1
+    end
+    i = 0
+    while i < raw.write_count do
+        let sock: any = raw.write[i]
+        ready_write[i] = Socket(sock.fd, sock.addr, sock.port, sock.open)
+        i = i + 1
+    end
+    i = 0
+    while i < raw.error_count do
+        let sock: any = raw.error[i]
+        ready_error[i] = Socket(sock.fd, sock.addr, sock.port, sock.open)
+        i = i + 1
+    end
+
+    return SelectResult(ready_read, raw.read_count, ready_write, raw.write_count, ready_error, raw.error_count)
 end

--- a/internal/vm/architecture_importer_windows_test.go
+++ b/internal/vm/architecture_importer_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package vm
+
+import "testing"
+
+func TestArchitectureImporterLoadsWindowsModuleExportData(t *testing.T) {
+	loaded, err := newArchitectureImporter(t).Import("golang.org/x/sys/windows")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if symbol := loaded.Scope().Lookup("Handle"); symbol == nil {
+		t.Fatal("golang.org/x/sys/windows export data is missing Handle")
+	}
+}
+
+func TestArchitectureImporterReportsUnresolvedModule(t *testing.T) {
+	loaded, err := newArchitectureImporter(t).Import("noxy-vm/internal/architecture_missing_package")
+	if err == nil {
+		t.Fatalf("loaded=%v, want module resolution error", loaded)
+	}
+	if loaded != nil {
+		t.Fatalf("loaded=%v alongside error=%v, want nil package", loaded, err)
+	}
+}

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -451,6 +451,109 @@ func readArchitectureSources(directory string) ([]architectureSource, error) {
 	return sources, nil
 }
 
+func networkConsumingProbeMatches(t *testing.T, sources []architectureSource) []string {
+	t.Helper()
+	forbiddenFields := map[string]map[string]bool{
+		"ListenerResource": {"bufferedAccept": true, "acceptProbeDeadline": true},
+		"SocketResource":   {"bufferedRead": true, "readProbeDeadline": true},
+	}
+	forbiddenFunctions := map[string]bool{
+		"beginListenerProbe":  true,
+		"finishListenerProbe": true,
+		"selectListener":      true,
+		"beginSocketProbe":    true,
+		"finishSocketProbe":   true,
+		"selectSocket":        true,
+	}
+	found := make(map[string]bool)
+	for _, source := range sources {
+		file, err := parser.ParseFile(token.NewFileSet(), source.filename, source.source, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", source.filename, err)
+		}
+		for _, declaration := range file.Decls {
+			switch typed := declaration.(type) {
+			case *ast.FuncDecl:
+				if forbiddenFunctions[typed.Name.Name] {
+					found[typed.Name.Name] = true
+				}
+			case *ast.GenDecl:
+				for _, specification := range typed.Specs {
+					typeSpec, ok := specification.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					fields := forbiddenFields[typeSpec.Name.Name]
+					structure, ok := typeSpec.Type.(*ast.StructType)
+					if len(fields) == 0 || !ok {
+						continue
+					}
+					for _, field := range structure.Fields.List {
+						for _, name := range field.Names {
+							if fields[name.Name] {
+								found[typeSpec.Name.Name+"."+name.Name] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	matches := make([]string, 0, len(found))
+	for match := range found {
+		matches = append(matches, match)
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func TestNetworkArchitectureExcludesConsumingProbes(t *testing.T) {
+	sources, err := readArchitectureSources(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, match := range networkConsumingProbeMatches(t, sources) {
+		t.Errorf("obsolete consuming network probe structure: %s", match)
+	}
+}
+
+func TestNetworkArchitectureGuardMatchesExactSyntax(t *testing.T) {
+	source := `package guarded
+type ListenerResource struct {
+	bufferedAccept int
+	acceptProbeDeadline int
+}
+type SocketResource struct {
+	bufferedRead, readProbeDeadline int
+}
+type Unrelated struct { bufferedRead int }
+func beginListenerProbe() {}
+func finishListenerProbe() {}
+func selectListener() {}
+func beginSocketProbe() {}
+func finishSocketProbe() {}
+func selectSocket() {}
+var _ = "func beginSocketProbe; bufferedAccept"
+// func selectListener() {}
+`
+	got := networkConsumingProbeMatches(t, []architectureSource{{filename: "guarded.go", source: source}})
+	want := []string{
+		"ListenerResource.acceptProbeDeadline",
+		"ListenerResource.bufferedAccept",
+		"SocketResource.bufferedRead",
+		"SocketResource.readProbeDeadline",
+		"beginListenerProbe",
+		"beginSocketProbe",
+		"finishListenerProbe",
+		"finishSocketProbe",
+		"selectListener",
+		"selectSocket",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("matches=%v, want %v", got, want)
+	}
+}
+
 func checkArchitecturePackage(packagePath string, sources []architectureSource, loader types.Importer, ignoreBodies bool) *architecturePackage {
 	fileSet := token.NewFileSet()
 	files := make([]*ast.File, 0, len(sources))

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"bytes"
 	"go/ast"
+	"go/build"
 	"go/constant"
 	"go/importer"
 	"go/parser"
@@ -11,6 +12,7 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -197,6 +199,13 @@ func productionGoFiles(t *testing.T) []string {
 		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
+		matches, err := build.Default.MatchFile(filepath.Dir(path), filepath.Base(path))
+		if err != nil {
+			return err
+		}
+		if !matches {
+			return nil
+		}
 		files = append(files, path)
 		return nil
 	})
@@ -204,6 +213,37 @@ func productionGoFiles(t *testing.T) []string {
 		t.Fatal(err)
 	}
 	return files
+}
+
+func TestReadArchitectureSourcesRespectsActivePlatform(t *testing.T) {
+	directory := t.TempDir()
+	otherPlatform := "linux"
+	if runtime.GOOS == "linux" {
+		otherPlatform = "windows"
+	}
+	sources := map[string]string{
+		"common.go":                         "package fixture\n",
+		"active_" + runtime.GOOS + ".go":    "package fixture\n",
+		"inactive_" + otherPlatform + ".go": "package fixture\n",
+	}
+	for filename, source := range sources {
+		if err := os.WriteFile(filepath.Join(directory, filename), []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := readArchitectureSources(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var basenames []string
+	for _, source := range got {
+		basenames = append(basenames, filepath.Base(source.filename))
+	}
+	want := []string{"active_" + runtime.GOOS + ".go", "common.go"}
+	if strings.Join(basenames, ",") != strings.Join(want, ",") {
+		t.Fatalf("sources=%v, want %v", basenames, want)
+	}
 }
 
 func expressionText(t *testing.T, expression ast.Expr) string {
@@ -319,6 +359,13 @@ func readArchitectureSources(directory string) ([]architectureSource, error) {
 	var sources []architectureSource
 	for _, filename := range filenames {
 		if strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+		matches, err := build.Default.MatchFile(directory, filepath.Base(filename))
+		if err != nil {
+			return nil, err
+		}
+		if !matches {
 			continue
 		}
 		source, err := os.ReadFile(filename)

--- a/internal/vm/architecture_test.go
+++ b/internal/vm/architecture_test.go
@@ -2,6 +2,9 @@ package vm
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"go/ast"
 	"go/build"
 	"go/constant"
@@ -10,7 +13,9 @@ import (
 	"go/printer"
 	"go/token"
 	"go/types"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -303,10 +308,12 @@ type architecturePackage struct {
 }
 
 type architectureImporter struct {
-	moduleRoot string
-	packages   map[string]*types.Package
-	loading    map[string]bool
-	fallback   types.Importer
+	moduleRoot    string
+	packages      map[string]*types.Package
+	loading       map[string]bool
+	fallback      types.Importer
+	exportFiles   map[string]string
+	moduleImports types.Importer
 }
 
 func newArchitectureImporter(t *testing.T) *architectureImporter {
@@ -315,12 +322,15 @@ func newArchitectureImporter(t *testing.T) *architectureImporter {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &architectureImporter{
-		moduleRoot: moduleRoot,
-		packages:   make(map[string]*types.Package),
-		loading:    make(map[string]bool),
-		fallback:   importer.Default(),
+	loader := &architectureImporter{
+		moduleRoot:  moduleRoot,
+		packages:    make(map[string]*types.Package),
+		loading:     make(map[string]bool),
+		fallback:    importer.Default(),
+		exportFiles: make(map[string]string),
 	}
+	loader.moduleImports = importer.ForCompiler(token.NewFileSet(), "gc", loader.openExportData)
+	return loader
 }
 
 func (loader *architectureImporter) Import(importPath string) (*types.Package, error) {
@@ -340,15 +350,78 @@ func (loader *architectureImporter) Import(importPath string) (*types.Package, e
 			}
 		}
 	}
-	if loaded, err := loader.fallback.Import(importPath); err == nil {
+	loaded, fallbackErr := loader.fallback.Import(importPath)
+	if fallbackErr == nil {
 		loader.packages[importPath] = loaded
 		return loaded, nil
 	}
-	name := importPath[strings.LastIndex(importPath, "/")+1:]
-	stub := types.NewPackage(importPath, name)
-	stub.MarkComplete()
-	loader.packages[importPath] = stub
-	return stub, nil
+	loaded, moduleErr := loader.importModuleExportData(importPath)
+	if moduleErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("default importer for %q: %w", importPath, fallbackErr),
+			fmt.Errorf("module-aware importer for %q: %w", importPath, moduleErr),
+		)
+	}
+	loader.packages[importPath] = loaded
+	return loaded, nil
+}
+
+type architectureListedPackage struct {
+	ImportPath string
+	Export     string
+	Error      *struct {
+		Err string
+	}
+}
+
+func (loader *architectureImporter) importModuleExportData(importPath string) (*types.Package, error) {
+	if loader.exportFiles[importPath] == "" {
+		command := exec.Command("go", "list", "-deps", "-export", "-json", importPath)
+		command.Dir = loader.moduleRoot
+		output, err := command.Output()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
+				return nil, fmt.Errorf("go list: %s: %w", strings.TrimSpace(string(exitErr.Stderr)), err)
+			}
+			return nil, fmt.Errorf("go list: %w", err)
+		}
+		decoder := json.NewDecoder(bytes.NewReader(output))
+		for {
+			var listed architectureListedPackage
+			if err := decoder.Decode(&listed); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return nil, fmt.Errorf("decode go list output: %w", err)
+			}
+			if listed.Error != nil {
+				return nil, fmt.Errorf("go list package %q: %s", listed.ImportPath, listed.Error.Err)
+			}
+			if listed.Export != "" {
+				loader.exportFiles[listed.ImportPath] = listed.Export
+			}
+		}
+	}
+	if loader.exportFiles[importPath] == "" {
+		return nil, fmt.Errorf("go list returned no export data")
+	}
+	loaded, err := loader.moduleImports.Import(importPath)
+	if err != nil {
+		return nil, fmt.Errorf("read export data: %w", err)
+	}
+	return loaded, nil
+}
+
+func (loader *architectureImporter) openExportData(importPath string) (io.ReadCloser, error) {
+	filename := loader.exportFiles[importPath]
+	if filename == "" {
+		return nil, fmt.Errorf("no export data for %q", importPath)
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("open export data for %q: %w", importPath, err)
+	}
+	return file, nil
 }
 
 func readArchitectureSources(directory string) ([]architectureSource, error) {

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -465,8 +465,12 @@ func (vm *VM) defineNetworkBuiltins() {
 			_ = listener.Close()
 			return socketValue(-1, host, port, false), nil
 		}
+		boundPort := port
+		if address, addressOK := listener.Addr().(*net.TCPAddr); addressOK {
+			boundPort = address.Port
+		}
 		handle := machine.shared.Listeners.add(&ListenerResource{listener: configuredListener})
-		return socketValue(handle, host, port, true), nil
+		return socketValue(handle, host, boundPort, true), nil
 	})
 
 	vm.DefineContextualNative("net_accept", func(context value.NativeContext, args []value.Value) (value.Value, error) {

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -19,6 +19,12 @@ type deadlineListener interface {
 
 var networkDialTimeout = net.DialTimeout
 
+var defaultNetworkPoller = networkPoller{
+	platform: systemNetworkPlatform(),
+	now:      time.Now,
+	sleep:    time.Sleep,
+}
+
 func validateNetworkTimeout(milliseconds int64) (time.Duration, error) {
 	if milliseconds <= 0 {
 		return 0, fmt.Errorf("network timeout must be positive")
@@ -60,19 +66,11 @@ func networkSocketDescriptor(socket value.Value) (int, error) {
 	return handle, nil
 }
 
-func effectiveNetworkDeadline(now time.Time, timeout time.Duration, probeBound time.Time) time.Time {
-	deadline := time.Time{}
+func effectiveNetworkDeadline(now time.Time, timeout time.Duration) time.Time {
 	if timeout > 0 {
-		deadline = now.Add(timeout)
+		return now.Add(timeout)
 	}
-	if !probeBound.IsZero() && (deadline.IsZero() || probeBound.Before(deadline)) {
-		return probeBound
-	}
-	return deadline
-}
-
-func networkProbeDeadline(started time.Time, selectTimeout time.Duration, ioTimeout time.Duration) time.Time {
-	return effectiveNetworkDeadline(started, ioTimeout, started.Add(selectTimeout))
+	return time.Time{}
 }
 
 func configureSocketTimeout(resource *SocketResource, timeout time.Duration) error {
@@ -90,8 +88,8 @@ func configureSocketTimeout(resource *SocketResource, timeout time.Duration) err
 	oldReadDeadline := resource.lastReadDeadline
 	oldWriteDeadline := resource.lastWriteDeadline
 	now := time.Now()
-	readDeadline := effectiveNetworkDeadline(now, timeout, resource.readProbeDeadline)
-	writeDeadline := effectiveNetworkDeadline(now, timeout, time.Time{})
+	readDeadline := effectiveNetworkDeadline(now, timeout)
+	writeDeadline := effectiveNetworkDeadline(now, timeout)
 	resource.stateMu.Unlock()
 
 	readErr := connection.SetReadDeadline(readDeadline)
@@ -183,7 +181,7 @@ func configureListenerTimeout(resource *ListenerResource, timeout time.Duration)
 	generation := resource.deadlineGeneration
 	listener := resource.listener
 	oldDeadline := resource.lastAcceptDeadline
-	deadline := effectiveNetworkDeadline(time.Now(), timeout, resource.acceptProbeDeadline)
+	deadline := effectiveNetworkDeadline(time.Now(), timeout)
 	resource.stateMu.Unlock()
 
 	applicationErr := listener.SetDeadline(deadline)
@@ -255,7 +253,7 @@ func prepareSocketRead(resource *SocketResource) (net.Conn, error) {
 	resource.deadlineGeneration++
 	generation := resource.deadlineGeneration
 	connection := resource.connection
-	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, resource.readProbeDeadline)
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout)
 	resource.stateMu.Unlock()
 
 	if err := connection.SetReadDeadline(deadline); err != nil {
@@ -282,7 +280,7 @@ func prepareSocketWrite(resource *SocketResource) (net.Conn, error) {
 	resource.deadlineGeneration++
 	generation := resource.deadlineGeneration
 	connection := resource.connection
-	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout)
 	resource.stateMu.Unlock()
 
 	if err := connection.SetWriteDeadline(deadline); err != nil {
@@ -309,7 +307,7 @@ func prepareListenerAccept(resource *ListenerResource) (deadlineListener, error)
 	resource.deadlineGeneration++
 	generation := resource.deadlineGeneration
 	listener := resource.listener
-	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, resource.acceptProbeDeadline)
+	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout)
 	resource.stateMu.Unlock()
 
 	if err := listener.SetDeadline(deadline); err != nil {
@@ -351,24 +349,6 @@ func acceptConnection(resource *ListenerResource) (net.Conn, error) {
 		resource.stateMu.Unlock()
 		return nil, net.ErrClosed
 	}
-	if resource.bufferedAccept != nil {
-		connection := resource.bufferedAccept
-		resource.stateMu.Unlock()
-		clearErr := connection.SetDeadline(time.Time{})
-
-		resource.stateMu.Lock()
-		if resource.closed || resource.bufferedAccept != connection {
-			resource.stateMu.Unlock()
-			return nil, net.ErrClosed
-		}
-		resource.bufferedAccept = nil
-		resource.stateMu.Unlock()
-		if clearErr != nil {
-			_ = connection.Close()
-			return nil, clearErr
-		}
-		return connection, nil
-	}
 	resource.stateMu.Unlock()
 
 	listener, err := prepareListenerAccept(resource)
@@ -406,23 +386,10 @@ func receiveSocket(resource *SocketResource, size int) value.Value {
 		resource.stateMu.Unlock()
 		return netResult(true, "", 0, "")
 	}
-	if len(resource.bufferedRead) >= size {
-		data := append([]byte(nil), resource.bufferedRead[:size]...)
-		resource.bufferedRead = resource.bufferedRead[size:]
-		resource.stateMu.Unlock()
-		return netResult(true, string(data), len(data), "")
-	}
 	resource.stateMu.Unlock()
 
 	connection, deadlineErr := prepareSocketRead(resource)
 	if deadlineErr != nil {
-		resource.stateMu.Lock()
-		buffered := append([]byte(nil), resource.bufferedRead...)
-		resource.bufferedRead = nil
-		resource.stateMu.Unlock()
-		if len(buffered) != 0 {
-			return netResult(true, string(buffered), len(buffered), "")
-		}
 		return netResult(false, "", 0, networkErrorMessage(deadlineErr))
 	}
 
@@ -431,27 +398,15 @@ func receiveSocket(resource *SocketResource, size int) value.Value {
 		resource.stateMu.Unlock()
 		return netResult(false, "", 0, "invalid socket")
 	}
-	buffered := append([]byte(nil), resource.bufferedRead...)
-	resource.bufferedRead = nil
 	resource.stateMu.Unlock()
 
 	buffer := make([]byte, size)
-	read := 0
-	if len(buffered) != 0 {
-		copy(buffer, buffered)
-		read = len(buffered)
-	}
-	if read < size {
-		additional, readErr := connection.Read(buffer[read:])
-		if additional > 0 {
-			read += additional
+	read, readErr := connection.Read(buffer)
+	if readErr != nil && read == 0 {
+		if readErr == io.EOF {
+			return netResult(true, "", 0, "")
 		}
-		if readErr != nil && read == 0 {
-			if readErr == io.EOF {
-				return netResult(true, "", 0, "")
-			}
-			return netResult(false, "", 0, networkErrorMessage(readErr))
-		}
+		return netResult(false, "", 0, networkErrorMessage(readErr))
 	}
 	return netResult(true, string(buffer[:read]), read, "")
 }
@@ -470,214 +425,6 @@ func sendSocket(resource *SocketResource, data string) value.Value {
 		return netResult(false, "", written, networkErrorMessage(writeErr))
 	}
 	return netResult(true, "", written, "")
-}
-
-func beginListenerProbe(resource *ListenerResource, timeout time.Duration) (deadlineListener, bool, error) {
-	resource.deadlineMu.Lock()
-	defer resource.deadlineMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.listener == nil {
-		resource.stateMu.Unlock()
-		return nil, true, nil
-	}
-	resource.deadlineGeneration++
-	generation := resource.deadlineGeneration
-	listener := resource.listener
-	started := time.Now()
-	probeBound := started.Add(timeout)
-	resource.acceptProbeDeadline = probeBound
-	deadline := networkProbeDeadline(started, timeout, resource.ioTimeout)
-	resource.stateMu.Unlock()
-
-	setterErr := listener.SetDeadline(deadline)
-	resource.stateMu.Lock()
-	defer resource.stateMu.Unlock()
-	if resource.closed || resource.deadlineGeneration != generation {
-		return nil, true, nil
-	}
-	if setterErr != nil {
-		resource.acceptProbeDeadline = time.Time{}
-		return nil, false, setterErr
-	}
-	resource.lastAcceptDeadline = deadline
-	return listener, false, nil
-}
-
-func finishListenerProbe(resource *ListenerResource, listener deadlineListener, connection net.Conn) (bool, error) {
-	resource.deadlineMu.Lock()
-	defer resource.deadlineMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.listener != listener {
-		resource.stateMu.Unlock()
-		if connection != nil {
-			_ = connection.Close()
-		}
-		return true, nil
-	}
-	if connection != nil {
-		resource.bufferedAccept = connection
-	}
-	resource.acceptProbeDeadline = time.Time{}
-	resource.deadlineGeneration++
-	generation := resource.deadlineGeneration
-	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
-	resource.stateMu.Unlock()
-
-	setterErr := listener.SetDeadline(deadline)
-	resource.stateMu.Lock()
-	defer resource.stateMu.Unlock()
-	if resource.closed || resource.deadlineGeneration != generation {
-		return true, nil
-	}
-	if setterErr != nil {
-		return false, setterErr
-	}
-	resource.lastAcceptDeadline = deadline
-	return false, nil
-}
-
-func selectListener(resource *ListenerResource, timeout time.Duration) (bool, error) {
-	resource.acceptMu.Lock()
-	defer resource.acceptMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.listener == nil {
-		resource.stateMu.Unlock()
-		return false, nil
-	}
-	if resource.bufferedAccept != nil {
-		resource.stateMu.Unlock()
-		return true, nil
-	}
-	resource.stateMu.Unlock()
-
-	listener, closed, err := beginListenerProbe(resource, timeout)
-	if err != nil {
-		return false, err
-	}
-	if closed {
-		return false, nil
-	}
-	connection, acceptErr := listener.Accept()
-	ordinarySuccess := acceptErr == nil && connection != nil
-	closed, restoreErr := finishListenerProbe(resource, listener, func() net.Conn {
-		if ordinarySuccess {
-			return connection
-		}
-		return nil
-	}())
-	if restoreErr != nil {
-		return false, restoreErr
-	}
-	if closed || !ordinarySuccess {
-		return false, nil
-	}
-	return true, nil
-}
-
-func beginSocketProbe(resource *SocketResource, timeout time.Duration) (net.Conn, bool, error) {
-	resource.deadlineMu.Lock()
-	defer resource.deadlineMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.connection == nil {
-		resource.stateMu.Unlock()
-		return nil, true, nil
-	}
-	resource.deadlineGeneration++
-	generation := resource.deadlineGeneration
-	connection := resource.connection
-	started := time.Now()
-	probeBound := started.Add(timeout)
-	resource.readProbeDeadline = probeBound
-	deadline := networkProbeDeadline(started, timeout, resource.ioTimeout)
-	resource.stateMu.Unlock()
-
-	setterErr := connection.SetReadDeadline(deadline)
-	resource.stateMu.Lock()
-	defer resource.stateMu.Unlock()
-	if resource.closed || resource.deadlineGeneration != generation {
-		return nil, true, nil
-	}
-	if setterErr != nil {
-		resource.readProbeDeadline = time.Time{}
-		return nil, false, setterErr
-	}
-	resource.lastReadDeadline = deadline
-	return connection, false, nil
-}
-
-func finishSocketProbe(resource *SocketResource, connection net.Conn, ready []byte) (bool, error) {
-	resource.deadlineMu.Lock()
-	defer resource.deadlineMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.connection != connection {
-		resource.stateMu.Unlock()
-		return true, nil
-	}
-	if len(ready) != 0 {
-		resource.bufferedRead = append(resource.bufferedRead, ready...)
-	}
-	resource.readProbeDeadline = time.Time{}
-	resource.deadlineGeneration++
-	generation := resource.deadlineGeneration
-	deadline := effectiveNetworkDeadline(time.Now(), resource.ioTimeout, time.Time{})
-	resource.stateMu.Unlock()
-
-	setterErr := connection.SetReadDeadline(deadline)
-	resource.stateMu.Lock()
-	defer resource.stateMu.Unlock()
-	if resource.closed || resource.deadlineGeneration != generation {
-		return true, nil
-	}
-	if setterErr != nil {
-		return false, setterErr
-	}
-	resource.lastReadDeadline = deadline
-	return false, nil
-}
-
-func selectSocket(resource *SocketResource, timeout time.Duration) (bool, error) {
-	resource.readMu.Lock()
-	defer resource.readMu.Unlock()
-
-	resource.stateMu.Lock()
-	if resource.closed || resource.connection == nil {
-		resource.stateMu.Unlock()
-		return false, nil
-	}
-	if len(resource.bufferedRead) != 0 {
-		resource.stateMu.Unlock()
-		return true, nil
-	}
-	resource.stateMu.Unlock()
-
-	connection, closed, err := beginSocketProbe(resource, timeout)
-	if err != nil {
-		return false, err
-	}
-	if closed {
-		return false, nil
-	}
-	buffer := make([]byte, 1)
-	read, readErr := connection.Read(buffer)
-	ordinarySuccess := readErr == nil && read > 0
-	closed, restoreErr := finishSocketProbe(resource, connection, func() []byte {
-		if ordinarySuccess {
-			return buffer[:read]
-		}
-		return nil
-	}())
-	if restoreErr != nil {
-		return false, restoreErr
-	}
-	if closed || !ordinarySuccess {
-		return false, nil
-	}
-	return true, nil
 }
 
 func closeListener(resource *ListenerResource) {
@@ -887,48 +634,10 @@ func (vm *VM) defineNetworkBuiltins() {
 		if err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) < 4 {
-			return value.NewNull(), nil
+		sets, timeout, err := validateNetworkPollArguments(args)
+		if err != nil {
+			return value.NewNull(), err
 		}
-		timeoutMilliseconds := int(args[3].AsInt)
-		if timeoutMilliseconds < 1 {
-			timeoutMilliseconds = 1
-		}
-		timeout := time.Millisecond * time.Duration(timeoutMilliseconds)
-		readyRead := make([]value.Value, 0)
-		if array, ok := args[0].Obj.(*value.ObjArray); args[0].Type == value.VAL_OBJ && ok {
-			for _, candidate := range array.Elements {
-				if candidate.Type != value.VAL_OBJ {
-					continue
-				}
-				handle := int64(-1)
-				if socket, ok := candidate.Obj.(*value.ObjMap); ok {
-					if fdValue, exists := socket.Get("fd"); exists {
-						handle = fdValue.AsInt
-					}
-				} else if instance, ok := candidate.Obj.(*value.ObjInstance); ok {
-					if fdValue, exists := instance.Fields["fd"]; exists {
-						handle = fdValue.AsInt
-					}
-				}
-				if handle == -1 {
-					continue
-				}
-				ready := false
-				var probeErr error
-				if listener, exists := machine.shared.Listeners.get(int(handle)); exists {
-					ready, probeErr = selectListener(listener, timeout)
-				} else if socket, exists := machine.shared.Sockets.get(int(handle)); exists {
-					ready, probeErr = selectSocket(socket, timeout)
-				}
-				if probeErr != nil {
-					return value.NewNull(), probeErr
-				}
-				if ready {
-					readyRead = append(readyRead, candidate)
-				}
-			}
-		}
-		return selectResult(readyRead, nil, nil), nil
+		return defaultNetworkPoller.Poll(machine.shared, sets, timeout)
 	})
 }

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -629,6 +629,10 @@ func (vm *VM) defineNetworkBuiltins() {
 		return value.NewNull(), nil
 	})
 
+	vm.DefineNative("net_socket_set", func([]value.Value) value.Value {
+		return fixedNetworkSet(nil)
+	})
+
 	vm.DefineContextualNative("net_select", func(context value.NativeContext, args []value.Value) (value.Value, error) {
 		machine, err := nativeVM(context)
 		if err != nil {

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -359,29 +359,6 @@ func netResult(ok bool, data string, count int, message string) value.Value {
 	})
 }
 
-func selectResult(readyRead []value.Value) value.Value {
-	read := make([]value.Value, 64)
-	for index := range read {
-		if index < len(readyRead) {
-			read[index] = readyRead[index]
-		} else {
-			read[index] = value.NewNull()
-		}
-	}
-	empty := make([]value.Value, 64)
-	for index := range empty {
-		empty[index] = value.NewNull()
-	}
-	return value.NewMapWithData(map[string]value.Value{
-		"read":        value.NewArray(read),
-		"read_count":  value.NewInt(int64(len(readyRead))),
-		"write":       value.NewArray(empty),
-		"write_count": value.NewInt(0),
-		"error":       value.NewArray(empty),
-		"error_count": value.NewInt(0),
-	})
-}
-
 func acceptConnection(resource *ListenerResource) (net.Conn, error) {
 	resource.acceptMu.Lock()
 	defer resource.acceptMu.Unlock()
@@ -991,6 +968,6 @@ func (vm *VM) defineNetworkBuiltins() {
 				}
 			}
 		}
-		return selectResult(readyRead), nil
+		return selectResult(readyRead, nil, nil), nil
 	})
 }

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -119,15 +119,11 @@ func configureSocketTimeout(resource *SocketResource, timeout time.Duration) err
 			resource.deadlineMu.Unlock()
 			return readErr
 		}
-		resource.closed = true
-		resource.deadlineGeneration++
-		resource.connection = nil
-		resource.bufferedRead = nil
-		resource.readProbeDeadline = time.Time{}
+		detached, _ := detachSocketLocked(resource)
 		resource.stateMu.Unlock()
 		resource.deadlineMu.Unlock()
-		closeErr := connection.Close()
-		return errors.Join(readErr, rollbackErr, closeErr)
+		detachErr := finishSocketDetach(detached)
+		return errors.Join(readErr, rollbackErr, detachErr)
 	}
 
 	writeErr := connection.SetWriteDeadline(writeDeadline)
@@ -167,15 +163,11 @@ func configureSocketTimeout(resource *SocketResource, timeout time.Duration) err
 		resource.deadlineMu.Unlock()
 		return writeErr
 	}
-	resource.closed = true
-	resource.deadlineGeneration++
-	resource.connection = nil
-	resource.bufferedRead = nil
-	resource.readProbeDeadline = time.Time{}
+	detached, _ := detachSocketLocked(resource)
 	resource.stateMu.Unlock()
 	resource.deadlineMu.Unlock()
-	closeErr := connection.Close()
-	return errors.Join(writeErr, readRollbackErr, writeRollbackErr, closeErr)
+	detachErr := finishSocketDetach(detached)
+	return errors.Join(writeErr, readRollbackErr, writeRollbackErr, detachErr)
 }
 
 func configureListenerTimeout(resource *ListenerResource, timeout time.Duration) error {
@@ -223,20 +215,11 @@ func configureListenerTimeout(resource *ListenerResource, timeout time.Duration)
 		resource.deadlineMu.Unlock()
 		return applicationErr
 	}
-	resource.closed = true
-	resource.deadlineGeneration++
-	resource.listener = nil
-	buffered := resource.bufferedAccept
-	resource.bufferedAccept = nil
-	resource.acceptProbeDeadline = time.Time{}
+	detached, _ := detachListenerLocked(resource)
 	resource.stateMu.Unlock()
 	resource.deadlineMu.Unlock()
-	listenerCloseErr := listener.Close()
-	var bufferedCloseErr error
-	if buffered != nil {
-		bufferedCloseErr = buffered.Close()
-	}
-	return errors.Join(applicationErr, rollbackErr, listenerCloseErr, bufferedCloseErr)
+	detachErr := finishListenerDetach(detached)
+	return errors.Join(applicationErr, rollbackErr, detachErr)
 }
 
 func configureNetworkTimeout(machine *VM, socket value.Value, timeout time.Duration) error {
@@ -699,41 +682,19 @@ func selectSocket(resource *SocketResource, timeout time.Duration) (bool, error)
 
 func closeListener(resource *ListenerResource) {
 	resource.stateMu.Lock()
-	if resource.closed {
-		resource.stateMu.Unlock()
-		return
-	}
-	resource.closed = true
-	resource.deadlineGeneration++
-	listener := resource.listener
-	resource.listener = nil
-	resource.acceptProbeDeadline = time.Time{}
-	buffered := resource.bufferedAccept
-	resource.bufferedAccept = nil
+	detached, ok := detachListenerLocked(resource)
 	resource.stateMu.Unlock()
-	if listener != nil {
-		_ = listener.Close()
-	}
-	if buffered != nil {
-		_ = buffered.Close()
+	if ok {
+		_ = finishListenerDetach(detached)
 	}
 }
 
 func closeSocket(resource *SocketResource) {
 	resource.stateMu.Lock()
-	if resource.closed {
-		resource.stateMu.Unlock()
-		return
-	}
-	resource.closed = true
-	resource.deadlineGeneration++
-	connection := resource.connection
-	resource.connection = nil
-	resource.readProbeDeadline = time.Time{}
-	resource.bufferedRead = nil
+	detached, ok := detachSocketLocked(resource)
 	resource.stateMu.Unlock()
-	if connection != nil {
-		_ = connection.Close()
+	if ok {
+		_ = finishSocketDetach(detached)
 	}
 }
 

--- a/internal/vm/builtins_net_deadlines_test.go
+++ b/internal/vm/builtins_net_deadlines_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -40,6 +41,49 @@ type controlledDeadlineListener struct {
 	setFn      func(time.Time) error
 	closeFn    func() error
 }
+
+type nestedControlTracker struct {
+	mu       sync.Mutex
+	active   int
+	released chan struct{}
+}
+
+type closeAwareRawConn struct {
+	descriptor uintptr
+	resource   *SocketResource
+	tracker    *nestedControlTracker
+}
+
+type networkInvocationResult struct {
+	value value.Value
+	err   error
+}
+
+func (raw *closeAwareRawConn) Control(callback func(uintptr)) error {
+	raw.resource.stateMu.Lock()
+	closed := raw.resource.closed
+	raw.resource.stateMu.Unlock()
+	if closed {
+		return net.ErrClosed
+	}
+	raw.tracker.mu.Lock()
+	raw.tracker.active++
+	raw.tracker.mu.Unlock()
+	callback(raw.descriptor)
+	raw.tracker.mu.Lock()
+	raw.tracker.active--
+	if raw.tracker.active == 0 {
+		select {
+		case raw.tracker.released <- struct{}{}:
+		default:
+		}
+	}
+	raw.tracker.mu.Unlock()
+	return nil
+}
+
+func (*closeAwareRawConn) Read(func(uintptr) bool) error  { return nil }
+func (*closeAwareRawConn) Write(func(uintptr) bool) error { return nil }
 
 func (listener *controlledDeadlineListener) Accept() (net.Conn, error) {
 	if listener.acceptFn != nil {
@@ -140,6 +184,408 @@ func (connection *controlledDeadlineConn) closes() int {
 	return connection.closeCount
 }
 
+func (connection *controlledDeadlineConn) SyscallConn() (syscall.RawConn, error) {
+	syscallConnection, ok := connection.Conn.(syscall.Conn)
+	if !ok {
+		return nil, fmt.Errorf("controlled connection does not expose SyscallConn")
+	}
+	return syscallConnection.SyscallConn()
+}
+
+func (listener *controlledDeadlineListener) SyscallConn() (syscall.RawConn, error) {
+	syscallListener, ok := listener.Listener.(syscall.Conn)
+	if !ok {
+		return nil, fmt.Errorf("controlled listener does not expose SyscallConn")
+	}
+	return syscallListener.SyscallConn()
+}
+
+func waitForNetworkPollWaiter(t *testing.T, waiters func() int) {
+	t.Helper()
+	deadline := time.After(statefulBuiltinTimeout)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if waiters() != 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("net_select did not register its close waiter")
+		case <-ticker.C:
+		}
+	}
+}
+
+func requirePromptNetworkCloseAndPoll(t *testing.T, machine *VM, candidate value.Value, poll <-chan networkInvocationResult) {
+	t.Helper()
+	closeNative := requireBuiltin(t, machine, "net_close")
+	closed := make(chan error, 1)
+	go func() {
+		_, err := closeNative.Invoke(machine, []value.Value{candidate})
+		closed <- err
+	}()
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	for poll != nil || closed != nil {
+		select {
+		case invocation := <-poll:
+			if invocation.err != nil {
+				t.Fatal(invocation.err)
+			}
+			assertBuiltinValue(t, builtinMapField(t, invocation.value, "read_count"), value.NewInt(0))
+			poll = nil
+		case err := <-closed:
+			if err != nil {
+				t.Fatal(err)
+			}
+			closed = nil
+		case <-timer.C:
+			t.Fatal("net_select and local close did not both complete before the one-second fallback chunk")
+		}
+	}
+}
+
+func TestNetSelectDoesNotMutateDeadlines(t *testing.T) {
+	machine := New()
+	_, _, server := setupAcceptedLoopback(t, machine)
+	_, resource := requireSocketResource(t, machine, server)
+	resource.stateMu.Lock()
+	original := resource.connection
+	controlled := &controlledDeadlineConn{Conn: original}
+	readDeadline := time.Unix(100, 0)
+	writeDeadline := time.Unix(200, 0)
+	resource.connection = controlled
+	resource.lastReadDeadline = readDeadline
+	resource.lastWriteDeadline = writeDeadline
+	resource.stateMu.Unlock()
+
+	selected := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(0))
+	controlled.mu.Lock()
+	readSetterCalls := len(controlled.readDeadlines)
+	writeSetterCalls := len(controlled.writeDeadlines)
+	combinedSetterCalls := len(controlled.deadlines)
+	controlled.mu.Unlock()
+	resource.stateMu.Lock()
+	gotReadDeadline := resource.lastReadDeadline
+	gotWriteDeadline := resource.lastWriteDeadline
+	resource.stateMu.Unlock()
+	if readSetterCalls != 0 || writeSetterCalls != 0 || combinedSetterCalls != 0 {
+		t.Fatalf("deadline setter calls read/write/combined=%d/%d/%d, want 0/0/0", readSetterCalls, writeSetterCalls, combinedSetterCalls)
+	}
+	if !gotReadDeadline.Equal(readDeadline) || !gotWriteDeadline.Equal(writeDeadline) {
+		t.Fatalf("deadlines read/write=%v/%v, want %v/%v", gotReadDeadline, gotWriteDeadline, readDeadline, writeDeadline)
+	}
+}
+
+func TestNetSelectCloseWakesAndOmitsLocalResource(t *testing.T) {
+	t.Run("socket", func(t *testing.T) {
+		machine := New()
+		_, _, server := setupAcceptedLoopback(t, machine)
+		_, resource := requireSocketResource(t, machine, server)
+		native := requireBuiltin(t, machine, "net_select")
+		result := make(chan networkInvocationResult, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			result <- networkInvocationResult{selected, err}
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		requirePromptNetworkCloseAndPoll(t, machine, server, result)
+	})
+
+	t.Run("listener", func(t *testing.T) {
+		machine := New()
+		cleanupNetworkResources(t, machine)
+		listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+		handle := int(builtinMapField(t, listener, "fd").AsInt)
+		resource, exists := machine.shared.Listeners.get(handle)
+		if !exists {
+			t.Fatalf("listener descriptor %d is not registered", handle)
+		}
+		native := requireBuiltin(t, machine, "net_select")
+		result := make(chan networkInvocationResult, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{listener}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			result <- networkInvocationResult{selected, err}
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		requirePromptNetworkCloseAndPoll(t, machine, listener, result)
+	})
+}
+
+func TestNetSelectRollbackPoisonWakesBeforeResourceClose(t *testing.T) {
+	runSocket := func(t *testing.T, configureControlled func(*controlledDeadlineConn) []error) {
+		machine := New()
+		_, _, server := setupAcceptedLoopback(t, machine)
+		_, resource := requireSocketResource(t, machine, server)
+		resource.stateMu.Lock()
+		underlying := resource.connection
+		controlled := &controlledDeadlineConn{Conn: underlying}
+		resource.connection = controlled
+		resource.stateMu.Unlock()
+		wantErrors := configureControlled(controlled)
+
+		native := requireBuiltin(t, machine, "net_select")
+		pollReturned := make(chan struct{})
+		pollResult := make(chan struct {
+			value value.Value
+			err   error
+		}, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			pollResult <- struct {
+				value value.Value
+				err   error
+			}{selected, err}
+			close(pollReturned)
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		closeBeforePoll := errors.New("resource close ran before blocked poll returned")
+		controlled.closeFn = func() error {
+			select {
+			case <-pollReturned:
+			case <-time.After(statefulBuiltinTimeout):
+				return closeBeforePoll
+			}
+			return underlying.Close()
+		}
+
+		err := configureSocketTimeout(resource, time.Second)
+		for _, want := range wantErrors {
+			if !errors.Is(err, want) {
+				t.Fatalf("configuration error=%v, want joined %v", err, want)
+			}
+		}
+		if errors.Is(err, closeBeforePoll) {
+			t.Fatal(closeBeforePoll)
+		}
+		invocation := <-pollResult
+		if invocation.err != nil {
+			t.Fatal(invocation.err)
+		}
+		assertBuiltinValue(t, builtinMapField(t, invocation.value, "read_count"), value.NewInt(0))
+	}
+
+	t.Run("socket read application and rollback", func(t *testing.T) {
+		applicationFailure := errors.New("read deadline failed")
+		rollbackFailure := errors.New("read rollback failed")
+		runSocket(t, func(controlled *controlledDeadlineConn) []error {
+			calls := 0
+			controlled.setReadFn = func(time.Time) error {
+				calls++
+				if calls == 1 {
+					return applicationFailure
+				}
+				return rollbackFailure
+			}
+			return []error{applicationFailure, rollbackFailure}
+		})
+	})
+
+	t.Run("socket write application and read rollback", func(t *testing.T) {
+		applicationFailure := errors.New("write deadline failed")
+		rollbackFailure := errors.New("read rollback failed")
+		runSocket(t, func(controlled *controlledDeadlineConn) []error {
+			readCalls := 0
+			controlled.setReadFn = func(time.Time) error {
+				readCalls++
+				if readCalls == 2 {
+					return rollbackFailure
+				}
+				return nil
+			}
+			controlled.setWriteFn = func(time.Time) error { return applicationFailure }
+			return []error{applicationFailure, rollbackFailure}
+		})
+	})
+
+	t.Run("listener application and rollback", func(t *testing.T) {
+		machine := New()
+		cleanupNetworkResources(t, machine)
+		listenerValue := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+		handle := int(builtinMapField(t, listenerValue, "fd").AsInt)
+		resource, exists := machine.shared.Listeners.get(handle)
+		if !exists {
+			t.Fatalf("listener descriptor %d is not registered", handle)
+		}
+		resource.stateMu.Lock()
+		underlying := resource.listener
+		controlled := &controlledDeadlineListener{Listener: underlying}
+		resource.listener = controlled
+		resource.stateMu.Unlock()
+		applicationFailure := errors.New("listener deadline failed")
+		rollbackFailure := errors.New("listener rollback failed")
+		setterCalls := 0
+		controlled.setFn = func(time.Time) error {
+			setterCalls++
+			if setterCalls == 1 {
+				return applicationFailure
+			}
+			return rollbackFailure
+		}
+
+		native := requireBuiltin(t, machine, "net_select")
+		pollReturned := make(chan struct{})
+		pollResult := make(chan struct {
+			value value.Value
+			err   error
+		}, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{listenerValue}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			pollResult <- struct {
+				value value.Value
+				err   error
+			}{selected, err}
+			close(pollReturned)
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		closeBeforePoll := errors.New("listener close ran before blocked poll returned")
+		controlled.closeFn = func() error {
+			select {
+			case <-pollReturned:
+			case <-time.After(statefulBuiltinTimeout):
+				return closeBeforePoll
+			}
+			return underlying.Close()
+		}
+
+		err := configureListenerTimeout(resource, time.Second)
+		for _, want := range []error{applicationFailure, rollbackFailure} {
+			if !errors.Is(err, want) {
+				t.Fatalf("configuration error=%v, want joined %v", err, want)
+			}
+		}
+		if errors.Is(err, closeBeforePoll) {
+			t.Fatal(closeBeforePoll)
+		}
+		invocation := <-pollResult
+		if invocation.err != nil {
+			t.Fatal(invocation.err)
+		}
+		assertBuiltinValue(t, builtinMapField(t, invocation.value, "read_count"), value.NewInt(0))
+	})
+}
+
+func TestNetSelectPermanentWakeFailureFallsBackWithinTwoNativeChunks(t *testing.T) {
+	machine := New()
+	tracker := &nestedControlTracker{released: make(chan struct{}, 1)}
+	closeEntered := make(chan struct{})
+	resources := make([]*SocketResource, 2)
+	values := make([]value.Value, 2)
+	for index := range resources {
+		connection, peer := net.Pipe()
+		t.Cleanup(func() { _ = peer.Close() })
+		resource := &SocketResource{}
+		raw := &closeAwareRawConn{descriptor: uintptr(index + 10), resource: resource, tracker: tracker}
+		controlled := &controlledDeadlineConn{Conn: &syscallTestConn{Conn: connection, raw: raw}}
+		if index == 0 {
+			controlled.closeFn = func() error {
+				close(closeEntered)
+				for {
+					tracker.mu.Lock()
+					active := tracker.active
+					tracker.mu.Unlock()
+					if active == 0 {
+						return connection.Close()
+					}
+					<-tracker.released
+				}
+			}
+		}
+		resource.connection = controlled
+		resources[index] = resource
+		handle := machine.shared.Sockets.add(resource)
+		values[index] = socketValue(handle, "nested", 0, true)
+		t.Cleanup(func() {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(resource)
+		})
+	}
+
+	wakeFailure := errors.New("permanent wake signal failure")
+	chunkEntered := make(chan int32, 2)
+	releaseChunk := make(chan struct{}, 2)
+	platform := &fakeNetworkPlatform{wake: &fakePlatformWake{signalErr: wakeFailure}}
+	platform.waitFn = func(_ []networkPollFD, _ uintptr, milliseconds int32) (networkPollBatch, error) {
+		chunkEntered <- milliseconds
+		<-releaseChunk
+		return networkPollBatch{}, nil
+	}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	pollResult := make(chan error, 1)
+	go func() {
+		_, err := poller.Poll(machine.shared, pollSets(values, nil, nil), 3*time.Second)
+		pollResult <- err
+	}()
+	firstChunk := <-chunkEntered
+	if firstChunk != 1000 {
+		t.Fatalf("first native chunk=%dms, want one-second cap", firstChunk)
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		closeSocket(resources[0])
+		close(closed)
+	}()
+	select {
+	case <-closeEntered:
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("close did not reach the controlled connection")
+	}
+	select {
+	case <-closed:
+		t.Fatal("close completed while nested RawConn.Control references were still held")
+	default:
+	}
+	releaseChunk <- struct{}{}
+
+	chunks := 1
+	for chunks <= 2 {
+		select {
+		case <-closed:
+			if err := <-pollResult; err != nil {
+				t.Fatalf("poll after local close: %v", err)
+			}
+			return
+		case next := <-chunkEntered:
+			chunks++
+			if next > 1000 {
+				t.Fatalf("native chunk=%dms, want at most 1000ms", next)
+			}
+			releaseChunk <- struct{}{}
+		case <-time.After(statefulBuiltinTimeout):
+			t.Fatal("close did not make fallback progress within safety chunk")
+		}
+	}
+	t.Fatal("close required more than two one-second native chunks")
+}
+
 func requireWakeSignals(t *testing.T, wakes ...*fakePlatformWake) {
 	t.Helper()
 	for index, wake := range wakes {
@@ -204,16 +650,12 @@ func TestListenerDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	controlled := &controlledDeadlineListener{Listener: underlying}
-	accepted, peer := net.Pipe()
-	t.Cleanup(func() { _ = peer.Close() })
-	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
 	firstRaw := &fakePlatformWake{}
 	secondRaw := &fakePlatformWake{}
 	first := newNetworkWake(firstRaw)
 	second := newNetworkWake(secondRaw)
 	resource := &ListenerResource{
 		listener:           controlled,
-		bufferedAccept:     controlledAccepted,
 		deadlineGeneration: 11,
 		pollWaiters:        map[*networkWake]struct{}{first: {}, second: {}},
 	}
@@ -224,16 +666,14 @@ func TestListenerDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
 	closedAfterFirst := resource.closed
 	generationAfterFirst := resource.deadlineGeneration
 	listenerAfterFirst := resource.listener
-	bufferedAfterFirst := resource.bufferedAccept
 	waitersAfterFirst := resource.pollWaiters
 	resource.stateMu.Unlock()
 	listenerClosesAfterFirst := controlled.closes()
-	bufferedClosesAfterFirst := controlledAccepted.closes()
-	if !closedAfterFirst || generationAfterFirst != 12 || listenerAfterFirst != nil || bufferedAfterFirst != nil || waitersAfterFirst != nil {
-		t.Fatalf("first close: closed=%v generation=%d listener=%v buffered=%v waiters=%v", closedAfterFirst, generationAfterFirst, listenerAfterFirst, bufferedAfterFirst, waitersAfterFirst)
+	if !closedAfterFirst || generationAfterFirst != 12 || listenerAfterFirst != nil || waitersAfterFirst != nil {
+		t.Fatalf("first close: closed=%v generation=%d listener=%v waiters=%v", closedAfterFirst, generationAfterFirst, listenerAfterFirst, waitersAfterFirst)
 	}
-	if listenerClosesAfterFirst != 1 || bufferedClosesAfterFirst != 1 {
-		t.Fatalf("first close calls: listener=%d accepted=%d, want 1 each", listenerClosesAfterFirst, bufferedClosesAfterFirst)
+	if listenerClosesAfterFirst != 1 {
+		t.Fatalf("first close calls=%d, want 1", listenerClosesAfterFirst)
 	}
 
 	closeListener(resource)
@@ -242,14 +682,13 @@ func TestListenerDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
 	closedAfterSecond := resource.closed
 	generationAfterSecond := resource.deadlineGeneration
 	listenerAfterSecond := resource.listener
-	bufferedAfterSecond := resource.bufferedAccept
 	waitersAfterSecond := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if !closedAfterSecond || generationAfterSecond != generationAfterFirst || listenerAfterSecond != nil || bufferedAfterSecond != nil || waitersAfterSecond != nil {
-		t.Fatalf("second close: closed=%v generation=%d listener=%v buffered=%v waiters=%v", closedAfterSecond, generationAfterSecond, listenerAfterSecond, bufferedAfterSecond, waitersAfterSecond)
+	if !closedAfterSecond || generationAfterSecond != generationAfterFirst || listenerAfterSecond != nil || waitersAfterSecond != nil {
+		t.Fatalf("second close: closed=%v generation=%d listener=%v waiters=%v", closedAfterSecond, generationAfterSecond, listenerAfterSecond, waitersAfterSecond)
 	}
-	if controlled.closes() != listenerClosesAfterFirst || controlledAccepted.closes() != bufferedClosesAfterFirst {
-		t.Fatalf("second close calls: listener=%d accepted=%d, want unchanged %d and %d", controlled.closes(), controlledAccepted.closes(), listenerClosesAfterFirst, bufferedClosesAfterFirst)
+	if controlled.closes() != listenerClosesAfterFirst {
+		t.Fatalf("second close calls=%d, want unchanged %d", controlled.closes(), listenerClosesAfterFirst)
 	}
 }
 
@@ -418,12 +857,8 @@ func TestListenerRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
 			return closeFailure
 		},
 	}
-	accepted, peer := net.Pipe()
-	t.Cleanup(func() { _ = peer.Close() })
-	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
 	resource := &ListenerResource{
-		listener:       controlled,
-		bufferedAccept: controlledAccepted,
+		listener: controlled,
 		pollWaiters: map[*networkWake]struct{}{
 			newNetworkWake(firstRaw):  {},
 			newNetworkWake(secondRaw): {},
@@ -440,28 +875,25 @@ func TestListenerRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
 	closedAfterPoison := resource.closed
 	generationAfterPoison := resource.deadlineGeneration
 	listenerAfterPoison := resource.listener
-	bufferedAfterPoison := resource.bufferedAccept
 	waitersAfterPoison := resource.pollWaiters
 	resource.stateMu.Unlock()
 	listenerClosesAfterPoison := controlled.closes()
-	bufferedClosesAfterPoison := controlledAccepted.closes()
 	closeListener(resource)
 	requireWakeSignals(t, firstRaw, secondRaw)
 	resource.stateMu.Lock()
 	closedAfterClose := resource.closed
 	generationAfterClose := resource.deadlineGeneration
 	listenerAfterClose := resource.listener
-	bufferedAfterClose := resource.bufferedAccept
 	waitersAfterClose := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if !closedAfterPoison || !closedAfterClose || listenerAfterPoison != nil || listenerAfterClose != nil || bufferedAfterPoison != nil || bufferedAfterClose != nil || waitersAfterPoison != nil || waitersAfterClose != nil {
-		t.Fatalf("closed before/after=%v/%v listener before/after=%v/%v buffered before/after=%v/%v waiters before/after=%v/%v", closedAfterPoison, closedAfterClose, listenerAfterPoison, listenerAfterClose, bufferedAfterPoison, bufferedAfterClose, waitersAfterPoison, waitersAfterClose)
+	if !closedAfterPoison || !closedAfterClose || listenerAfterPoison != nil || listenerAfterClose != nil || waitersAfterPoison != nil || waitersAfterClose != nil {
+		t.Fatalf("closed before/after=%v/%v listener before/after=%v/%v waiters before/after=%v/%v", closedAfterPoison, closedAfterClose, listenerAfterPoison, listenerAfterClose, waitersAfterPoison, waitersAfterClose)
 	}
 	if generationAfterClose != generationAfterPoison {
 		t.Fatalf("generation after close=%d, want unchanged %d", generationAfterClose, generationAfterPoison)
 	}
-	if listenerClosesAfterPoison != 1 || bufferedClosesAfterPoison != 1 || controlled.closes() != listenerClosesAfterPoison || controlledAccepted.closes() != bufferedClosesAfterPoison {
-		t.Fatalf("close calls before/after: listener=%d/%d accepted=%d/%d, want 1/1 each", listenerClosesAfterPoison, controlled.closes(), bufferedClosesAfterPoison, controlledAccepted.closes())
+	if listenerClosesAfterPoison != 1 || controlled.closes() != listenerClosesAfterPoison {
+		t.Fatalf("close calls before/after=%d/%d, want 1/1", listenerClosesAfterPoison, controlled.closes())
 	}
 }
 
@@ -627,12 +1059,14 @@ func TestReceiveSocketInstallsDeadlineBeforeRead(t *testing.T) {
 	result := receiveSocket(resource, 1)
 
 	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, result, "count"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes(""))
 	if controlled.readDeadlineCount() != 1 {
 		t.Fatalf("read deadline calls=%d, want 1", controlled.readDeadlineCount())
 	}
 }
 
-func TestReceiveSocketFullyBufferedSkipsDeadlineSetter(t *testing.T) {
+func TestReceiveSocketZeroSizeSkipsDeadlineSetter(t *testing.T) {
 	connection, peer := net.Pipe()
 	t.Cleanup(func() {
 		_ = connection.Close()
@@ -645,14 +1079,14 @@ func TestReceiveSocketFullyBufferedSkipsDeadlineSetter(t *testing.T) {
 		},
 	}
 	resource := &SocketResource{
-		connection:   controlled,
-		bufferedRead: []byte("x"),
-		ioTimeout:    50 * time.Millisecond,
+		connection: controlled,
+		ioTimeout:  50 * time.Millisecond,
 	}
-	result := receiveSocket(resource, 1)
+	result := receiveSocket(resource, 0)
 
 	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
-	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, result, "count"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes(""))
 	if controlled.readDeadlineCount() != 0 {
 		t.Fatalf("read deadline calls=%d, want 0", controlled.readDeadlineCount())
 	}
@@ -753,147 +1187,6 @@ func TestCloseDoesNotWaitForBlockedDeadlineSetter(t *testing.T) {
 	}
 }
 
-func TestBufferedAcceptCloseWinsDuringDeadlineClear(t *testing.T) {
-	for _, setterError := range []error{nil, errors.New("clear failed")} {
-		name := "setter success"
-		if setterError != nil {
-			name = "setter failure"
-		}
-		t.Run(name, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			if err != nil {
-				t.Fatal(err)
-			}
-			deadlineCapable := listener.(deadlineListener)
-			connection, peer := net.Pipe()
-			t.Cleanup(func() { _ = peer.Close() })
-			setterEntered := make(chan struct{})
-			releaseSetter := make(chan struct{})
-			controlled := &controlledDeadlineConn{
-				Conn: connection,
-				setDeadlineFn: func(time.Time) error {
-					close(setterEntered)
-					<-releaseSetter
-					return setterError
-				},
-			}
-			resource := &ListenerResource{listener: deadlineCapable, bufferedAccept: controlled}
-			t.Cleanup(func() {
-				_ = listener.Close()
-				_ = connection.Close()
-			})
-			accepted := make(chan struct {
-				connection net.Conn
-				err        error
-			}, 1)
-			go func() {
-				connection, err := acceptConnection(resource)
-				accepted <- struct {
-					connection net.Conn
-					err        error
-				}{connection: connection, err: err}
-			}()
-			select {
-			case <-setterEntered:
-			case <-time.After(time.Second):
-				t.Fatal("accepted connection deadline clear was not entered")
-			}
-
-			closeListener(resource)
-			if controlled.closes() != 1 {
-				t.Fatalf("close calls=%d, want listener close ownership", controlled.closes())
-			}
-			close(releaseSetter)
-			select {
-			case result := <-accepted:
-				if result.connection != nil || result.err == nil {
-					t.Fatalf("accept=(%v, %v), want nil connection and error", result.connection, result.err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("accept did not finish")
-			}
-			if controlled.closes() != 1 {
-				t.Fatalf("close calls after accept=%d, want 1", controlled.closes())
-			}
-		})
-	}
-}
-
-func TestNetSelectRestoresPersistentSocketDeadline(t *testing.T) {
-	connection, peer := net.Pipe()
-	t.Cleanup(func() {
-		_ = connection.Close()
-		_ = peer.Close()
-	})
-	controlled := &controlledDeadlineConn{
-		Conn: connection,
-		readFn: func(buffer []byte) (int, error) {
-			buffer[0] = 'x'
-			return 1, nil
-		},
-	}
-	resource := &SocketResource{connection: controlled, ioTimeout: 100 * time.Millisecond}
-	started := time.Now()
-	ready, err := selectSocket(resource, 10*time.Millisecond)
-	if err != nil || !ready {
-		t.Fatalf("selectSocket=(%v, %v), want ready", ready, err)
-	}
-
-	controlled.mu.Lock()
-	deadlines := append([]time.Time(nil), controlled.readDeadlines...)
-	controlled.mu.Unlock()
-	if len(deadlines) != 2 {
-		t.Fatalf("read deadline calls=%d, want probe and restoration", len(deadlines))
-	}
-	if deadlines[0].Before(started.Add(5*time.Millisecond)) || deadlines[0].After(started.Add(50*time.Millisecond)) {
-		t.Fatalf("probe deadline=%v, want select bound", deadlines[0])
-	}
-	if deadlines[1].IsZero() || !deadlines[1].After(deadlines[0]) {
-		t.Fatalf("restored deadline=%v, want fresh persistent deadline after %v", deadlines[1], deadlines[0])
-	}
-	resource.stateMu.Lock()
-	buffered := string(resource.bufferedRead)
-	resource.stateMu.Unlock()
-	if buffered != "x" {
-		t.Fatalf("buffered read=%q, want x", buffered)
-	}
-}
-
-func TestNetSelectRestorationFailureKeepsReadyByte(t *testing.T) {
-	connection, peer := net.Pipe()
-	t.Cleanup(func() {
-		_ = connection.Close()
-		_ = peer.Close()
-	})
-	restoreFailure := errors.New("restore failed")
-	setterCalls := 0
-	controlled := &controlledDeadlineConn{
-		Conn: connection,
-		readFn: func(buffer []byte) (int, error) {
-			buffer[0] = 'x'
-			return 1, nil
-		},
-		setReadFn: func(time.Time) error {
-			setterCalls++
-			if setterCalls == 2 {
-				return restoreFailure
-			}
-			return nil
-		},
-	}
-	resource := &SocketResource{connection: controlled, ioTimeout: 100 * time.Millisecond}
-	ready, err := selectSocket(resource, 10*time.Millisecond)
-	if ready || !errors.Is(err, restoreFailure) {
-		t.Fatalf("selectSocket=(%v, %v), want restoration failure", ready, err)
-	}
-	resource.stateMu.Lock()
-	buffered := string(resource.bufferedRead)
-	resource.stateMu.Unlock()
-	if buffered != "x" {
-		t.Fatalf("buffered read=%q, want x after restoration failure", buffered)
-	}
-}
-
 func TestSocketConfigurationRollsBackExactDeadlines(t *testing.T) {
 	connection, peer := net.Pipe()
 	t.Cleanup(func() {
@@ -972,7 +1265,6 @@ func TestSocketRollbackFailurePoisonsAndCloses(t *testing.T) {
 		ioTimeout:         10 * time.Second,
 		lastReadDeadline:  time.Now().Add(2 * time.Second),
 		lastWriteDeadline: time.Now().Add(3 * time.Second),
-		bufferedRead:      []byte("x"),
 	}
 	err := configureSocketTimeout(resource, 5*time.Second)
 	if !errors.Is(err, applicationFailure) || !errors.Is(err, rollbackFailure) {
@@ -981,10 +1273,9 @@ func TestSocketRollbackFailurePoisonsAndCloses(t *testing.T) {
 	resource.stateMu.Lock()
 	closed := resource.closed
 	underlying := resource.connection
-	buffered := len(resource.bufferedRead)
 	resource.stateMu.Unlock()
-	if !closed || underlying != nil || buffered != 0 {
-		t.Fatalf("poisoned state: closed=%v connection=%v buffered=%d", closed, underlying, buffered)
+	if !closed || underlying != nil {
+		t.Fatalf("poisoned state: closed=%v connection=%v", closed, underlying)
 	}
 	if controlled.closes() != 1 {
 		t.Fatalf("close calls=%d, want 1", controlled.closes())
@@ -1045,12 +1336,8 @@ func TestListenerRollbackFailurePoisonsOwnedResources(t *testing.T) {
 			return rollbackFailure
 		},
 	}
-	accepted, peer := net.Pipe()
-	t.Cleanup(func() { _ = peer.Close() })
-	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
 	resource := &ListenerResource{
 		listener:           controlledListener,
-		bufferedAccept:     controlledAccepted,
 		ioTimeout:          10 * time.Second,
 		lastAcceptDeadline: time.Now().Add(2 * time.Second),
 	}
@@ -1061,13 +1348,12 @@ func TestListenerRollbackFailurePoisonsOwnedResources(t *testing.T) {
 	resource.stateMu.Lock()
 	closed := resource.closed
 	listener := resource.listener
-	buffered := resource.bufferedAccept
 	resource.stateMu.Unlock()
-	if !closed || listener != nil || buffered != nil {
-		t.Fatalf("poisoned listener: closed=%v listener=%v buffered=%v", closed, listener, buffered)
+	if !closed || listener != nil {
+		t.Fatalf("poisoned listener: closed=%v listener=%v", closed, listener)
 	}
-	if controlledListener.closes() != 1 || controlledAccepted.closes() != 1 {
-		t.Fatalf("close calls: listener=%d accepted=%d, want 1 each", controlledListener.closes(), controlledAccepted.closes())
+	if controlledListener.closes() != 1 {
+		t.Fatalf("listener close calls=%d, want 1", controlledListener.closes())
 	}
 }
 
@@ -1246,27 +1532,6 @@ func TestNetSetTimeoutAcceptsTypedSocketAndRejectsTypedNil(t *testing.T) {
 	}
 }
 
-func TestNetworkProbeDeadlineUsesOneStartInstant(t *testing.T) {
-	started := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name          string
-		selectTimeout time.Duration
-		ioTimeout     time.Duration
-		want          time.Time
-	}{
-		{name: "persistent shorter", selectTimeout: 10 * time.Millisecond, ioTimeout: 9 * time.Millisecond, want: started.Add(9 * time.Millisecond)},
-		{name: "select shorter", selectTimeout: 9 * time.Millisecond, ioTimeout: 10 * time.Millisecond, want: started.Add(9 * time.Millisecond)},
-		{name: "blocking mode", selectTimeout: 9 * time.Millisecond, ioTimeout: 0, want: started.Add(9 * time.Millisecond)},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := networkProbeDeadline(started, test.selectTimeout, test.ioTimeout); !got.Equal(test.want) {
-				t.Fatalf("deadline=%v, want %v", got, test.want)
-			}
-		})
-	}
-}
-
 func TestSocketRollbackStopsWhenCloseInvalidatesGeneration(t *testing.T) {
 	connection, peer := net.Pipe()
 	t.Cleanup(func() { _ = peer.Close() })
@@ -1441,25 +1706,6 @@ func TestAcceptedSocketDoesNotInheritListenerTimeout(t *testing.T) {
 	}
 }
 
-func TestPartialBufferedReadSurvivesDeadlineInstallationFailure(t *testing.T) {
-	connection, peer := net.Pipe()
-	t.Cleanup(func() {
-		_ = connection.Close()
-		_ = peer.Close()
-	})
-	controlled := &controlledDeadlineConn{
-		Conn: connection,
-		setReadFn: func(time.Time) error {
-			return errors.New("deadline install failed")
-		},
-	}
-	resource := &SocketResource{connection: controlled, bufferedRead: []byte("x"), ioTimeout: 20 * time.Millisecond}
-	result := receiveSocket(resource, 2)
-	assertBuiltinValue(t, builtinMapField(t, result, "ok"), value.NewBool(true))
-	assertBuiltinValue(t, builtinMapField(t, result, "data"), value.NewBytes("x"))
-	assertBuiltinValue(t, builtinMapField(t, result, "count"), value.NewInt(1))
-}
-
 func TestConcurrentTimeoutConfigurationsCommitInDeadlineOrder(t *testing.T) {
 	connection, peer := net.Pipe()
 	t.Cleanup(func() {
@@ -1502,85 +1748,6 @@ func TestConcurrentTimeoutConfigurationsCommitInDeadlineOrder(t *testing.T) {
 	resource.stateMu.Unlock()
 	if timeout != 20*time.Millisecond {
 		t.Fatalf("ioTimeout=%v, want second configuration 20ms", timeout)
-	}
-}
-
-func TestListenerSelectRestorationFailureKeepsAcceptedConnection(t *testing.T) {
-	underlying, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	accepted, peer := net.Pipe()
-	t.Cleanup(func() { _ = peer.Close() })
-	restoreFailure := errors.New("listener restore failed")
-	setterCalls := 0
-	controlled := &controlledDeadlineListener{
-		Listener: underlying,
-		acceptFn: func() (net.Conn, error) {
-			return accepted, nil
-		},
-		setFn: func(time.Time) error {
-			setterCalls++
-			if setterCalls == 2 {
-				return restoreFailure
-			}
-			return nil
-		},
-	}
-	resource := &ListenerResource{listener: controlled, ioTimeout: 100 * time.Millisecond}
-	t.Cleanup(func() { closeListener(resource) })
-	ready, err := selectListener(resource, 10*time.Millisecond)
-	if ready || !errors.Is(err, restoreFailure) {
-		t.Fatalf("selectListener=(%v, %v), want restoration failure", ready, err)
-	}
-	resource.stateMu.Lock()
-	buffered := resource.bufferedAccept
-	resource.stateMu.Unlock()
-	if buffered != accepted {
-		t.Fatalf("buffered accept=%v, want accepted connection", buffered)
-	}
-}
-
-func TestNetSelectManagementFailureStopsLaterCandidatesAndKeepsEarlierBuffer(t *testing.T) {
-	machine := New()
-	makeControlled := func(readFn func([]byte) (int, error), setReadFn func(time.Time) error) (*SocketResource, value.Value, *controlledDeadlineConn) {
-		connection, peer := net.Pipe()
-		t.Cleanup(func() {
-			_ = connection.Close()
-			_ = peer.Close()
-		})
-		controlled := &controlledDeadlineConn{Conn: connection, readFn: readFn, setReadFn: setReadFn}
-		resource := &SocketResource{connection: controlled}
-		handle := machine.shared.Sockets.add(resource)
-		t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
-		return resource, socketValue(handle, "pipe", 0, true), controlled
-	}
-	first, firstValue, _ := makeControlled(func(buffer []byte) (int, error) {
-		buffer[0] = 'a'
-		return 1, nil
-	}, nil)
-	managementFailure := errors.New("probe install failed")
-	_, secondValue, _ := makeControlled(nil, func(time.Time) error { return managementFailure })
-	thirdReads := 0
-	_, thirdValue, _ := makeControlled(func([]byte) (int, error) {
-		thirdReads++
-		return 0, io.EOF
-	}, nil)
-
-	_, err := invokeBuiltin(t, machine, "net_select",
-		value.NewArray([]value.Value{firstValue, secondValue, thirdValue}),
-		value.NewArray(nil), value.NewArray(nil), value.NewInt(10))
-	if !errors.Is(err, managementFailure) {
-		t.Fatalf("net_select error=%v, want management failure", err)
-	}
-	first.stateMu.Lock()
-	buffered := string(first.bufferedRead)
-	first.stateMu.Unlock()
-	if buffered != "a" {
-		t.Fatalf("earlier buffer=%q, want a", buffered)
-	}
-	if thirdReads != 0 {
-		t.Fatalf("later candidate reads=%d, want 0", thirdReads)
 	}
 }
 
@@ -1708,84 +1875,5 @@ func TestCloseDoesNotWaitForBlockedListenerDeadlineSetter(t *testing.T) {
 	}
 	if controlled.closes() != 1 {
 		t.Fatalf("close calls=%d, want 1", controlled.closes())
-	}
-}
-
-func TestActiveSocketProbeBoundsConcurrentConfiguration(t *testing.T) {
-	tests := []struct {
-		name              string
-		configuredTimeout time.Duration
-		wantAgainstProbe  string
-		wantRestoredZero  bool
-	}{
-		{name: "longer timeout cannot extend", configuredTimeout: 200 * time.Millisecond, wantAgainstProbe: "equal"},
-		{name: "shorter timeout may shorten", configuredTimeout: 20 * time.Millisecond, wantAgainstProbe: "before"},
-		{name: "blocking cannot remove", configuredTimeout: 0, wantAgainstProbe: "equal", wantRestoredZero: true},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			connection, peer := net.Pipe()
-			t.Cleanup(func() {
-				_ = connection.Close()
-				_ = peer.Close()
-			})
-			readEntered := make(chan struct{})
-			releaseRead := make(chan struct{})
-			controlled := &controlledDeadlineConn{
-				Conn: connection,
-				readFn: func(buffer []byte) (int, error) {
-					close(readEntered)
-					<-releaseRead
-					buffer[0] = 'x'
-					return 1, nil
-				},
-			}
-			resource := &SocketResource{connection: controlled}
-			selected := make(chan error, 1)
-			go func() {
-				ready, err := selectSocket(resource, 100*time.Millisecond)
-				if err == nil && !ready {
-					err = errors.New("probe was not ready")
-				}
-				selected <- err
-			}()
-			select {
-			case <-readEntered:
-			case <-time.After(time.Second):
-				t.Fatal("probe read did not start")
-			}
-			if err := configureSocketTimeout(resource, test.configuredTimeout); err != nil {
-				t.Fatalf("concurrent configuration: %v", err)
-			}
-			controlled.mu.Lock()
-			installed := append([]time.Time(nil), controlled.readDeadlines...)
-			controlled.mu.Unlock()
-			if len(installed) != 2 {
-				t.Fatalf("deadlines before cleanup=%v, want probe and configuration", installed)
-			}
-			switch test.wantAgainstProbe {
-			case "equal":
-				if !installed[1].Equal(installed[0]) {
-					t.Fatalf("configured deadline=%v, want probe bound %v", installed[1], installed[0])
-				}
-			case "before":
-				if !installed[1].Before(installed[0]) {
-					t.Fatalf("configured deadline=%v, want before probe bound %v", installed[1], installed[0])
-				}
-			}
-			close(releaseRead)
-			if err := <-selected; err != nil {
-				t.Fatalf("selectSocket: %v", err)
-			}
-			controlled.mu.Lock()
-			restored := controlled.readDeadlines[len(controlled.readDeadlines)-1]
-			controlled.mu.Unlock()
-			if restored.IsZero() != test.wantRestoredZero {
-				t.Fatalf("restored deadline=%v, want zero=%v", restored, test.wantRestoredZero)
-			}
-			if !test.wantRestoredZero && restored.Before(installed[1]) {
-				t.Fatalf("restored deadline=%v, want no earlier than %v", restored, installed[1])
-			}
-		})
 	}
 }

--- a/internal/vm/builtins_net_deadlines_test.go
+++ b/internal/vm/builtins_net_deadlines_test.go
@@ -161,24 +161,40 @@ func TestSocketDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
 	first := newNetworkWake(firstRaw)
 	second := newNetworkWake(secondRaw)
 	resource := &SocketResource{
-		connection:  controlled,
-		pollWaiters: map[*networkWake]struct{}{first: {}, second: {}},
+		connection:         controlled,
+		deadlineGeneration: 7,
+		pollWaiters:        map[*networkWake]struct{}{first: {}, second: {}},
 	}
 
 	closeSocket(resource)
-	closeSocket(resource)
-
 	requireWakeSignals(t, firstRaw, secondRaw)
 	resource.stateMu.Lock()
-	closed := resource.closed
-	connectionAfterClose := resource.connection
-	waiters := resource.pollWaiters
+	closedAfterFirst := resource.closed
+	generationAfterFirst := resource.deadlineGeneration
+	connectionAfterFirst := resource.connection
+	waitersAfterFirst := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if !closed || connectionAfterClose != nil || waiters != nil {
-		t.Fatalf("closed=%v connection=%v waiters=%v", closed, connectionAfterClose, waiters)
+	closesAfterFirst := controlled.closes()
+	if !closedAfterFirst || generationAfterFirst != 8 || connectionAfterFirst != nil || waitersAfterFirst != nil {
+		t.Fatalf("first close: closed=%v generation=%d connection=%v waiters=%v", closedAfterFirst, generationAfterFirst, connectionAfterFirst, waitersAfterFirst)
 	}
-	if controlled.closes() != 1 {
-		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	if closesAfterFirst != 1 {
+		t.Fatalf("first close calls=%d, want 1", closesAfterFirst)
+	}
+
+	closeSocket(resource)
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closedAfterSecond := resource.closed
+	generationAfterSecond := resource.deadlineGeneration
+	connectionAfterSecond := resource.connection
+	waitersAfterSecond := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closedAfterSecond || generationAfterSecond != generationAfterFirst || connectionAfterSecond != nil || waitersAfterSecond != nil {
+		t.Fatalf("second close: closed=%v generation=%d connection=%v waiters=%v", closedAfterSecond, generationAfterSecond, connectionAfterSecond, waitersAfterSecond)
+	}
+	if controlled.closes() != closesAfterFirst {
+		t.Fatalf("second close calls=%d, want unchanged %d", controlled.closes(), closesAfterFirst)
 	}
 }
 
@@ -196,26 +212,44 @@ func TestListenerDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
 	first := newNetworkWake(firstRaw)
 	second := newNetworkWake(secondRaw)
 	resource := &ListenerResource{
-		listener:       controlled,
-		bufferedAccept: controlledAccepted,
-		pollWaiters:    map[*networkWake]struct{}{first: {}, second: {}},
+		listener:           controlled,
+		bufferedAccept:     controlledAccepted,
+		deadlineGeneration: 11,
+		pollWaiters:        map[*networkWake]struct{}{first: {}, second: {}},
 	}
 
 	closeListener(resource)
-	closeListener(resource)
-
 	requireWakeSignals(t, firstRaw, secondRaw)
 	resource.stateMu.Lock()
-	closed := resource.closed
-	listenerAfterClose := resource.listener
-	bufferedAfterClose := resource.bufferedAccept
-	waiters := resource.pollWaiters
+	closedAfterFirst := resource.closed
+	generationAfterFirst := resource.deadlineGeneration
+	listenerAfterFirst := resource.listener
+	bufferedAfterFirst := resource.bufferedAccept
+	waitersAfterFirst := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if !closed || listenerAfterClose != nil || bufferedAfterClose != nil || waiters != nil {
-		t.Fatalf("closed=%v listener=%v buffered=%v waiters=%v", closed, listenerAfterClose, bufferedAfterClose, waiters)
+	listenerClosesAfterFirst := controlled.closes()
+	bufferedClosesAfterFirst := controlledAccepted.closes()
+	if !closedAfterFirst || generationAfterFirst != 12 || listenerAfterFirst != nil || bufferedAfterFirst != nil || waitersAfterFirst != nil {
+		t.Fatalf("first close: closed=%v generation=%d listener=%v buffered=%v waiters=%v", closedAfterFirst, generationAfterFirst, listenerAfterFirst, bufferedAfterFirst, waitersAfterFirst)
 	}
-	if controlled.closes() != 1 || controlledAccepted.closes() != 1 {
-		t.Fatalf("close calls: listener=%d accepted=%d, want 1 each", controlled.closes(), controlledAccepted.closes())
+	if listenerClosesAfterFirst != 1 || bufferedClosesAfterFirst != 1 {
+		t.Fatalf("first close calls: listener=%d accepted=%d, want 1 each", listenerClosesAfterFirst, bufferedClosesAfterFirst)
+	}
+
+	closeListener(resource)
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closedAfterSecond := resource.closed
+	generationAfterSecond := resource.deadlineGeneration
+	listenerAfterSecond := resource.listener
+	bufferedAfterSecond := resource.bufferedAccept
+	waitersAfterSecond := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closedAfterSecond || generationAfterSecond != generationAfterFirst || listenerAfterSecond != nil || bufferedAfterSecond != nil || waitersAfterSecond != nil {
+		t.Fatalf("second close: closed=%v generation=%d listener=%v buffered=%v waiters=%v", closedAfterSecond, generationAfterSecond, listenerAfterSecond, bufferedAfterSecond, waitersAfterSecond)
+	}
+	if controlled.closes() != listenerClosesAfterFirst || controlledAccepted.closes() != bufferedClosesAfterFirst {
+		t.Fatalf("second close calls: listener=%d accepted=%d, want unchanged %d and %d", controlled.closes(), controlledAccepted.closes(), listenerClosesAfterFirst, bufferedClosesAfterFirst)
 	}
 }
 
@@ -259,10 +293,28 @@ func TestSocketReadRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
 		}
 	}
 	resource.stateMu.Lock()
-	waiters := resource.pollWaiters
+	closedAfterPoison := resource.closed
+	generationAfterPoison := resource.deadlineGeneration
+	connectionAfterPoison := resource.connection
+	waitersAfterPoison := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if waiters != nil || controlled.closes() != 1 {
-		t.Fatalf("waiters=%v close calls=%d, want nil and 1", waiters, controlled.closes())
+	closesAfterPoison := controlled.closes()
+	closeSocket(resource)
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closedAfterClose := resource.closed
+	generationAfterClose := resource.deadlineGeneration
+	connectionAfterClose := resource.connection
+	waitersAfterClose := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closedAfterPoison || !closedAfterClose || connectionAfterPoison != nil || connectionAfterClose != nil || waitersAfterPoison != nil || waitersAfterClose != nil {
+		t.Fatalf("closed before/after=%v/%v connection before/after=%v/%v waiters before/after=%v/%v", closedAfterPoison, closedAfterClose, connectionAfterPoison, connectionAfterClose, waitersAfterPoison, waitersAfterClose)
+	}
+	if generationAfterClose != generationAfterPoison {
+		t.Fatalf("generation after close=%d, want unchanged %d", generationAfterClose, generationAfterPoison)
+	}
+	if closesAfterPoison != 1 || controlled.closes() != closesAfterPoison {
+		t.Fatalf("close calls before/after=%d/%d, want 1/1", closesAfterPoison, controlled.closes())
 	}
 }
 
@@ -314,10 +366,28 @@ func TestSocketWriteRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
 		}
 	}
 	resource.stateMu.Lock()
-	waiters := resource.pollWaiters
+	closedAfterPoison := resource.closed
+	generationAfterPoison := resource.deadlineGeneration
+	connectionAfterPoison := resource.connection
+	waitersAfterPoison := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if waiters != nil || controlled.closes() != 1 {
-		t.Fatalf("waiters=%v close calls=%d, want nil and 1", waiters, controlled.closes())
+	closesAfterPoison := controlled.closes()
+	closeSocket(resource)
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closedAfterClose := resource.closed
+	generationAfterClose := resource.deadlineGeneration
+	connectionAfterClose := resource.connection
+	waitersAfterClose := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closedAfterPoison || !closedAfterClose || connectionAfterPoison != nil || connectionAfterClose != nil || waitersAfterPoison != nil || waitersAfterClose != nil {
+		t.Fatalf("closed before/after=%v/%v connection before/after=%v/%v waiters before/after=%v/%v", closedAfterPoison, closedAfterClose, connectionAfterPoison, connectionAfterClose, waitersAfterPoison, waitersAfterClose)
+	}
+	if generationAfterClose != generationAfterPoison {
+		t.Fatalf("generation after close=%d, want unchanged %d", generationAfterClose, generationAfterPoison)
+	}
+	if closesAfterPoison != 1 || controlled.closes() != closesAfterPoison {
+		t.Fatalf("close calls before/after=%d/%d, want 1/1", closesAfterPoison, controlled.closes())
 	}
 }
 
@@ -367,10 +437,31 @@ func TestListenerRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
 		}
 	}
 	resource.stateMu.Lock()
-	waiters := resource.pollWaiters
+	closedAfterPoison := resource.closed
+	generationAfterPoison := resource.deadlineGeneration
+	listenerAfterPoison := resource.listener
+	bufferedAfterPoison := resource.bufferedAccept
+	waitersAfterPoison := resource.pollWaiters
 	resource.stateMu.Unlock()
-	if waiters != nil || controlled.closes() != 1 || controlledAccepted.closes() != 1 {
-		t.Fatalf("waiters=%v close calls: listener=%d accepted=%d, want nil and 1 each", waiters, controlled.closes(), controlledAccepted.closes())
+	listenerClosesAfterPoison := controlled.closes()
+	bufferedClosesAfterPoison := controlledAccepted.closes()
+	closeListener(resource)
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closedAfterClose := resource.closed
+	generationAfterClose := resource.deadlineGeneration
+	listenerAfterClose := resource.listener
+	bufferedAfterClose := resource.bufferedAccept
+	waitersAfterClose := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closedAfterPoison || !closedAfterClose || listenerAfterPoison != nil || listenerAfterClose != nil || bufferedAfterPoison != nil || bufferedAfterClose != nil || waitersAfterPoison != nil || waitersAfterClose != nil {
+		t.Fatalf("closed before/after=%v/%v listener before/after=%v/%v buffered before/after=%v/%v waiters before/after=%v/%v", closedAfterPoison, closedAfterClose, listenerAfterPoison, listenerAfterClose, bufferedAfterPoison, bufferedAfterClose, waitersAfterPoison, waitersAfterClose)
+	}
+	if generationAfterClose != generationAfterPoison {
+		t.Fatalf("generation after close=%d, want unchanged %d", generationAfterClose, generationAfterPoison)
+	}
+	if listenerClosesAfterPoison != 1 || bufferedClosesAfterPoison != 1 || controlled.closes() != listenerClosesAfterPoison || controlledAccepted.closes() != bufferedClosesAfterPoison {
+		t.Fatalf("close calls before/after: listener=%d/%d accepted=%d/%d, want 1/1 each", listenerClosesAfterPoison, controlled.closes(), bufferedClosesAfterPoison, controlledAccepted.closes())
 	}
 }
 

--- a/internal/vm/builtins_net_deadlines_test.go
+++ b/internal/vm/builtins_net_deadlines_test.go
@@ -28,6 +28,7 @@ type controlledDeadlineConn struct {
 	setDeadlineFn  func(time.Time) error
 	setReadFn      func(time.Time) error
 	setWriteFn     func(time.Time) error
+	closeFn        func() error
 }
 
 type controlledDeadlineListener struct {
@@ -37,6 +38,7 @@ type controlledDeadlineListener struct {
 	closeCount int
 	acceptFn   func() (net.Conn, error)
 	setFn      func(time.Time) error
+	closeFn    func() error
 }
 
 func (listener *controlledDeadlineListener) Accept() (net.Conn, error) {
@@ -60,6 +62,9 @@ func (listener *controlledDeadlineListener) Close() error {
 	listener.mu.Lock()
 	listener.closeCount++
 	listener.mu.Unlock()
+	if listener.closeFn != nil {
+		return listener.closeFn()
+	}
 	return listener.Listener.Close()
 }
 
@@ -123,6 +128,9 @@ func (connection *controlledDeadlineConn) Close() error {
 	connection.mu.Lock()
 	connection.closeCount++
 	connection.mu.Unlock()
+	if connection.closeFn != nil {
+		return connection.closeFn()
+	}
 	return connection.Conn.Close()
 }
 
@@ -130,6 +138,240 @@ func (connection *controlledDeadlineConn) closes() int {
 	connection.mu.Lock()
 	defer connection.mu.Unlock()
 	return connection.closeCount
+}
+
+func requireWakeSignals(t *testing.T, wakes ...*fakePlatformWake) {
+	t.Helper()
+	for index, wake := range wakes {
+		wake.mu.Lock()
+		signals := wake.signals
+		wake.mu.Unlock()
+		if signals != 1 {
+			t.Fatalf("wake %d signals=%d, want 1 before close", index, signals)
+		}
+	}
+}
+
+func TestSocketDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	controlled := &controlledDeadlineConn{Conn: connection}
+	firstRaw := &fakePlatformWake{}
+	secondRaw := &fakePlatformWake{}
+	first := newNetworkWake(firstRaw)
+	second := newNetworkWake(secondRaw)
+	resource := &SocketResource{
+		connection:  controlled,
+		pollWaiters: map[*networkWake]struct{}{first: {}, second: {}},
+	}
+
+	closeSocket(resource)
+	closeSocket(resource)
+
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closed := resource.closed
+	connectionAfterClose := resource.connection
+	waiters := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closed || connectionAfterClose != nil || waiters != nil {
+		t.Fatalf("closed=%v connection=%v waiters=%v", closed, connectionAfterClose, waiters)
+	}
+	if controlled.closes() != 1 {
+		t.Fatalf("close calls=%d, want 1", controlled.closes())
+	}
+}
+
+func TestListenerDetachWakesAllWaitersAndClosesOnce(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlled := &controlledDeadlineListener{Listener: underlying}
+	accepted, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
+	firstRaw := &fakePlatformWake{}
+	secondRaw := &fakePlatformWake{}
+	first := newNetworkWake(firstRaw)
+	second := newNetworkWake(secondRaw)
+	resource := &ListenerResource{
+		listener:       controlled,
+		bufferedAccept: controlledAccepted,
+		pollWaiters:    map[*networkWake]struct{}{first: {}, second: {}},
+	}
+
+	closeListener(resource)
+	closeListener(resource)
+
+	requireWakeSignals(t, firstRaw, secondRaw)
+	resource.stateMu.Lock()
+	closed := resource.closed
+	listenerAfterClose := resource.listener
+	bufferedAfterClose := resource.bufferedAccept
+	waiters := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if !closed || listenerAfterClose != nil || bufferedAfterClose != nil || waiters != nil {
+		t.Fatalf("closed=%v listener=%v buffered=%v waiters=%v", closed, listenerAfterClose, bufferedAfterClose, waiters)
+	}
+	if controlled.closes() != 1 || controlledAccepted.closes() != 1 {
+		t.Fatalf("close calls: listener=%d accepted=%d, want 1 each", controlled.closes(), controlledAccepted.closes())
+	}
+}
+
+func TestSocketReadRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	applicationFailure := errors.New("read deadline failed")
+	rollbackFailure := errors.New("read rollback failed")
+	signalFailure := errors.New("wake signal failed")
+	closeFailure := errors.New("socket close failed")
+	firstRaw := &fakePlatformWake{signalErr: signalFailure}
+	secondRaw := &fakePlatformWake{}
+	readCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			readCalls++
+			if readCalls == 1 {
+				return applicationFailure
+			}
+			return rollbackFailure
+		},
+		closeFn: func() error {
+			requireWakeSignals(t, firstRaw, secondRaw)
+			_ = connection.Close()
+			return closeFailure
+		},
+	}
+	resource := &SocketResource{
+		connection: controlled,
+		pollWaiters: map[*networkWake]struct{}{
+			newNetworkWake(firstRaw):  {},
+			newNetworkWake(secondRaw): {},
+		},
+	}
+
+	err := configureSocketTimeout(resource, time.Second)
+	for _, want := range []error{applicationFailure, rollbackFailure, signalFailure, closeFailure} {
+		if !errors.Is(err, want) {
+			t.Fatalf("configuration error=%v, want joined %v", err, want)
+		}
+	}
+	resource.stateMu.Lock()
+	waiters := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if waiters != nil || controlled.closes() != 1 {
+		t.Fatalf("waiters=%v close calls=%d, want nil and 1", waiters, controlled.closes())
+	}
+}
+
+func TestSocketWriteRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
+	connection, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	applicationFailure := errors.New("write deadline failed")
+	rollbackFailure := errors.New("read rollback failed")
+	signalFailure := errors.New("wake signal failed")
+	closeFailure := errors.New("socket close failed")
+	firstRaw := &fakePlatformWake{signalErr: signalFailure}
+	secondRaw := &fakePlatformWake{}
+	readCalls := 0
+	writeCalls := 0
+	controlled := &controlledDeadlineConn{
+		Conn: connection,
+		setReadFn: func(time.Time) error {
+			readCalls++
+			if readCalls == 2 {
+				return rollbackFailure
+			}
+			return nil
+		},
+		setWriteFn: func(time.Time) error {
+			writeCalls++
+			if writeCalls == 1 {
+				return applicationFailure
+			}
+			return nil
+		},
+		closeFn: func() error {
+			requireWakeSignals(t, firstRaw, secondRaw)
+			_ = connection.Close()
+			return closeFailure
+		},
+	}
+	resource := &SocketResource{
+		connection: controlled,
+		pollWaiters: map[*networkWake]struct{}{
+			newNetworkWake(firstRaw):  {},
+			newNetworkWake(secondRaw): {},
+		},
+	}
+
+	err := configureSocketTimeout(resource, time.Second)
+	for _, want := range []error{applicationFailure, rollbackFailure, signalFailure, closeFailure} {
+		if !errors.Is(err, want) {
+			t.Fatalf("configuration error=%v, want joined %v", err, want)
+		}
+	}
+	resource.stateMu.Lock()
+	waiters := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if waiters != nil || controlled.closes() != 1 {
+		t.Fatalf("waiters=%v close calls=%d, want nil and 1", waiters, controlled.closes())
+	}
+}
+
+func TestListenerRollbackPoisonWakesBeforeCloseAndJoinsErrors(t *testing.T) {
+	underlying, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	applicationFailure := errors.New("accept deadline failed")
+	rollbackFailure := errors.New("accept rollback failed")
+	signalFailure := errors.New("wake signal failed")
+	closeFailure := errors.New("listener close failed")
+	firstRaw := &fakePlatformWake{signalErr: signalFailure}
+	secondRaw := &fakePlatformWake{}
+	setterCalls := 0
+	controlled := &controlledDeadlineListener{
+		Listener: underlying,
+		setFn: func(time.Time) error {
+			setterCalls++
+			if setterCalls == 1 {
+				return applicationFailure
+			}
+			return rollbackFailure
+		},
+		closeFn: func() error {
+			requireWakeSignals(t, firstRaw, secondRaw)
+			_ = underlying.Close()
+			return closeFailure
+		},
+	}
+	accepted, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	controlledAccepted := &controlledDeadlineConn{Conn: accepted}
+	resource := &ListenerResource{
+		listener:       controlled,
+		bufferedAccept: controlledAccepted,
+		pollWaiters: map[*networkWake]struct{}{
+			newNetworkWake(firstRaw):  {},
+			newNetworkWake(secondRaw): {},
+		},
+	}
+
+	err = configureListenerTimeout(resource, time.Second)
+	for _, want := range []error{applicationFailure, rollbackFailure, signalFailure, closeFailure} {
+		if !errors.Is(err, want) {
+			t.Fatalf("configuration error=%v, want joined %v", err, want)
+		}
+	}
+	resource.stateMu.Lock()
+	waiters := resource.pollWaiters
+	resource.stateMu.Unlock()
+	if waiters != nil || controlled.closes() != 1 || controlledAccepted.closes() != 1 {
+		t.Fatalf("waiters=%v close calls: listener=%d accepted=%d, want nil and 1 each", waiters, controlled.closes(), controlledAccepted.closes())
+	}
 }
 
 func invokeBuiltin(t *testing.T, machine *VM, name string, args ...value.Value) (value.Value, error) {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -50,6 +50,34 @@ func interpretVMSourceWithinBound(t *testing.T, machine *VM, source string) erro
 	}
 }
 
+func TestNetSelectPublicWrappersAreExecutable(t *testing.T) {
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+
+	err := interpretVMSourceWithinBound(t, machine, `use net
+let read: net.Socket[64] = net.socket_set()
+let write: net.Socket[64] = net.socket_set()
+let errors: net.Socket[64] = net.socket_set()
+let selected: net.SelectResult = net.poll(read, write, errors, 0)
+test_report(selected.read)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, ok := captured.Obj.(*value.ObjArray)
+	if captured.Type != value.VAL_OBJ || !ok {
+		t.Fatalf("net.socket_set() = %#v, want array", captured)
+	}
+	if len(set.Elements) != networkSetCapacity {
+		t.Fatalf("net.socket_set() length = %d, want %d", len(set.Elements), networkSetCapacity)
+	}
+}
+
 func recordDeferredListenerResource(machine *VM, captured **ListenerResource) {
 	machine.DefineNative("record_listener_resource", func(args []value.Value) value.Value {
 		if len(args) != 1 {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"errors"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -282,20 +283,108 @@ func requireValidSelectResult(t *testing.T, result value.Value) {
 	}
 }
 
-func TestNetSelectBufferIsSharedAcrossVMs(t *testing.T) {
+func TestNetSelectDoesNotConsumeSocketData(t *testing.T) {
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 	child := NewWithShared(machine.shared, machine.Config)
+	_, resource := requireSocketResource(t, machine, server)
+	resource.stateMu.Lock()
+	underlying := resource.connection
+	readCalls := 0
+	resource.connection = &controlledDeadlineConn{
+		Conn: underlying,
+		readFn: func(buffer []byte) (int, error) {
+			readCalls++
+			return underlying.Read(buffer)
+		},
+	}
+	resource.stateMu.Unlock()
 
-	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("xy"))
 	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
-	selected := callBuiltinWithinBound(t, machine, "net_select",
-		value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(250))
-	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
-	received := callBuiltinWithinBound(t, child, "net_recv", server, value.NewInt(1))
+	for attempt := 0; attempt < 2; attempt++ {
+		selected := callBuiltinWithinBound(t, machine, "net_select",
+			value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(0))
+		assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
+	}
+	if readCalls != 0 {
+		t.Fatalf("socket reads during net_select=%d, want 0", readCalls)
+	}
+	received := callBuiltinWithinBound(t, child, "net_recv", server, value.NewInt(2))
 	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
-	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(1))
-	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("xy"))
+}
+
+func TestNetSelectDoesNotAcceptPendingConnection(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
+	if !exists {
+		t.Fatalf("listener descriptor %d is not registered", listenerFD)
+	}
+	listenerResource.stateMu.Lock()
+	underlying := listenerResource.listener
+	acceptCalls := 0
+	listenerResource.listener = &controlledDeadlineListener{
+		Listener: underlying,
+		acceptFn: func() (net.Conn, error) {
+			acceptCalls++
+			return underlying.Accept()
+		},
+	}
+	address := underlying.Addr().(*net.TCPAddr)
+	listenerResource.stateMu.Unlock()
+	client := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("127.0.0.1"), value.NewInt(int64(address.Port)))
+
+	for attempt := 0; attempt < 2; attempt++ {
+		selected := callBuiltinWithinBound(t, machine, "net_select",
+			value.NewArray([]value.Value{listener}), value.NewArray(nil), value.NewArray(nil), value.NewInt(0))
+		assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
+	}
+	if acceptCalls != 0 {
+		t.Fatalf("listener accepts during net_select=%d, want 0", acceptCalls)
+	}
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	assertBuiltinValue(t, builtinMapField(t, accepted, "open"), value.NewBool(true))
+	if acceptCalls != 1 {
+		t.Fatalf("listener accepts after net_accept=%d, want exactly 1", acceptCalls)
+	}
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("ok"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "count"), value.NewInt(2))
+	received := callBuiltinWithinBound(t, machine, "net_recv", accepted, value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("ok"))
+}
+
+func TestNetSelectValidatesArgumentsSynchronously(t *testing.T) {
+	machine := New()
+	empty := value.NewArray(nil)
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	tests := []struct {
+		name string
+		args []value.Value
+	}{
+		{"wrong arity", []value.Value{empty}},
+		{"wrong read set", []value.Value{value.NewNull(), empty, empty, value.NewInt(0)}},
+		{"wrong write set", []value.Value{empty, value.NewNull(), empty, value.NewInt(0)}},
+		{"wrong error set", []value.Value{empty, empty, value.NewNull(), value.NewInt(0)}},
+		{"wrong timeout type", []value.Value{empty, empty, empty, value.NewString("0")}},
+		{"negative timeout", []value.Value{empty, empty, empty, value.NewInt(-1)}},
+		{"overflow timeout", []value.Value{empty, empty, empty, value.NewInt(maximum + 1)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := invokeBuiltin(t, machine, "net_select", test.args...)
+			if err == nil {
+				t.Fatalf("net_select result=%v, want synchronous error", result)
+			}
+			if result.Type != value.VAL_NULL {
+				t.Fatalf("net_select result=%v, want null on error", result)
+			}
+		})
+	}
 }
 
 func TestConcurrentNetSelect(t *testing.T) {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -387,34 +387,6 @@ func TestNetSelectValidatesArgumentsSynchronously(t *testing.T) {
 	}
 }
 
-func TestConcurrentNetSelect(t *testing.T) {
-	machine := New()
-	_, client, server := setupAcceptedLoopback(t, machine)
-	child := NewWithShared(machine.shared, machine.Config)
-
-	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
-	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
-	start := make(chan struct{})
-	done := make(chan value.Value, 2)
-	for _, current := range []*VM{machine, child} {
-		current := current
-		go func() {
-			<-start
-			done <- callBuiltinWithinBound(t, current, "net_select",
-				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5))
-		}()
-	}
-	close(start)
-	for i := 0; i < 2; i++ {
-		select {
-		case result := <-done:
-			requireValidSelectResult(t, result)
-		case <-time.After(statefulBuiltinTimeout):
-			t.Fatal("concurrent net_select did not complete")
-		}
-	}
-}
-
 func TestNetworkBuiltinsLoopbackLifecycle(t *testing.T) {
 	machine := New()
 	defer func() {

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -294,6 +294,22 @@ func setupAcceptedLoopback(t *testing.T, machine *VM) (value.Value, value.Value,
 	return listener, client, server
 }
 
+func TestNetListenZeroReturnsAssignedPort(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
+	assignedPort := builtinMapField(t, listener, "port").AsInt
+	if assignedPort <= 0 {
+		t.Fatalf("net_listen port=%d, want OS-assigned positive port", assignedPort)
+	}
+
+	client := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("127.0.0.1"), value.NewInt(assignedPort))
+	assertBuiltinValue(t, builtinMapField(t, client, "open"), value.NewBool(true))
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	assertBuiltinValue(t, builtinMapField(t, accepted, "open"), value.NewBool(true))
+}
+
 func requireValidSelectResult(t *testing.T, result value.Value) {
 	t.Helper()
 	mapping := requireBuiltinMap(t, result)

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -21,7 +21,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"io_remove", "io_stat", "io_write", "io_write_result", "iprint", "json_dumps",
 		"json_dumps_result", "json_loads", "json_parse", "keys", "length", "make_chan",
 		"make_wg", "net_accept", "net_close", "net_connect", "net_listen",
-		"net_recv", "net_select", "net_send", "net_setblocking", "net_settimeout", "ord",
+		"net_recv", "net_select", "net_send", "net_setblocking", "net_settimeout", "net_socket_set", "ord",
 		"pop", "print", "slice", "spawn", "spawn_task", "sqlite_bind_float",
 		"sqlite_bind_int", "sqlite_bind_text", "sqlite_close", "sqlite_exec",
 		"sqlite_exec_params", "sqlite_finalize", "sqlite_open",

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -1,0 +1,80 @@
+package vm
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"noxy-vm/internal/value"
+)
+
+const networkSetCapacity = 64
+
+type networkInterest uint8
+
+const (
+	networkReadable networkInterest = 1 << iota
+	networkWritable
+	networkErrorInterest
+)
+
+type networkEvent uint8
+
+const (
+	networkReadReady networkEvent = 1 << iota
+	networkWriteReady
+	networkErrorReady
+)
+
+func validateNetworkPollArguments(args []value.Value) ([3]*value.ObjArray, time.Duration, error) {
+	var sets [3]*value.ObjArray
+	if len(args) != 4 {
+		return sets, 0, fmt.Errorf("net_select expects exactly 4 arguments")
+	}
+	for index := 0; index < 3; index++ {
+		array, ok := args[index].Obj.(*value.ObjArray)
+		if args[index].Type != value.VAL_OBJ || !ok || array == nil {
+			return sets, 0, fmt.Errorf("net_select read, write, and error arguments must be arrays")
+		}
+		sets[index] = array
+	}
+	if args[3].Type != value.VAL_INT {
+		return sets, 0, fmt.Errorf("network poll timeout must be an int")
+	}
+	milliseconds := args[3].AsInt
+	if milliseconds < 0 {
+		return sets, 0, fmt.Errorf("network poll timeout must be non-negative")
+	}
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	if milliseconds > maximum {
+		return sets, 0, fmt.Errorf("network poll timeout is too large")
+	}
+	return sets, time.Duration(milliseconds) * time.Millisecond, nil
+}
+
+func boundedNetworkCandidates(array *value.ObjArray) []value.Value {
+	if len(array.Elements) <= networkSetCapacity {
+		return array.Elements
+	}
+	return array.Elements[:networkSetCapacity]
+}
+
+func fixedNetworkSet(ready []value.Value) value.Value {
+	elements := make([]value.Value, networkSetCapacity)
+	for i := range elements {
+		elements[i] = value.NewNull()
+	}
+	copy(elements, ready[:min(len(ready), networkSetCapacity)])
+	return value.NewArray(elements)
+}
+
+func selectResult(read, write, errors []value.Value) value.Value {
+	read = read[:min(len(read), networkSetCapacity)]
+	write = write[:min(len(write), networkSetCapacity)]
+	errors = errors[:min(len(errors), networkSetCapacity)]
+	return value.NewMapWithData(map[string]value.Value{
+		"read": fixedNetworkSet(read), "read_count": value.NewInt(int64(len(read))),
+		"write": fixedNetworkSet(write), "write_count": value.NewInt(int64(len(write))),
+		"error": fixedNetworkSet(errors), "error_count": value.NewInt(int64(len(errors))),
+	})
+}

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -224,8 +224,10 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 
 	pollRegistrations := make([]*networkRegistration, 0, len(registrations))
 	attachedCount := 0
+	concurrentAttachClose := false
 	for _, registration := range registrations {
 		if !attachNetworkRegistration(shared, registration, wake) {
+			concurrentAttachClose = true
 			continue
 		}
 		attachedCount++
@@ -241,7 +243,7 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 		}
 		pollRegistrations = append(pollRegistrations, registration)
 	}
-	if attachedCount == 0 {
+	if concurrentAttachClose || attachedCount == 0 {
 		return selectResult(nil, nil, nil), nil
 	}
 

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -190,6 +190,7 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 		deadline = now().Add(timeout)
 	}
 	registrations, occurrences := collectNetworkRegistrations(shared, sets)
+	registrations = initiallyOpenNetworkRegistrations(shared, registrations)
 	if len(registrations) == 0 {
 		if timeout > 0 {
 			remaining := deadline.Sub(now())
@@ -241,12 +242,6 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 		pollRegistrations = append(pollRegistrations, registration)
 	}
 	if attachedCount == 0 {
-		if timeout > 0 {
-			remaining := deadline.Sub(now())
-			if remaining > 0 {
-				poller.networkSleep()(remaining)
-			}
-		}
 		return selectResult(nil, nil, nil), nil
 	}
 
@@ -366,6 +361,37 @@ func lookupNetworkRegistration(shared *SharedState, handle int) *networkRegistra
 		return &networkRegistration{handle: handle, socket: socket}
 	}
 	return nil
+}
+
+func initiallyOpenNetworkRegistrations(shared *SharedState, registrations []*networkRegistration) []*networkRegistration {
+	open := make([]*networkRegistration, 0, len(registrations))
+	for _, registration := range registrations {
+		if networkRegistrationOpen(shared, registration) {
+			open = append(open, registration)
+		}
+	}
+	return open
+}
+
+func networkRegistrationOpen(shared *SharedState, registration *networkRegistration) bool {
+	if shared == nil || registration == nil {
+		return false
+	}
+	if registration.listener != nil {
+		resource := registration.listener
+		resource.stateMu.Lock()
+		defer resource.stateMu.Unlock()
+		current, exists := shared.Listeners.get(registration.handle)
+		return exists && current == resource && !resource.closed && resource.listener != nil
+	}
+	if registration.socket == nil {
+		return false
+	}
+	resource := registration.socket
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	current, exists := shared.Sockets.get(registration.handle)
+	return exists && current == resource && !resource.closed && resource.connection != nil
 }
 
 func attachNetworkRegistration(shared *SharedState, registration *networkRegistration, wake *networkWake) bool {

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -1,9 +1,12 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"sync"
+	"syscall"
 	"time"
 
 	"noxy-vm/internal/value"
@@ -73,6 +76,436 @@ const (
 	networkWriteReady
 	networkErrorReady
 )
+
+type networkPollFD struct {
+	descriptor uintptr
+	interests  networkInterest
+	listener   bool
+}
+
+type networkPollBatch struct {
+	events      []networkEvent
+	woke        bool
+	interrupted bool
+}
+
+type networkPlatform struct {
+	newWake func() (platformNetworkWake, error)
+	wait    func([]networkPollFD, uintptr, int32) (networkPollBatch, error)
+}
+
+type networkPoller struct {
+	platform networkPlatform
+	now      func() time.Time
+	sleep    func(time.Duration)
+}
+
+type networkRegistration struct {
+	handle          int
+	requested       networkInterest
+	nativeInterests networkInterest
+	pollable        bool
+	listener        *ListenerResource
+	socket          *SocketResource
+	attached        any
+	raw             syscall.RawConn
+}
+
+type networkOccurrence struct {
+	candidate    value.Value
+	registration *networkRegistration
+}
+
+type networkAcquisitionStage uint8
+
+const (
+	networkAcquireSyscallConn networkAcquisitionStage = iota
+	networkAcquireControl
+)
+
+type networkAcquisitionError struct {
+	registration    *networkRegistration
+	stage           networkAcquisitionStage
+	callbackEntered bool
+	err             error
+}
+
+func (failure *networkAcquisitionError) Error() string { return failure.err.Error() }
+func (failure *networkAcquisitionError) Unwrap() error { return failure.err }
+
+func networkPollMilliseconds(remaining time.Duration) int32 {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining > time.Second {
+		remaining = time.Second
+	}
+	milliseconds := remaining / time.Millisecond
+	if remaining%time.Millisecond != 0 {
+		milliseconds++
+	}
+	return int32(milliseconds)
+}
+
+func withNetworkDescriptors(
+	registrations []*networkRegistration,
+	pollfds []networkPollFD,
+	index int,
+	wait func([]networkPollFD) (networkPollBatch, error),
+) (batch networkPollBatch, failure *networkAcquisitionError, err error) {
+	if index == len(registrations) {
+		batch, err = wait(pollfds)
+		return batch, nil, err
+	}
+	registration := registrations[index]
+	callbackEntered := false
+	controlErr := registration.raw.Control(func(fd uintptr) {
+		callbackEntered = true
+		pollfds[index] = networkPollFD{
+			descriptor: fd,
+			interests:  registration.nativeInterests,
+			listener:   registration.listener != nil,
+		}
+		batch, failure, err = withNetworkDescriptors(registrations, pollfds, index+1, wait)
+	})
+	if failure != nil || err != nil {
+		return batch, failure, err
+	}
+	if controlErr != nil {
+		return batch, &networkAcquisitionError{
+			registration:    registration,
+			stage:           networkAcquireControl,
+			callbackEntered: callbackEntered,
+			err:             controlErr,
+		}, nil
+	}
+	return batch, nil, nil
+}
+
+func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, timeout time.Duration) (result value.Value, err error) {
+	result = value.NewNull()
+	registrations, occurrences := collectNetworkRegistrations(shared, sets)
+	if len(registrations) == 0 {
+		if timeout > 0 {
+			poller.networkSleep()(timeout)
+		}
+		return selectResult(nil, nil, nil), nil
+	}
+
+	operationStart := poller.networkNow()()
+	deadline := operationStart.Add(timeout)
+	if poller.platform.newWake == nil || poller.platform.wait == nil {
+		return result, fmt.Errorf("network poll platform is unavailable")
+	}
+	platformWake, wakeErr := poller.platform.newWake()
+	if wakeErr != nil {
+		return result, wakeErr
+	}
+	if platformWake == nil {
+		return result, fmt.Errorf("network poll wake is unavailable")
+	}
+	wake := newNetworkWake(platformWake)
+	defer func() {
+		for _, registration := range registrations {
+			unregisterNetworkWake(registration, wake)
+		}
+		err = errors.Join(err, wake.Close())
+		if err != nil {
+			result = value.NewNull()
+		}
+	}()
+
+	pollRegistrations := make([]*networkRegistration, 0, len(registrations))
+	attachedCount := 0
+	for _, registration := range registrations {
+		if !attachNetworkRegistration(shared, registration, wake) {
+			continue
+		}
+		attachedCount++
+		if !registration.pollable {
+			continue
+		}
+		failure := acquireNetworkRawConn(registration)
+		if failure != nil {
+			if !networkRegistrationCurrent(shared, failure.registration) {
+				return selectResult(nil, nil, nil), nil
+			}
+			return result, failure
+		}
+		pollRegistrations = append(pollRegistrations, registration)
+	}
+	if attachedCount == 0 {
+		return selectResult(nil, nil, nil), nil
+	}
+
+	ready := make(map[*networkRegistration]networkInterest, len(pollRegistrations))
+	pollfds := make([]networkPollFD, len(pollRegistrations))
+	waitOnce := func(milliseconds int32) (networkPollBatch, *networkAcquisitionError, error) {
+		return withNetworkDescriptors(pollRegistrations, pollfds, 0, func(descriptors []networkPollFD) (networkPollBatch, error) {
+			return poller.platform.wait(descriptors, platformWake.descriptor(), milliseconds)
+		})
+	}
+
+	if timeout == 0 {
+		batch, failure, waitErr := waitOnce(0)
+		if failure != nil {
+			if !networkRegistrationCurrent(shared, failure.registration) {
+				return selectResult(nil, nil, nil), nil
+			}
+			return result, failure
+		}
+		if waitErr != nil {
+			return result, waitErr
+		}
+		applyNetworkEvents(pollRegistrations, batch.events, ready)
+		return reconstructNetworkResult(shared, occurrences, ready), nil
+	}
+
+	for {
+		remaining := deadline.Sub(poller.networkNow()())
+		if remaining <= 0 {
+			break
+		}
+		batch, failure, waitErr := waitOnce(networkPollMilliseconds(remaining))
+		if failure != nil {
+			if !networkRegistrationCurrent(shared, failure.registration) {
+				return reconstructNetworkResult(shared, occurrences, ready), nil
+			}
+			return result, failure
+		}
+		if waitErr != nil {
+			return result, waitErr
+		}
+		applyNetworkEvents(pollRegistrations, batch.events, ready)
+		if len(ready) != 0 {
+			break
+		}
+		if batch.woke && anyNetworkRegistrationClosed(shared, registrations) {
+			break
+		}
+	}
+	return reconstructNetworkResult(shared, occurrences, ready), nil
+}
+
+func (poller *networkPoller) networkNow() func() time.Time {
+	if poller.now != nil {
+		return poller.now
+	}
+	return time.Now
+}
+
+func (poller *networkPoller) networkSleep() func(time.Duration) {
+	if poller.sleep != nil {
+		return poller.sleep
+	}
+	return time.Sleep
+}
+
+func collectNetworkRegistrations(shared *SharedState, sets [3]*value.ObjArray) ([]*networkRegistration, [3][]networkOccurrence) {
+	var occurrences [3][]networkOccurrence
+	registrations := make([]*networkRegistration, 0)
+	byHandle := make(map[int]*networkRegistration)
+	interests := [3]networkInterest{networkReadable, networkWritable, networkErrorInterest}
+	for setIndex, set := range sets {
+		if set == nil {
+			continue
+		}
+		for _, candidate := range boundedNetworkCandidates(set) {
+			handle, extractionErr := networkSocketDescriptor(candidate)
+			if extractionErr != nil {
+				continue
+			}
+			registration, exists := byHandle[handle]
+			if !exists {
+				registration = lookupNetworkRegistration(shared, handle)
+				if registration == nil {
+					continue
+				}
+				byHandle[handle] = registration
+				registrations = append(registrations, registration)
+			}
+			registration.requested |= interests[setIndex]
+			occurrences[setIndex] = append(occurrences[setIndex], networkOccurrence{
+				candidate:    candidate,
+				registration: registration,
+			})
+		}
+	}
+	for _, registration := range registrations {
+		registration.nativeInterests = registration.requested
+		if registration.listener != nil {
+			registration.nativeInterests &^= networkWritable
+			registration.pollable = registration.nativeInterests&(networkReadable|networkErrorInterest) != 0
+		} else {
+			registration.pollable = true
+		}
+	}
+	return registrations, occurrences
+}
+
+func lookupNetworkRegistration(shared *SharedState, handle int) *networkRegistration {
+	if shared == nil {
+		return nil
+	}
+	if listener, exists := shared.Listeners.get(handle); exists {
+		return &networkRegistration{handle: handle, listener: listener}
+	}
+	if socket, exists := shared.Sockets.get(handle); exists {
+		return &networkRegistration{handle: handle, socket: socket}
+	}
+	return nil
+}
+
+func attachNetworkRegistration(shared *SharedState, registration *networkRegistration, wake *networkWake) bool {
+	if registration.listener != nil {
+		resource := registration.listener
+		resource.stateMu.Lock()
+		defer resource.stateMu.Unlock()
+		current, exists := shared.Listeners.get(registration.handle)
+		if !exists || current != resource || resource.closed || resource.listener == nil {
+			return false
+		}
+		if resource.pollWaiters == nil {
+			resource.pollWaiters = make(map[*networkWake]struct{})
+		}
+		resource.pollWaiters[wake] = struct{}{}
+		registration.attached = resource.listener
+		return true
+	}
+	resource := registration.socket
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	current, exists := shared.Sockets.get(registration.handle)
+	if !exists || current != resource || resource.closed || resource.connection == nil {
+		return false
+	}
+	if resource.pollWaiters == nil {
+		resource.pollWaiters = make(map[*networkWake]struct{})
+	}
+	resource.pollWaiters[wake] = struct{}{}
+	registration.attached = resource.connection
+	return true
+}
+
+func acquireNetworkRawConn(registration *networkRegistration) *networkAcquisitionError {
+	connection, ok := registration.attached.(syscall.Conn)
+	if !ok {
+		return &networkAcquisitionError{
+			registration: registration,
+			stage:        networkAcquireSyscallConn,
+			err:          fmt.Errorf("network resource does not expose SyscallConn"),
+		}
+	}
+	raw, err := connection.SyscallConn()
+	if err != nil {
+		return &networkAcquisitionError{
+			registration: registration,
+			stage:        networkAcquireSyscallConn,
+			err:          err,
+		}
+	}
+	registration.raw = raw
+	return nil
+}
+
+func unregisterNetworkWake(registration *networkRegistration, wake *networkWake) {
+	if registration.listener != nil {
+		registration.listener.stateMu.Lock()
+		delete(registration.listener.pollWaiters, wake)
+		registration.listener.stateMu.Unlock()
+		return
+	}
+	registration.socket.stateMu.Lock()
+	delete(registration.socket.pollWaiters, wake)
+	registration.socket.stateMu.Unlock()
+}
+
+func networkRegistrationCurrent(shared *SharedState, registration *networkRegistration) bool {
+	if registration.attached == nil {
+		return false
+	}
+	if registration.listener != nil {
+		resource := registration.listener
+		resource.stateMu.Lock()
+		defer resource.stateMu.Unlock()
+		current, exists := shared.Listeners.get(registration.handle)
+		return exists && current == resource && !resource.closed && sameNetworkAttachment(resource.listener, registration.attached)
+	}
+	resource := registration.socket
+	resource.stateMu.Lock()
+	defer resource.stateMu.Unlock()
+	current, exists := shared.Sockets.get(registration.handle)
+	return exists && current == resource && !resource.closed && sameNetworkAttachment(resource.connection, registration.attached)
+}
+
+func sameNetworkAttachment(current, attached any) bool {
+	if current == nil || attached == nil || reflect.TypeOf(current) != reflect.TypeOf(attached) {
+		return false
+	}
+	if !reflect.TypeOf(current).Comparable() {
+		return false
+	}
+	return current == attached
+}
+
+func anyNetworkRegistrationClosed(shared *SharedState, registrations []*networkRegistration) bool {
+	for _, registration := range registrations {
+		if registration.attached != nil && !networkRegistrationCurrent(shared, registration) {
+			return true
+		}
+	}
+	return false
+}
+
+func applyNetworkEvents(registrations []*networkRegistration, events []networkEvent, ready map[*networkRegistration]networkInterest) {
+	for index, registration := range registrations {
+		if index >= len(events) {
+			break
+		}
+		event := events[index]
+		var interests networkInterest
+		if event&networkErrorReady != 0 {
+			interests = registration.requested
+			if registration.listener != nil {
+				interests &^= networkWritable
+			}
+		} else {
+			if event&networkReadReady != 0 {
+				interests |= registration.requested & networkReadable
+			}
+			if event&networkWriteReady != 0 && registration.listener == nil {
+				interests |= registration.requested & networkWritable
+			}
+		}
+		if interests != 0 {
+			ready[registration] |= interests
+		}
+	}
+}
+
+func reconstructNetworkResult(shared *SharedState, occurrences [3][]networkOccurrence, ready map[*networkRegistration]networkInterest) value.Value {
+	interests := [3]networkInterest{networkReadable, networkWritable, networkErrorInterest}
+	sets := [3][]value.Value{}
+	valid := make(map[*networkRegistration]bool)
+	checked := make(map[*networkRegistration]bool)
+	for setIndex, candidates := range occurrences {
+		for _, occurrence := range candidates {
+			registration := occurrence.registration
+			if !checked[registration] {
+				checked[registration] = true
+				valid[registration] = networkRegistrationCurrent(shared, registration)
+			}
+			interest := interests[setIndex]
+			if registration.listener != nil && interest == networkWritable {
+				continue
+			}
+			if valid[registration] && ready[registration]&interest != 0 {
+				sets[setIndex] = append(sets[setIndex], occurrence.candidate)
+			}
+		}
+	}
+	return selectResult(sets[0], sets[1], sets[2])
+}
 
 func validateNetworkPollArguments(args []value.Value) ([3]*value.ObjArray, time.Duration, error) {
 	var sets [3]*value.ObjArray

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -3,10 +3,58 @@ package vm
 import (
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"noxy-vm/internal/value"
 )
+
+type platformNetworkWake interface {
+	descriptor() uintptr
+	signal() error
+	close() error
+}
+
+type networkWakeState uint8
+
+const (
+	networkWakeOpen networkWakeState = iota
+	networkWakeSignaled
+	networkWakeClosed
+)
+
+type networkWake struct {
+	mu       sync.Mutex
+	state    networkWakeState
+	platform platformNetworkWake
+}
+
+func newNetworkWake(platform platformNetworkWake) *networkWake {
+	return &networkWake{platform: platform}
+}
+
+func (wake *networkWake) Signal() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	if wake.state != networkWakeOpen {
+		return nil
+	}
+	if err := wake.platform.signal(); err != nil {
+		return err
+	}
+	wake.state = networkWakeSignaled
+	return nil
+}
+
+func (wake *networkWake) Close() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	if wake.state == networkWakeClosed {
+		return nil
+	}
+	wake.state = networkWakeClosed
+	return wake.platform.close()
+}
 
 const networkSetCapacity = 64
 

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -184,16 +184,22 @@ func withNetworkDescriptors(
 
 func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, timeout time.Duration) (result value.Value, err error) {
 	result = value.NewNull()
+	now := poller.networkNow()
+	deadline := time.Time{}
+	if timeout > 0 {
+		deadline = now().Add(timeout)
+	}
 	registrations, occurrences := collectNetworkRegistrations(shared, sets)
 	if len(registrations) == 0 {
 		if timeout > 0 {
-			poller.networkSleep()(timeout)
+			remaining := deadline.Sub(now())
+			if remaining > 0 {
+				poller.networkSleep()(remaining)
+			}
 		}
 		return selectResult(nil, nil, nil), nil
 	}
 
-	operationStart := poller.networkNow()()
-	deadline := operationStart.Add(timeout)
 	if poller.platform.newWake == nil || poller.platform.wait == nil {
 		return result, fmt.Errorf("network poll platform is unavailable")
 	}
@@ -262,7 +268,7 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 	}
 
 	for {
-		remaining := deadline.Sub(poller.networkNow()())
+		remaining := deadline.Sub(now())
 		if remaining <= 0 {
 			break
 		}

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -241,6 +241,12 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 		pollRegistrations = append(pollRegistrations, registration)
 	}
 	if attachedCount == 0 {
+		if timeout > 0 {
+			remaining := deadline.Sub(now())
+			if remaining > 0 {
+				poller.networkSleep()(remaining)
+			}
+		}
 		return selectResult(nil, nil, nil), nil
 	}
 
@@ -286,7 +292,7 @@ func (poller *networkPoller) Poll(shared *SharedState, sets [3]*value.ObjArray, 
 		if len(ready) != 0 {
 			break
 		}
-		if batch.woke && anyNetworkRegistrationClosed(shared, registrations) {
+		if anyNetworkRegistrationClosed(shared, registrations) {
 			break
 		}
 	}

--- a/internal/vm/network_poller_integration_test.go
+++ b/internal/vm/network_poller_integration_test.go
@@ -1,0 +1,391 @@
+//go:build windows || aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package vm
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"noxy-vm/internal/value"
+)
+
+func networkPollIntegrationSelect(
+	t *testing.T,
+	machine *VM,
+	read, write, errors []value.Value,
+	timeoutMilliseconds int64,
+) value.Value {
+	t.Helper()
+	return callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray(read), value.NewArray(write), value.NewArray(errors), value.NewInt(timeoutMilliseconds))
+}
+
+func requireNetworkPollIntegrationSet(t *testing.T, result value.Value, field string, want ...value.Value) {
+	t.Helper()
+	count := builtinMapField(t, result, field+"_count")
+	assertBuiltinValue(t, count, value.NewInt(int64(len(want))))
+	arrayValue := builtinMapField(t, result, field)
+	array, ok := arrayValue.Obj.(*value.ObjArray)
+	if arrayValue.Type != value.VAL_OBJ || !ok || array == nil {
+		t.Fatalf("select %s=%v, want array", field, arrayValue)
+	}
+	if len(array.Elements) != 64 {
+		t.Fatalf("select %s length=%d, want 64", field, len(array.Elements))
+	}
+	for index, expected := range want {
+		gotMap := requireBuiltinMap(t, array.Elements[index])
+		wantMap := requireBuiltinMap(t, expected)
+		if gotMap != wantMap {
+			t.Fatalf("select %s[%d] did not preserve the requested occurrence", field, index)
+		}
+		gotFD := builtinMapField(t, array.Elements[index], "fd")
+		wantFD := builtinMapField(t, expected, "fd")
+		assertBuiltinValue(t, gotFD, wantFD)
+	}
+	for index := len(want); index < len(array.Elements); index++ {
+		if array.Elements[index].Type != value.VAL_NULL {
+			t.Fatalf("select %s[%d]=%v, want null padding", field, index, array.Elements[index])
+		}
+	}
+}
+
+func requireNetworkPollIntegrationTCPConn(t *testing.T, machine *VM, socket value.Value) *net.TCPConn {
+	t.Helper()
+	_, resource := requireSocketResource(t, machine, socket)
+	resource.stateMu.Lock()
+	underlying := resource.connection
+	resource.stateMu.Unlock()
+	connection, ok := underlying.(*net.TCPConn)
+	if !ok {
+		t.Fatalf("socket connection=%T, want *net.TCPConn", underlying)
+	}
+	return connection
+}
+
+func requireNetworkPollIntegrationPromptClose(
+	t *testing.T,
+	machine *VM,
+	candidate value.Value,
+	poll <-chan networkInvocationResult,
+) {
+	t.Helper()
+	closeNative := requireBuiltin(t, machine, "net_close")
+	closed := make(chan error, 1)
+	go func() {
+		_, err := closeNative.Invoke(machine, []value.Value{candidate})
+		closed <- err
+	}()
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	for poll != nil || closed != nil {
+		select {
+		case invocation := <-poll:
+			if invocation.err != nil {
+				t.Fatal(invocation.err)
+			}
+			for _, field := range []string{"read", "write", "error"} {
+				requireNetworkPollIntegrationSet(t, invocation.value, field)
+			}
+			poll = nil
+		case err := <-closed:
+			if err != nil {
+				t.Fatal(err)
+			}
+			closed = nil
+		case <-timer.C:
+			t.Fatal("net_select and local close did not complete promptly")
+		}
+	}
+}
+
+func TestNetworkPollIntegrationRepeatedReadPollsPreserveExactUnreadBytes(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("exact"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "count"), value.NewInt(5))
+	for attempt := 0; attempt < 2; attempt++ {
+		selected := networkPollIntegrationSelect(t, machine, []value.Value{server}, nil, nil, 0)
+		requireNetworkPollIntegrationSet(t, selected, "read", server)
+	}
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(5))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(5))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("exact"))
+}
+
+func TestNetworkPollIntegrationRepeatedListenerPollsPreservePendingAccept(t *testing.T) {
+	machine := New()
+	cleanupNetworkResources(t, machine)
+	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	resource, exists := machine.shared.Listeners.get(listenerFD)
+	if !exists {
+		t.Fatalf("listener descriptor %d is not registered", listenerFD)
+	}
+	resource.stateMu.Lock()
+	address := resource.listener.Addr().(*net.TCPAddr)
+	resource.stateMu.Unlock()
+	client := callBuiltinWithinBound(t, machine, "net_connect", value.NewString("127.0.0.1"), value.NewInt(int64(address.Port)))
+
+	for attempt := 0; attempt < 2; attempt++ {
+		selected := networkPollIntegrationSelect(t, machine, []value.Value{listener}, nil, nil, 0)
+		requireNetworkPollIntegrationSet(t, selected, "read", listener)
+	}
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", listener)
+	assertBuiltinValue(t, builtinMapField(t, accepted, "open"), value.NewBool(true))
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("ok"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "count"), value.NewInt(2))
+	received := callBuiltinWithinBound(t, machine, "net_recv", accepted, value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("ok"))
+}
+
+func TestNetworkPollIntegrationConnectedSocketIsWritable(t *testing.T) {
+	machine := New()
+	_, client, _ := setupAcceptedLoopback(t, machine)
+
+	selected := networkPollIntegrationSelect(t, machine, nil, []value.Value{client}, nil, 250)
+	requireNetworkPollIntegrationSet(t, selected, "write", client)
+}
+
+func TestNetworkPollIntegrationDuplicateOccurrencesPreserveOrder(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+	handle := int(builtinMapField(t, server, "fd").AsInt)
+	first := socketValue(handle, "first occurrence", 0, true)
+	second := socketValue(handle, "second occurrence", 0, true)
+
+	selected := networkPollIntegrationSelect(t, machine, []value.Value{first, second}, nil, nil, 250)
+	requireNetworkPollIntegrationSet(t, selected, "read", first, second)
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("x"))
+}
+
+func TestNetworkPollIntegrationCopiesSocketToEveryMatchingSet(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+
+	selected := networkPollIntegrationSelect(t, machine,
+		[]value.Value{server}, []value.Value{server}, []value.Value{server}, 250)
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	requireNetworkPollIntegrationSet(t, selected, "write", server)
+	requireNetworkPollIntegrationSet(t, selected, "error")
+}
+
+func TestNetworkPollIntegrationIgnoresCandidatesAfterIndex63(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("s"))
+	callBuiltinWithinBound(t, machine, "net_send", server, value.NewBytes("c"))
+	read := make([]value.Value, 65)
+	for index := 0; index < 64; index++ {
+		read[index] = server
+	}
+	read[64] = client
+
+	selected := networkPollIntegrationSelect(t, machine, read, nil, nil, 250)
+	want := make([]value.Value, 64)
+	for index := range want {
+		want[index] = server
+	}
+	requireNetworkPollIntegrationSet(t, selected, "read", want...)
+	requireNetworkPollIntegrationSet(t, selected, "write")
+	requireNetworkPollIntegrationSet(t, selected, "error")
+}
+
+func TestNetworkPollIntegrationZeroTimeoutEmptyPollReturnsPromptly(t *testing.T) {
+	machine := New()
+	started := time.Now()
+	selected := networkPollIntegrationSelect(t, machine, nil, nil, nil, 0)
+	elapsed := time.Since(started)
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("zero-time empty poll elapsed=%s, want less than 100ms", elapsed)
+	}
+	for _, field := range []string{"read", "write", "error"} {
+		requireNetworkPollIntegrationSet(t, selected, field)
+	}
+}
+
+func TestNetworkPollIntegrationPositiveEmptyPollUsesOneGlobalTimeout(t *testing.T) {
+	machine := New()
+	started := time.Now()
+	selected := networkPollIntegrationSelect(t, machine, nil, nil, nil, 80)
+	elapsed := time.Since(started)
+	if elapsed < 60*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("positive empty poll elapsed=%s, want 60-400ms", elapsed)
+	}
+	for _, field := range []string{"read", "write", "error"} {
+		requireNetworkPollIntegrationSet(t, selected, field)
+	}
+}
+
+func TestNetworkPollIntegrationIdleSocketsUseOneGlobalTimeout(t *testing.T) {
+	machine := New()
+	servers := make([]value.Value, 8)
+	for index := range servers {
+		_, _, servers[index] = setupAcceptedLoopback(t, machine)
+	}
+
+	started := time.Now()
+	selected := networkPollIntegrationSelect(t, machine, servers, nil, nil, 80)
+	elapsed := time.Since(started)
+	if elapsed < 60*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("idle socket poll elapsed=%s, want one 60-400ms timeout", elapsed)
+	}
+	requireNetworkPollIntegrationSet(t, selected, "read")
+}
+
+func TestNetworkPollIntegrationOrderlyEOFIsReadableAndRecvSucceeds(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	callBuiltinWithinBound(t, machine, "net_close", client)
+
+	selected := networkPollIntegrationSelect(t, machine, []value.Value{server}, nil, nil, 500)
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes(""))
+}
+
+func TestNetworkPollIntegrationTCPHalfCloseIsReadable(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	peer := requireNetworkPollIntegrationTCPConn(t, machine, client)
+	if err := peer.CloseWrite(); err != nil {
+		t.Skipf("TCP half-close is not supported: %v", err)
+	}
+
+	selected := networkPollIntegrationSelect(t, machine, []value.Value{server}, nil, nil, 500)
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+}
+
+func TestNetworkPollIntegrationTailPrecedesEOF(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("tail"))
+	callBuiltinWithinBound(t, machine, "net_close", client)
+
+	selected := networkPollIntegrationSelect(t, machine, []value.Value{server}, nil, nil, 500)
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	tail := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(4))
+	assertBuiltinValue(t, builtinMapField(t, tail, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, tail, "count"), value.NewInt(4))
+	assertBuiltinValue(t, builtinMapField(t, tail, "data"), value.NewBytes("tail"))
+
+	selected = networkPollIntegrationSelect(t, machine, []value.Value{server}, nil, nil, 500)
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	eof := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, eof, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, eof, "count"), value.NewInt(0))
+	assertBuiltinValue(t, builtinMapField(t, eof, "data"), value.NewBytes(""))
+}
+
+func TestNetworkPollIntegrationCloseWakesAndOmitsLocalResource(t *testing.T) {
+	t.Run("socket", func(t *testing.T) {
+		machine := New()
+		_, _, server := setupAcceptedLoopback(t, machine)
+		_, resource := requireSocketResource(t, machine, server)
+		native := requireBuiltin(t, machine, "net_select")
+		result := make(chan networkInvocationResult, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			result <- networkInvocationResult{value: selected, err: err}
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		requireNetworkPollIntegrationPromptClose(t, machine, server, result)
+	})
+
+	t.Run("listener", func(t *testing.T) {
+		machine := New()
+		cleanupNetworkResources(t, machine)
+		listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
+		handle := int(builtinMapField(t, listener, "fd").AsInt)
+		resource, exists := machine.shared.Listeners.get(handle)
+		if !exists {
+			t.Fatalf("listener descriptor %d is not registered", handle)
+		}
+		native := requireBuiltin(t, machine, "net_select")
+		result := make(chan networkInvocationResult, 1)
+		go func() {
+			selected, err := native.Invoke(machine, []value.Value{
+				value.NewArray([]value.Value{listener}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			result <- networkInvocationResult{value: selected, err: err}
+		}()
+		waitForNetworkPollWaiter(t, func() int {
+			resource.stateMu.Lock()
+			defer resource.stateMu.Unlock()
+			return len(resource.pollWaiters)
+		})
+		requireNetworkPollIntegrationPromptClose(t, machine, listener, result)
+	})
+}
+
+func TestNetworkPollIntegrationConcurrentNetSelect(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+	_, resource := requireSocketResource(t, machine, server)
+	const pollCount = 4
+	start := make(chan struct{})
+	done := make(chan networkInvocationResult, pollCount)
+	for index := 0; index < pollCount; index++ {
+		current := NewWithShared(machine.shared, machine.Config)
+		native := requireBuiltin(t, current, "net_select")
+		go func(current *VM, native *value.ObjNative) {
+			<-start
+			selected, err := native.Invoke(current, []value.Value{
+				value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray(nil), value.NewInt(5000),
+			})
+			done <- networkInvocationResult{value: selected, err: err}
+		}(current, native)
+	}
+	close(start)
+	waitForNetworkPollWaiter(t, func() int {
+		resource.stateMu.Lock()
+		defer resource.stateMu.Unlock()
+		return len(resource.pollWaiters)
+	})
+	waitDeadline := time.NewTimer(statefulBuiltinTimeout)
+	defer waitDeadline.Stop()
+	waitTicker := time.NewTicker(time.Millisecond)
+	defer waitTicker.Stop()
+	for {
+		resource.stateMu.Lock()
+		waiters := len(resource.pollWaiters)
+		resource.stateMu.Unlock()
+		if waiters == pollCount {
+			break
+		}
+		select {
+		case <-waitTicker.C:
+		case <-waitDeadline.C:
+			t.Fatalf("registered poll waiters=%d, want %d", waiters, pollCount)
+		}
+	}
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
+
+	for i := 0; i < pollCount; i++ {
+		select {
+		case invocation := <-done:
+			if invocation.err != nil {
+				t.Fatal(invocation.err)
+			}
+			requireNetworkPollIntegrationSet(t, invocation.value, "read", server)
+		case <-time.After(statefulBuiltinTimeout):
+			t.Fatal("concurrent net_select did not complete")
+		}
+	}
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("x"))
+}

--- a/internal/vm/network_poller_linux_test.go
+++ b/internal/vm/network_poller_linux_test.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package vm
+
+import (
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"noxy-vm/internal/value"
+)
+
+func TestUnixReadHangupMatchesLinuxPOLLRDHUP(t *testing.T) {
+	if networkPollReadHangup != unix.POLLRDHUP {
+		t.Fatalf("networkPollReadHangup=%#x, want POLLRDHUP=%#x", networkPollReadHangup, unix.POLLRDHUP)
+	}
+	if got := normalizeUnixPollEvents(unix.POLLRDHUP); got != networkReadReady|networkWriteReady|networkErrorReady {
+		t.Fatalf("normalized POLLRDHUP=%#x", got)
+	}
+}
+
+func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+
+	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientResource, exists := machine.shared.Sockets.get(clientHandle)
+	if !exists {
+		t.Fatalf("client descriptor %d is not registered", clientHandle)
+	}
+	clientResource.stateMu.Lock()
+	peer, ok := clientResource.connection.(*net.TCPConn)
+	clientResource.stateMu.Unlock()
+	if !ok {
+		t.Fatalf("peer connection=%T, want *net.TCPConn", clientResource.connection)
+	}
+	if err := peer.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+
+	serverHandle := int(builtinMapField(t, server, "fd").AsInt)
+	serverResource, exists := machine.shared.Sockets.get(serverHandle)
+	if !exists {
+		t.Fatalf("server descriptor %d is not registered", serverHandle)
+	}
+	serverResource.stateMu.Lock()
+	serverConnection := serverResource.connection
+	serverResource.stateMu.Unlock()
+	raw, err := serverConnection.(syscall.Conn).SyscallConn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var revents int16
+	if err := raw.Control(func(descriptor uintptr) {
+		pollfds := []unix.PollFd{{Fd: int32(descriptor), Events: unix.POLLIN | unix.POLLRDHUP}}
+		if _, pollErr := unix.Poll(pollfds, 1000); pollErr != nil {
+			err = pollErr
+			return
+		}
+		revents = pollfds[0].Revents
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revents&unix.POLLRDHUP == 0 {
+		t.Fatalf("raw poll revents=%#x, want POLLRDHUP", revents)
+	}
+
+	selected := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray([]value.Value{server}), value.NewInt(1000))
+	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+}
+
+func TestLinuxNetworkPollResetPreservesPendingSocketError(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+
+	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientResource, exists := machine.shared.Sockets.get(clientHandle)
+	if !exists {
+		t.Fatalf("client descriptor %d is not registered", clientHandle)
+	}
+	clientResource.stateMu.Lock()
+	peer, ok := clientResource.connection.(*net.TCPConn)
+	clientResource.stateMu.Unlock()
+	if !ok {
+		t.Fatalf("peer connection=%T, want *net.TCPConn", clientResource.connection)
+	}
+	if err := peer.SetLinger(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := peer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	poller := networkPoller{platform: systemNetworkPlatform(), now: time.Now, sleep: time.Sleep}
+	sets := [3]*value.ObjArray{
+		{Elements: []value.Value{server}},
+		{Elements: []value.Value{server}},
+		{Elements: []value.Value{server}},
+	}
+	type pollResult struct {
+		value value.Value
+		err   error
+	}
+	result := make(chan pollResult, 1)
+	go func() {
+		selected, err := poller.Poll(machine.shared, sets, time.Second)
+		result <- pollResult{value: selected, err: err}
+	}()
+	var selected value.Value
+	select {
+	case outcome := <-result:
+		if outcome.err != nil {
+			t.Fatal(outcome.err)
+		}
+		selected = outcome.value
+	case <-time.After(time.Second):
+		t.Fatal("poll did not report loopback RST within one second")
+	}
+	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, selected, "write_count"), value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(false))
+	message := builtinMapField(t, received, "error").String()
+	if message == "" || strings.Contains(strings.ToLower(message), "timeout") {
+		t.Fatalf("net_recv error=%q, want non-timeout connection error", message)
+	}
+}

--- a/internal/vm/network_poller_linux_test.go
+++ b/internal/vm/network_poller_linux_test.go
@@ -22,7 +22,7 @@ func TestUnixReadHangupMatchesLinuxPOLLRDHUP(t *testing.T) {
 	}
 }
 
-func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
+func TestLinuxNetworkPollDataAndReadHangupCoexistWithoutConsumption(t *testing.T) {
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
@@ -37,6 +37,8 @@ func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
 	if !ok {
 		t.Fatalf("peer connection=%T, want *net.TCPConn", clientResource.connection)
 	}
+	sent := callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("tail"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "count"), value.NewInt(4))
 	if err := peer.CloseWrite(); err != nil {
 		t.Fatal(err)
 	}
@@ -55,8 +57,18 @@ func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
 	}
 	var revents int16
 	if err := raw.Control(func(descriptor uintptr) {
-		pollfds := []unix.PollFd{{Fd: int32(descriptor), Events: unix.POLLIN | unix.POLLRDHUP}}
+		pollfds := []unix.PollFd{{Fd: int32(descriptor), Events: unix.POLLRDHUP}}
 		if _, pollErr := unix.Poll(pollfds, 1000); pollErr != nil {
+			err = pollErr
+			return
+		}
+		if pollfds[0].Revents&unix.POLLRDHUP == 0 {
+			revents = pollfds[0].Revents
+			return
+		}
+		pollfds[0].Events = unix.POLLIN | unix.POLLRDHUP
+		pollfds[0].Revents = 0
+		if _, pollErr := unix.Poll(pollfds, 0); pollErr != nil {
 			err = pollErr
 			return
 		}
@@ -67,14 +79,18 @@ func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if revents&unix.POLLRDHUP == 0 {
-		t.Fatalf("raw poll revents=%#x, want POLLRDHUP", revents)
+	if revents&(unix.POLLIN|unix.POLLRDHUP) != unix.POLLIN|unix.POLLRDHUP {
+		t.Fatalf("raw poll revents=%#x, want coexisting POLLIN|POLLRDHUP", revents)
 	}
 
 	selected := callBuiltinWithinBound(t, machine, "net_select",
 		value.NewArray([]value.Value{server}), value.NewArray(nil), value.NewArray([]value.Value{server}), value.NewInt(1000))
 	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
 	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(4))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, received, "count"), value.NewInt(4))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("tail"))
 }
 
 func TestNetworkPollIntegrationLinuxResetCopiesTerminalEventAndPreservesPendingError(t *testing.T) {

--- a/internal/vm/network_poller_linux_test.go
+++ b/internal/vm/network_poller_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -78,7 +77,7 @@ func TestLinuxNetworkPollCloseWriteReportsReadHangup(t *testing.T) {
 	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
 }
 
-func TestLinuxNetworkPollResetPreservesPendingSocketError(t *testing.T) {
+func TestNetworkPollIntegrationLinuxResetCopiesTerminalEventAndPreservesPendingError(t *testing.T) {
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
@@ -100,34 +99,22 @@ func TestLinuxNetworkPollResetPreservesPendingSocketError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	poller := networkPoller{platform: systemNetworkPlatform(), now: time.Now, sleep: time.Sleep}
-	sets := [3]*value.ObjArray{
-		{Elements: []value.Value{server}},
-		{Elements: []value.Value{server}},
-		{Elements: []value.Value{server}},
-	}
-	type pollResult struct {
-		value value.Value
-		err   error
-	}
-	result := make(chan pollResult, 1)
-	go func() {
-		selected, err := poller.Poll(machine.shared, sets, time.Second)
-		result <- pollResult{value: selected, err: err}
-	}()
-	var selected value.Value
-	select {
-	case outcome := <-result:
-		if outcome.err != nil {
-			t.Fatal(outcome.err)
-		}
-		selected = outcome.value
-	case <-time.After(time.Second):
-		t.Fatal("poll did not report loopback RST within one second")
-	}
-	assertBuiltinValue(t, builtinMapField(t, selected, "read_count"), value.NewInt(1))
-	assertBuiltinValue(t, builtinMapField(t, selected, "write_count"), value.NewInt(1))
-	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+	selected := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}),
+		value.NewArray(nil),
+		value.NewArray([]value.Value{server}),
+		value.NewInt(1000))
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	requireNetworkPollIntegrationSet(t, selected, "error", server)
+
+	selected = callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}),
+		value.NewArray([]value.Value{server}),
+		value.NewArray([]value.Value{server}),
+		value.NewInt(0))
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	requireNetworkPollIntegrationSet(t, selected, "write", server)
+	requireNetworkPollIntegrationSet(t, selected, "error", server)
 
 	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
 	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(false))

--- a/internal/vm/network_poller_no_rdhup.go
+++ b/internal/vm/network_poller_no_rdhup.go
@@ -1,0 +1,9 @@
+//go:build aix || darwin || dragonfly || netbsd || openbsd || solaris
+
+package vm
+
+import "golang.org/x/sys/unix"
+
+const networkPollReadHangup int16 = 0
+
+func addNetworkPollReadHangup(*unix.PollFd) {}

--- a/internal/vm/network_poller_rdhup.go
+++ b/internal/vm/network_poller_rdhup.go
@@ -1,0 +1,11 @@
+//go:build linux || freebsd
+
+package vm
+
+import "golang.org/x/sys/unix"
+
+const networkPollReadHangup int16 = unix.POLLRDHUP
+
+func addNetworkPollReadHangup(descriptor *unix.PollFd) {
+	descriptor.Events |= unix.POLLRDHUP
+}

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -475,9 +475,20 @@ func TestNetworkPollerPoisonClosedCandidateSleepsRemainingPositiveTimeout(t *tes
 		return current
 	}
 	var slept []time.Duration
-	platform := &fakeNetworkPlatform{}
+	newWakeCalls := 0
+	wakeFailure := errors.New("new wake must not be called")
+	platform := networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			newWakeCalls++
+			return nil, wakeFailure
+		},
+		wait: func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+			t.Fatal("native wait called for poison-closed-only input")
+			return networkPollBatch{}, nil
+		},
+	}
 	poller := networkPoller{
-		platform: platform.boundary(),
+		platform: platform,
 		now:      now,
 		sleep:    func(duration time.Duration) { slept = append(slept, duration) },
 	}
@@ -489,9 +500,64 @@ func TestNetworkPollerPoisonClosedCandidateSleepsRemainingPositiveTimeout(t *tes
 	if len(slept) != 1 || slept[0] != 3*time.Millisecond {
 		t.Fatalf("slept=%v, want literal remaining budget [3ms]", slept)
 	}
-	if len(platform.timeouts) != 0 || len(resultSet(t, result, "read")) != 0 {
-		t.Fatalf("waits=%v result=%v, want empty result without native wait", platform.timeouts, result)
+	if newWakeCalls != 0 || len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("newWake calls=%d result=%v, want empty result without wake setup", newWakeCalls, result)
 	}
+}
+
+func TestNetworkPollerCloseDuringWakeSetupReturnsPromptlyWithoutSleeping(t *testing.T) {
+	machine := New()
+	resource, socket := addPollTestSocket(t, machine, 10)
+	platformWake := &fakePlatformWake{}
+	newWakeCalls := 0
+	waitCalls := 0
+	platform := networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			newWakeCalls++
+			closeSocket(resource)
+			return platformWake, nil
+		},
+		wait: func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+			waitCalls++
+			return networkPollBatch{}, nil
+		},
+	}
+	var slept []time.Duration
+	start := time.Unix(100, 0)
+	poller := networkPoller{
+		platform: platform,
+		now:      func() time.Time { return start },
+		sleep:    func(duration time.Duration) { slept = append(slept, duration) },
+	}
+
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 10*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newWakeCalls != 1 || waitCalls != 0 || len(slept) != 0 {
+		t.Fatalf("newWake=%d wait=%d slept=%v, want one wake setup and prompt return", newWakeCalls, waitCalls, slept)
+	}
+	if len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("concurrently closed socket unexpectedly ready: %v", result)
+	}
+}
+
+func TestNetworkPollerIgnoresPoisonClosedCandidateBesideLiveCandidate(t *testing.T) {
+	machine := New()
+	closedResource, closedSocket := addPollTestSocket(t, machine, 10)
+	closeSocket(closedResource)
+	_, liveSocket := addPollTestSocket(t, machine, 20)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{closedSocket, liveSocket}, nil, nil), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.descriptors) != 1 || len(platform.descriptors[0]) != 1 || platform.descriptors[0][0].descriptor != 20 {
+		t.Fatalf("native descriptors=%v, want only live descriptor 20", platform.descriptors)
+	}
+	requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{liveSocket})
 }
 
 func TestNetworkPollerZeroTimeoutCallsWaitExactlyOnce(t *testing.T) {

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -1,12 +1,101 @@
 package vm
 
 import (
+	"errors"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
 	"noxy-vm/internal/value"
 )
+
+type fakePlatformWake struct {
+	mu         sync.Mutex
+	signals    int
+	closes     int
+	closed     bool
+	afterClose bool
+	signalErr  error
+}
+
+func (*fakePlatformWake) descriptor() uintptr { return 99 }
+
+func (wake *fakePlatformWake) signal() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	if wake.closed {
+		wake.afterClose = true
+	}
+	wake.signals++
+	return wake.signalErr
+}
+
+func (wake *fakePlatformWake) close() error {
+	wake.mu.Lock()
+	defer wake.mu.Unlock()
+	wake.closed = true
+	wake.closes++
+	return nil
+}
+
+func TestNetworkWakeSerializesSignalAndClose(t *testing.T) {
+	raw := &fakePlatformWake{}
+	wake := newNetworkWake(raw)
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			_ = wake.Signal()
+		}()
+	}
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		_ = wake.Close()
+	}()
+	close(start)
+	workers.Wait()
+	_ = wake.Signal()
+	raw.mu.Lock()
+	defer raw.mu.Unlock()
+	if raw.afterClose {
+		t.Fatal("platform signal ran after platform close")
+	}
+	if raw.signals > 1 || raw.closes != 1 {
+		t.Fatalf("signals=%d closes=%d", raw.signals, raw.closes)
+	}
+}
+
+func TestNetworkWakeSignalFailureRemainsClosable(t *testing.T) {
+	signalFailure := errors.New("wake signal failed")
+	raw := &fakePlatformWake{signalErr: signalFailure}
+	wake := newNetworkWake(raw)
+	if err := wake.Signal(); !errors.Is(err, signalFailure) {
+		t.Fatalf("signal error=%v, want %v", err, signalFailure)
+	}
+	if err := wake.Close(); err != nil {
+		t.Fatalf("close error=%v", err)
+	}
+	if err := wake.Close(); err != nil {
+		t.Fatalf("second close error=%v", err)
+	}
+	if err := wake.Signal(); err != nil {
+		t.Fatalf("signal after close error=%v", err)
+	}
+	raw.mu.Lock()
+	defer raw.mu.Unlock()
+	if raw.afterClose {
+		t.Fatal("platform signal ran after platform close")
+	}
+	if raw.signals != 1 || raw.closes != 1 {
+		t.Fatalf("signals=%d closes=%d, want 1 each", raw.signals, raw.closes)
+	}
+}
 
 func TestValidateNetworkPollArguments(t *testing.T) {
 	empty := value.NewArray(nil)

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -460,6 +460,40 @@ func TestNetworkPollerEmptyCandidatesUseInjectedSleeperOnlyForPositiveTimeout(t 
 	}
 }
 
+func TestNetworkPollerPoisonClosedCandidateSleepsRemainingPositiveTimeout(t *testing.T) {
+	machine := New()
+	resource, socket := addPollTestSocket(t, machine, 10)
+	closeSocket(resource)
+
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start.Add(7 * time.Millisecond)}
+	now := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	var slept []time.Duration
+	platform := &fakeNetworkPlatform{}
+	poller := networkPoller{
+		platform: platform.boundary(),
+		now:      now,
+		sleep:    func(duration time.Duration) { slept = append(slept, duration) },
+	}
+
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slept) != 1 || slept[0] != 3*time.Millisecond {
+		t.Fatalf("slept=%v, want literal remaining budget [3ms]", slept)
+	}
+	if len(platform.timeouts) != 0 || len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("waits=%v result=%v, want empty result without native wait", platform.timeouts, result)
+	}
+}
+
 func TestNetworkPollerZeroTimeoutCallsWaitExactlyOnce(t *testing.T) {
 	machine := New()
 	_, socket := addPollTestSocket(t, machine, 10)
@@ -673,6 +707,47 @@ func TestNetworkPollerWriteOnlyListenerWaitsWithoutNativeDescriptor(t *testing.T
 	resource.stateMu.Unlock()
 	if waiters != 0 {
 		t.Fatalf("waiters=%d, want 0", waiters)
+	}
+}
+
+func TestNetworkPollerPermanentWakeFailureStillDetectsClosedWriteOnlyListenerAfterOneChunk(t *testing.T) {
+	machine := New()
+	resource, listener := addPollTestListener(t, machine, 30)
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start, start.Add(time.Second), start.Add(3 * time.Second)}
+	now := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	wakeFailure := errors.New("permanent wake signal failure")
+	platform := &fakeNetworkPlatform{wake: &fakePlatformWake{signalErr: wakeFailure}}
+	platform.waitFn = func(descriptors []networkPollFD, _ uintptr, _ int32) (networkPollBatch, error) {
+		if len(descriptors) != 0 {
+			t.Fatalf("write-only listener descriptors=%v, want wake descriptor only", descriptors)
+		}
+		closeListener(resource)
+		return networkPollBatch{}, nil
+	}
+	poller := networkPoller{platform: platform.boundary(), now: now, sleep: time.Sleep}
+
+	result, err := poller.Poll(machine.shared, pollSets(nil, []value.Value{listener}, nil), 3*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 1 || platform.timeouts[0] != 1000 {
+		t.Fatalf("native timeouts=%v, want one safety chunk [1000]", platform.timeouts)
+	}
+	platform.wake.mu.Lock()
+	signals := platform.wake.signals
+	platform.wake.mu.Unlock()
+	if signals != 1 {
+		t.Fatalf("wake signal attempts=%d, want one permanent failure", signals)
+	}
+	if len(resultSet(t, result, "write")) != 0 {
+		t.Fatalf("closed write-only listener unexpectedly ready: %v", result)
 	}
 }
 

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -118,9 +118,11 @@ type trackingRawConn struct {
 }
 
 func (raw *trackingRawConn) Control(callback func(uintptr)) error {
-	raw.active.Add(1)
-	defer raw.active.Add(-1)
-	return raw.raw.Control(callback)
+	return raw.raw.Control(func(descriptor uintptr) {
+		raw.active.Add(1)
+		defer raw.active.Add(-1)
+		callback(descriptor)
+	})
 }
 
 func (raw *trackingRawConn) Read(callback func(uintptr) bool) error {
@@ -129,6 +131,24 @@ func (raw *trackingRawConn) Read(callback func(uintptr) bool) error {
 
 func (raw *trackingRawConn) Write(callback func(uintptr) bool) error {
 	return raw.raw.Write(callback)
+}
+
+func TestTrackingRawConnCountsOnlyControlCallbackLifetime(t *testing.T) {
+	active := &atomic.Int32{}
+	var before, inside, after int32
+	underlying := &fakeRawConn{controlFn: func(callback func(uintptr)) error {
+		before = active.Load()
+		callback(10)
+		after = active.Load()
+		return nil
+	}}
+	tracked := &trackingRawConn{raw: underlying, active: active}
+	if err := tracked.Control(func(uintptr) { inside = active.Load() }); err != nil {
+		t.Fatal(err)
+	}
+	if before != 0 || inside != 1 || after != 0 || active.Load() != 0 {
+		t.Fatalf("active before=%d inside=%d after=%d final=%d, want 0,1,0,0", before, inside, after, active.Load())
+	}
 }
 
 func (listener *syscallTestListener) SyscallConn() (syscall.RawConn, error) {
@@ -424,7 +444,8 @@ func TestNetworkPollerBackendFailureReturnsNoPartialResult(t *testing.T) {
 func TestNetworkPollerEmptyCandidatesUseInjectedSleeperOnlyForPositiveTimeout(t *testing.T) {
 	platform := &fakeNetworkPlatform{}
 	var slept []time.Duration
-	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: func(duration time.Duration) { slept = append(slept, duration) }}
+	start := time.Unix(100, 0)
+	poller := networkPoller{platform: platform.boundary(), now: func() time.Time { return start }, sleep: func(duration time.Duration) { slept = append(slept, duration) }}
 	machine := New()
 	invalid := value.NewString("not a socket")
 
@@ -472,6 +493,74 @@ func TestNetworkPollerPositiveTimeoutUsesAbsoluteDeadlineCeilingAndOneSecondChun
 	}
 	if len(platform.timeouts) != 2 || platform.timeouts[0] != 1000 || platform.timeouts[1] != 1 {
 		t.Fatalf("timeouts=%v, want [1000 1]", platform.timeouts)
+	}
+}
+
+func TestNetworkPollerDeadlineStartsBeforeRegistryLookup(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	start := time.Unix(100, 0)
+	var elapsed atomic.Int64
+	firstClockRead := make(chan struct{}, 1)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{
+		platform: platform.boundary(),
+		now: func() time.Time {
+			select {
+			case firstClockRead <- struct{}{}:
+			default:
+			}
+			return start.Add(time.Duration(elapsed.Load()))
+		},
+		sleep: time.Sleep,
+	}
+
+	machine.shared.Listeners.mu.Lock()
+	done := make(chan error, 1)
+	go func() {
+		_, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 10*time.Millisecond)
+		done <- err
+	}()
+	clockReadBeforeLookup := false
+	select {
+	case <-firstClockRead:
+		clockReadBeforeLookup = true
+	case <-time.After(time.Second):
+	}
+	elapsed.Store(int64(7 * time.Millisecond))
+	machine.shared.Listeners.mu.Unlock()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if !clockReadBeforeLookup {
+		t.Fatal("operation clock was not read before the contended registry lookup")
+	}
+	if len(platform.timeouts) != 1 || platform.timeouts[0] != 3 {
+		t.Fatalf("timeouts=%v, want literal remaining budget [3]", platform.timeouts)
+	}
+}
+
+func TestNetworkPollerEmptyInputSleepsOnlyRemainingBudget(t *testing.T) {
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start.Add(7 * time.Millisecond)}
+	now := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	var slept []time.Duration
+	poller := networkPoller{
+		platform: (&fakeNetworkPlatform{}).boundary(),
+		now:      now,
+		sleep:    func(duration time.Duration) { slept = append(slept, duration) },
+	}
+	if _, err := poller.Poll(New().shared, pollSets(nil, nil, nil), 10*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if len(slept) != 1 || slept[0] != 3*time.Millisecond {
+		t.Fatalf("slept=%v, want literal remaining budget [3ms]", slept)
 	}
 }
 
@@ -776,18 +865,24 @@ func TestNetworkControlCloseClassification(t *testing.T) {
 		machine := New()
 		first, firstValue := addPollTestSocket(t, machine, 10)
 		second, secondValue := addPollTestSocket(t, machine, 20)
-		invariantFailure := errors.New("second control invariant failure")
+		outerFailure := errors.New("first outer control failure")
+		deeperFailure := errors.New("second deeper control failure")
+		firstRaw := first.connection.(*syscallTestConn).raw.(*fakeRawConn)
+		firstRaw.controlErr = outerFailure
 		secondRaw := second.connection.(*syscallTestConn).raw.(*fakeRawConn)
 		secondRaw.controlFn = func(func(uintptr)) error {
 			firstHandle, _ := networkSocketDescriptor(firstValue)
 			machine.shared.Sockets.remove(firstHandle)
 			closeSocket(first)
-			return invariantFailure
+			return deeperFailure
 		}
 		platform := &fakeNetworkPlatform{}
 		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
 		result, err := poller.Poll(machine.shared, pollSets([]value.Value{firstValue, secondValue}, nil, nil), time.Second)
-		if !errors.Is(err, invariantFailure) || result.Type != value.VAL_NULL || len(platform.timeouts) != 0 {
+		var acquisitionFailure *networkAcquisitionError
+		if !errors.Is(err, deeperFailure) || errors.Is(err, outerFailure) || !errors.As(err, &acquisitionFailure) ||
+			acquisitionFailure.registration.socket != second || acquisitionFailure.stage != networkAcquireControl ||
+			result.Type != value.VAL_NULL || len(platform.timeouts) != 0 {
 			t.Fatalf("result=%v error=%v waits=%v", result, err, platform.timeouts)
 		}
 	})

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -3,7 +3,10 @@ package vm
 import (
 	"errors"
 	"math"
+	"net"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -17,6 +20,7 @@ type fakePlatformWake struct {
 	closed     bool
 	afterClose bool
 	signalErr  error
+	closeErr   error
 }
 
 func (*fakePlatformWake) descriptor() uintptr { return 99 }
@@ -36,7 +40,157 @@ func (wake *fakePlatformWake) close() error {
 	defer wake.mu.Unlock()
 	wake.closed = true
 	wake.closes++
-	return nil
+	return wake.closeErr
+}
+
+type fakeNetworkPlatform struct {
+	wake        *fakePlatformWake
+	waits       []networkPollBatch
+	timeouts    []int32
+	descriptors [][]networkPollFD
+	err         error
+	waitFn      func([]networkPollFD, uintptr, int32) (networkPollBatch, error)
+}
+
+func (platform *fakeNetworkPlatform) boundary() networkPlatform {
+	if platform.wake == nil {
+		platform.wake = &fakePlatformWake{}
+	}
+	return networkPlatform{
+		newWake: func() (platformNetworkWake, error) { return platform.wake, nil },
+		wait: func(descriptors []networkPollFD, wake uintptr, timeout int32) (networkPollBatch, error) {
+			platform.timeouts = append(platform.timeouts, timeout)
+			platform.descriptors = append(platform.descriptors, append([]networkPollFD(nil), descriptors...))
+			if platform.waitFn != nil {
+				return platform.waitFn(descriptors, wake, timeout)
+			}
+			if platform.err != nil {
+				return networkPollBatch{}, platform.err
+			}
+			if len(platform.waits) == 0 {
+				return networkPollBatch{}, nil
+			}
+			batch := platform.waits[0]
+			platform.waits = platform.waits[1:]
+			return batch, nil
+		},
+	}
+}
+
+type fakeRawConn struct {
+	descriptor uintptr
+	controlErr error
+	controlFn  func(func(uintptr)) error
+}
+
+func (raw *fakeRawConn) Control(callback func(uintptr)) error {
+	if raw.controlFn != nil {
+		return raw.controlFn(callback)
+	}
+	callback(raw.descriptor)
+	return raw.controlErr
+}
+
+func (*fakeRawConn) Read(func(uintptr) bool) error  { return nil }
+func (*fakeRawConn) Write(func(uintptr) bool) error { return nil }
+
+type syscallTestConn struct {
+	net.Conn
+	raw       syscall.RawConn
+	syscallFn func() (syscall.RawConn, error)
+}
+
+func (connection *syscallTestConn) SyscallConn() (syscall.RawConn, error) {
+	if connection.syscallFn != nil {
+		return connection.syscallFn()
+	}
+	return connection.raw, nil
+}
+
+type syscallTestListener struct {
+	*net.TCPListener
+	raw syscall.RawConn
+}
+
+type trackingRawConn struct {
+	raw    syscall.RawConn
+	active *atomic.Int32
+}
+
+func (raw *trackingRawConn) Control(callback func(uintptr)) error {
+	raw.active.Add(1)
+	defer raw.active.Add(-1)
+	return raw.raw.Control(callback)
+}
+
+func (raw *trackingRawConn) Read(callback func(uintptr) bool) error {
+	return raw.raw.Read(callback)
+}
+
+func (raw *trackingRawConn) Write(callback func(uintptr) bool) error {
+	return raw.raw.Write(callback)
+}
+
+func (listener *syscallTestListener) SyscallConn() (syscall.RawConn, error) {
+	return listener.raw, nil
+}
+
+func addPollTestSocket(t *testing.T, machine *VM, descriptor uintptr) (*SocketResource, value.Value) {
+	t.Helper()
+	connection, peer := net.Pipe()
+	wrapped := &syscallTestConn{Conn: connection, raw: &fakeRawConn{descriptor: descriptor}}
+	resource := &SocketResource{connection: wrapped}
+	handle := machine.shared.Sockets.add(resource)
+	t.Cleanup(func() {
+		machine.shared.Sockets.remove(handle)
+		closeSocket(resource)
+		_ = peer.Close()
+	})
+	return resource, socketValue(handle, "poll-test", 0, true)
+}
+
+func addPollTestListener(t *testing.T, machine *VM, descriptor uintptr) (*ListenerResource, value.Value) {
+	t.Helper()
+	underlying, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapped := &syscallTestListener{TCPListener: underlying, raw: &fakeRawConn{descriptor: descriptor}}
+	resource := &ListenerResource{listener: wrapped}
+	handle := machine.shared.Listeners.add(resource)
+	t.Cleanup(func() {
+		machine.shared.Listeners.remove(handle)
+		closeListener(resource)
+	})
+	return resource, socketValue(handle, "listener-test", 0, true)
+}
+
+func pollSets(read, write, networkErrors []value.Value) [3]*value.ObjArray {
+	return [3]*value.ObjArray{
+		value.NewArray(read).Obj.(*value.ObjArray),
+		value.NewArray(write).Obj.(*value.ObjArray),
+		value.NewArray(networkErrors).Obj.(*value.ObjArray),
+	}
+}
+
+func resultSet(t *testing.T, result value.Value, name string) []value.Value {
+	t.Helper()
+	mapping := requireBuiltinMap(t, result)
+	count := requireTestMapValue(t, mapping, name+"_count").AsInt
+	array := requireTestMapValue(t, mapping, name).Obj.(*value.ObjArray)
+	return array.Elements[:count]
+}
+
+func requireCandidateOrder(t *testing.T, got, want []value.Value) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("candidate count=%d, want %d", len(got), len(want))
+	}
+	for index := range want {
+		if got[index].Obj != want[index].Obj {
+			t.Fatalf("candidate %d=%v, want %v", index, got[index], want[index])
+		}
+	}
 }
 
 func TestNetworkWakeSerializesSignalAndClose(t *testing.T) {
@@ -144,4 +298,497 @@ func TestSelectResultPadsTruncatesAndCountsCopiedValues(t *testing.T) {
 	if len(read.Elements) != 64 {
 		t.Fatalf("read length=%d", len(read.Elements))
 	}
+}
+
+func TestNetworkPollerPreservesOccurrenceOrderAndRegistersEachResourceOnce(t *testing.T) {
+	machine := New()
+	_, first := addPollTestSocket(t, machine, 10)
+	_, second := addPollTestSocket(t, machine, 20)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{
+		networkReadReady | networkWriteReady | networkErrorReady,
+		networkReadReady | networkWriteReady | networkErrorReady,
+	}}}}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+
+	result, err := poller.Poll(machine.shared, pollSets(
+		[]value.Value{first, second, first},
+		[]value.Value{second, first, second},
+		[]value.Value{first, first, second},
+	), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{first, second, first})
+	requireCandidateOrder(t, resultSet(t, result, "write"), []value.Value{second, first, second})
+	requireCandidateOrder(t, resultSet(t, result, "error"), []value.Value{first, first, second})
+	if len(platform.descriptors) != 1 || len(platform.descriptors[0]) != 2 {
+		t.Fatalf("descriptor batches=%v, want one batch with two unique resources", platform.descriptors)
+	}
+}
+
+func TestNetworkPollerLimitsEachInputSetToFirst64Values(t *testing.T) {
+	machine := New()
+	_, first := addPollTestSocket(t, machine, 10)
+	_, excluded := addPollTestSocket(t, machine, 20)
+	read := make([]value.Value, 65)
+	for index := range read[:64] {
+		read[index] = first
+	}
+	read[64] = excluded
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+
+	result, err := poller.Poll(machine.shared, pollSets(read, nil, nil), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready := resultSet(t, result, "read")
+	if len(ready) != 64 {
+		t.Fatalf("read count=%d, want 64", len(ready))
+	}
+	if len(platform.descriptors[0]) != 1 || platform.descriptors[0][0].descriptor != 10 {
+		t.Fatalf("descriptors=%v, want only first resource", platform.descriptors[0])
+	}
+}
+
+func TestNetworkPollerMapsListenerAndSocketTerminalEvents(t *testing.T) {
+	t.Run("listener normal write is suppressed", func(t *testing.T) {
+		machine := New()
+		_, listener := addPollTestListener(t, machine, 25)
+		platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkWriteReady}}}}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{listener}, []value.Value{listener}, nil), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireCandidateOrder(t, resultSet(t, result, "write"), nil)
+	})
+
+	t.Run("listener suppresses write and terminal populates requested read and error", func(t *testing.T) {
+		machine := New()
+		_, listener := addPollTestListener(t, machine, 30)
+		platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkErrorReady}}}}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{listener}, []value.Value{listener}, []value.Value{listener}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{listener})
+		requireCandidateOrder(t, resultSet(t, result, "write"), nil)
+		requireCandidateOrder(t, resultSet(t, result, "error"), []value.Value{listener})
+		if got := platform.descriptors[0][0].interests; got != networkReadable|networkErrorInterest {
+			t.Fatalf("listener interests=%v, want read|error", got)
+		}
+	})
+
+	t.Run("generic read does not populate error", func(t *testing.T) {
+		machine := New()
+		_, socket := addPollTestSocket(t, machine, 40)
+		platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkReadReady}}}}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, []value.Value{socket}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{socket})
+		requireCandidateOrder(t, resultSet(t, result, "error"), nil)
+	})
+
+	t.Run("socket terminal populates every requested set", func(t *testing.T) {
+		machine := New()
+		_, socket := addPollTestSocket(t, machine, 50)
+		platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkErrorReady}}}}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, []value.Value{socket}, []value.Value{socket}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{socket})
+		requireCandidateOrder(t, resultSet(t, result, "write"), []value.Value{socket})
+		requireCandidateOrder(t, resultSet(t, result, "error"), []value.Value{socket})
+	})
+}
+
+func TestNetworkPollerBackendFailureReturnsNoPartialResult(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	failure := errors.New("backend failed")
+	platform := &fakeNetworkPlatform{err: failure}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 0)
+	if !errors.Is(err, failure) || result.Type != value.VAL_NULL {
+		t.Fatalf("result=%v error=%v, want null and backend failure", result, err)
+	}
+}
+
+func TestNetworkPollerEmptyCandidatesUseInjectedSleeperOnlyForPositiveTimeout(t *testing.T) {
+	platform := &fakeNetworkPlatform{}
+	var slept []time.Duration
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: func(duration time.Duration) { slept = append(slept, duration) }}
+	machine := New()
+	invalid := value.NewString("not a socket")
+
+	if _, err := poller.Poll(machine.shared, pollSets([]value.Value{invalid}, nil, nil), 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := poller.Poll(machine.shared, pollSets(nil, nil, nil), 0); err != nil {
+		t.Fatal(err)
+	}
+	if len(slept) != 1 || slept[0] != 25*time.Millisecond || len(platform.timeouts) != 0 {
+		t.Fatalf("slept=%v waits=%v", slept, platform.timeouts)
+	}
+}
+
+func TestNetworkPollerZeroTimeoutCallsWaitExactlyOnce(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{interrupted: true}, {events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 1 || platform.timeouts[0] != 0 || len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("timeouts=%v result=%v", platform.timeouts, result)
+	}
+}
+
+func TestNetworkPollerPositiveTimeoutUsesAbsoluteDeadlineCeilingAndOneSecondChunks(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start, start.Add(1499*time.Millisecond + 500*time.Microsecond), start.Add(1500 * time.Millisecond)}
+	nextTime := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	platform := &fakeNetworkPlatform{}
+	poller := networkPoller{platform: platform.boundary(), now: nextTime, sleep: time.Sleep}
+	if _, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 1500*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 2 || platform.timeouts[0] != 1000 || platform.timeouts[1] != 1 {
+		t.Fatalf("timeouts=%v, want [1000 1]", platform.timeouts)
+	}
+}
+
+func TestNetworkPollerRetriesInterruptionOnlyForPositiveTimeout(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	start := time.Unix(100, 0)
+	now := start
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{interrupted: true}, {events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: func() time.Time { return now }, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 2 {
+		t.Fatalf("wait count=%d, want 2", len(platform.timeouts))
+	}
+	requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{socket})
+}
+
+func TestNetworkPollerRetriesNonLocalSpuriousWake(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	start := time.Unix(100, 0)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{woke: true}, {events: []networkEvent{networkReadReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: func() time.Time { return start }, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 2 {
+		t.Fatalf("wait count=%d, want 2", len(platform.timeouts))
+	}
+	requireCandidateOrder(t, resultSet(t, result, "read"), []value.Value{socket})
+}
+
+func TestNetworkPollerCloseBeforeAttachmentReturnsWithoutWaiting(t *testing.T) {
+	machine := New()
+	resource, socket := addPollTestSocket(t, machine, 10)
+	platform := &fakeNetworkPlatform{}
+	closeSocket(resource)
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.timeouts) != 0 || len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("waits=%v result=%v", platform.timeouts, result)
+	}
+}
+
+func TestNetworkPollerLocalCloseWakeReturnsPromptlyAndUnregistersWaiter(t *testing.T) {
+	machine := New()
+	resource, socket := addPollTestSocket(t, machine, 10)
+	platform := &fakeNetworkPlatform{}
+	platform.waitFn = func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+		machine.shared.Sockets.remove(int(requireTestMapFD(t, socket)))
+		closeSocket(resource)
+		return networkPollBatch{woke: true}, nil
+	}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resultSet(t, result, "read")) != 0 || len(platform.timeouts) != 1 {
+		t.Fatalf("result=%v waits=%d", result, len(platform.timeouts))
+	}
+	resource.stateMu.Lock()
+	waiters := len(resource.pollWaiters)
+	resource.stateMu.Unlock()
+	if waiters != 0 {
+		t.Fatalf("waiters=%d, want 0", waiters)
+	}
+}
+
+func requireTestMapFD(t *testing.T, socket value.Value) int64 {
+	t.Helper()
+	mapping := socket.Obj.(*value.ObjMap)
+	fd, _ := mapping.Get("fd")
+	return fd.AsInt
+}
+
+func TestNetworkPollerWriteOnlyListenerWaitsWithoutNativeDescriptor(t *testing.T) {
+	machine := New()
+	resource, listener := addPollTestListener(t, machine, 30)
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start, start.Add(5 * time.Millisecond)}
+	now := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	platform := &fakeNetworkPlatform{}
+	poller := networkPoller{platform: platform.boundary(), now: now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets(nil, []value.Value{listener}, nil), 5*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.descriptors) != 1 || len(platform.descriptors[0]) != 0 || platform.timeouts[0] != 5 {
+		t.Fatalf("descriptors=%v timeouts=%v", platform.descriptors, platform.timeouts)
+	}
+	if len(resultSet(t, result, "write")) != 0 {
+		t.Fatalf("write-only listener unexpectedly ready")
+	}
+	resource.stateMu.Lock()
+	waiters := len(resource.pollWaiters)
+	resource.stateMu.Unlock()
+	if waiters != 0 {
+		t.Fatalf("waiters=%d, want 0", waiters)
+	}
+}
+
+func TestNetworkPollerErrorOnlyListenerRemainsPollable(t *testing.T) {
+	machine := New()
+	_, listener := addPollTestListener(t, machine, 30)
+	platform := &fakeNetworkPlatform{waits: []networkPollBatch{{events: []networkEvent{networkErrorReady}}}}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets(nil, nil, []value.Value{listener}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(platform.descriptors[0]) != 1 || platform.descriptors[0][0].interests != networkErrorInterest {
+		t.Fatalf("descriptors=%v", platform.descriptors[0])
+	}
+	requireCandidateOrder(t, resultSet(t, result, "error"), []value.Value{listener})
+}
+
+func TestNetworkPollerWakeCloseFailureReturnsNoPartialResult(t *testing.T) {
+	machine := New()
+	_, socket := addPollTestSocket(t, machine, 10)
+	closeFailure := errors.New("wake close failed")
+	platform := &fakeNetworkPlatform{
+		wake:  &fakePlatformWake{closeErr: closeFailure},
+		waits: []networkPollBatch{{events: []networkEvent{networkReadReady}}},
+	}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{socket}, nil, nil), 0)
+	if !errors.Is(err, closeFailure) || result.Type != value.VAL_NULL {
+		t.Fatalf("result=%v error=%v, want null and close failure", result, err)
+	}
+}
+
+func TestNetworkDescriptorsRemainControlledDuringWait(t *testing.T) {
+	machine := New()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	active := &atomic.Int32{}
+	values := make([]value.Value, 0, 2)
+	for index := 0; index < 2; index++ {
+		client, dialErr := net.Dial("tcp", listener.Addr().String())
+		if dialErr != nil {
+			t.Fatal(dialErr)
+		}
+		server, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			t.Fatal(acceptErr)
+		}
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+		syscallConnection := client.(syscall.Conn)
+		raw, rawErr := syscallConnection.SyscallConn()
+		if rawErr != nil {
+			t.Fatal(rawErr)
+		}
+		wrapped := &syscallTestConn{Conn: client, raw: &trackingRawConn{raw: raw, active: active}}
+		resource := &SocketResource{connection: wrapped}
+		handle := machine.shared.Sockets.add(resource)
+		t.Cleanup(func() {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(resource)
+		})
+		values = append(values, socketValue(handle, "loopback", 0, true))
+	}
+	platform := &fakeNetworkPlatform{}
+	platform.waitFn = func(descriptors []networkPollFD, _ uintptr, _ int32) (networkPollBatch, error) {
+		if got := active.Load(); got != 2 {
+			t.Fatalf("active RawConn.Control callbacks=%d, want 2", got)
+		}
+		return networkPollBatch{events: []networkEvent{networkReadReady, networkReadReady}}, nil
+	}
+	poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+	if _, err := poller.Poll(machine.shared, pollSets(values, nil, nil), 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNetworkControlCloseClassification(t *testing.T) {
+	closedFailure := errors.New("descriptor closed during acquisition")
+
+	t.Run("SyscallConn close of attributed registration is local", func(t *testing.T) {
+		machine := New()
+		connection, peer := net.Pipe()
+		t.Cleanup(func() { _ = peer.Close() })
+		resource := &SocketResource{}
+		handle := machine.shared.Sockets.add(resource)
+		wrapped := &syscallTestConn{Conn: connection}
+		resource.connection = wrapped
+		wrapped.syscallFn = func() (syscall.RawConn, error) {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(resource)
+			return nil, closedFailure
+		}
+		platform := &fakeNetworkPlatform{}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{socketValue(handle, "local", 0, true)}, nil, nil), time.Second)
+		if err != nil || len(resultSet(t, result, "read")) != 0 || len(platform.timeouts) != 0 {
+			t.Fatalf("result=%v error=%v waits=%v", result, err, platform.timeouts)
+		}
+	})
+
+	t.Run("SyscallConn error on unchanged registration is synchronous", func(t *testing.T) {
+		machine := New()
+		connection, peer := net.Pipe()
+		t.Cleanup(func() { _ = peer.Close() })
+		wrapped := &syscallTestConn{Conn: connection, syscallFn: func() (syscall.RawConn, error) { return nil, closedFailure }}
+		resource := &SocketResource{connection: wrapped}
+		handle := machine.shared.Sockets.add(resource)
+		t.Cleanup(func() {
+			machine.shared.Sockets.remove(handle)
+			closeSocket(resource)
+		})
+		platform := &fakeNetworkPlatform{}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{socketValue(handle, "open", 0, true)}, nil, nil), time.Second)
+		if !errors.Is(err, closedFailure) || result.Type != value.VAL_NULL || len(platform.timeouts) != 0 {
+			t.Fatalf("result=%v error=%v waits=%v", result, err, platform.timeouts)
+		}
+	})
+
+	for _, closeIndex := range []int{0, 1} {
+		t.Run("Control close at nested boundary "+string(rune('A'+closeIndex)), func(t *testing.T) {
+			machine := New()
+			resources := make([]*SocketResource, 2)
+			handles := make([]int, 2)
+			values := make([]value.Value, 2)
+			for index := range resources {
+				connection, peer := net.Pipe()
+				t.Cleanup(func() { _ = peer.Close() })
+				raw := &fakeRawConn{descriptor: uintptr(index + 10)}
+				wrapped := &syscallTestConn{Conn: connection, raw: raw}
+				resources[index] = &SocketResource{connection: wrapped}
+				handles[index] = machine.shared.Sockets.add(resources[index])
+				values[index] = socketValue(handles[index], "control", 0, true)
+			}
+			t.Cleanup(func() {
+				for index, resource := range resources {
+					machine.shared.Sockets.remove(handles[index])
+					closeSocket(resource)
+				}
+			})
+			target := resources[closeIndex].connection.(*syscallTestConn).raw.(*fakeRawConn)
+			target.controlFn = func(func(uintptr)) error {
+				machine.shared.Sockets.remove(handles[closeIndex])
+				closeSocket(resources[closeIndex])
+				return closedFailure
+			}
+			platform := &fakeNetworkPlatform{}
+			poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+			result, err := poller.Poll(machine.shared, pollSets(values, nil, nil), time.Second)
+			if err != nil || result.Type == value.VAL_NULL || len(platform.timeouts) != 0 {
+				t.Fatalf("result=%v error=%v waits=%v", result, err, platform.timeouts)
+			}
+		})
+	}
+
+	t.Run("unrelated close cannot suppress SyscallConn error", func(t *testing.T) {
+		machine := New()
+		first, firstValue := addPollTestSocket(t, machine, 10)
+		connection, peer := net.Pipe()
+		t.Cleanup(func() { _ = peer.Close() })
+		second := &SocketResource{}
+		secondHandle := machine.shared.Sockets.add(second)
+		wrapped := &syscallTestConn{Conn: connection}
+		second.connection = wrapped
+		wrapped.syscallFn = func() (syscall.RawConn, error) {
+			firstHandle, _ := networkSocketDescriptor(firstValue)
+			machine.shared.Sockets.remove(firstHandle)
+			closeSocket(first)
+			return nil, closedFailure
+		}
+		t.Cleanup(func() {
+			machine.shared.Sockets.remove(secondHandle)
+			closeSocket(second)
+		})
+		platform := &fakeNetworkPlatform{}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{firstValue, socketValue(secondHandle, "second", 0, true)}, nil, nil), time.Second)
+		if !errors.Is(err, closedFailure) || result.Type != value.VAL_NULL {
+			t.Fatalf("result=%v error=%v", result, err)
+		}
+	})
+
+	t.Run("deeper Control error wins over unrelated outer close", func(t *testing.T) {
+		machine := New()
+		first, firstValue := addPollTestSocket(t, machine, 10)
+		second, secondValue := addPollTestSocket(t, machine, 20)
+		invariantFailure := errors.New("second control invariant failure")
+		secondRaw := second.connection.(*syscallTestConn).raw.(*fakeRawConn)
+		secondRaw.controlFn = func(func(uintptr)) error {
+			firstHandle, _ := networkSocketDescriptor(firstValue)
+			machine.shared.Sockets.remove(firstHandle)
+			closeSocket(first)
+			return invariantFailure
+		}
+		platform := &fakeNetworkPlatform{}
+		poller := networkPoller{platform: platform.boundary(), now: time.Now, sleep: time.Sleep}
+		result, err := poller.Poll(machine.shared, pollSets([]value.Value{firstValue, secondValue}, nil, nil), time.Second)
+		if !errors.Is(err, invariantFailure) || result.Type != value.VAL_NULL || len(platform.timeouts) != 0 {
+			t.Fatalf("result=%v error=%v waits=%v", result, err, platform.timeouts)
+		}
+	})
 }

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -542,6 +542,101 @@ func TestNetworkPollerCloseDuringWakeSetupReturnsPromptlyWithoutSleeping(t *test
 	}
 }
 
+func TestNetworkPollerOneConcurrentAttachCloseReturnsBeforeWaitingOnSurvivor(t *testing.T) {
+	machine := New()
+	survivorResource, survivorSocket := addPollTestSocket(t, machine, 20)
+	closingResource, closingSocket := addPollTestSocket(t, machine, 10)
+	survivorConnection := survivorResource.connection.(*syscallTestConn)
+	survivorAttached := false
+	survivorConnection.syscallFn = func() (syscall.RawConn, error) {
+		survivorResource.stateMu.Lock()
+		survivorAttached = len(survivorResource.pollWaiters) == 1
+		survivorResource.stateMu.Unlock()
+		return survivorConnection.raw, nil
+	}
+
+	platformWake := &fakePlatformWake{}
+	newWakeCalls := 0
+	waitCalls := 0
+	platform := networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			newWakeCalls++
+			closeSocket(closingResource)
+			return platformWake, nil
+		},
+		wait: func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+			waitCalls++
+			return networkPollBatch{}, nil
+		},
+	}
+	start := time.Unix(100, 0)
+	times := []time.Time{start, start, start.Add(3 * time.Second)}
+	now := func() time.Time {
+		current := times[0]
+		if len(times) > 1 {
+			times = times[1:]
+		}
+		return current
+	}
+	var slept []time.Duration
+	poller := networkPoller{
+		platform: platform,
+		now:      now,
+		sleep:    func(duration time.Duration) { slept = append(slept, duration) },
+	}
+
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{survivorSocket, closingSocket}, nil, nil), 3*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !survivorAttached {
+		t.Fatal("surviving registration never observed its installed poll waiter")
+	}
+	if newWakeCalls != 1 || waitCalls != 0 || len(slept) != 0 {
+		t.Fatalf("newWake=%d wait=%d slept=%v, want prompt return before native wait", newWakeCalls, waitCalls, slept)
+	}
+	if len(resultSet(t, result, "read")) != 0 {
+		t.Fatalf("concurrent close returned a partial result: %v", result)
+	}
+	survivorResource.stateMu.Lock()
+	waiters := len(survivorResource.pollWaiters)
+	survivorResource.stateMu.Unlock()
+	platformWake.mu.Lock()
+	wakeCloses := platformWake.closes
+	platformWake.mu.Unlock()
+	if waiters != 0 || wakeCloses != 1 {
+		t.Fatalf("survivor waiters=%d wake closes=%d, want complete cleanup", waiters, wakeCloses)
+	}
+}
+
+func TestNetworkPollerConcurrentAttachCloseDoesNotMaskOpenAcquisitionFailure(t *testing.T) {
+	machine := New()
+	closingResource, closingSocket := addPollTestSocket(t, machine, 10)
+	brokenResource, brokenSocket := addPollTestSocket(t, machine, 20)
+	brokenConnection := brokenResource.connection.(*syscallTestConn)
+	acquisitionFailure := errors.New("open survivor syscall failure")
+	brokenConnection.syscallFn = func() (syscall.RawConn, error) {
+		return nil, acquisitionFailure
+	}
+	platformWake := &fakePlatformWake{}
+	platform := networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			closeSocket(closingResource)
+			return platformWake, nil
+		},
+		wait: func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+			t.Fatal("native wait called after acquisition failure")
+			return networkPollBatch{}, nil
+		},
+	}
+	poller := networkPoller{platform: platform, now: time.Now, sleep: time.Sleep}
+
+	result, err := poller.Poll(machine.shared, pollSets([]value.Value{closingSocket, brokenSocket}, nil, nil), time.Second)
+	if !errors.Is(err, acquisitionFailure) || result.Type != value.VAL_NULL {
+		t.Fatalf("result=%v error=%v, want attributed open-resource acquisition failure", result, err)
+	}
+}
+
 func TestNetworkPollerIgnoresPoisonClosedCandidateBesideLiveCandidate(t *testing.T) {
 	machine := New()
 	closedResource, closedSocket := addPollTestSocket(t, machine, 10)

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -1,0 +1,58 @@
+package vm
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"noxy-vm/internal/value"
+)
+
+func TestValidateNetworkPollArguments(t *testing.T) {
+	empty := value.NewArray(nil)
+	maximum := int64(math.MaxInt64) / int64(time.Millisecond)
+	tests := []struct {
+		name      string
+		args      []value.Value
+		want      time.Duration
+		wantError string
+	}{
+		{"zero", []value.Value{empty, empty, empty, value.NewInt(0)}, 0, ""},
+		{"positive", []value.Value{empty, empty, empty, value.NewInt(25)}, 25 * time.Millisecond, ""},
+		{"negative", []value.Value{empty, empty, empty, value.NewInt(-1)}, 0, "network poll timeout must be non-negative"},
+		{"overflow", []value.Value{empty, empty, empty, value.NewInt(maximum + 1)}, 0, "network poll timeout is too large"},
+		{"wrong arity", []value.Value{empty}, 0, "net_select expects exactly 4 arguments"},
+		{"wrong set", []value.Value{value.NewNull(), empty, empty, value.NewInt(0)}, 0, "net_select read, write, and error arguments must be arrays"},
+		{"wrong timeout", []value.Value{empty, empty, empty, value.NewString("0")}, 0, "network poll timeout must be an int"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, got, err := validateNetworkPollArguments(test.args)
+			if test.wantError != "" {
+				if err == nil || err.Error() != test.wantError {
+					t.Fatalf("error=%v want=%q", err, test.wantError)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("timeout=%v error=%v want=%v", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestSelectResultPadsTruncatesAndCountsCopiedValues(t *testing.T) {
+	values := make([]value.Value, 65)
+	for i := range values {
+		values[i] = socketValue(i+1, "test", 0, true)
+	}
+	result := selectResult(values, values[:2], values[:1])
+	mapping := requireBuiltinMap(t, result)
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "read_count"), value.NewInt(64))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "write_count"), value.NewInt(2))
+	assertBuiltinValue(t, requireTestMapValue(t, mapping, "error_count"), value.NewInt(1))
+	read := requireTestMapValue(t, mapping, "read").Obj.(*value.ObjArray)
+	if len(read.Elements) != 64 {
+		t.Fatalf("read length=%d", len(read.Elements))
+	}
+}

--- a/internal/vm/network_poller_unix.go
+++ b/internal/vm/network_poller_unix.go
@@ -1,0 +1,170 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package vm
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+type unixNetworkOps struct {
+	socketpair  func(int, int, int) ([2]int, error)
+	setNonblock func(int, bool) error
+	write       func(int, []byte) (int, error)
+	close       func(int) error
+}
+
+func systemUnixNetworkOps() unixNetworkOps {
+	return unixNetworkOps{
+		socketpair:  unix.Socketpair,
+		setNonblock: unix.SetNonblock,
+		write:       unix.Write,
+		close:       unix.Close,
+	}
+}
+
+type unixNetworkWake struct {
+	reader int
+	writer int
+	ops    unixNetworkOps
+}
+
+func newUnixNetworkWake(ops unixNetworkOps) (*unixNetworkWake, error) {
+	pair, err := ops.socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+	fail := func(setupErr error) (*unixNetworkWake, error) {
+		return nil, errors.Join(
+			setupErr,
+			ops.close(pair[1]),
+			ops.close(pair[0]),
+		)
+	}
+	if err := ops.setNonblock(pair[0], true); err != nil {
+		return fail(err)
+	}
+	if err := ops.setNonblock(pair[1], true); err != nil {
+		return fail(err)
+	}
+	return &unixNetworkWake{reader: pair[0], writer: pair[1], ops: ops}, nil
+}
+
+func (wake *unixNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
+
+func (wake *unixNetworkWake) signal() error {
+	for {
+		_, err := wake.ops.write(wake.writer, []byte{1})
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (wake *unixNetworkWake) close() error {
+	return errors.Join(
+		wake.ops.close(wake.writer),
+		wake.ops.close(wake.reader),
+	)
+}
+
+func unixPollEvents(interests networkInterest) uint16 {
+	var events uint16
+	if interests&networkReadable != 0 {
+		events |= uint16(unix.POLLIN)
+	}
+	if interests&networkWritable != 0 {
+		events |= uint16(unix.POLLOUT)
+	}
+	return events
+}
+
+func normalizeUnixPollEvents(events uint16) networkEvent {
+	var normalized networkEvent
+	if events&uint16(unix.POLLIN) != 0 {
+		normalized |= networkReadReady
+	}
+	if events&uint16(unix.POLLOUT) != 0 {
+		normalized |= networkWriteReady
+	}
+	if events&(uint16(unix.POLLHUP)|uint16(unix.POLLERR)|uint16(unix.POLLNVAL)|uint16(networkPollReadHangup)) != 0 {
+		normalized |= networkReadReady | networkWriteReady | networkErrorReady
+	}
+	return normalized
+}
+
+var callUnixPoll = unix.Poll
+
+func unixPollDescriptor(descriptor uintptr) (int32, error) {
+	converted := int32(descriptor)
+	if converted < 0 || uintptr(converted) != descriptor {
+		return 0, fmt.Errorf("network poll descriptor %d cannot be represented as int32", descriptor)
+	}
+	return converted, nil
+}
+
+func unixNetworkWait(descriptors []networkPollFD, wakeDescriptor uintptr, timeout int32) (networkPollBatch, error) {
+	wakeFD, err := unixPollDescriptor(wakeDescriptor)
+	if err != nil {
+		return networkPollBatch{}, err
+	}
+	pollfds := make([]unix.PollFd, len(descriptors)+1)
+	pollfds[0] = unix.PollFd{Fd: wakeFD, Events: unix.POLLIN}
+	for index, descriptor := range descriptors {
+		fd, descriptorErr := unixPollDescriptor(descriptor.descriptor)
+		if descriptorErr != nil {
+			return networkPollBatch{}, descriptorErr
+		}
+		interests := descriptor.interests
+		if descriptor.listener {
+			interests &^= networkWritable
+		}
+		pollfds[index+1] = unix.PollFd{Fd: fd}
+		events := unixPollEvents(interests)
+		if events&uint16(unix.POLLIN) != 0 {
+			pollfds[index+1].Events |= unix.POLLIN
+		}
+		if events&uint16(unix.POLLOUT) != 0 {
+			pollfds[index+1].Events |= unix.POLLOUT
+		}
+		if !descriptor.listener {
+			addNetworkPollReadHangup(&pollfds[index+1])
+		}
+	}
+
+	if _, err := callUnixPoll(pollfds, int(timeout)); err != nil {
+		if errors.Is(err, unix.EINTR) {
+			return networkPollBatch{interrupted: true}, nil
+		}
+		return networkPollBatch{}, err
+	}
+
+	batch := networkPollBatch{events: make([]networkEvent, len(descriptors))}
+	wakeEvents := uint16(pollfds[0].Revents)
+	if wakeEvents&(uint16(unix.POLLIN)|uint16(unix.POLLHUP)|uint16(unix.POLLERR)|uint16(unix.POLLNVAL)|uint16(networkPollReadHangup)) != 0 {
+		batch.woke = true
+	}
+	for index, descriptor := range descriptors {
+		event := normalizeUnixPollEvents(uint16(pollfds[index+1].Revents))
+		if descriptor.listener {
+			event &^= networkWriteReady
+		}
+		batch.events[index] = event
+	}
+	return batch, nil
+}
+
+func systemNetworkPlatform() networkPlatform {
+	return networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			return newUnixNetworkWake(systemUnixNetworkOps())
+		},
+		wait: unixNetworkWait,
+	}
+}

--- a/internal/vm/network_poller_unix_test.go
+++ b/internal/vm/network_poller_unix_test.go
@@ -1,0 +1,393 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package vm
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestUnixPollEventMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		poll uint16
+		want networkEvent
+	}{
+		{name: "POLLIN", poll: unix.POLLIN, want: networkReadReady},
+		{name: "POLLOUT", poll: unix.POLLOUT, want: networkWriteReady},
+		{name: "POLLHUP", poll: unix.POLLHUP, want: networkReadReady | networkWriteReady | networkErrorReady},
+		{name: "POLLERR", poll: unix.POLLERR, want: networkReadReady | networkWriteReady | networkErrorReady},
+		{name: "POLLNVAL", poll: unix.POLLNVAL, want: networkReadReady | networkWriteReady | networkErrorReady},
+		{name: "POLLPRI", poll: unix.POLLPRI, want: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeUnixPollEvents(test.poll); got != test.want {
+				t.Fatalf("events=%#x, want %#x", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUnixPollInterestNeverRequestsPOLLPRI(t *testing.T) {
+	got := unixPollEvents(networkReadable | networkWritable | networkErrorInterest)
+	if got&uint16(unix.POLLPRI) != 0 {
+		t.Fatalf("events=%#x include POLLPRI", got)
+	}
+	if got != uint16(unix.POLLIN)|uint16(unix.POLLOUT) {
+		t.Fatalf("events=%#x, want %#x", got, uint16(unix.POLLIN)|uint16(unix.POLLOUT))
+	}
+	if got := unixPollEvents(networkErrorInterest); got != 0 {
+		t.Fatalf("error-only events=%#x, want zero normal flags", got)
+	}
+}
+
+func TestUnixReadHangupMaskConfiguration(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		if networkPollReadHangup == 0 {
+			t.Fatal("POLLRDHUP extension mask is zero")
+		}
+		want := networkReadReady | networkWriteReady | networkErrorReady
+		if got := normalizeUnixPollEvents(uint16(networkPollReadHangup)); got != want {
+			t.Fatalf("normalized POLLRDHUP=%#x, want %#x", got, want)
+		}
+	default:
+		if networkPollReadHangup != 0 {
+			t.Fatalf("extension mask=%#x, want zero", networkPollReadHangup)
+		}
+	}
+}
+
+func TestUnixPollPreservesOrderAndSocketReadHangupInterest(t *testing.T) {
+	originalPoll := callUnixPoll
+	t.Cleanup(func() { callUnixPoll = originalPoll })
+	callUnixPoll = func(pollfds []unix.PollFd, timeout int) (int, error) {
+		if timeout != 37 {
+			t.Fatalf("timeout=%d, want 37", timeout)
+		}
+		if len(pollfds) != 4 {
+			t.Fatalf("descriptor count=%d, want 4", len(pollfds))
+		}
+		if pollfds[0].Fd != 99 || uint16(pollfds[0].Events) != uint16(unix.POLLIN) {
+			t.Fatalf("wake descriptor=%+v", pollfds[0])
+		}
+		wantFDs := []int32{11, 12, 13}
+		wantEvents := []uint16{
+			uint16(unix.POLLIN) | uint16(networkPollReadHangup),
+			uint16(networkPollReadHangup),
+			uint16(unix.POLLIN),
+		}
+		for index := range wantFDs {
+			got := pollfds[index+1]
+			if got.Fd != wantFDs[index] || uint16(got.Events) != wantEvents[index] {
+				t.Fatalf("descriptor %d=%+v, want fd=%d events=%#x", index, got, wantFDs[index], wantEvents[index])
+			}
+			if uint16(got.Events)&uint16(unix.POLLPRI) != 0 {
+				t.Fatalf("descriptor %d events=%#x include POLLPRI", index, got.Events)
+			}
+		}
+		pollfds[0].Revents = unix.POLLIN
+		pollfds[1].Revents = unix.POLLOUT
+		pollfds[2].Revents = unix.POLLERR
+		pollfds[3].Revents = unix.POLLOUT
+		return 4, nil
+	}
+
+	descriptors := []networkPollFD{
+		{descriptor: 11, interests: networkReadable},
+		{descriptor: 12, interests: networkErrorInterest},
+		{descriptor: 13, interests: networkReadable | networkWritable, listener: true},
+	}
+	batch, err := unixNetworkWait(descriptors, 99, 37)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !batch.woke || batch.interrupted {
+		t.Fatalf("batch woke=%t interrupted=%t", batch.woke, batch.interrupted)
+	}
+	want := []networkEvent{
+		networkWriteReady,
+		networkReadReady | networkWriteReady | networkErrorReady,
+		0,
+	}
+	if len(batch.events) != len(want) {
+		t.Fatalf("events=%v, want %v", batch.events, want)
+	}
+	for index := range want {
+		if batch.events[index] != want[index] {
+			t.Fatalf("event %d=%#x, want %#x", index, batch.events[index], want[index])
+		}
+	}
+}
+
+func TestUnixPollRejectsDescriptorsThatDoNotRoundTripThroughInt32(t *testing.T) {
+	originalPoll := callUnixPoll
+	t.Cleanup(func() { callUnixPoll = originalPoll })
+	called := false
+	callUnixPoll = func([]unix.PollFd, int) (int, error) {
+		called = true
+		return 0, nil
+	}
+
+	tooLarge := uintptr(1 << 31)
+	for _, test := range []struct {
+		name        string
+		descriptors []networkPollFD
+		wake        uintptr
+	}{
+		{name: "wake", wake: tooLarge},
+		{name: "socket", descriptors: []networkPollFD{{descriptor: tooLarge, interests: networkReadable}}, wake: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			called = false
+			if _, err := unixNetworkWait(test.descriptors, test.wake, 0); err == nil {
+				t.Fatal("wait accepted descriptor that cannot round-trip through int32")
+			}
+			if called {
+				t.Fatal("poll called after descriptor validation failed")
+			}
+		})
+	}
+}
+
+func TestUnixPollEINTRReturnsInterruptedBatch(t *testing.T) {
+	originalPoll := callUnixPoll
+	t.Cleanup(func() { callUnixPoll = originalPoll })
+	callUnixPoll = func([]unix.PollFd, int) (int, error) { return 0, unix.EINTR }
+	batch, err := unixNetworkWait(nil, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !batch.interrupted || batch.woke || len(batch.events) != 0 {
+		t.Fatalf("batch=%+v, want interrupted-only", batch)
+	}
+}
+
+func TestUnixWakeSocketpairSignalsPoll(t *testing.T) {
+	platform := systemNetworkPlatform()
+	platformWake, err := platform.newWake()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := newNetworkWake(platformWake)
+	t.Cleanup(func() {
+		if err := wake.Close(); err != nil {
+			t.Errorf("close wake: %v", err)
+		}
+	})
+
+	batch, err := platform.wait(nil, platformWake.descriptor(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.woke {
+		t.Fatal("fresh wake socketpair was readable")
+	}
+	if err := wake.Signal(); err != nil {
+		t.Fatal(err)
+	}
+	if err := wake.Signal(); err != nil {
+		t.Fatal(err)
+	}
+	batch, err = platform.wait(nil, platformWake.descriptor(), 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !batch.woke {
+		t.Fatal("poll did not report the signaled wake socketpair")
+	}
+}
+
+type fakeUnixWakeOps struct {
+	failAt  string
+	failure error
+	created []int
+	closed  []int
+	writes  []error
+}
+
+func (fake *fakeUnixWakeOps) boundary() unixNetworkOps {
+	setNonblockCalls := 0
+	return unixNetworkOps{
+		socketpair: func(int, int, int) ([2]int, error) {
+			if fake.failAt == "socketpair" {
+				return [2]int{}, fake.failure
+			}
+			pair := [2]int{101, 102}
+			fake.created = append(fake.created, pair[:]...)
+			return pair, nil
+		},
+		setNonblock: func(int, bool) error {
+			setNonblockCalls++
+			stage := "reader nonblock"
+			if setNonblockCalls == 2 {
+				stage = "writer nonblock"
+			}
+			if fake.failAt == stage {
+				return fake.failure
+			}
+			return nil
+		},
+		write: func(int, []byte) (int, error) {
+			if len(fake.writes) == 0 {
+				return 1, nil
+			}
+			err := fake.writes[0]
+			fake.writes = fake.writes[1:]
+			if err != nil {
+				return 0, err
+			}
+			return 1, nil
+		},
+		close: func(descriptor int) error {
+			fake.closed = append(fake.closed, descriptor)
+			return nil
+		},
+	}
+}
+
+func requireBalancedUnixWakeDescriptors(t *testing.T, fake *fakeUnixWakeOps) {
+	t.Helper()
+	if len(fake.created) != len(fake.closed) {
+		t.Fatalf("created=%v closed=%v", fake.created, fake.closed)
+	}
+	balances := make(map[int]int, len(fake.created))
+	for _, descriptor := range fake.created {
+		balances[descriptor]++
+	}
+	for _, descriptor := range fake.closed {
+		balances[descriptor]--
+	}
+	for descriptor, balance := range balances {
+		if balance != 0 {
+			t.Fatalf("descriptor %d balance=%d; created=%v closed=%v", descriptor, balance, fake.created, fake.closed)
+		}
+	}
+}
+
+func TestUnixWakeSetupBalancesDescriptorsAtEveryFailure(t *testing.T) {
+	failure := errors.New("injected setup failure")
+	for _, test := range []struct {
+		stage       string
+		wantCreated int
+	}{
+		{stage: "socketpair", wantCreated: 0},
+		{stage: "reader nonblock", wantCreated: 2},
+		{stage: "writer nonblock", wantCreated: 2},
+	} {
+		t.Run(test.stage, func(t *testing.T) {
+			fake := &fakeUnixWakeOps{failAt: test.stage, failure: failure}
+			wake, err := newUnixNetworkWake(fake.boundary())
+			if wake != nil {
+				t.Fatalf("wake=%#v, want nil", wake)
+			}
+			if !errors.Is(err, failure) {
+				t.Fatalf("error=%v, want injected failure", err)
+			}
+			if len(fake.created) != test.wantCreated || len(fake.closed) != test.wantCreated {
+				t.Fatalf("created=%v closed=%v, want %d each", fake.created, fake.closed, test.wantCreated)
+			}
+			requireBalancedUnixWakeDescriptors(t, fake)
+		})
+	}
+}
+
+func TestUnixWakeCloseIsIdempotentThroughCommonLifecycle(t *testing.T) {
+	fake := &fakeUnixWakeOps{}
+	platformWake, err := newUnixNetworkWake(fake.boundary())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := newNetworkWake(platformWake)
+	if err := wake.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := wake.Close(); err != nil {
+		t.Fatal(err)
+	}
+	requireBalancedUnixWakeDescriptors(t, fake)
+}
+
+func TestUnixWakeSignalRetriesEINTRAndAcceptsWouldBlock(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		writes []error
+	}{
+		{name: "EINTR retry", writes: []error{unix.EINTR, nil}},
+		{name: "EAGAIN", writes: []error{unix.EAGAIN}},
+		{name: "EWOULDBLOCK", writes: []error{unix.EWOULDBLOCK}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeUnixWakeOps{writes: append([]error(nil), test.writes...)}
+			wake := &unixNetworkWake{writer: 102, ops: fake.boundary()}
+			if err := wake.signal(); err != nil {
+				t.Fatalf("signal error=%v", err)
+			}
+			if len(fake.writes) != 0 {
+				t.Fatalf("unconsumed write results=%v", fake.writes)
+			}
+		})
+	}
+}
+
+type unixWakeRaceTracker struct {
+	mu         sync.Mutex
+	closed     map[int]bool
+	afterClose bool
+}
+
+func TestUnixWakeSignalCloseRace(t *testing.T) {
+	for iteration := 0; iteration < 100; iteration++ {
+		ops := systemUnixNetworkOps()
+		tracker := &unixWakeRaceTracker{closed: make(map[int]bool)}
+		write := ops.write
+		closeDescriptor := ops.close
+		ops.write = func(descriptor int, payload []byte) (int, error) {
+			tracker.mu.Lock()
+			if tracker.closed[descriptor] {
+				tracker.afterClose = true
+			}
+			tracker.mu.Unlock()
+			return write(descriptor, payload)
+		}
+		ops.close = func(descriptor int) error {
+			tracker.mu.Lock()
+			tracker.closed[descriptor] = true
+			tracker.mu.Unlock()
+			return closeDescriptor(descriptor)
+		}
+
+		platformWake, err := newUnixNetworkWake(ops)
+		if err != nil {
+			t.Fatalf("iteration %d: %v", iteration, err)
+		}
+		wake := newNetworkWake(platformWake)
+		start := make(chan struct{})
+		errorsOut := make(chan error, 2)
+		go func() {
+			<-start
+			errorsOut <- wake.Signal()
+		}()
+		go func() {
+			<-start
+			errorsOut <- wake.Close()
+		}()
+		close(start)
+		for call := 0; call < 2; call++ {
+			if err := <-errorsOut; err != nil {
+				t.Fatalf("iteration %d: signal/close error: %v", iteration, err)
+			}
+		}
+		tracker.mu.Lock()
+		afterClose := tracker.afterClose
+		tracker.mu.Unlock()
+		if afterClose {
+			t.Fatalf("iteration %d: write called after descriptor close", iteration)
+		}
+	}
+}

--- a/internal/vm/network_poller_unsupported.go
+++ b/internal/vm/network_poller_unsupported.go
@@ -1,0 +1,18 @@
+//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package vm
+
+import "fmt"
+
+const unsupportedNetworkPollingError = "network polling is not supported on this platform"
+
+func systemNetworkPlatform() networkPlatform {
+	return networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			return nil, fmt.Errorf(unsupportedNetworkPollingError)
+		},
+		wait: func([]networkPollFD, uintptr, int32) (networkPollBatch, error) {
+			return networkPollBatch{}, fmt.Errorf(unsupportedNetworkPollingError)
+		},
+	}
+}

--- a/internal/vm/network_poller_unsupported_test.go
+++ b/internal/vm/network_poller_unsupported_test.go
@@ -1,0 +1,18 @@
+//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package vm
+
+import "testing"
+
+func TestUnsupportedNetworkPlatformReturnsStableErrors(t *testing.T) {
+	const want = "network polling is not supported on this platform"
+	platform := systemNetworkPlatform()
+	wake, err := platform.newWake()
+	if wake != nil || err == nil || err.Error() != want {
+		t.Fatalf("newWake=(%v, %v), want (nil, %q)", wake, err, want)
+	}
+	batch, err := platform.wait(nil, 0, 0)
+	if err == nil || err.Error() != want {
+		t.Fatalf("wait=(%+v, %v), want error %q", batch, err, want)
+	}
+}

--- a/internal/vm/network_poller_windows.go
+++ b/internal/vm/network_poller_windows.go
@@ -1,0 +1,201 @@
+//go:build windows
+
+package vm
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type wsaPollFD struct {
+	FD      uintptr
+	Events  int16
+	Revents int16
+}
+
+const (
+	pollRDNORM  int16 = 0x0100
+	pollWRNORM  int16 = 0x0010
+	pollERR     int16 = 0x0001
+	pollHUP     int16 = 0x0002
+	pollNVAL    int16 = 0x0004
+	pollPRI     int16 = 0x0400
+	socketError int32 = -1
+)
+
+var (
+	ws2                 = windows.NewLazySystemDLL("Ws2_32.dll")
+	procWSAPoll         = ws2.NewProc("WSAPoll")
+	procWSAGetLastError = ws2.NewProc("WSAGetLastError")
+	callWSAPoll         = func(first *wsaPollFD, count uint32, timeout int32) (uintptr, uintptr, error) {
+		return procWSAPoll.Call(
+			uintptr(unsafe.Pointer(first)),
+			uintptr(count),
+			uintptr(timeout),
+		)
+	}
+	callWSAGetLastError = func() (uintptr, uintptr, error) {
+		return procWSAGetLastError.Call()
+	}
+)
+
+type windowsNetworkOps struct {
+	socket      func(int, int, int) (windows.Handle, error)
+	bind        func(windows.Handle, windows.Sockaddr) error
+	getsockname func(windows.Handle) (windows.Sockaddr, error)
+	setNonblock func(windows.Handle, bool) error
+	sendto      func(windows.Handle, []byte, int, windows.Sockaddr) error
+	closeSocket func(windows.Handle) error
+}
+
+func systemWindowsNetworkOps() windowsNetworkOps {
+	return windowsNetworkOps{
+		socket:      windows.Socket,
+		bind:        windows.Bind,
+		getsockname: windows.Getsockname,
+		setNonblock: func(handle windows.Handle, nonblocking bool) error {
+			return syscall.SetNonblock(syscall.Handle(handle), nonblocking)
+		},
+		sendto:      windows.Sendto,
+		closeSocket: windows.Closesocket,
+	}
+}
+
+type windowsNetworkWake struct {
+	reader  windows.Handle
+	writer  windows.Handle
+	address *windows.SockaddrInet4
+	ops     windowsNetworkOps
+}
+
+func newWindowsNetworkWake(ops windowsNetworkOps) (*windowsNetworkWake, error) {
+	reader, err := ops.socket(windows.AF_INET, windows.SOCK_DGRAM, windows.IPPROTO_UDP)
+	if err != nil {
+		return nil, err
+	}
+	fail := func(setupErr error, handles ...windows.Handle) (*windowsNetworkWake, error) {
+		errorsToJoin := []error{setupErr}
+		for index := len(handles) - 1; index >= 0; index-- {
+			errorsToJoin = append(errorsToJoin, ops.closeSocket(handles[index]))
+		}
+		return nil, errors.Join(errorsToJoin...)
+	}
+
+	loopback := &windows.SockaddrInet4{Addr: [4]byte{127, 0, 0, 1}}
+	if err := ops.bind(reader, loopback); err != nil {
+		return fail(err, reader)
+	}
+	bound, err := ops.getsockname(reader)
+	if err != nil {
+		return fail(err, reader)
+	}
+	address, ok := bound.(*windows.SockaddrInet4)
+	if !ok {
+		return fail(errors.New("Windows UDP wake address is not IPv4"), reader)
+	}
+
+	writer, err := ops.socket(windows.AF_INET, windows.SOCK_DGRAM, windows.IPPROTO_UDP)
+	if err != nil {
+		return fail(err, reader)
+	}
+	if err := ops.setNonblock(reader, true); err != nil {
+		return fail(err, reader, writer)
+	}
+	if err := ops.setNonblock(writer, true); err != nil {
+		return fail(err, reader, writer)
+	}
+	return &windowsNetworkWake{
+		reader:  reader,
+		writer:  writer,
+		address: address,
+		ops:     ops,
+	}, nil
+}
+
+func (wake *windowsNetworkWake) descriptor() uintptr { return uintptr(wake.reader) }
+
+func (wake *windowsNetworkWake) signal() error {
+	err := wake.ops.sendto(wake.writer, []byte{1}, 0, wake.address)
+	if errors.Is(err, windows.WSAEWOULDBLOCK) {
+		return nil
+	}
+	return err
+}
+
+func (wake *windowsNetworkWake) close() error {
+	return errors.Join(
+		wake.ops.closeSocket(wake.writer),
+		wake.ops.closeSocket(wake.reader),
+	)
+}
+
+func windowsPollEvents(interests networkInterest) int16 {
+	var events int16
+	if interests&networkReadable != 0 {
+		events |= pollRDNORM
+	}
+	if interests&networkWritable != 0 {
+		events |= pollWRNORM
+	}
+	return events
+}
+
+func normalizeWindowsPollEvents(events int16) networkEvent {
+	var normalized networkEvent
+	if events&pollRDNORM != 0 {
+		normalized |= networkReadReady
+	}
+	if events&pollWRNORM != 0 {
+		normalized |= networkWriteReady
+	}
+	if events&(pollHUP|pollERR|pollNVAL) != 0 {
+		normalized |= networkReadReady | networkWriteReady | networkErrorReady
+	}
+	return normalized
+}
+
+func windowsNetworkWait(descriptors []networkPollFD, wakeDescriptor uintptr, timeout int32) (networkPollBatch, error) {
+	pollfds := make([]wsaPollFD, len(descriptors)+1)
+	pollfds[0] = wsaPollFD{FD: wakeDescriptor, Events: pollRDNORM}
+	for index, descriptor := range descriptors {
+		interests := descriptor.interests
+		if descriptor.listener {
+			interests &^= networkWritable
+		}
+		pollfds[index+1] = wsaPollFD{
+			FD:     descriptor.descriptor,
+			Events: windowsPollEvents(interests),
+		}
+	}
+
+	result, _, _ := callWSAPoll(&pollfds[0], uint32(len(pollfds)), timeout)
+	if int32(result) == socketError {
+		code, _, _ := callWSAGetLastError()
+		return networkPollBatch{}, syscall.Errno(code)
+	}
+
+	batch := networkPollBatch{events: make([]networkEvent, len(descriptors))}
+	if pollfds[0].Revents&(pollRDNORM|pollHUP|pollERR|pollNVAL) != 0 {
+		batch.woke = true
+	}
+	for index, descriptor := range descriptors {
+		event := normalizeWindowsPollEvents(pollfds[index+1].Revents)
+		if descriptor.listener {
+			event &^= networkWriteReady
+		}
+		batch.events[index] = event
+	}
+	return batch, nil
+}
+
+func systemNetworkPlatform() networkPlatform {
+	return networkPlatform{
+		newWake: func() (platformNetworkWake, error) {
+			return newWindowsNetworkWake(systemWindowsNetworkOps())
+		},
+		wait: windowsNetworkWait,
+	}
+}

--- a/internal/vm/network_poller_windows_test.go
+++ b/internal/vm/network_poller_windows_test.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"syscall"
 	"testing"
-	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -374,7 +373,7 @@ func TestWindowsWakeTreatsWouldBlockAsAlreadySignaled(t *testing.T) {
 	}
 }
 
-func TestWSAPollLoopbackResetPreservesPendingSocketError(t *testing.T) {
+func TestNetworkPollIntegrationWSAPollResetCopiesTerminalEventAndPreservesPendingError(t *testing.T) {
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
@@ -396,32 +395,22 @@ func TestWSAPollLoopbackResetPreservesPendingSocketError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	poller := networkPoller{platform: systemNetworkPlatform(), now: time.Now, sleep: time.Sleep}
-	sets := [3]*value.ObjArray{
-		{Elements: []value.Value{server}},
-		{Elements: []value.Value{server}},
-		{Elements: []value.Value{server}},
-	}
-	type pollResult struct {
-		value value.Value
-		err   error
-	}
-	result := make(chan pollResult, 1)
-	go func() {
-		selected, err := poller.Poll(machine.shared, sets, time.Second)
-		result <- pollResult{value: selected, err: err}
-	}()
-	var selected value.Value
-	select {
-	case outcome := <-result:
-		if outcome.err != nil {
-			t.Fatal(outcome.err)
-		}
-		selected = outcome.value
-	case <-time.After(time.Second):
-		t.Fatal("WSAPoll did not report loopback RST within one second")
-	}
-	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+	selected := callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}),
+		value.NewArray(nil),
+		value.NewArray([]value.Value{server}),
+		value.NewInt(1000))
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	requireNetworkPollIntegrationSet(t, selected, "error", server)
+
+	selected = callBuiltinWithinBound(t, machine, "net_select",
+		value.NewArray([]value.Value{server}),
+		value.NewArray([]value.Value{server}),
+		value.NewArray([]value.Value{server}),
+		value.NewInt(0))
+	requireNetworkPollIntegrationSet(t, selected, "read", server)
+	requireNetworkPollIntegrationSet(t, selected, "write", server)
+	requireNetworkPollIntegrationSet(t, selected, "error", server)
 
 	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
 	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(false))

--- a/internal/vm/network_poller_windows_test.go
+++ b/internal/vm/network_poller_windows_test.go
@@ -1,0 +1,432 @@
+//go:build windows
+
+package vm
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"noxy-vm/internal/value"
+)
+
+func TestWSAPollFDLayout(t *testing.T) {
+	var descriptor wsaPollFD
+	if unsafe.Offsetof(descriptor.Events) != unsafe.Sizeof(uintptr(0)) {
+		t.Fatalf("events offset=%d", unsafe.Offsetof(descriptor.Events))
+	}
+	if unsafe.Offsetof(descriptor.Revents) != unsafe.Sizeof(uintptr(0))+2 {
+		t.Fatalf("revents offset=%d", unsafe.Offsetof(descriptor.Revents))
+	}
+}
+
+func TestWindowsPollInterestNeverRequestsPOLLPRI(t *testing.T) {
+	got := windowsPollEvents(networkReadable | networkWritable | networkErrorInterest)
+	if got&pollPRI != 0 {
+		t.Fatalf("events=%#x include POLLPRI", got)
+	}
+	if got != pollRDNORM|pollWRNORM {
+		t.Fatalf("events=%#x", got)
+	}
+}
+
+func TestWindowsPollNormalizesTerminalEvents(t *testing.T) {
+	got := normalizeWindowsPollEvents(pollHUP | pollERR)
+	want := networkReadReady | networkWriteReady | networkErrorReady
+	if got != want {
+		t.Fatalf("events=%#x want=%#x", got, want)
+	}
+}
+
+func TestWindowsPollEventMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		poll int16
+		want networkEvent
+	}{
+		{name: "POLLRDNORM", poll: pollRDNORM, want: networkReadReady},
+		{name: "POLLWRNORM", poll: pollWRNORM, want: networkWriteReady},
+		{name: "POLLHUP", poll: pollHUP, want: networkReadReady | networkWriteReady | networkErrorReady},
+		{name: "POLLERR", poll: pollERR, want: networkReadReady | networkWriteReady | networkErrorReady},
+		{name: "POLLNVAL", poll: pollNVAL, want: networkReadReady | networkWriteReady | networkErrorReady},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeWindowsPollEvents(test.poll); got != test.want {
+				t.Fatalf("events=%#x want=%#x", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWSAPollPreservesDescriptorOrderAndListenerInvariant(t *testing.T) {
+	originalWSAPoll := callWSAPoll
+	originalLastError := callWSAGetLastError
+	t.Cleanup(func() {
+		callWSAPoll = originalWSAPoll
+		callWSAGetLastError = originalLastError
+	})
+
+	callWSAPoll = func(first *wsaPollFD, count uint32, timeout int32) (uintptr, uintptr, error) {
+		if timeout != 37 {
+			t.Fatalf("timeout=%d, want 37", timeout)
+		}
+		pollfds := unsafe.Slice(first, int(count))
+		if len(pollfds) != 4 {
+			t.Fatalf("descriptor count=%d, want 4", len(pollfds))
+		}
+		if pollfds[0].FD != 99 || pollfds[0].Events != pollRDNORM {
+			t.Fatalf("wake descriptor=%+v", pollfds[0])
+		}
+		wantEvents := []int16{pollRDNORM, 0, pollRDNORM}
+		for index, want := range wantEvents {
+			if got := pollfds[index+1].Events; got != want {
+				t.Fatalf("descriptor %d events=%#x, want %#x", index, got, want)
+			}
+		}
+		pollfds[1].Revents = pollWRNORM
+		pollfds[2].Revents = pollERR
+		pollfds[3].Revents = pollWRNORM
+		return 3, 0, syscall.Errno(1234)
+	}
+	callWSAGetLastError = func() (uintptr, uintptr, error) {
+		t.Fatal("WSAGetLastError called after successful WSAPoll")
+		return 0, 0, nil
+	}
+
+	descriptors := []networkPollFD{
+		{descriptor: 11, interests: networkReadable},
+		{descriptor: 12, interests: networkErrorInterest},
+		{descriptor: 13, interests: networkReadable | networkWritable, listener: true},
+	}
+	batch, err := windowsNetworkWait(descriptors, 99, 37)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.interrupted {
+		t.Fatal("Windows poll unexpectedly marked interrupted")
+	}
+	want := []networkEvent{
+		networkWriteReady,
+		networkReadReady | networkWriteReady | networkErrorReady,
+		0,
+	}
+	if len(batch.events) != len(want) {
+		t.Fatalf("events=%v, want %v", batch.events, want)
+	}
+	for index := range want {
+		if batch.events[index] != want[index] {
+			t.Fatalf("event %d=%#x, want %#x", index, batch.events[index], want[index])
+		}
+	}
+}
+
+func TestWSAPollUsesExplicitWSAError(t *testing.T) {
+	originalWSAPoll := callWSAPoll
+	originalLastError := callWSAGetLastError
+	t.Cleanup(func() {
+		callWSAPoll = originalWSAPoll
+		callWSAGetLastError = originalLastError
+	})
+
+	callWSAPoll = func(*wsaPollFD, uint32, int32) (uintptr, uintptr, error) {
+		return ^uintptr(0), 0, syscall.Errno(5)
+	}
+	callWSAGetLastError = func() (uintptr, uintptr, error) {
+		return uintptr(windows.WSAECONNREFUSED), 0, syscall.Errno(6)
+	}
+
+	_, err := windowsNetworkWait(nil, 99, 0)
+	if !errors.Is(err, windows.WSAECONNREFUSED) {
+		t.Fatalf("error=%v, want %v", err, windows.WSAECONNREFUSED)
+	}
+	if errors.Is(err, syscall.Errno(5)) || errors.Is(err, syscall.Errno(6)) {
+		t.Fatalf("error=%v came from LazyProc.Call last-error", err)
+	}
+}
+
+func TestWindowsWakeDescriptorAndSignal(t *testing.T) {
+	platform := systemNetworkPlatform()
+	platformWake, err := platform.newWake()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := newNetworkWake(platformWake)
+	t.Cleanup(func() {
+		if err := wake.Close(); err != nil {
+			t.Errorf("close wake: %v", err)
+		}
+	})
+
+	if _, err := platform.wait(nil, platformWake.descriptor(), 0); err != nil {
+		t.Fatalf("zero-time WSAPoll rejected wake descriptor: %v", err)
+	}
+	if err := wake.Signal(); err != nil {
+		t.Fatal(err)
+	}
+	if err := wake.Signal(); err != nil {
+		t.Fatal(err)
+	}
+	batch, err := platform.wait(nil, platformWake.descriptor(), 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !batch.woke {
+		t.Fatal("WSAPoll did not report the signaled wake descriptor")
+	}
+}
+
+type windowsWakeRaceTracker struct {
+	mu         sync.Mutex
+	closed     map[windows.Handle]bool
+	afterClose bool
+}
+
+func TestWindowsWakeSignalCloseRace(t *testing.T) {
+	for iteration := 0; iteration < 100; iteration++ {
+		ops := systemWindowsNetworkOps()
+		tracker := &windowsWakeRaceTracker{closed: make(map[windows.Handle]bool)}
+		sendto := ops.sendto
+		closeSocket := ops.closeSocket
+		ops.sendto = func(handle windows.Handle, payload []byte, flags int, address windows.Sockaddr) error {
+			tracker.mu.Lock()
+			if tracker.closed[handle] {
+				tracker.afterClose = true
+			}
+			tracker.mu.Unlock()
+			return sendto(handle, payload, flags, address)
+		}
+		ops.closeSocket = func(handle windows.Handle) error {
+			tracker.mu.Lock()
+			tracker.closed[handle] = true
+			tracker.mu.Unlock()
+			return closeSocket(handle)
+		}
+
+		platformWake, err := newWindowsNetworkWake(ops)
+		if err != nil {
+			t.Fatalf("iteration %d: %v", iteration, err)
+		}
+		wake := newNetworkWake(platformWake)
+		start := make(chan struct{})
+		errorsOut := make(chan error, 2)
+		go func() {
+			<-start
+			errorsOut <- wake.Signal()
+		}()
+		go func() {
+			<-start
+			errorsOut <- wake.Close()
+		}()
+		close(start)
+		for call := 0; call < 2; call++ {
+			if err := <-errorsOut; err != nil {
+				t.Fatalf("iteration %d: signal/close error: %v", iteration, err)
+			}
+		}
+		tracker.mu.Lock()
+		afterClose := tracker.afterClose
+		tracker.mu.Unlock()
+		if afterClose {
+			t.Fatalf("iteration %d: Winsock send called after handle close", iteration)
+		}
+	}
+}
+
+type fakeWindowsWakeOps struct {
+	failAt  string
+	failure error
+	created []windows.Handle
+	closed  []windows.Handle
+}
+
+func requireBalancedWindowsWakeHandles(t *testing.T, created, closed []windows.Handle) {
+	t.Helper()
+	open := make(map[windows.Handle]int, len(created))
+	for _, handle := range created {
+		open[handle]++
+	}
+	for _, handle := range closed {
+		open[handle]--
+	}
+	for handle, count := range open {
+		if count != 0 {
+			t.Fatalf("handle %d balance=%d; created=%v closed=%v", handle, count, created, closed)
+		}
+	}
+	if len(created) != len(closed) {
+		t.Fatalf("created=%v closed=%v", created, closed)
+	}
+}
+
+func (fake *fakeWindowsWakeOps) boundary() windowsNetworkOps {
+	socketCalls := 0
+	return windowsNetworkOps{
+		socket: func(int, int, int) (windows.Handle, error) {
+			socketCalls++
+			stage := "reader socket"
+			if socketCalls == 2 {
+				stage = "writer socket"
+			}
+			if fake.failAt == stage {
+				return windows.InvalidHandle, fake.failure
+			}
+			handle := windows.Handle(100 + socketCalls)
+			fake.created = append(fake.created, handle)
+			return handle, nil
+		},
+		bind: func(windows.Handle, windows.Sockaddr) error {
+			if fake.failAt == "bind" {
+				return fake.failure
+			}
+			return nil
+		},
+		getsockname: func(windows.Handle) (windows.Sockaddr, error) {
+			if fake.failAt == "getsockname" {
+				return nil, fake.failure
+			}
+			return &windows.SockaddrInet4{Port: 4321, Addr: [4]byte{127, 0, 0, 1}}, nil
+		},
+		setNonblock: func(handle windows.Handle, _ bool) error {
+			stage := "reader nonblock"
+			if len(fake.created) == 2 && handle == fake.created[1] {
+				stage = "writer nonblock"
+			}
+			if fake.failAt == stage {
+				return fake.failure
+			}
+			return nil
+		},
+		sendto: func(windows.Handle, []byte, int, windows.Sockaddr) error { return nil },
+		closeSocket: func(handle windows.Handle) error {
+			fake.closed = append(fake.closed, handle)
+			return nil
+		},
+	}
+}
+
+func TestWindowsWakeSetupBalancesHandlesAtEveryFailure(t *testing.T) {
+	failure := errors.New("injected setup failure")
+	tests := []struct {
+		stage       string
+		wantCreated int
+	}{
+		{stage: "reader socket", wantCreated: 0},
+		{stage: "bind", wantCreated: 1},
+		{stage: "getsockname", wantCreated: 1},
+		{stage: "writer socket", wantCreated: 1},
+		{stage: "reader nonblock", wantCreated: 2},
+		{stage: "writer nonblock", wantCreated: 2},
+	}
+	for _, test := range tests {
+		t.Run(test.stage, func(t *testing.T) {
+			fake := &fakeWindowsWakeOps{failAt: test.stage, failure: failure}
+			wake, err := newWindowsNetworkWake(fake.boundary())
+			if wake != nil {
+				t.Fatalf("wake=%#v, want nil", wake)
+			}
+			if !errors.Is(err, failure) {
+				t.Fatalf("error=%v, want injected failure", err)
+			}
+			if len(fake.created) != test.wantCreated || len(fake.closed) != test.wantCreated {
+				t.Fatalf("created=%v closed=%v, want %d each", fake.created, fake.closed, test.wantCreated)
+			}
+			requireBalancedWindowsWakeHandles(t, fake.created, fake.closed)
+		})
+	}
+}
+
+func TestWindowsWakeCloseBalancesSuccessfulSetup(t *testing.T) {
+	fake := &fakeWindowsWakeOps{}
+	wake, err := newWindowsNetworkWake(fake.boundary())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wake.close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.created) != 2 || len(fake.closed) != 2 {
+		t.Fatalf("created=%v closed=%v, want two each", fake.created, fake.closed)
+	}
+	requireBalancedWindowsWakeHandles(t, fake.created, fake.closed)
+}
+
+func TestWindowsWakeTreatsWouldBlockAsAlreadySignaled(t *testing.T) {
+	fake := &fakeWindowsWakeOps{}
+	ops := fake.boundary()
+	ops.sendto = func(windows.Handle, []byte, int, windows.Sockaddr) error {
+		return windows.WSAEWOULDBLOCK
+	}
+	wake, err := newWindowsNetworkWake(ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = wake.close() })
+	if err := wake.signal(); err != nil {
+		t.Fatalf("signal error=%v, want nil", err)
+	}
+}
+
+func TestWSAPollLoopbackResetPreservesPendingSocketError(t *testing.T) {
+	machine := New()
+	_, client, server := setupAcceptedLoopback(t, machine)
+
+	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientResource, exists := machine.shared.Sockets.get(clientHandle)
+	if !exists {
+		t.Fatalf("client descriptor %d is not registered", clientHandle)
+	}
+	clientResource.stateMu.Lock()
+	peer, ok := clientResource.connection.(*net.TCPConn)
+	clientResource.stateMu.Unlock()
+	if !ok {
+		t.Fatalf("peer connection=%T, want *net.TCPConn", clientResource.connection)
+	}
+	if err := peer.SetLinger(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := peer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	poller := networkPoller{platform: systemNetworkPlatform(), now: time.Now, sleep: time.Sleep}
+	sets := [3]*value.ObjArray{
+		{Elements: []value.Value{server}},
+		{Elements: []value.Value{server}},
+		{Elements: []value.Value{server}},
+	}
+	type pollResult struct {
+		value value.Value
+		err   error
+	}
+	result := make(chan pollResult, 1)
+	go func() {
+		selected, err := poller.Poll(machine.shared, sets, time.Second)
+		result <- pollResult{value: selected, err: err}
+	}()
+	var selected value.Value
+	select {
+	case outcome := <-result:
+		if outcome.err != nil {
+			t.Fatal(outcome.err)
+		}
+		selected = outcome.value
+	case <-time.After(time.Second):
+		t.Fatal("WSAPoll did not report loopback RST within one second")
+	}
+	assertBuiltinValue(t, builtinMapField(t, selected, "error_count"), value.NewInt(1))
+
+	received := callBuiltinWithinBound(t, machine, "net_recv", server, value.NewInt(1))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(false))
+	message := builtinMapField(t, received, "error").String()
+	if message == "" || strings.Contains(strings.ToLower(message), "timeout") {
+		t.Fatalf("net_recv error=%q, want non-timeout connection error", message)
+	}
+}

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -100,17 +100,15 @@ func (resource *FileResource) close() error {
 }
 
 type ListenerResource struct {
-	stateMu             sync.Mutex
-	deadlineMu          sync.Mutex
-	acceptMu            sync.Mutex
-	listener            deadlineListener
-	bufferedAccept      net.Conn
-	ioTimeout           time.Duration
-	acceptProbeDeadline time.Time
-	lastAcceptDeadline  time.Time
-	deadlineGeneration  uint64
-	closed              bool
-	pollWaiters         map[*networkWake]struct{}
+	stateMu            sync.Mutex
+	deadlineMu         sync.Mutex
+	acceptMu           sync.Mutex
+	listener           deadlineListener
+	ioTimeout          time.Duration
+	lastAcceptDeadline time.Time
+	deadlineGeneration uint64
+	closed             bool
+	pollWaiters        map[*networkWake]struct{}
 }
 
 type SocketResource struct {
@@ -119,9 +117,7 @@ type SocketResource struct {
 	readMu             sync.Mutex
 	writeMu            sync.Mutex
 	connection         net.Conn
-	bufferedRead       []byte
 	ioTimeout          time.Duration
-	readProbeDeadline  time.Time
 	lastReadDeadline   time.Time
 	lastWriteDeadline  time.Time
 	deadlineGeneration uint64
@@ -136,7 +132,6 @@ type detachedSocket struct {
 
 type detachedListener struct {
 	listener deadlineListener
-	buffered net.Conn
 	waiters  []*networkWake
 }
 
@@ -159,8 +154,6 @@ func detachSocketLocked(resource *SocketResource) (detachedSocket, bool) {
 		waiters:    takeNetworkWaiters(resource.pollWaiters),
 	}
 	resource.connection = nil
-	resource.bufferedRead = nil
-	resource.readProbeDeadline = time.Time{}
 	resource.pollWaiters = nil
 	return detached, true
 }
@@ -173,12 +166,9 @@ func detachListenerLocked(resource *ListenerResource) (detachedListener, bool) {
 	resource.deadlineGeneration++
 	detached := detachedListener{
 		listener: resource.listener,
-		buffered: resource.bufferedAccept,
 		waiters:  takeNetworkWaiters(resource.pollWaiters),
 	}
 	resource.listener = nil
-	resource.bufferedAccept = nil
-	resource.acceptProbeDeadline = time.Time{}
 	resource.pollWaiters = nil
 	return detached, true
 }
@@ -199,7 +189,7 @@ func finishSocketDetach(detached detachedSocket) error {
 }
 
 func finishListenerDetach(detached detachedListener) error {
-	errs := make([]error, 0, len(detached.waiters)+2)
+	errs := make([]error, 0, len(detached.waiters)+1)
 	for _, waiter := range detached.waiters {
 		if err := waiter.Signal(); err != nil {
 			errs = append(errs, err)
@@ -207,11 +197,6 @@ func finishListenerDetach(detached detachedListener) error {
 	}
 	if detached.listener != nil {
 		if err := detached.listener.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if detached.buffered != nil {
-		if err := detached.buffered.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/vm/resources.go
+++ b/internal/vm/resources.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"database/sql"
+	"errors"
 	"net"
 	"os"
 	"sync"
@@ -109,6 +110,7 @@ type ListenerResource struct {
 	lastAcceptDeadline  time.Time
 	deadlineGeneration  uint64
 	closed              bool
+	pollWaiters         map[*networkWake]struct{}
 }
 
 type SocketResource struct {
@@ -124,6 +126,96 @@ type SocketResource struct {
 	lastWriteDeadline  time.Time
 	deadlineGeneration uint64
 	closed             bool
+	pollWaiters        map[*networkWake]struct{}
+}
+
+type detachedSocket struct {
+	connection net.Conn
+	waiters    []*networkWake
+}
+
+type detachedListener struct {
+	listener deadlineListener
+	buffered net.Conn
+	waiters  []*networkWake
+}
+
+func takeNetworkWaiters(waiters map[*networkWake]struct{}) []*networkWake {
+	result := make([]*networkWake, 0, len(waiters))
+	for waiter := range waiters {
+		result = append(result, waiter)
+	}
+	return result
+}
+
+func detachSocketLocked(resource *SocketResource) (detachedSocket, bool) {
+	if resource.closed {
+		return detachedSocket{}, false
+	}
+	resource.closed = true
+	resource.deadlineGeneration++
+	detached := detachedSocket{
+		connection: resource.connection,
+		waiters:    takeNetworkWaiters(resource.pollWaiters),
+	}
+	resource.connection = nil
+	resource.bufferedRead = nil
+	resource.readProbeDeadline = time.Time{}
+	resource.pollWaiters = nil
+	return detached, true
+}
+
+func detachListenerLocked(resource *ListenerResource) (detachedListener, bool) {
+	if resource.closed {
+		return detachedListener{}, false
+	}
+	resource.closed = true
+	resource.deadlineGeneration++
+	detached := detachedListener{
+		listener: resource.listener,
+		buffered: resource.bufferedAccept,
+		waiters:  takeNetworkWaiters(resource.pollWaiters),
+	}
+	resource.listener = nil
+	resource.bufferedAccept = nil
+	resource.acceptProbeDeadline = time.Time{}
+	resource.pollWaiters = nil
+	return detached, true
+}
+
+func finishSocketDetach(detached detachedSocket) error {
+	errs := make([]error, 0, len(detached.waiters)+1)
+	for _, waiter := range detached.waiters {
+		if err := waiter.Signal(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if detached.connection != nil {
+		if err := detached.connection.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func finishListenerDetach(detached detachedListener) error {
+	errs := make([]error, 0, len(detached.waiters)+2)
+	for _, waiter := range detached.waiters {
+		if err := waiter.Signal(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if detached.listener != nil {
+		if err := detached.listener.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if detached.buffered != nil {
+		if err := detached.buffered.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 type DatabaseResource struct {

--- a/noxy_examples/network_poller.nx
+++ b/noxy_examples/network_poller.nx
@@ -1,0 +1,102 @@
+use net
+use sys select exit
+
+func assert(condition: bool, message: string) -> void
+    if !condition then
+        print("network poller: FAIL - " + message)
+        exit(1)
+    end
+end
+
+func fail_listener(listener: net.Socket, message: string) -> void
+    net.socket_close(listener)
+    assert(false, message)
+end
+
+func fail_pair(listener: net.Socket, client: net.Socket, message: string) -> void
+    net.socket_close(client)
+    net.socket_close(listener)
+    assert(false, message)
+end
+
+func fail_all(listener: net.Socket, client: net.Socket, server: net.Socket, message: string) -> void
+    net.socket_close(server)
+    net.socket_close(client)
+    net.socket_close(listener)
+    assert(false, message)
+end
+
+func main() -> void
+    // Use an unprivileged dynamic-range port on loopback to reduce collisions.
+    let host: string = "127.0.0.1"
+    let port: int = 49197
+    let listener: net.Socket = net.listen(host, port)
+    assert(listener.open, "listener must open")
+    net.settimeout(listener, 500)
+
+    let listener_read: net.Socket[64] = net.socket_set()
+    let empty_write: net.Socket[64] = net.socket_set()
+    let empty_error: net.Socket[64] = net.socket_set()
+    listener_read[0] = listener
+
+    let before_connect: net.SelectResult = net.poll(listener_read, empty_write, empty_error, 0)
+    if before_connect.read_count != 0 then
+        fail_listener(listener, "listener must not be readable before connect")
+    end
+
+    let client: net.Socket = net.connect(host, port)
+    if !client.open then
+        fail_listener(listener, "client must connect")
+    end
+    net.settimeout(client, 500)
+
+    let after_connect: net.SelectResult = net.poll(listener_read, empty_write, empty_error, 0)
+    if after_connect.read_count != 1 || after_connect.read[0].fd != listener.fd then
+        fail_pair(listener, client, "listener must be immediately readable after connect")
+    end
+
+    let server: net.Socket = net.accept(listener)
+    if !server.open then
+        fail_pair(listener, client, "listener must accept the pending connection")
+    end
+    net.settimeout(server, 500)
+
+    let empty_read: net.Socket[64] = net.socket_set()
+    let client_write: net.Socket[64] = net.socket_set()
+    client_write[0] = client
+    let writable: net.SelectResult = net.poll(empty_read, client_write, empty_error, 250)
+    if writable.write_count != 1 || writable.write[0].fd != client.fd then
+        fail_all(listener, client, server, "connected client must become writable")
+    end
+
+    let payload: bytes = to_bytes("poll-data")
+    let sent: net.NetResult = net.socket_send(client, payload)
+    if !sent.ok || sent.count != 9 then
+        fail_all(listener, client, server, "client must send all poll-data bytes")
+    end
+
+    let server_read: net.Socket[64] = net.socket_set()
+    server_read[0] = server
+    let first_read: net.SelectResult = net.poll(server_read, empty_write, empty_error, 250)
+    if first_read.read_count != 1 || first_read.read[0].fd != server.fd then
+        fail_all(listener, client, server, "server must report the pending data")
+    end
+
+    // Polling is non-consuming: the unread bytes remain ready on the next call.
+    let second_read: net.SelectResult = net.poll(server_read, empty_write, empty_error, 250)
+    if second_read.read_count != 1 || second_read.read[0].fd != server.fd then
+        fail_all(listener, client, server, "repeated poll must preserve unread data")
+    end
+
+    let received: net.NetResult = net.socket_recv(server, 64)
+    if !received.ok || received.count != 9 || received.data != payload then
+        fail_all(listener, client, server, "server must receive exactly poll-data")
+    end
+
+    net.socket_close(server)
+    net.socket_close(client)
+    net.socket_close(listener)
+    print("network poller: PASS")
+end
+
+main()

--- a/noxy_examples/network_poller.nx
+++ b/noxy_examples/network_poller.nx
@@ -27,11 +27,11 @@ func fail_all(listener: net.Socket, client: net.Socket, server: net.Socket, mess
 end
 
 func main() -> void
-    // Use an unprivileged dynamic-range port on loopback to reduce collisions.
+    // Let the OS choose an available loopback port and use the bound port returned by net.listen.
     let host: string = "127.0.0.1"
-    let port: int = 49197
-    let listener: net.Socket = net.listen(host, port)
+    let listener: net.Socket = net.listen(host, 0)
     assert(listener.open, "listener must open")
+    assert(listener.port > 0, "listener must report its assigned port")
     net.settimeout(listener, 500)
 
     let listener_read: net.Socket[64] = net.socket_set()
@@ -44,7 +44,7 @@ func main() -> void
         fail_listener(listener, "listener must not be readable before connect")
     end
 
-    let client: net.Socket = net.connect(host, port)
+    let client: net.Socket = net.connect(host, listener.port)
     if !client.open then
         fail_listener(listener, "client must connect")
     end


### PR DESCRIPTION
## Resumo

Implementa a etapa `feat/network-poller` da evolução da linguagem, cobrindo os pontos 5, 6, 7 e 8 do plano:

- substitui o polling consumidor por readiness nativa sem `Read`, `Accept`, peek ou consulta destrutiva de erro;
- implementa `timeout=0` realmente imediato e um único deadline global para toda a operação;
- expõe conjuntos independentes de leitura, escrita e erro, cada um com 64 posições, ordem e duplicatas preservadas;
- adiciona backends específicos: `WSAPoll` no Windows e `poll(2)` no Unix, além de fallback explícito para plataformas não suportadas;
- define e documenta EOF, hangup, erro terminal/pending e coexistência com dados legíveis;
- acorda polls concorrentes em close local, inclusive nos caminhos de falha permanente do wake;
- faz `net.listen(host, 0)` retornar a porta atribuída pelo SO, permitindo exemplos loopback sem colisão.

A implementação segue como referência o modelo de readiness e deadline global da biblioteca de rede do Go, preservando as escolhas de tipo e compatibilidade da Noxy.

## Impacto

`net.poll` deixa de consumir dados ou conexões pendentes. Código existente continua usando `SelectResult`, mas agora recebe readiness portátil e previsível para leitura, escrita e erro. `net.setblocking(sock, false)` permanece como no-op deprecated de compatibilidade.

## Validação local (Windows)

- `go test ./internal/... -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s`
- regressões de fechamento/setup executadas 50 vezes
- `noxy_examples/network_poller.nx`: PASS
- runner Noxy: 160/160 PASS
- revisão independente final: aprovada sem findings residuais

Cross-build completo passou para Linux, Darwin e FreeBSD. Os backends/testes do poller compilam também para DragonFly, NetBSD, OpenBSD, Solaris e AIX; o build completo desses cinco targets continua bloqueado antes do poller pelo grafo preexistente de `modernc.org/sqlite/libc`.

## Orientação obrigatória para validar em Linux

Este host de desenvolvimento é Windows e não possui WSL. Antes de promover o PR de draft, validar em Ubuntu/Linux real:

```bash
go test ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=120s
go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s
go test ./internal/... -count=1
go run cmd/noxy/main.go noxy_examples/network_poller.nx
```

Confirmar especialmente os testes Linux de `POLLIN|POLLRDHUP`, dados legíveis coexistindo com hangup/error, RST com erro ainda pendente em `net_recv`, close concorrente e wake. O workflow **Network semantics** executa esses gates em `ubuntu-latest` e `windows-latest`.
