### PR TITLE
feat/fix-repl-data-input - REPL não congela mais com raw mode vazado no Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@
 
 ### Fixed
 
+- **REPL e `input()` congelavam em terminais com raw mode vazado no Windows.**
+  O modo de entrada do console é estado compartilhado do terminal: quando um
+  programa em raw mode (ex.: um jogo via `noxy-plugin-terminal`) morria sem
+  restaurar, `ENABLE_LINE_INPUT`/`ENABLE_ECHO_INPUT` ficavam desligados e o
+  próximo REPL naquele terminal mostrava `>>> ` mas nunca recebia a linha —
+  digitação invisível, Enter sem efeito, "resolvia" só abrindo outro terminal
+  (o PowerShell mascara o problema porque o PSReadLine redefine o modo a cada
+  prompt). Agora `internal/console.EnsureLineInput` normaliza o modo do console
+  antes de cada prompt do REPL e de cada `input()`.
 - Normal returns and runtime failures now share safe frame unwinding, preserving primary errors while collecting observable cleanup failures.
 - `net.setblocking(sock, true)` now restores indefinite blocking, while the deprecated `false` branch remains a compatibility no-op.
 - `net.poll`/`net_select` now reports non-consuming readiness through independent 64-entry read, write, and error sets, with immediate zero-time polls, one global positive timeout, portable EOF/hangup projection, and concurrent-close wakeups that omit detached resources.

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/console"
 	"noxy-vm/internal/lexer"
 	"noxy-vm/internal/parser"
 	"noxy-vm/internal/pkgmanager"
@@ -97,6 +98,10 @@ func startREPL(showDisasm bool) {
 	var inputBuffer string
 
 	for {
+		// A crashed raw-mode program (e.g. a terminal game) leaves the shared
+		// console without line input or echo, which would freeze Scan below.
+		console.EnsureLineInput()
+
 		if inputBuffer == "" {
 			fmt.Print(">>> ")
 		} else {

--- a/internal/console/console_other.go
+++ b/internal/console/console_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package console
+
+// EnsureLineInput is a no-op outside Windows: POSIX terminal state is managed
+// per-descriptor via termios and the shell restores it between commands.
+func EnsureLineInput() {}

--- a/internal/console/console_windows.go
+++ b/internal/console/console_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+// Package console normalizes shared terminal state that other processes may
+// have corrupted. On Windows the console input mode belongs to the console,
+// not to the process: when a program enables raw mode (x/term.MakeRaw clears
+// ENABLE_LINE_INPUT, ENABLE_ECHO_INPUT and ENABLE_PROCESSED_INPUT and sets
+// ENABLE_VIRTUAL_TERMINAL_INPUT) and dies without restoring, every later
+// process in that terminal inherits the raw mode. A line-oriented reader then
+// blocks forever: keystrokes arrive unassembled, without echo, and Enter
+// yields '\r' with no '\n'. Shells such as PSReadLine reset the mode at every
+// prompt, which hides the corruption until a program like the noxy REPL reads
+// stdin directly.
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const cookedInputFlags = windows.ENABLE_PROCESSED_INPUT |
+	windows.ENABLE_LINE_INPUT |
+	windows.ENABLE_ECHO_INPUT
+
+// EnsureLineInput makes the process's stdin console usable for line-oriented
+// reads, repairing a raw mode leaked by a crashed program. It is a no-op when
+// stdin is not a Windows console (pipe, file, MSYS terminal).
+func EnsureLineInput() {
+	ensureLineInputMode(windows.Handle(os.Stdin.Fd()))
+}
+
+func ensureLineInputMode(handle windows.Handle) error {
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return err
+	}
+	want := (mode | cookedInputFlags) &^ windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	if want == mode {
+		return nil
+	}
+	return windows.SetConsoleMode(handle, want)
+}

--- a/internal/console/console_windows_test.go
+++ b/internal/console/console_windows_test.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package console
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestEnsureLineInputRepairsLeakedRawMode re-runs the test binary with
+// CREATE_NO_WINDOW so the child owns a fresh console, poisons that console
+// with the exact mode x/term.MakeRaw leaves behind, and verifies
+// ensureLineInputMode restores a line-readable mode. The helper below does the
+// console work; this parent only asserts on its output.
+func TestEnsureLineInputRepairsLeakedRawMode(t *testing.T) {
+	if os.Getenv("NOXY_CONSOLE_TEST_HELPER") == "1" {
+		t.Skip("helper invocation")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestConsoleModeHelper", "-test.v")
+	cmd.Env = append(os.Environ(), "NOXY_CONSOLE_TEST_HELPER=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper process failed: %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "CONSOLE_MODE_REPAIRED") {
+		t.Fatalf("helper did not confirm repair; output:\n%s", out)
+	}
+}
+
+func TestConsoleModeHelper(t *testing.T) {
+	if os.Getenv("NOXY_CONSOLE_TEST_HELPER") != "1" {
+		t.Skip("only runs as helper subprocess")
+	}
+
+	conin, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open CONIN$: %v", err)
+	}
+	defer conin.Close()
+	handle := windows.Handle(conin.Fd())
+
+	var original uint32
+	if err := windows.GetConsoleMode(handle, &original); err != nil {
+		t.Fatalf("GetConsoleMode: %v", err)
+	}
+
+	leaked := original &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT)
+	leaked |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	if err := windows.SetConsoleMode(handle, leaked); err != nil {
+		t.Fatalf("SetConsoleMode(leaked): %v", err)
+	}
+
+	if err := ensureLineInputMode(handle); err != nil {
+		t.Fatalf("ensureLineInputMode: %v", err)
+	}
+
+	var repaired uint32
+	if err := windows.GetConsoleMode(handle, &repaired); err != nil {
+		t.Fatalf("GetConsoleMode after repair: %v", err)
+	}
+	if repaired&cookedInputFlags != cookedInputFlags {
+		t.Fatalf("cooked flags missing: mode=%#x", repaired)
+	}
+	if repaired&windows.ENABLE_VIRTUAL_TERMINAL_INPUT != 0 {
+		t.Fatalf("virtual terminal input still set: mode=%#x", repaired)
+	}
+	t.Log("CONSOLE_MODE_REPAIRED")
+}

--- a/internal/vm/builtins_io.go
+++ b/internal/vm/builtins_io.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"noxy-vm/internal/console"
 	"noxy-vm/internal/value"
 )
 
