### PR TITLE
fix/cow-readonly-natives - has_key e keys não tornam mais quadrática a escrita seguinte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `has_key` e `keys` entraram na allowlist de natives só-leitura do CoW
+  (`internal/vm/cow_natives.go`). Sem elas, passar um map para qualquer um dos
+  dois o marcava `Shared` e a mutação seguinte clonava a estrutura inteira —
+  o padrão ler-antes-de-escrever (o laço normal de banco/cache/índice) ficava
+  O(N²). Medido no repro: `has_key`+`put` a N=5000 caiu de 5.807ms para 15ms,
+  agora linear e igual à leitura por índice. Regressão ancorada no contador de
+  clones (`TestHasKeyThenWriteDoesNotClone`, `TestKeysThenWriteDoesNotClone`),
+  com caso negativo garantindo o default conservador para natives fora da
+  allowlist (`TestUnlistedNativeStillMarksArgs`).
+
 ## [0.4.0] - 2026-08-16
 
 ### Changed (BREAKING) — Semântica de valor com copy-on-write

--- a/internal/vm/cow_natives.go
+++ b/internal/vm/cow_natives.go
@@ -23,4 +23,6 @@ var readonlyNatives = map[string]bool{
 	"typeof":      true,
 	"chan_recv":   true, // recebe o canal; o payload foi marcado no send
 	"test_report": true, // harness de teste: apenas observa
+	"has_key":     true, // só consulta o mapa; devolve bool novo
+	"keys":        true, // Snapshot + array novo; não compartilha estrutura
 }

--- a/internal/vm/value_semantics_test.go
+++ b/internal/vm/value_semantics_test.go
@@ -239,6 +239,85 @@ main()
 	}
 }
 
+// vmWithCloneReset devolve uma VM com o native de teste test_reset_clones,
+// para zerar o contador de clones depois do setup do programa.
+func vmWithCloneReset() *VM {
+	machine := New()
+	machine.DefineNative("test_reset_clones", func(args []value.Value) value.Value {
+		ResetCloneCount()
+		return value.NewNull()
+	})
+	return machine
+}
+
+func TestHasKeyThenWriteDoesNotClone(t *testing.T) {
+	machine := vmWithCloneReset()
+	if err := interpretVMSource(t, machine, `
+func main()
+    let m: map[string, string] = {}
+    test_reset_clones()
+    let i: int = 0
+    while i < 20 do
+        let e: bool = has_key(m, "key:" + to_str(i))
+        m["key:" + to_str(i)] = "v"
+        i = i + 1
+    end
+end
+main()
+`); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if n := CloneCountValue(); n != 0 {
+		t.Fatalf("has_key intercalado com escrita deveria custar 0 clones, veio %d", n)
+	}
+}
+
+func TestKeysThenWriteDoesNotClone(t *testing.T) {
+	machine := vmWithCloneReset()
+	if err := interpretVMSource(t, machine, `
+func main()
+    let m: map[string, string] = {}
+    test_reset_clones()
+    let i: int = 0
+    while i < 20 do
+        let ks: string[] = keys(m)
+        m["key:" + to_str(i)] = "v"
+        i = i + 1
+    end
+end
+main()
+`); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if n := CloneCountValue(); n != 0 {
+		t.Fatalf("keys intercalado com escrita deveria custar 0 clones, veio %d", n)
+	}
+}
+
+// Caso negativo: native sem assinatura fora da allowlist tem que continuar
+// marcando os args (default conservador) — a escrita seguinte deve clonar.
+func TestUnlistedNativeStillMarksArgs(t *testing.T) {
+	machine := vmWithCloneReset()
+	machine.DefineNative("test_observe", func(args []value.Value) value.Value {
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, `
+func main()
+    let m: map[string, string] = {}
+    m["a"] = "1"
+    test_reset_clones()
+    test_observe(m)
+    m["b"] = "2"
+end
+main()
+`); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if n := CloneCountValue(); n != 1 {
+		t.Fatalf("native fora da allowlist deve marcar o arg: escrita seguinte deveria clonar 1x, veio %d", n)
+	}
+}
+
 func TestChanSendDeliversIndependentValue(t *testing.T) {
 	got := captureVMSource(t, `
 func main()


### PR DESCRIPTION
## Summary
- Adiciona `has_key` e `keys` à allowlist `readonlyNatives` de `internal/vm/cow_natives.go`, após auditoria dos corpos Go: nenhum dos dois retém ou muta o argumento (`has_key` faz uma consulta e devolve bool novo; `keys` lê via `Snapshot()` e monta um array novo sem compartilhar estrutura com o map).
- Sem a allowlist, passar um map para qualquer um dos dois o marcava `Shared` (default conservador de native sem assinatura), e a **próxima mutação** clonava a estrutura inteira — o padrão ler-antes-de-escrever (o laço normal de qualquer banco, cache ou índice) ficava O(N²).
- Medido no repro do relatório (Windows 11, mesmo laço variando só a leitura intercalada), N=5000:

| padrão do laço | antes | depois |
|---|---:|---:|
| só `put` | 11 ms | 12 ms |
| índice + `put` | 14 ms | 12 ms |
| `has_key` + `put` | **5.807 ms** | **15 ms** |
| `keys` + `put` | 7.863 ms | 2.412 ms |

- `has_key`+`put` volta a ser linear (4→6→15 ms dobrando N) e indistinguível da leitura por índice. O laço com `keys` continua superlinear em tempo de parede por custo inerente do native (materializa O(k) chaves por chamada) — o clone CoW relatado sumiu (contador assere 0).
- Impacto prático: no NoxyDB, `get`/`remove`/`exists` e o `replay` do log de abertura usam `has_key` no caminho quente — o `replay` deixava a abertura do banco quadrática no tamanho do log.
- Natives **com** assinatura (`delete`, `append`, …) tomam o branch `Signature != nil` em `calls.go` e nem consultam a allowlist — ela estruturalmente não alcança natives mutantes.
- Fila de auditoria para entradas futuras (não incluídas, não auditadas): `json_dumps` (maior impacto — serializar antes de gravar é ler-depois-escrever), `contains`, `print`/`iprint`; `slice` exige checar compartilhamento de backing store; `net_send`, retenção do buffer.

## Components
- `internal/vm/cow_natives.go` — duas entradas novas na allowlist `readonlyNatives`, com o critério de auditoria no comentário
- `internal/vm/value_semantics_test.go` — `TestHasKeyThenWriteDoesNotClone` e `TestKeysThenWriteDoesNotClone` (asserem 0 clones no laço leitura+escrita; falhavam com 20 antes da correção), `TestUnlistedNativeStillMarksArgs` (caso negativo: native fora da allowlist continua marcando e a escrita seguinte clona 1x) e helper `vmWithCloneReset`
- `CHANGELOG.md` — entrada em `[Unreleased]` / Fixed

## Test Plan
- [x] Testes de regressão vistos falhando antes da correção (TDD: 20 clones → 0)
- [x] `go test ./...` completo verde
- [x] `go vet` limpo
- [x] Repro do relatório re-medido com o binário rebuildado (N=1250/2500/5000, tabela acima)
- [x] Validar no workload real do NoxyDB (refactor v0.4.0 em andamento)

🤖 Generated with [Claude Code](https://claude.com/claude-code)