### PR TITLE
docs/update-benchmark-results - RESULTS.md registra a validação O(1) pela tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
   `internal/vm/runtime_type_validation_test.go` (confiança na tag, primeira
   marcação ainda varre, conflito rejeitado).
 
+### Changed
+
+- `benchmarks/RESULTS.md` virou registro corrido de comparações (mais recente
+  primeiro): ganhou a seção da validação O(1) pela tag (PR #31) com a tabela
+  intercalada develop × candidato — `bench_call_light` −97,1%,
+  `bench_typed_call_map` −94,3% (mediana de 5 intercaladas), `share_mutate`
+  −65,7%, sem regressões — e o "achado colateral" da seção CoW foi anotado
+  como resolvido, apontando para a seção nova.
+
 ### Added
 
 - `docs/SHOWCASE.md`: vitrine dos projetos reais escritos em Noxy, começando

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,56 @@
-# Benchmarks: baseline (0.3.0, c429bd7) × CoW (feat/cow-value-semantics)
+# Benchmarks
+
+Registro corrido das comparações de performance, mais recente primeiro. Cada
+seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
+
+## develop (c0a89c9) × validação O(1) pela tag `RuntimeType` (PR #31)
+
+**Data:** 2026-08-16/17 · Windows 11 · medições intercaladas (mediana de 5),
+mesma máquina e protocolo da seção CoW abaixo.
+
+**Checksums idênticos em todos os benchmarks; corpus de exemplos 130/130 com
+saídas iguais** — as duas versões computam os mesmos resultados.
+
+| bench | perfil | develop_ms | o1_ms | delta | veredito |
+|---|---|---|---|---|---|
+| bench_call_light | chamada O(1), array 10k por valor | 4269 | 122 | **−97,1%** | ✅ |
+| bench_typed_call_map¹ | chamada tipada in-module, map 2,5k via ref | 2156 | 123 | **−94,3%** | ✅ |
+| bench_share_mutate | compartilha e muta em loop | 1105 | 379 | **−65,7%** | ✅ |
+| bench_call_readonly | leitor puro O(n), array 20k | 2815 | 2529 | −10,2% | ✅ |
+| bench_call_ref | mutação in-place via ref | 7287 | 6898 | −5,3% | ✅ |
+| bench_map_churn | escrita intensa em map | 692 | 665 | −3,9% | ✅ |
+| bench_bubblesort | sort in-place via ref | 7258 | 6988 | −3,7% | ✅ |
+| bench_conway | grid mutado via ref, 60 gerações | 4374 | 4270 | −2,4% | ✅ |
+| bench_path_update | `a[i].x = v` em loop, dono único | 977 | 960 | −1,8% | ✅ |
+| bench_spawn_sum | soma paralela via spawn_task | 1395 | 1411 | +1,1% | ✅ ruído |
+
+¹ Benchmark novo, adicionado junto com a mudança: ancora o padrão que motivou
+o trabalho (função tipada do mesmo módulo recebendo `ref` para struct com map
+grande, chamada em laço de mutação — o formato do put/get do NoxyDB).
+
+### Interpretação
+
+A validação de tipos em runtime varria o contêiner inteiro do argumento a
+cada chamada com assinatura estaticamente conhecida — duas vezes (prova +
+aplicação), inclusive através de `ref` e em funções que só leem. Isso tornava
+O(N²) qualquer laço quente que passasse um map/array grande para função tipada
+do mesmo módulo, e era o custo que mascarava o ganho do `ref` no NoxyDB: com
+o CoW corrigido, o laço de puts continuava quadrático só pela varredura. Com
+a tag `RuntimeType` aceita valendo como prova em O(1), o padrão vira linear —
+no repro do NoxyDB (N=4000 puts), de 6.715ms para 157ms.
+
+Onde o ganho aparece: quanto maior o contêiner e mais quente o laço de
+chamadas tipadas, maior o corte (`call_light` −97%, `typed_call_map` −94%).
+`share_mutate`, o pior caso documentado do CoW, caiu 66% porque também pagava
+varredura de validação por cima do clone. O resto da suite fica entre o ruído
+e ganhos de poucos por cento — não há caso de regressão.
+
+A varredura completa continua existindo onde é necessária: na primeira
+marcação de um contêiner ainda sem tag (é ela que grava a tag) e em
+contêineres que nunca ganham tag (ex.: `any`). Conflito de tag continua
+rejeitado. Contrato fixado em `internal/vm/runtime_type_validation_test.go`.
+
+## baseline (0.3.0, c429bd7) × CoW (feat/cow-value-semantics)
 
 **Data:** 2026-08-16 · Windows 11 · medições intercaladas (os dois binários
 alternados dentro da mesma janela — rodadas sequenciais por rótulo mostraram
@@ -8,7 +60,7 @@ ficam em `results/baseline.md` e `results/cow.md` como registro do harness).
 **Checksums idênticos em todos os benchmarks** — as duas versões computam os
 mesmos resultados.
 
-## Tabela consolidada (mediana de 5 execuções intercaladas)
+### Tabela consolidada (mediana de 5 execuções intercaladas)
 
 | bench | perfil | baseline_ms | cow_ms | delta | critério (spec §5.3) | veredito |
 |---|---|---|---|---|---|---|
@@ -30,7 +82,7 @@ clone O(n) por iteração — exatamente o custo que a semântica promete nesse
 padrão. Migração: quem quer compartilhamento usa `ref` (custo zero, ver
 `bench_call_ref`).
 
-## Interpretação
+### Interpretação
 
 **Onde o CoW ganha:** chamadas que só leem o composto deixam de pagar a cópia
 rasa ansiosa O(n) por chamada. No caso assintótico (`call_light`: função O(1)
@@ -49,7 +101,13 @@ todos os elementos do array a cada chamada tipada
 (`internal/vm/runtime_type_validation.go`, caso `TYPE_ARRAY`). Em
 `call_light`, ela domina o tempo restante nas duas versões. Validar pela tag
 `RuntimeType` em O(1) quando presente é a próxima otimização natural, fora do
-escopo desta mudança.
+escopo desta mudança. *(Resolvido no PR #31 — ver a seção da validação O(1)
+no topo deste arquivo: a varredura valia para maps/structs/refs também, não
+só arrays, e em `call_light` era 97% do tempo.)*
+
+Os números absolutos desta tabela e da tabela do PR #31 não são comparáveis
+entre si (sessões diferentes; o aviso de drift térmico acima vale entre
+seções) — dentro de cada seção, a comparação é intercalada e válida.
 
 ## Reprodução
 


### PR DESCRIPTION
## Summary
- `benchmarks/RESULTS.md` vira registro corrido de comparações (mais recente primeiro), em vez de documento de uma comparação única.
- Nova seção **develop (c0a89c9) × validação O(1) pela tag `RuntimeType` (PR #31)** com a tabela intercalada completa: `bench_call_light` **−97,1%**, `bench_typed_call_map` **−94,3%**, `bench_share_mutate` −65,7%, demais entre −1,8% e −10,2%, `spawn_sum` +1,1% (ruído) — sem regressões, checksums idênticos e corpus de exemplos 130/130.
- O `bench_typed_call_map` ficou fora da rodada original da suíte (foi criado depois do glob do script), então sua linha foi medida agora pelo protocolo intercalado (mediana de 5 alternadas: 2.156ms → 123ms).
- O **achado colateral** da seção CoW (validação O(n) por chamada) foi anotado como resolvido, apontando para a seção nova — com a nota de que a varredura valia para maps/structs/refs, não só arrays, e a ressalva de que números absolutos não comparam entre seções (sessões diferentes, drift térmico).

## Components
- `benchmarks/RESULTS.md`: reestruturação em registro corrido + seção nova + nota de resolução no achado colateral (seção histórica do CoW preservada na íntegra).
- `CHANGELOG.md`: entrada em `### Changed` no `[Unreleased]`.

## Test Plan
- [x] Linha do `bench_typed_call_map` medida pelo protocolo intercalado do repo (mediana de 5 alternadas, mesma máquina)
- [x] Demais números da tabela vêm de `benchmarks/results/interleaved.md` (rodada do PR #31, já versionada)
- [x] Seção histórica baseline × CoW preservada sem alteração de conteúdo (só rebaixamento de headings e nota de resolução)
- [ ] Revisão de leitura: estrutura de registro corrido faz sentido para os próximos comparativos

🤖 Generated with [Claude Code](https://claude.com/claude-code)