@@ -338,6 +339,9 @@ func (vm *VM) defineIOBuiltins() {
 		return value.NewBool(os.MkdirAll(args[0].String(), 0755) == nil)
 	})
 	vm.DefineNative("input", func(args []value.Value) value.Value {
+		// Repair a raw console mode leaked by a crashed program before a
+		// line-oriented read, which would otherwise block forever.
+		console.EnsureLineInput()
 		if len(args) > 0 {
 			fmt.Print(args[0].String())
 		}

--- a/noxy_examples/run_all_tests.nx
+++ b/noxy_examples/run_all_tests.nx
@@ -36,7 +36,7 @@ func should_ignore(s: string) -> bool
     "simple_server.nx", "web_app.nx", "http_server_basic.nx", "http_server_docs.nx", 
     "form_app.nx", "http_server_sockets.nx", "todo_app2.nx", "todo_app.nx", "cadastro_usuarios.nx", "md2html.nx",
     "watch_file.nx", "stress_test.nx", "division_error.nx", "error_type.nx", "error_arity.nx", "test_let_error.nx", "error_index.nx", "to_int_conversion_demo.nx",
-    "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "space_invaders.nx", "space_invaders2.nx"]
+    "test_let_error_function.nx", "test_unclosed.nx", "benchmark_parallel.nx", "concurrency.nx", "concurrency_parallel_sum.nx", "concurrency_producer_consumer.nx", "space_invaders.nx", "space_invaders2.nx", "signal_demo.nx"]
     if contains(exclusions, s) then
          return true
     end


### PR DESCRIPTION
## Summary
- Corrige o congelamento intermitente do REPL no Windows: o modo de entrada do console é estado compartilhado do terminal, e um programa raw-mode que morre sem restaurar (ex.: jogo via `noxy-plugin-terminal`, que chama `term.MakeRaw` no `CONIN$`) deixava o terminal sem `ENABLE_LINE_INPUT`/`ENABLE_ECHO_INPUT` — o REPL mostrava `>>> ` mas o `bufio.Scanner` nunca via um `\n` (digitação sem echo, Enter produz só `\r`)
- O PSReadLine redefine o modo a cada prompt, por isso o PowerShell continuava funcionando e só o noxy parecia travado até abrir um terminal novo
- Novo `internal/console.EnsureLineInput()` religa os flags cooked e desliga `ENABLE_VIRTUAL_TERMINAL_INPUT` quando stdin é um console Windows (no-op para pipes/arquivos e fora do Windows), chamado antes de cada prompt do REPL e de cada `input()`
- Exclui `signal_demo.nx` do `run_all_tests.nx`: o demo espera Ctrl+C humano e engole encerramento via `signal.Notify`, travando execuções automatizadas para sempre e vazando processos noxy zumbis (três foram encontrados vivos após 10+ horas)

## Components
- `internal/console/console_windows.go` — novo pacote com `EnsureLineInput()` e o core `ensureLineInputMode(handle)` via `golang.org/x/sys/windows` (dependência direta já existente)
- `internal/console/console_other.go` — no-op fora do Windows
- `internal/console/console_windows_test.go` — teste de regressão que envenena e repara um console próprio em subprocesso (`CREATE_NO_WINDOW`), sem tocar o terminal do desenvolvedor
- `cmd/noxy/main.go` — `EnsureLineInput()` antes de cada prompt do REPL (cobre também jogos executados dentro da sessão)
- `internal/vm/builtins_io.go` — `EnsureLineInput()` no builtin `input()`
- `noxy_examples/run_all_tests.nx` — `signal_demo.nx` adicionado às exclusões (o runner concorrente já excluía)
- `CHANGELOG.md` — entrada em Unreleased/Fixed

## Test Plan
- [x] Reprodução mecânica RED→GREEN: harness cria console oculto, injeta o estado exato que `MakeRaw` vaza, roda o REPL e digita `40+2` via `WriteConsoleInput` — binário antigo nunca responde, binário corrigido responde `42`
- [x] Console de controle limpo responde nos dois binários (valida o harness)
- [x] `go test ./internal/console -count=1` passa (subprocesso com console próprio)
- [x] Suíte completa `go test ./...` verde
- [x] `go vet` nos pacotes alterados
- [ ] Validação manual: reproduzir um terminal envenenado (matar um jogo raw-mode no meio) e confirmar que o REPL novo aceita input

🤖 Generated with [Claude Code](https://claude.com/claude-code)