### PR TITLE
fix/pages-exclude-superpowers - Build do GitHub Pages quebrado por Liquid nos planos internos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- Build do GitHub Pages voltou a passar: `superpowers/` entrou no `exclude:`
+  do Jekyll (`docs/_config.yml`). Os planos internos em
+  `docs/superpowers/plans` contêm literais de struct no estilo Go (`{{...}}`)
+  que o Liquid interpretava como variável não terminada, derrubando o build
+  (`Liquid::SyntaxError` em `2026-08-14-runtime-defer-unwind.md:308`). Os
+  documentos continuam no repositório; apenas saem do site publicado.
+
 - `has_key` e `keys` entraram na allowlist de natives só-leitura do CoW
   (`internal/vm/cow_natives.go`). Sem elas, passar um map para qualquer um dos
   dois o marcava `Shared` e a mutação seguinte clonava a estrutura inteira —

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,6 +20,7 @@ exclude:
   - Gemfile.lock
   - node_modules
   - vendor
+  - superpowers
 
 # SEO settings
 author: "Noxy Team"


### PR DESCRIPTION
@
## Summary
- Adiciona `superpowers` ao `exclude:` do Jekyll em `docs/_config.yml`, tirando os planos/specs internos do build do GitHub Pages.
- Root cause: `docs/superpowers/plans/2026-08-14-runtime-defer-unwind.md` (linha 308) contém o literal Go `{{Registration: SourceLocation{...}`, que o Liquid interpreta como variável `{{ }}` não terminada e aborta o build com `Liquid::SyntaxError` (run 31972299687). Outros planos já geravam warnings de Liquid pelo mesmo motivo.
- A exclusão cobre o diretório inteiro, então novos planos com `{{...}}` não voltam a quebrar o site. Os arquivos continuam versionados no repositório — só deixam de ser renderizados/publicados.

## Components
- Docs: `docs/_config.yml` (lista `exclude:` do Jekyll)
- Docs: `CHANGELOG.md` (entrada em Unreleased/Fixed)

## Test Plan
- [x] Root cause extraído do log do Actions (`Liquid::SyntaxError` fatal no plano de defer unwind)
- [x] Verificado que todas as ocorrências de `{{` em `docs/` estão sob `docs/superpowers/plans/` — nenhum outro arquivo do site em risco
- [ ] Build "pages build and deployment" verde após o merge chegar ao `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@