### PR TITLE
perf/cow-uniqueness-rc - Unicidade por contagem de donos elimina O(N²) de compartilhamento morto (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,19 @@
   laço de puts por valor caiu de 3 clones/put para O(1) clones no laço
   inteiro (`TestByValueCallLoopClonesO1AfterFlip`: 600 → ≤8 clones em 200
   iterações). Corpus de exemplos 130/130 idêntico em todas as verificações
-  (após o flip e após cada round de correção), `go test ./...` e `-race`
-  verdes. Custo do bookkeeping: mesmo após a limpeza do bit morto,
+  (após o flip e após cada round de correção); `go test ./...` verde,
+  `-race` verde em `internal/value` e na suíte completa de `internal/vm`
+  (contador `Owners` é atômico; o requisito é o mesmo do ARC sob tasks
+  paralelas). Custo do bookkeeping: mesmo após a limpeza do bit morto,
   `bench_map_churn` (+10,9%) e `bench_spawn_sum` (+10,4%) seguem acima do
   gate ≤~5% da suíte intercalada — escrita intensa em map e handoff de
   argumentos para tasks pagam inc/dec por elemento/argumento em cada
   operação. Aceito e documentado como o preço do RC nesta fase; as válvulas
-  (drops precisos da fase 2, elisão de pares inc/dec, fast path para stores
-  escalares — spec §8, risco 3) ficam como otimização futura. Tabela
-  completa e interpretação em `benchmarks/RESULTS.md`.
+  apontadas para quando isso for revisitado: drops precisos da fase 2 e
+  elisão de pares inc/dec no mesmo bytecode (spec §8, risco 3), mais um
+  fast path para stores de valores escalares apontado na investigação da
+  fase 1 (fora do texto da spec). Tabela completa e interpretação em
+  `benchmarks/RESULTS.md`.
 
 ### Changed
 
@@ -117,13 +121,17 @@
   acontece **in-place e é visível** — sob o bit sticky antigo, o bind por
   valor que criava um segundo dono temporário ligava a marca para sempre, e a
   mutação seguinte através do `ref` podia clonar em vez de mutar, perdendo a
-  escrita. Divergência forma-dependente no merge-base: o mesmo programa
-  (lista encadeada, escrita via `setit(ref n, v)` seguida de escrita via
-  `let u: ref Node = ...; u.valor = 77`) imprimia 107 numa forma e 50 na
-  outra, a depender de qual caminho de vínculo tocava o nó por último; com a
-  unicidade por contagem de donos as duas formas imprimem **107**, o valor
-  correto pelo contrato CoW 0.4.0 (§2, regra 6: mutação através de `ref` é
-  sempre visível). Pinado por `TestRefWriteToUniquelyOwnedNodeMutatesInPlace`.
+  escrita. O teste committado pina o valor correto: **107** (antes: 50 —
+  escrita perdida) para o mesmo programa (lista encadeada, escrita via
+  `setit(ref n, v)` seguida de escrita via `let u: ref Node = ...;
+  u.valor = 77`). A investigação da Task 7 confirmou adicionalmente que o
+  comportamento antigo era dependente da forma do vínculo (o próprio
+  merge-base já imprimia 107 quando o mesmo alias era escrito só via
+  parâmetro `ref`, sem a passagem por valor intermediária) — variantes
+  registradas no relatório da task, não na suíte. O resultado correto pelo
+  contrato CoW 0.4.0 é 107 em qualquer forma (§2, regra 6: mutação através
+  de `ref` é sempre visível). Pinado por
+  `TestRefWriteToUniquelyOwnedNodeMutatesInPlace`.
 
 ## [0.4.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,34 @@
   `internal/vm/runtime_type_validation_test.go` (confiança na tag, primeira
   marcação ainda varre, conflito rejeitado).
 
+- Unicidade de arrays/maps/instâncias passou a ser decidida por um contador
+  `Owners` de referências duráveis (`internal/value/cow.go`,
+  `IsShared = Owners > 1`) no lugar do bit sticky `Shared`, que só ligava e
+  nunca desligava — qualquer passagem por valor condenava o contêiner a
+  clonar para sempre, mesmo depois de o alias que motivou a marca deixar de
+  existir (compartilhamento morto). O clone agora só acontece quando existe
+  um segundo dono vivo no momento da mutação; o modelo é o CoW do Swift
+  adaptado a bytecode com GC (spec
+  `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`, fase 1).
+  Caso emblemático (NoxyDB): um helper `database_file(db)` chamado por valor
+  dentro do laço de puts marcava `db`/`state`/o map de payloads como
+  compartilhados para sempre — 3 clones por put, O(N²). Benchmark novo
+  `benchmarks/bench_value_call_mutate.nx` ancora o padrão do NoxyDB (helper
+  por valor em laço de mutação com map crescendo): **−93,5%** na intercalada
+  final (mediana de 9), de quadrático para flat (~1,5s → ~100ms a N=2500); o
+  laço de puts por valor caiu de 3 clones/put para O(1) clones no laço
+  inteiro (`TestByValueCallLoopClonesO1AfterFlip`: 600 → ≤8 clones em 200
+  iterações). Corpus de exemplos 130/130 idêntico em todas as verificações
+  (após o flip e após cada round de correção), `go test ./...` e `-race`
+  verdes. Custo do bookkeeping: mesmo após a limpeza do bit morto,
+  `bench_map_churn` (+10,9%) e `bench_spawn_sum` (+10,4%) seguem acima do
+  gate ≤~5% da suíte intercalada — escrita intensa em map e handoff de
+  argumentos para tasks pagam inc/dec por elemento/argumento em cada
+  operação. Aceito e documentado como o preço do RC nesta fase; as válvulas
+  (drops precisos da fase 2, elisão de pares inc/dec, fast path para stores
+  escalares — spec §8, risco 3) ficam como otimização futura. Tabela
+  completa e interpretação em `benchmarks/RESULTS.md`.
+
 ### Changed
 
 - `benchmarks/RESULTS.md` virou registro corrido de comparações (mais recente
@@ -84,6 +112,18 @@
   clones (`TestHasKeyThenWriteDoesNotClone`, `TestKeysThenWriteDoesNotClone`),
   com caso negativo garantindo o default conservador para natives fora da
   allowlist (`TestUnlistedNativeStillMarksArgs`).
+
+- Escrita através de `ref` para um nó com exatamente um dono durável agora
+  acontece **in-place e é visível** — sob o bit sticky antigo, o bind por
+  valor que criava um segundo dono temporário ligava a marca para sempre, e a
+  mutação seguinte através do `ref` podia clonar em vez de mutar, perdendo a
+  escrita. Divergência forma-dependente no merge-base: o mesmo programa
+  (lista encadeada, escrita via `setit(ref n, v)` seguida de escrita via
+  `let u: ref Node = ...; u.valor = 77`) imprimia 107 numa forma e 50 na
+  outra, a depender de qual caminho de vínculo tocava o nó por último; com a
+  unicidade por contagem de donos as duas formas imprimem **107**, o valor
+  correto pelo contrato CoW 0.4.0 (§2, regra 6: mutação através de `ref` é
+  sempre visível). Pinado por `TestRefWriteToUniquelyOwnedNodeMutatesInPlace`.
 
 ## [0.4.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,11 @@
   (contador `Owners` é atômico; o requisito é o mesmo do ARC sob tasks
   paralelas). Custo do bookkeeping: mesmo após a limpeza do bit morto,
   `bench_map_churn` (+10,9%) e `bench_spawn_sum` (+10,4%) seguem acima do
-  gate ≤~5% da suíte intercalada — escrita intensa em map e handoff de
-  argumentos para tasks pagam inc/dec por elemento/argumento em cada
-  operação. Aceito e documentado como o preço do RC nesta fase; as válvulas
+  gate ≤~5% da suíte intercalada — escrita intensa em map paga inc/dec por
+  elemento em cada operação, e os laços quentes dos workers de task pagam a
+  passagem pelos funis de RC no rebind de locais escalares (Retain/Release
+  são no-ops em primitivos; o custo é o funil por iteração, não contagem).
+  Aceito e documentado como o preço do RC nesta fase; as válvulas
   apontadas para quando isso for revisitado: drops precisos da fase 2 e
   elisão de pares inc/dec no mesmo bytecode (spec §8, risco 3), mais um
   fast path para stores de valores escalares apontado na investigação da

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.0] - 2026-08-17
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.4.0
+Noxy REPL v0.5.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,127 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## develop (fac7542) × RC-uniqueness fase 1 (perf/cow-uniqueness-rc)
+
+**Data:** 2026-08-17 · Windows 11 · medição intercalada final, mediana de 9
+execuções (repetida em Runs=5 e Runs=9 para checar ruído — ver nota ² abaixo).
+Spec: `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`.
+
+**Corpus de exemplos 130/130 idêntico** em todas as verificações — rodado
+após o flip do mecanismo (bit sticky `Shared` → contador `Owners`), após
+cada round de correção relevante e após a limpeza final do bit morto.
+`go test ./...` verde; `-race` verde.
+
+| bench | perfil | develop_ms | rc_ms | delta | veredito |
+|---|---|---|---|---|---|
+| bench_value_call_mutate¹ | helper por valor em laço de mutação, map crescendo | 1558.5 | 101.6 | **−93,5%** | ✅ alvo |
+| bench_typed_call_map | chamada tipada in-module, map 2,5k via ref | 110.7 | 109.9 | −0,7% | ✅ gate |
+| bench_share_mutate | compartilha e muta em loop | 322 | 332 | +3,1% | ✅ gate |
+| bench_conway | grid mutado via ref, 60 gerações | 3734.1 | 3861.5 | +3,4% | ✅ |
+| bench_bubblesort | sort in-place via ref | 6045.6 | 6285.7 | +4% | ✅ |
+| bench_call_ref | mutação in-place via ref | 6139.3 | 6447.3 | +5% | ✅ |
+| bench_call_light | chamada O(1), array 10k por valor | 100.3 | 105.4 | +5,1% | ✅ |
+| bench_call_readonly | leitor puro O(n), array 20k | 2362.8 | 2519.8 | +6,6% | ⚠️ ruído² |
+| bench_path_update | `a[i].x = v` em loop, dono único | 880.4 | 943.2 | +7,1% | ⚠️ ruído² |
+| bench_spawn_sum | soma paralela via spawn_task | 1325.9 | 1463.5 | **+10,4%** | ❌ acima do gate |
+| bench_map_churn | escrita intensa em map | 601.8 | 667.5 | **+10,9%** | ❌ acima do gate |
+
+¹ Benchmark novo, adicionado nesta fase: ancora o padrão emblemático (NoxyDB
+`database_file(db)` por valor dentro do laço de puts) que motivou a spec —
+o mesmo formato do `bench_typed_call_map`, mas sem `ref` no helper.
+
+² `bubblesort` já tinha variância documentada de até ±10% entre sessões (ver
+seção baseline × CoW abaixo); `call_readonly` e `path_update` oscilaram
+dentro de ~1-4 pontos percentuais entre as duas rodadas (Runs=5 e Runs=9)
+desta seção, consistente com o mesmo ruído de máquina relatado nos rounds de
+correção da fase 1 — não são benches rastreados pelo gate (ver Interpretação).
+
+### Perfil de cada bench
+
+- **`bench_value_call_mutate`** — o alvo da fase 1. `struct State{payloads:
+  map[...]}`, `struct Db{state: State}`; um `helper(db: Db) -> int` recebido
+  **por valor** é chamado a cada volta de um laço de 2500 `put`s que também
+  escreve em `db.state.payloads` via `ref db`. Sob o bit sticky, o bind por
+  valor do helper marcava `db` (e, por clone raso, `state` e `payloads`)
+  como compartilhados para sempre: cada `put` reclonava os três — 3 clones
+  por put, O(N²) porque o clone do map cresce com N. Sob RC, o retain do
+  parâmetro do helper morre no fim do frame dele; os donos voltam a 1 e as
+  escritas seguintes mutam no lugar.
+- **`bench_typed_call_map`** — espelho do bench acima, mas o helper recebe
+  `ref` em vez de valor: já não tinha o custo de compartilhamento morto
+  (nem no bit sticky, nem no RC) — fica dentro do gate como esperado.
+- **`bench_share_mutate`** — pior caso do CoW por construção
+  (`let b = a` seguido de mutação): +3,1%, o custo adicional é só o inc/dec
+  do bind do `let`, que já é O(1) por vínculo.
+- **`bench_conway`/`bench_bubblesort`/`bench_call_ref`** — mutação in-place
+  via `ref` sobre grid/array grandes: pagam só o branch de checagem de
+  unicidade (agora contador em vez de bit) por escrita — dentro do gate.
+- **`bench_call_light`** — chamada O(1) com array de 10k por valor: paga o
+  inc/dec de um único bind por chamada — dentro do gate.
+- **`bench_call_readonly`/`bench_path_update`** — leitor O(n) e mutação de
+  dono único em loop: acima de 5% nesta medição, mas variam mais que os
+  quatro benches efetivamente rastreados pelo gate ao longo dos rounds de
+  correção da fase 1 (ver nota ² acima) — tratados como ruído, não regressão
+  do RC.
+- **`bench_map_churn`/`bench_spawn_sum`** — os dois que **seguem acima do
+  gate** mesmo após a limpeza do bit sticky morto (ver Interpretação).
+
+### Interpretação
+
+**Onde o RC ganha:** o compartilhamento morto — clone pago por um alias que
+já não existe no momento da mutação — deixa de existir por construção.
+`bench_value_call_mutate` vai de curva quadrática a flat (~1,5s → ~100ms a
+N=2500): o padrão do NoxyDB (helper de validação chamado por valor dentro do
+laço de puts) deixa de custar 3 clones por iteração e passa a custar O(1)
+clones no laço inteiro.
+
+**Onde fica neutro (dentro do gate ≤~5%):** os quatro benches rastreados ao
+longo dos rounds de correção da fase 1 — `bench_share_mutate` (+3,1%) e
+`bench_typed_call_map` (−0,7%) fecham dentro do gate; `bench_conway`,
+`bench_bubblesort`, `bench_call_ref` e `bench_call_light` também ficam
+dentro ou na borda dele. `bench_call_readonly` (+6,6%) e `bench_path_update`
+(+7,1%) passam de 5% nesta medição, mas com variância maior que os benches
+gate ao longo da fase — não foram tratados como regressão formal pelo
+controller.
+
+**Onde paga, sem maquiagem:** `bench_map_churn` (+10,9%) e `bench_spawn_sum`
+(+10,4%) **seguem acima do gate de ~5% mesmo depois da limpeza do bit sticky
+morto** (Task 8, commit `ae45d8f`) — não é a marcação morta que sobrava, é o
+bookkeeping de RC em si: `map_churn` faz muitas inserções/remoções de chave
+(inc/dec por elemento a cada operação) e `spawn_sum` faz handoff de
+argumentos primitivos para várias goroutines (retain/release pareado no
+preparo da task). Comparado ao round 4 da Task 7 (map_churn +9,8%, spawn_sum
++14,9%, já com o bookkeeping completo mas antes da limpeza do bit sticky), a
+remoção do bit reduziu `spawn_sum` (14,9%→10,4%) e manteve `map_churn` na
+mesma faixa (9,8%→10,9%, dentro do ruído) — a limpeza **não** fecha esses
+dois deltas. **Aceito e documentado como o preço do RC nesta fase**; a spec
+(§8, risco 3) nomeia as válvulas para quando isso for revisitado: drops
+precisos da fase 2 (Perceus-lite, §5), elisão de pares inc/dec no mesmo
+bytecode, e um fast path para stores de valores escalares.
+
+**O que resta:** fase 1 libera locais de bloco mortos só no fim do frame
+(inflação temporária segura, nunca unsound); a fase 1.5 (drops de escopo de
+bloco emitidos pelo compilador) e a fase 2 (drops de último uso,
+Perceus-lite) atacam o resíduo de compartilhamento morto que sobrevive
+dentro de um frame (`do let b = a end; a[i] = x` em laço) — spec §5. A
+estrutura persistente (HAMT) para snapshots genuinamente vivos continua fora
+de escopo (spec §9): um programa que de fato consome N cópias paga
+O(rodadas×n) em qualquer linguagem de semântica de valor.
+
+### Divergência corrigida
+
+Escrita através de `ref` para um nó com exatamente um dono durável agora
+acontece in-place e é visível. Sob o bit sticky, o mesmo programa (lista
+encadeada, escrita via `setit(ref n, v)` seguida de escrita via
+`let u: ref Node = ...; u.valor = 77`) respondia 107 numa forma e 50 na
+outra — forma-dependente, porque o bind por valor que criava um segundo
+dono temporário ligava a marca para sempre e a mutação seguinte via `ref`
+clonava em vez de mutar, perdendo a escrita. Com a unicidade por contagem de
+donos as duas formas respondem 107, o valor correto pelo contrato CoW 0.4.0
+(§2, regra 6). Pinado por `TestRefWriteToUniquelyOwnedNodeMutatesInPlace`
+(`internal/vm/rc_uniqueness_test.go`). Nenhum exemplo do corpus muda
+(130/130) — é dead-share, não um caso exercitado pelos exemplos existentes.
+
 ## develop (c0a89c9) × validação O(1) pela tag `RuntimeType` (PR #31)
 
 **Data:** 2026-08-16/17 · Windows 11 · medições intercaladas (mediana de 5),

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -93,9 +93,14 @@ controller.
 (+10,4%) **seguem acima do gate de ~5% mesmo depois da limpeza do bit sticky
 morto** (Task 8, commit `ae45d8f`) — não é a marcação morta que sobrava, é o
 bookkeeping de RC em si: `map_churn` faz muitas inserções/remoções de chave
-(inc/dec por elemento a cada operação) e `spawn_sum` faz handoff de
-argumentos primitivos para várias goroutines (retain/release pareado no
-preparo da task). Comparado ao round 4 da Task 7 (map_churn +9,8%, spawn_sum
+(inc/dec por elemento a cada operação) e `spawn_sum` paga nos laços quentes
+dos workers, onde cada rebind de local escalar (`s = ...`, `i = ...`) passa
+pelos funis de RC do OP_SET_LOCAL (ownSlot + Release por iteração). Os args
+do bench são primitivos e canal — Retain/Release são no-ops neles, então o
+custo é a passagem pelos funis em si, não contagem; o preparo da task
+(retain de captura + bind de posse dos parâmetros por valor no frame da
+task) roda 4 vezes no bench inteiro e não aparece na conta.
+Comparado ao round 4 da Task 7 (map_churn +9,8%, spawn_sum
 +14,9%, já com o bookkeeping completo mas antes da limpeza do bit sticky), a
 remoção do bit reduziu `spawn_sum` (14,9%→10,4%) e manteve `map_churn` na
 mesma faixa (9,8%→10,9%, dentro do ruído) — a limpeza **não** fecha esses

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -12,7 +12,10 @@ Spec: `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`.
 **Corpus de exemplos 130/130 idêntico** em todas as verificações — rodado
 após o flip do mecanismo (bit sticky `Shared` → contador `Owners`), após
 cada round de correção relevante e após a limpeza final do bit morto.
-`go test ./...` verde; `-race` verde.
+`go test ./...` verde; `-race` verde em `internal/value` e na suíte completa
+de `internal/vm` (`go test ./internal/value -race`: 1,9s; `go test
+./internal/vm -race`, sem filtro: 150,3s — o contador `Owners` é atômico
+justamente pelo requisito de tasks paralelas).
 
 | bench | perfil | develop_ms | rc_ms | delta | veredito |
 |---|---|---|---|---|---|
@@ -96,10 +99,12 @@ preparo da task). Comparado ao round 4 da Task 7 (map_churn +9,8%, spawn_sum
 +14,9%, já com o bookkeeping completo mas antes da limpeza do bit sticky), a
 remoção do bit reduziu `spawn_sum` (14,9%→10,4%) e manteve `map_churn` na
 mesma faixa (9,8%→10,9%, dentro do ruído) — a limpeza **não** fecha esses
-dois deltas. **Aceito e documentado como o preço do RC nesta fase**; a spec
-(§8, risco 3) nomeia as válvulas para quando isso for revisitado: drops
-precisos da fase 2 (Perceus-lite, §5), elisão de pares inc/dec no mesmo
-bytecode, e um fast path para stores de valores escalares.
+dois deltas. **Aceito e documentado como o preço do RC nesta fase**; as
+válvulas para quando isso for revisitado: drops precisos da fase 2
+(Perceus-lite, §5) e elisão de pares inc/dec no mesmo bytecode (ambas
+nomeadas na spec §8, risco 3), mais um fast path para stores de valores
+escalares apontado na investigação da fase 1 (Task 7), fora do texto da
+spec.
 
 **O que resta:** fase 1 libera locais de bloco mortos só no fim do frame
 (inflação temporária segura, nunca unsound); a fase 1.5 (drops de escopo de
@@ -113,16 +118,26 @@ O(rodadas×n) em qualquer linguagem de semântica de valor.
 ### Divergência corrigida
 
 Escrita através de `ref` para um nó com exatamente um dono durável agora
-acontece in-place e é visível. Sob o bit sticky, o mesmo programa (lista
-encadeada, escrita via `setit(ref n, v)` seguida de escrita via
-`let u: ref Node = ...; u.valor = 77`) respondia 107 numa forma e 50 na
-outra — forma-dependente, porque o bind por valor que criava um segundo
-dono temporário ligava a marca para sempre e a mutação seguinte via `ref`
-clonava em vez de mutar, perdendo a escrita. Com a unicidade por contagem de
-donos as duas formas respondem 107, o valor correto pelo contrato CoW 0.4.0
-(§2, regra 6). Pinado por `TestRefWriteToUniquelyOwnedNodeMutatesInPlace`
-(`internal/vm/rc_uniqueness_test.go`). Nenhum exemplo do corpus muda
-(130/130) — é dead-share, não um caso exercitado pelos exemplos existentes.
+acontece in-place e é visível. O teste committado
+(`TestRefWriteToUniquelyOwnedNodeMutatesInPlace`,
+`internal/vm/rc_uniqueness_test.go`) pina o valor correto para o programa
+(lista encadeada, escrita via `setit(ref n, v)` seguida de escrita via
+`let u: ref Node = ...; u.valor = 77`): **107** com a unicidade por contagem
+de donos, contra **50** no binário pré-chave (bit sticky ligado pelo bind
+por valor intermediário, mutação seguinte via `ref` clonava em vez de
+mutar — escrita perdida).
+
+A investigação da Task 7 (repros à mão, não parte da suíte) confirmou
+adicionalmente que o comportamento antigo era dependente da forma do
+vínculo, não um bug de contagem isolado: o próprio merge-base já respondia
+107 quando o mesmo alias era escrito só via parâmetro `ref` (forma
+canônica, sem a passagem por valor intermediária que liga o bit sticky) —
+variante `rv_h1_paramform`, registrada em
+`.superpowers/sdd/2026-08-17-cow-rc-uniqueness-fase1/task-7-report.md`, não
+na suíte de testes. O 107 é o valor correto pelo contrato CoW 0.4.0 em
+qualquer forma (§2, regra 6: mutação através de `ref` é sempre visível).
+Nenhum exemplo do corpus muda (130/130) — é dead-share, não um caso
+exercitado pelos exemplos existentes.
 
 ## develop (c0a89c9) × validação O(1) pela tag `RuntimeType` (PR #31)
 

--- a/benchmarks/bench_value_call_mutate.nx
+++ b/benchmarks/bench_value_call_mutate.nx
@@ -1,0 +1,37 @@
+// Laco de mutacao onde um helper recebe o agregado POR VALOR a cada volta.
+// Sob o bit sticky Shared, o bind do parametro por valor marcava db (e, via
+// clone raso, state e payloads) como compartilhado para sempre: cada put()
+// reclonava os tres, e o clone do map cresce com N -> O(N^2) no laco.
+// Com a unicidade por contagem de donos, o retain do parametro morre com o
+// frame do helper, os donos voltam a 1 e as mutacoes seguintes mutam no
+// lugar: O(1) clones no laco inteiro.
+// Padrao real: NoxyDB put chamando um helper de validacao por valor.
+struct State
+    payloads: map[string, string]
+end
+
+struct Db
+    state: State
+end
+
+func helper(db: Db) -> int
+    return 1
+end
+
+func put(db: ref Db, key: string, val: string) -> void
+    let x: int = helper(db)
+    db.state.payloads[key] = val
+end
+
+func main()
+    let payloads: map[string, string] = {}
+    let db: Db = Db(State(payloads))
+    let i: int = 0
+    while i < 2500 do
+        put(ref db, f"key{i}", "value")
+        i = i + 1
+    end
+    print(f"CHECKSUM:{length(keys(db.state.payloads))}")
+end
+
+main()

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,13 +1,13 @@
 | bench | baseline_ms | cow_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 6125.6 | 6111.5 | -0.2% |
-| bench_call_light.nx | 106.2 | 104.9 | -1.2% |
-| bench_call_readonly.nx | 2521.6 | 2588.5 | 2.7% |
-| bench_call_ref.nx | 6505.9 | 6459.8 | -0.7% |
-| bench_conway.nx | 3807.7 | 3931.8 | 3.3% |
-| bench_map_churn.nx | 619.2 | 671.2 | 8.4% |
-| bench_path_update.nx | 874.2 | 914.4 | 4.6% |
-| bench_share_mutate.nx | 332.9 | 353.2 | 6.1% |
-| bench_spawn_sum.nx | 1323.3 | 1506.3 | 13.8% |
-| bench_typed_call_map.nx | 108.6 | 115.1 | 6% |
-| bench_value_call_mutate.nx | 1501.4 | 106.6 | -92.9% |
+| bench_bubblesort.nx | 6103.9 | 5971.8 | -2.2% |
+| bench_call_light.nx | 124.5 | 124.9 | 0.3% |
+| bench_call_readonly.nx | 2802 | 2889.1 | 3.1% |
+| bench_call_ref.nx | 6145 | 6171.2 | 0.4% |
+| bench_conway.nx | 3779.8 | 3913 | 3.5% |
+| bench_map_churn.nx | 592.6 | 651.2 | 9.9% |
+| bench_path_update.nx | 863.8 | 906.5 | 4.9% |
+| bench_share_mutate.nx | 351.6 | 350 | -0.5% |
+| bench_spawn_sum.nx | 1259.4 | 1490.7 | 18.4% |
+| bench_typed_call_map.nx | 108.8 | 106.1 | -2.5% |
+| bench_value_call_mutate.nx | 1477.6 | 102.6 | -93.1% |

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,13 +1,13 @@
 | bench | baseline_ms | cow_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 5934.1 | 5880.7 | -0.9% |
-| bench_call_light.nx | 104.8 | 103.4 | -1.3% |
-| bench_call_readonly.nx | 2342.7 | 2459.7 | 5% |
-| bench_call_ref.nx | 6201.4 | 6159.2 | -0.7% |
-| bench_conway.nx | 3752 | 3823.5 | 1.9% |
-| bench_map_churn.nx | 588.8 | 646.3 | 9.8% |
-| bench_path_update.nx | 880.3 | 912.8 | 3.7% |
-| bench_share_mutate.nx | 311.4 | 350.8 | 12.7% |
-| bench_spawn_sum.nx | 1235.2 | 1419.1 | 14.9% |
-| bench_typed_call_map.nx | 107.8 | 108.2 | 0.4% |
-| bench_value_call_mutate.nx | 1481.7 | 99.9 | -93.3% |
+| bench_bubblesort.nx | 6045.6 | 6285.7 | 4% |
+| bench_call_light.nx | 100.3 | 105.4 | 5.1% |
+| bench_call_readonly.nx | 2362.8 | 2519.8 | 6.6% |
+| bench_call_ref.nx | 6139.3 | 6447.3 | 5% |
+| bench_conway.nx | 3734.1 | 3861.5 | 3.4% |
+| bench_map_churn.nx | 601.8 | 667.5 | 10.9% |
+| bench_path_update.nx | 880.4 | 943.2 | 7.1% |
+| bench_share_mutate.nx | 322 | 332 | 3.1% |
+| bench_spawn_sum.nx | 1325.9 | 1463.5 | 10.4% |
+| bench_typed_call_map.nx | 110.7 | 109.9 | -0.7% |
+| bench_value_call_mutate.nx | 1558.5 | 101.6 | -93.5% |

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,11 +1,13 @@
 | bench | baseline_ms | cow_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 7258.2 | 6987.5 | -3.7% |
-| bench_call_light.nx | 4269 | 121.7 | -97.1% |
-| bench_call_readonly.nx | 2814.5 | 2528.6 | -10.2% |
-| bench_call_ref.nx | 7287.2 | 6898.4 | -5.3% |
-| bench_conway.nx | 4373.5 | 4269.9 | -2.4% |
-| bench_map_churn.nx | 691.8 | 665.1 | -3.9% |
-| bench_path_update.nx | 976.7 | 959.5 | -1.8% |
-| bench_share_mutate.nx | 1104.8 | 379 | -65.7% |
-| bench_spawn_sum.nx | 1395.4 | 1411 | 1.1% |
+| bench_bubblesort.nx | 6125.6 | 6111.5 | -0.2% |
+| bench_call_light.nx | 106.2 | 104.9 | -1.2% |
+| bench_call_readonly.nx | 2521.6 | 2588.5 | 2.7% |
+| bench_call_ref.nx | 6505.9 | 6459.8 | -0.7% |
+| bench_conway.nx | 3807.7 | 3931.8 | 3.3% |
+| bench_map_churn.nx | 619.2 | 671.2 | 8.4% |
+| bench_path_update.nx | 874.2 | 914.4 | 4.6% |
+| bench_share_mutate.nx | 332.9 | 353.2 | 6.1% |
+| bench_spawn_sum.nx | 1323.3 | 1506.3 | 13.8% |
+| bench_typed_call_map.nx | 108.6 | 115.1 | 6% |
+| bench_value_call_mutate.nx | 1501.4 | 106.6 | -92.9% |

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,13 +1,13 @@
 | bench | baseline_ms | cow_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 6046.2 | 6032.7 | -0.2% |
-| bench_call_light.nx | 96.9 | 98.6 | 1.8% |
-| bench_call_readonly.nx | 2337.7 | 2439.7 | 4.4% |
-| bench_call_ref.nx | 6109.7 | 6211.7 | 1.7% |
-| bench_conway.nx | 3715.5 | 3839.4 | 3.3% |
-| bench_map_churn.nx | 616.5 | 641.3 | 4% |
-| bench_path_update.nx | 894 | 895.5 | 0.2% |
-| bench_share_mutate.nx | 311.4 | 361.7 | 16.2% |
-| bench_spawn_sum.nx | 1235 | 1439.4 | 16.6% |
-| bench_typed_call_map.nx | 105.4 | 106.4 | 0.9% |
-| bench_value_call_mutate.nx | 1492.9 | 100.6 | -93.3% |
+| bench_bubblesort.nx | 5934.1 | 5880.7 | -0.9% |
+| bench_call_light.nx | 104.8 | 103.4 | -1.3% |
+| bench_call_readonly.nx | 2342.7 | 2459.7 | 5% |
+| bench_call_ref.nx | 6201.4 | 6159.2 | -0.7% |
+| bench_conway.nx | 3752 | 3823.5 | 1.9% |
+| bench_map_churn.nx | 588.8 | 646.3 | 9.8% |
+| bench_path_update.nx | 880.3 | 912.8 | 3.7% |
+| bench_share_mutate.nx | 311.4 | 350.8 | 12.7% |
+| bench_spawn_sum.nx | 1235.2 | 1419.1 | 14.9% |
+| bench_typed_call_map.nx | 107.8 | 108.2 | 0.4% |
+| bench_value_call_mutate.nx | 1481.7 | 99.9 | -93.3% |

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,13 +1,13 @@
 | bench | baseline_ms | cow_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 6103.9 | 5971.8 | -2.2% |
-| bench_call_light.nx | 124.5 | 124.9 | 0.3% |
-| bench_call_readonly.nx | 2802 | 2889.1 | 3.1% |
-| bench_call_ref.nx | 6145 | 6171.2 | 0.4% |
-| bench_conway.nx | 3779.8 | 3913 | 3.5% |
-| bench_map_churn.nx | 592.6 | 651.2 | 9.9% |
-| bench_path_update.nx | 863.8 | 906.5 | 4.9% |
-| bench_share_mutate.nx | 351.6 | 350 | -0.5% |
-| bench_spawn_sum.nx | 1259.4 | 1490.7 | 18.4% |
-| bench_typed_call_map.nx | 108.8 | 106.1 | -2.5% |
-| bench_value_call_mutate.nx | 1477.6 | 102.6 | -93.1% |
+| bench_bubblesort.nx | 6046.2 | 6032.7 | -0.2% |
+| bench_call_light.nx | 96.9 | 98.6 | 1.8% |
+| bench_call_readonly.nx | 2337.7 | 2439.7 | 4.4% |
+| bench_call_ref.nx | 6109.7 | 6211.7 | 1.7% |
+| bench_conway.nx | 3715.5 | 3839.4 | 3.3% |
+| bench_map_churn.nx | 616.5 | 641.3 | 4% |
+| bench_path_update.nx | 894 | 895.5 | 0.2% |
+| bench_share_mutate.nx | 311.4 | 361.7 | 16.2% |
+| bench_spawn_sum.nx | 1235 | 1439.4 | 16.6% |
+| bench_typed_call_map.nx | 105.4 | 106.4 | 0.9% |
+| bench_value_call_mutate.nx | 1492.9 | 100.6 | -93.3% |

--- a/docs/superpowers/plans/2026-08-17-cow-rc-uniqueness-fase1.md
+++ b/docs/superpowers/plans/2026-08-17-cow-rc-uniqueness-fase1.md
@@ -1,0 +1,903 @@
+# RC-Uniqueness Fase 1 — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Substituir o bit sticky `Shared` por contagem de referências
+duráveis (`Owners`), eliminando os O(N²) de compartilhamento morto em forma
+de chamada (fase 1 da spec).
+
+**Architecture:** Migração por **rastreamento duplo**: o contador `Owners`
+entra primeiro como bookkeeping paralelo (o bit sticky continua governando o
+comportamento), cada tarefa adiciona os inc/dec de um mecanismo e os audita
+por testes de contagem; a penúltima tarefa vira a chave (`IsShared` passa a
+ler `Owners > 1`) com os testes de aceite; a última limpa o mecanismo velho.
+Assim toda tarefa termina verde e é rejeitável isoladamente.
+
+**Tech Stack:** Go (interpretador bytecode em `internal/vm`, compilador em
+`internal/compiler`), testes `go test`, benchmarks PowerShell do repo.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`
+
+## Global Constraints
+
+- Contrato semântico da spec CoW 0.4.0 INALTERADO (spec §3); corpus de 130
+  exemplos com saídas idênticas é critério de aceite.
+- Direção de segurança: dec a menos é proibido; dec a mais (inflação) é
+  degradação aceitável. Em dúvida, não decremente.
+- Ordem retain-antes-de-release em toda substituição de ocupante de slot.
+- `Retain`/`Release` saturam: sem inc acima de `math.MaxInt32/2`, sem dec
+  abaixo de 0.
+- Não renumerar opcodes existentes em `internal/chunk/chunk.go` (novos
+  opcodes só no fim da lista; opcodes mortos ficam definidos).
+- O repo usa CRLF e não é gofmt-limpo — não rodar `gofmt -w`; seguir o
+  estilo local (comentários em pt-BR).
+- Branch: `perf/cow-uniqueness-rc`. Commits em conventional commits pt-BR
+  com o rodapé `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Baseline: `go test ./...` verde no início de cada tarefa.
+
+---
+
+### Task 1: Contador `Owners` no pacote value
+
+**Files:**
+- Modify: `internal/value/value.go` (structs `ObjArray`, `ObjMap`,
+  `ObjInstance` — localizar campo `Shared atomic.Bool` em cada um)
+- Modify: `internal/value/cow.go`
+- Test: `internal/value/owners_test.go` (novo)
+
+**Interfaces:**
+- Produces: `value.Retain(v Value) bool` (true se compôsto: incrementa e
+  informa que é rastreável), `value.Release(v Value)`,
+  `value.OwnersCount(v Value) int32` (introspecção para testes; -1 para
+  não-compostos). Campo novo `Owners atomic.Int32` ao lado de `Shared`
+  (que permanece intocado nesta tarefa).
+
+- [ ] **Step 1: Escrever os testes falhando**
+
+```go
+package value
+
+import "testing"
+
+func TestRetainReleaseCountsComposites(t *testing.T) {
+	arr := NewArray([]Value{NewInt(1)})
+	if OwnersCount(arr) != 0 {
+		t.Fatalf("array novo deve nascer com Owners=0, veio %d", OwnersCount(arr))
+	}
+	if !Retain(arr) {
+		t.Fatal("Retain de array deve retornar true")
+	}
+	if !Retain(arr) {
+		t.Fatal("segundo Retain deve retornar true")
+	}
+	if OwnersCount(arr) != 2 {
+		t.Fatalf("esperado Owners=2, veio %d", OwnersCount(arr))
+	}
+	Release(arr)
+	if OwnersCount(arr) != 1 {
+		t.Fatalf("esperado Owners=1 apos Release, veio %d", OwnersCount(arr))
+	}
+}
+
+func TestRetainIgnoresScalarsAndStrings(t *testing.T) {
+	if Retain(NewInt(7)) {
+		t.Fatal("Retain de int deve retornar false")
+	}
+	if Retain(NewString("s")) {
+		t.Fatal("Retain de string deve retornar false")
+	}
+	if OwnersCount(NewInt(7)) != -1 {
+		t.Fatal("OwnersCount de escalar deve ser -1")
+	}
+	Release(NewInt(7)) // nao deve entrar em panico
+}
+
+func TestReleaseClampsAtZero(t *testing.T) {
+	m := NewMap()
+	Release(m)
+	Release(m)
+	if OwnersCount(m) != 0 {
+		t.Fatalf("Release nao pode ir abaixo de 0, veio %d", OwnersCount(m))
+	}
+}
+
+func TestMapAndInstanceAlsoCount(t *testing.T) {
+	m := NewMap()
+	Retain(m)
+	if OwnersCount(m) != 1 {
+		t.Fatalf("map: esperado 1, veio %d", OwnersCount(m))
+	}
+	inst := Value{Type: VAL_OBJ, Obj: &ObjInstance{Fields: map[string]Value{}}}
+	Retain(inst)
+	if OwnersCount(inst) != 1 {
+		t.Fatalf("instance: esperado 1, veio %d", OwnersCount(inst))
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/value -run "TestRetain|TestRelease|TestMapAndInstance" -v`
+Expected: FAIL (undefined: Retain, Release, OwnersCount)
+
+- [ ] **Step 3: Implementação mínima**
+
+Em cada um dos três structs (`ObjArray`, `ObjMap`, `ObjInstance`) em
+`value.go`, adicionar ao lado do campo `Shared`:
+
+```go
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
+	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	Owners atomic.Int32
+```
+
+Em `cow.go`, adicionar (mantendo MarkShared/IsShared intocados):
+
+```go
+// ownersSaturation impede overflow do contador; acima disso o valor se
+// comporta como permanentemente compartilhado (equivalente ao sticky).
+const ownersSaturation = math.MaxInt32 / 2
+
+func ownersOf(v Value) *atomic.Int32 {
+	if v.Type != VAL_OBJ {
+		return nil
+	}
+	switch obj := v.Obj.(type) {
+	case *ObjArray:
+		return &obj.Owners
+	case *ObjMap:
+		return &obj.Owners
+	case *ObjInstance:
+		return &obj.Owners
+	}
+	return nil
+}
+
+// Retain registra um dono durável novo. Retorna true se o valor é um
+// composto rastreável (chamador decide se registra o slot para release).
+func Retain(v Value) bool {
+	owners := ownersOf(v)
+	if owners == nil {
+		return false
+	}
+	if owners.Load() < ownersSaturation {
+		owners.Add(1)
+	}
+	return true
+}
+
+// Release solta um dono durável. Nunca desce abaixo de zero (dec a mais é
+// proibido por design; o clamp protege contra funis duplicados).
+func Release(v Value) {
+	owners := ownersOf(v)
+	if owners == nil {
+		return
+	}
+	for {
+		current := owners.Load()
+		if current <= 0 || current >= ownersSaturation {
+			return
+		}
+		if owners.CompareAndSwap(current, current-1) {
+			return
+		}
+	}
+}
+
+// OwnersCount é introspecção para testes; -1 para não-compostos.
+func OwnersCount(v Value) int32 {
+	owners := ownersOf(v)
+	if owners == nil {
+		return -1
+	}
+	return owners.Load()
+}
+```
+
+Import `math` e `sync/atomic` conforme necessário.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `go test ./internal/value -v` — todos PASS, inclusive os antigos.
+
+- [ ] **Step 5: Commit**
+
+`perf(value): contador Owners de referencias duraveis (RC fase 1, bookkeeping paralelo)`
+
+---
+
+### Task 2: Retain de parâmetros + release central no fim do frame
+
+**Files:**
+- Modify: `internal/vm/stack.go` (struct `CallFrame` — localizar via grep
+  `type CallFrame struct`)
+- Modify: `internal/vm/calls.go:117-134` (`callPreparedClosure`)
+- Modify: `internal/vm/unwind.go:21-63` (`finalizeCurrentFrame`)
+- Test: `internal/vm/rc_uniqueness_test.go` (novo)
+
+**Interfaces:**
+- Consumes: `value.Retain/Release/OwnersCount` (Task 1).
+- Produces: campo `Owned []int` em `CallFrame` (índices absolutos de slots
+  de `vm.stack` retidos pelo frame); helper
+  `(f *CallFrame) ownSlot(vm *VM, slot int)` que retém e registra sem
+  duplicar. Tasks 3-6 usam `frame.ownSlot`.
+
+- [ ] **Step 1: Testes falhando**
+
+Usar o runner de programas dos testes existentes (grep
+`func runTypedFunctionProgram` em `internal/vm` para o helper; ele executa
+fonte noxy e devolve o valor de `test_report`). Os testes auditam contagem,
+não comportamento (sticky ainda governa):
+
+```go
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// O programa passa um map por valor a um helper e reporta depois do
+// retorno. O teste intercepta o valor via native de teste para medir
+// Owners em tres momentos.
+func TestParamRetainReleasedAfterReturn(t *testing.T) {
+	machine := New()
+	var during, after int32
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		during = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	// probe_during e native SEM assinatura fora da allowlist: hoje marca
+	// sticky, e nesta fase nao mexe em Owners — o que medimos e o retain
+	// do parametro de reader(), nao o do native.
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	src := `
+func reader(m: map[string, int]) -> int
+    probe_during(m)
+    return 1
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    reader(m)
+    probe_after(m)
+end
+
+main()`
+	if err := machine.InterpretSource(src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// during: slot do parametro de reader retido => >= 1
+	if during < 1 {
+		t.Fatalf("durante a chamada esperado Owners >= 1, veio %d", during)
+	}
+	// after: o retain do parametro foi liberado no fim do frame => o valor
+	// caiu em exatamente 1 em relacao ao pico medido durante
+	if after != during-1 {
+		t.Fatalf("apos o retorno esperado %d, veio %d", during-1, after)
+	}
+}
+
+func TestParamReleaseRunsOnUnwind(t *testing.T) {
+	machine := New()
+	var after int32
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	src := `
+func boom(m: map[string, int]) -> int
+    let arr: int[] = [1]
+    return arr[99]
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    boom(m)
+    probe_after(m)
+end
+
+main()`
+	_ = machine.InterpretSource(src) // erro esperado (index out of bounds)
+	_ = after
+	// Se o runtime aborta o programa inteiro no erro, este teste vira:
+	// unwind até o topo deve ter passado por finalizeCurrentFrame de boom.
+	// Verificação alternativa robusta: chamar de novo num programa com
+	// captura de erro se a linguagem tiver; senão, validar via teste Go
+	// direto de unwindTo com frame montado à mão (ver Step 1b).
+}
+```
+
+**Step 1b (obrigatório se o runtime abortar no erro):** teste Go direto —
+montar VM, `callPreparedClosure` com um map como arg, forçar
+`vm.unwindTo(0, frameOutcome{Err: fmt.Errorf("x")})` e verificar
+`value.OwnersCount(m) == 0`.
+
+Nota: se `InterpretSource` não existir com esse nome, localizar o
+equivalente usado por `runTypedFunctionProgram` e adaptar a chamada — o
+formato do programa e das asserções não muda.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/vm -run TestParamRetain -v`
+Expected: FAIL — `after == during` (release não existe ainda).
+
+- [ ] **Step 3: Implementação**
+
+Em `CallFrame` adicionar campo e helper:
+
+```go
+	// Owned: slots absolutos de vm.stack retidos por este frame
+	// (parametros e lets). Liberados em finalizeCurrentFrame.
+	Owned []int
+```
+
+```go
+// ownSlot retém o composto no slot e o registra para release no fim do
+// frame. Idempotente por slot: duplicata causaria release dobrado (dec a
+// menos — proibido pela spec §8.2).
+func (f *CallFrame) ownSlot(vm *VM, slot int) {
+	v := vm.stack[slot]
+	if !value.Retain(v) {
+		return
+	}
+	for _, existing := range f.Owned {
+		if existing == slot {
+			// Slot ja possuido: o retain acima cobre o ocupante novo; o
+			// release do ocupante velho e responsabilidade do site que
+			// sobrescreveu (Task 3+). Nao registrar de novo.
+			return
+		}
+	}
+	f.Owned = append(f.Owned, slot)
+}
+```
+
+Em `callPreparedClosure` (calls.go), após criar o `frame` e antes do push
+em `vm.frames`:
+
+```go
+	// RC: parametros sem ref sao vinculos duraveis do frame novo
+	params := closure.Function.Params
+	for i := 0; i < argCount; i++ {
+		if i < len(params) && params[i].IsRef {
+			continue
+		}
+		frame.ownSlot(vm, frame.LocalBase+1+i)
+	}
+```
+
+(Slot do parâmetro i é `LocalBase+1+i`: `LocalBase = stackTop-argCount-1`
+aponta para o callee; args começam em `LocalBase+1` — conferir com
+`baseArgs := vm.stackTop - argCount` em calls.go:99.)
+
+ATENÇÃO: `frame.ownSlot` precisa do `vm` antes de o frame estar em
+`vm.frames` — assinatura recebe `vm` explicitamente por isso.
+
+Em `finalizeCurrentFrame` (unwind.go), **depois** do loop de defers (os
+defers ainda usam os valores) e **antes** do loop de `closeUpvalue`/zeragem
+(linha 41):
+
+```go
+	// RC: solta os vinculos duraveis do frame (retorno normal e unwind
+	// passam ambos por aqui). Le o ocupante ATUAL do slot: sobrescritas
+	// durante a vida do frame ja fizeram seu proprio release/retain.
+	for _, slot := range frame.Owned {
+		if slot < vm.stackTop {
+			value.Release(vm.stack[slot])
+		}
+	}
+	frame.Owned = nil
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `go test ./internal/vm -run "TestParamRetain|TestParamRelease" -v` → PASS
+Run: `go test ./internal/vm` → PASS (nada de comportamento mudou; sticky governa)
+
+- [ ] **Step 5: Teste adicional — aninhamento**
+
+```go
+func TestNestedByValueCallsStackAndUnstack(t *testing.T) {
+	// f(m) chama g(m) chama probe_during(m); apos tudo, probe_after.
+	// during >= 2 (dois frames retendo); after == during - 2.
+}
+```
+
+Escrever no mesmo formato do Step 1 (dois helpers aninhados por valor),
+rodar, passar.
+
+- [ ] **Step 6: Commit**
+
+`perf(vm): retain de parametros por frame com release central em finalizeCurrentFrame`
+
+---
+
+### Task 3: Locais — `OP_OWN_LOCAL` no let e release/retain no `OP_SET_LOCAL`
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (novo opcode NO FIM da lista iota +
+  case em `String()` e no disassembler: `OP_OWN_LOCAL`, sem operando)
+- Modify: `internal/compiler/compiler.go:201-209` (branch local do
+  LetStatement)
+- Modify: `internal/vm/executor.go:210-213` (`OP_SET_LOCAL`) + novo case
+  `OP_OWN_LOCAL`
+- Test: `internal/vm/rc_uniqueness_test.go`
+
+**Interfaces:**
+- Consumes: `frame.ownSlot` (Task 2).
+- Produces: `OP_OWN_LOCAL` — retém topo da pilha e registra o slot
+  `vm.stackTop-1` no frame corrente.
+
+- [ ] **Step 1: Testes falhando**
+
+```go
+func TestLetBindRetainsComposite(t *testing.T) {
+	// programa: let m = {"a": 1} ; probe(m)
+	// probe (native de teste) le OwnersCount: esperado 1 (o slot do let).
+}
+
+func TestAssignReleasesOldRetainsNew(t *testing.T) {
+	// programa:
+	//   let a: map[string, int] = {"x": 1}
+	//   let b: map[string, int] = {"y": 2}
+	//   probe_a1(a)          // Owners(a) == 1
+	//   a = b                // slot de a solta o velho, retem b
+	//   probe_a2(a)          // objeto de b: Owners == 2 (slots a e b)
+	// e o objeto velho de a: capturar numa native antes e checar que caiu
+	// para 0 depois da reatribuicao.
+}
+```
+
+Escrever com natives de probe como na Task 2 (capturar `args[0]` num
+`value.Value` do teste e medir `OwnersCount` depois).
+
+- [ ] **Step 2: Ver falhar** (`go test ./internal/vm -run "TestLetBind|TestAssignReleases" -v`)
+
+- [ ] **Step 3: Implementação**
+
+Compiler (LetStatement, branch `c.scopeDepth > 0`, logo após
+`emitMarkSharedForStore` e antes de `addLocal`) — emitir sempre (o handler
+filtra escalares dinamicamente; tipos `any` podem carregar compostos):
+
+```go
+			// RC: o let e um vinculo duravel do frame (spec §4.2)
+			c.emitByte(byte(chunk.OP_OWN_LOCAL))
+```
+
+Executor:
+
+```go
+		case chunk.OP_OWN_LOCAL:
+			frame.ownSlot(vm, vm.stackTop-1)
+```
+
+`OP_SET_LOCAL` vira:
+
+```go
+		case chunk.OP_SET_LOCAL:
+			slot := c.Code[ip]
+			ip++
+			idx := frame.LocalBase + int(slot)
+			old := vm.stack[idx]
+			vm.stack[idx] = vm.peek(0)
+			// RC: retain-antes-de-release (auto-atribuicao x = x)
+			frame.ownSlot(vm, idx)
+			value.Release(old)
+```
+
+Nota: `ownSlot` já não duplica o registro; o retain dele cobre o ocupante
+novo, e o `Release(old)` solta o antigo. Para escalares ambos são no-op.
+
+- [ ] **Step 4: Ver passar + suíte vm inteira verde**
+
+- [ ] **Step 5: Commit** — `perf(vm): posse de locais (OP_OWN_LOCAL) e troca contada no OP_SET_LOCAL`
+
+---
+
+### Task 4: Globais, upvalues e o funil de escrita via ref
+
+**Files:**
+- Modify: `internal/vm/executor.go:197-202` (`OP_SET_GLOBAL`), `:942-947`
+  (`OP_SET_UPVALUE`), `:1270-1286` (`OP_GET_GLOBAL_MUT`), `:1288-1303`
+  (`OP_GET_UPVALUE_MUT`)
+- Modify: `internal/vm/references.go:154` (`storeReferenceValue`)
+- Modify: `internal/vm/cow.go:28-42` (`unicizeThroughRefValue`)
+- Modify: `internal/vm/executor.go` (`vm.closeUpvalue` — localizar via grep
+  `func (vm *VM) closeUpvalue`)
+- Test: `internal/vm/rc_uniqueness_test.go`
+
+**Interfaces:**
+- Consumes: `value.Retain/Release`.
+- Produces: invariante "toda escrita durável = retain novo + release velho"
+  para globais/upvalues/refs. O box de upvalue retém ao fechar
+  (`closeUpvalue`), compensando o release do slot no fim do frame.
+
+- [ ] **Step 1: Testes falhando** (mesmo formato de probes):
+  - global: `let` global de composto → Owners 1; reatribuição → velho 0,
+    novo +1.
+  - escrita via `ref` (função com `ref` param fazendo `*r = novo`):
+    velho released, novo retained.
+  - closure capturando composto sobrevive ao frame: depois que a função
+    externa retorna, `OwnersCount` do capturado ≥ 1 (box retém).
+
+- [ ] **Step 2: Ver falhar**
+
+- [ ] **Step 3: Implementação**
+
+`OP_SET_GLOBAL`:
+
+```go
+			name := nameVal.Obj.(string)
+			// RC: troca contada no ambiente
+			if old, ok := frame.Environment.GetLocal(name); ok {
+				value.Retain(vm.peek(0))
+				value.Release(old)
+			} else {
+				value.Retain(vm.peek(0))
+			}
+			frame.Environment.SetLocal(name, vm.peek(0))
+```
+
+(Conferir a assinatura real de `Environment.GetLocal` — usada em
+executor.go OP_GET_GLOBAL_MUT:1278.)
+
+`OP_SET_UPVALUE`: ler o valor atual antes do `Store` (o tipo do upvalue tem
+`Load()` — ver OP_GET_UPVALUE_MUT:1295), `Retain(novo)`, `Release(velho)`.
+
+`storeReferenceValue` (funil de STORE_REF/STORE_VIA_REF/
+SET_PROPERTY_DEREF): antes de gravar,
+
+```go
+	stored, _, store, err := vm.referenceStorage(ref)
+	if err != nil {
+		return err
+	}
+	value.Retain(updated)
+	value.Release(stored)
+	store(updated)
+```
+
+(Adaptar ao corpo real da função — a estrutura com `referenceStorage` já
+existe; adicionar o par retain/release imediatamente antes do `store`.)
+
+`unicizeThroughRefValue`: no branch `if changed { store(v) }` →
+
+```go
+	if changed {
+		value.Retain(v)
+		value.Release(stored)
+		store(v)
+	}
+```
+
+`OP_GET_GLOBAL_MUT` e `OP_GET_UPVALUE_MUT`: mesmos pares em torno de
+`owner.SetLocal(name, v)` / `upv.Store(v)` quando `changed`.
+
+`closeUpvalue`: ao mover o valor do slot para o box, `value.Retain(v)` —
+o box é dono durável; o slot será released pelo frame.
+
+- [ ] **Step 4: Ver passar + suíte vm verde**
+
+- [ ] **Step 5: Commit** — `perf(vm): troca contada em globais, upvalues e escrita via ref`
+
+---
+
+### Task 5: Contêineres — construção, escrita, clone e caminhos MUT
+
+**Files:**
+- Modify: `internal/vm/executor.go:972-982` (`OP_ARRAY`), `:984-1012`
+  (`OP_MAP`), `:1114-1149` (`OP_SET_INDEX`), `:1189-1217`
+  (`OP_SET_PROPERTY`), `:1259-1268` (`OP_GET_LOCAL_MUT`), `:1305-1349`
+  (`OP_GET_INDEX_MUT`), `:1351-1389` (`OP_GET_PROP_MUT`)
+- Modify: `internal/vm/calls.go:50-64` (`callPreparedValue` construtor),
+  `:138-175` (`copyValue`)
+- Test: `internal/vm/rc_uniqueness_test.go`
+
+**Interfaces:**
+- Consumes: `value.Retain/Release`.
+- Produces: invariante "elemento/campo de contêiner é dono durável" em
+  todos os caminhos de escrita e no clone.
+
+- [ ] **Step 1: Testes falhando**:
+  - `let arr = [x]` onde x é map: Owners do map == 2 (slot de x + elemento).
+  - `arr[0] = y`: velho released, novo retained.
+  - `m["k"] = v` sobre chave existente: velho released.
+  - `s.campo = v` (OP_SET_PROPERTY): idem.
+  - construtor `Box(m)`: campo retém (+1).
+  - clone: programa que compartilha e muta; após o clone, filhos com +1
+    (medir por probe no filho).
+  - caminho MUT: `a[0].x = 1` com `a[0]` compartilhado — o clone gravado de
+    volta retém e o velho released (auditar por contagem no velho).
+
+- [ ] **Step 2: Ver falhar**
+
+- [ ] **Step 3: Implementação** — padrão único em cada site:
+
+`OP_ARRAY` (o MarkShared da linha 980 ganha companhia; NÃO remover o
+MarkShared até a Task 8):
+
+```go
+				elements[i] = vm.pop()
+				value.MarkShared(elements[i]) // sticky: sai na Task 8
+				value.Retain(elements[i])     // RC: elemento e dono duravel
+```
+
+`OP_MAP` idem na linha 1009. `OP_SET_INDEX` array:
+
+```go
+					old := arr.Elements[idx]
+					value.Retain(val)
+					arr.Elements[idx] = val
+					value.Release(old)
+```
+
+`OP_SET_INDEX` map (e todos os `mapObj.Set` de escrita):
+
+```go
+					if old, exists := mapObj.Get(key); exists {
+						defer-free: value.Retain(val); mapObj.Set(key, val); value.Release(old)
+					} else {
+						value.Retain(val); mapObj.Set(key, val)
+					}
+```
+
+(escrever inline sem defer — o pseudocódigo acima só indica a ordem).
+
+`OP_SET_PROPERTY`: old = `instance.Fields[name]`; retain novo, gravar,
+release velho. `callPreparedValue` (linha 57): adicionar `value.Retain(arg)`
+ao lado do MarkShared. `copyValue`: nos três branches, ao lado de cada
+`value.MarkShared(el/val)` de filho, `value.Retain(...)`. Caminhos MUT
+(`GET_LOCAL_MUT`, `GET_INDEX_MUT`, `GET_PROP_MUT`, e o branch de map de
+`GET_PROP_MUT`): em cada store-back de clone (`vm.stack[idx] = v`,
+`arr.Elements[idx] = v`, `mapObj.Set(key, v)`, `instance.Fields[name] = fieldVal`),
+retain do clone + release do velho. Em `GET_LOCAL_MUT` usar
+`frame.ownSlot(vm, idx)` em vez de retain cru (mantém o slot listado).
+
+- [ ] **Step 4: Ver passar + suíte vm verde**
+
+- [ ] **Step 5: Commit** — `perf(vm): posse contada em conteineres, construtor, clone e caminhos MUT`
+
+---
+
+### Task 6: Fronteiras — append/pop/delete, canais, spawn/tasks, defer, natives
+
+**Files:**
+- Modify: `internal/vm/builtins_collections.go:101-125` (`append`),
+  `:133-...` (`pop`), delete (grep `"delete"` no mesmo arquivo)
+- Modify: `internal/vm/builtins_concurrency.go:59-62` (spawn args),
+  `:103-114` (`chan_send`), `:150-163` (`chan_recv`)
+- Modify: `internal/vm/defer.go:94-106` (`markPreparedArguments`) e o
+  release pós-invocação em `invokePreparedCall`/preparação (grep
+  `PreparedCall{` para o ponto de captura)
+- Modify: `internal/vm/task_execution.go:70-80` (args de task)
+- Modify: `internal/vm/calls.go:38-44` (natives sem assinatura)
+- Test: `internal/vm/rc_uniqueness_test.go`
+
+**Interfaces:**
+- Consumes: `value.Retain/Release`, `frame.ownSlot`.
+- Produces: fronteiras completas da tabela §4.2 da spec.
+
+- [ ] **Step 1: Testes falhando**:
+  - `append(ref a, item)`: item +1; `pop(ref a)`: elemento removido −1.
+  - `delete(m, k)`: valor removido −1.
+  - `chan_send`/`chan_recv` no mesmo task: envia (+1), recebe (−1) — medir
+    antes/depois com probes.
+  - defer capturando composto: +1 na captura; após rodar o defer
+    (fim da função externa), −1.
+  - native sem assinatura fora da allowlist: +1 permanente (e o teste
+    existente `TestUnlistedNativeStillMarksArgs` continua verde até a
+    Task 8).
+
+- [ ] **Step 2: Ver falhar**
+
+- [ ] **Step 3: Implementação**
+
+`append` (linha 120): `value.Retain(item)` ao lado do MarkShared.
+`pop`: após remover `last := arr.Elements[len-1]`, `value.Release(last)`.
+`delete`: obter o valor antes de deletar; `value.Release(old)`.
+`chan_send` (linha 111): `value.Retain(args[1])` ao lado do MarkShared.
+`chan_recv` (linha 162): antes de `return val`, `value.Release(val)` (o
+valor saiu do buffer; o vínculo seguinte retém).
+Spawn (linha 60): `value.Retain(arg)` ao lado do MarkShared **e** registrar
+o slot no frame da thread após criá-lo:
+
+```go
+	for i := range threadArgs {
+		if value.OwnersCount(threadArgs[i]) >= 0 {
+			frame.Owned = append(frame.Owned, 1+i)
+		}
+	}
+```
+
+(slots 1..argCount porque LocalBase=0 e slot 0 é a função; o retain já
+aconteceu no push acima — NÃO usar ownSlot aqui, que retém de novo.)
+CUIDADO: este é o único lugar onde registro e retain ficam separados;
+comentar no código.
+
+`markPreparedArguments` (defer/tasks): `value.Retain(args[i])` ao lado do
+MarkShared — a captura em `PreparedCall.Arguments`/args de task é durável.
+Release da captura: em `invokePreparedCall`, após a invocação completar
+(no defer de limpeza que já zera os slots, adicionar
+`value.Release(call.Arguments[i])` para cada arg — a invocação já retomou
+posse via `callPreparedClosure`). Em `task_execution.go`, espelhar: release
+dos `preparedArguments` quando a task conclui (grep pelo ponto onde a task
+termina e os argumentos saem de escopo).
+Natives sem assinatura (calls.go:42): `value.Retain(args[i])` ao lado do
+MarkShared (retenção permanente conservadora — sem release; comentar).
+
+- [ ] **Step 4: Ver passar + suíte vm verde + `go test ./internal/vm -race -run "Chan|Spawn|Task"`**
+
+- [ ] **Step 5: Commit** — `perf(vm): posse contada nas fronteiras (builtins mutantes, canais, tasks, defer, natives)`
+
+---
+
+### Task 7: A CHAVE — `IsShared` passa a ler `Owners`
+
+**Files:**
+- Modify: `internal/value/cow.go` (`IsShared`)
+- Create: `benchmarks/bench_value_call_mutate.nx`
+- Test: `internal/vm/rc_uniqueness_test.go`
+
+**Interfaces:**
+- Consumes: tudo acima.
+- Produces: comportamento novo — clones só com dono vivo.
+
+- [ ] **Step 1: Red test de aceite (ANTES da chave)**
+
+```go
+func TestByValueCallLoopClonesO1AfterFlip(t *testing.T) {
+	machine := New()
+	ResetCloneCount()
+	src := `
+struct State
+    payloads: map[string, string]
+end
+
+struct Db
+    state: State
+end
+
+func helper(db: Db) -> int
+    return 1
+end
+
+func put(db: ref Db, key: string, val: string) -> void
+    let x: int = helper(db)
+    db.state.payloads[key] = val
+end
+
+func main()
+    let payloads: map[string, string] = {}
+    let db: Db = Db(State(payloads))
+    let i: int = 0
+    while i < 200 do
+        put(ref db, f"k{i}", "v")
+        i = i + 1
+    end
+    test_report(length(keys(db.state.payloads)))
+end
+
+main()`
+	got := interpretForTest(t, machine, src) // usar o runner real do repo
+	if asInt(got) != 200 {
+		t.Fatalf("programa incorreto: %v", got)
+	}
+	if n := CloneCountValue(); n > 8 {
+		t.Fatalf("laco por-valor deveria clonar O(1); clonou %d", n)
+	}
+}
+```
+
+(Adaptar `interpretForTest`/`asInt` aos helpers reais; o contrato do teste
+é: 200 puts com helper por valor → `CloneCountValue() <= 8`.)
+
+- [ ] **Step 2: Ver falhar** — hoje clona ~3×200.
+
+- [ ] **Step 3: A chave em `value/cow.go`**
+
+```go
+func IsShared(v Value) bool {
+	owners := ownersOf(v)
+	return owners != nil && owners.Load() > 1
+}
+```
+
+(`MarkShared` continua existindo e escrevendo o bit — vira dead-weight até
+a Task 8; NÃO remover ainda.)
+
+- [ ] **Step 4: Rodar TUDO e tratar fallout caso a caso**
+
+Run: `go test ./... 2>&1 | tail -20`
+Regra da spec §3: testes de caracterização que ancoram contagem exata de
+clones podem mudar **para menos** — revisar um a um, atualizar a asserção
+com comentário citando a spec. Qualquer teste de INDEPENDÊNCIA que falhe é
+bug de contagem (dec a menos em algum funil): parar, achar o funil, corrigir
+na task correspondente, nunca "ajustar o teste".
+
+- [ ] **Step 5: Benchmark de aceite**
+
+Criar `benchmarks/bench_value_call_mutate.nx` (mesmo shape do red test com
+N=2500 e `print(f"CHECKSUM:{...}")` no padrão da suíte, helper por valor).
+Rodar contra o binário do develop e o do branch (best-of-3 manual):
+esperado quadrático→flat (~4,7s → ~150ms na escala do repro N=4000).
+
+- [ ] **Step 6: Verificação completa do repo**
+
+- `go test ./...` verde; `go vet ./internal/...` limpo.
+- `benchmarks/compare_examples.ps1` (develop × branch): 130/130 idênticos.
+- `benchmarks/interleaved_compare.ps1`: benches não-alvo ≤ ~5%.
+- `go test ./internal/vm -race` nos grupos de concorrência.
+
+- [ ] **Step 7: Commit** — `perf(vm)!: unicidade por contagem de donos — clones so com dono vivo (RC fase 1)`
+(sem `!` se nada observável mudou — decidir pelo fallout do Step 4; a spec
+prevê paridade, então provavelmente `perf(vm):` simples.)
+
+---
+
+### Task 8: Limpeza — aposentar o bit sticky
+
+**Files:**
+- Modify: `internal/value/value.go` (remover `Shared atomic.Bool` dos três
+  structs), `internal/value/cow.go` (remover `MarkShared`; `IsShared` fica)
+- Modify: todos os call sites de `MarkShared` (grep — são os mesmos das
+  Tasks 5-6 + executor 1408/1420) e `internal/compiler/cow_lowering.go`
+  (parar de emitir `OP_MARK_SHARED`/`OP_COPY` de marcação; opcodes ficam
+  DEFINIDOS em chunk.go, sem renumerar)
+- Modify: testes que referenciam `MarkShared` diretamente
+  (`cow_test.go`, `cow_mut_opcodes_test.go`, `cow_builtins_test.go` etc.):
+  trocar por `value.Retain` onde o teste monta o estado "compartilhado"
+- Test: suíte inteira
+
+- [ ] **Step 1:** Remover emissões e call sites; adaptar testes (montar
+  compartilhamento com dois Retains em vez de MarkShared).
+- [ ] **Step 2:** `go test ./...` verde; corpus 130/130 de novo (a remoção
+  não pode mudar comportamento — IsShared já lia Owners).
+- [ ] **Step 3: Commit** — `refactor(vm): remove o bit sticky Shared; Owners e a unica fonte de unicidade`
+
+---
+
+### Task 9: Documentação e PR
+
+**Files:**
+- Modify: `CHANGELOG.md` (entrada em `### Performance` no `[Unreleased]`,
+  no estilo da entrada do PR #31: mecanismo, números medidos, testes)
+- Modify: `benchmarks/RESULTS.md` (nova seção no topo do registro corrido:
+  develop × RC fase 1, tabela intercalada completa incluindo
+  `bench_value_call_mutate`, interpretação, o que resta — fases 1.5/2 e
+  snapshots vivos)
+- Modify: `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`
+  (status: proposta → implementada fase 1)
+
+- [ ] **Step 1:** Rodar a suíte intercalada completa + medição do bench
+  novo (mediana de 5 intercaladas), preencher RESULTS.md com números reais.
+- [ ] **Step 2:** CHANGELOG + status da spec.
+- [ ] **Step 3:** Commit `docs: registra RC fase 1 (CHANGELOG, RESULTS.md, spec)`.
+- [ ] **Step 4:** PR para `develop` via convenções do repo (`gh pr create`,
+  título `perf/cow-uniqueness-rc - Unicidade por contagem de donos elimina
+  O(N²) de compartilhamento morto`, label `not available to review`,
+  assignee `@me`, template Summary/Components/Test Plan com checkboxes;
+  rodapé `🤖 Generated with [Claude Code](https://claude.com/claude-code)`).
+
+---
+
+## Self-review (executado na escrita do plano)
+
+- **Cobertura da spec:** §4.1→Task 1; §4.2 parâmetros→Task 2, locais→Task 3,
+  globais/upvalues/ref→Task 4, contêineres→Task 5, fronteiras→Task 6;
+  §4.3→Task 5; §4.4→coberto por Task 2 (release lê ocupante atual; sem
+  promoção especial); §4.5→Task 8; §4.6→Tasks 1 e 7; §5 fase 1→Tasks 2-7;
+  §6→Task 7 Steps 5-6 e Task 9; §7→red tests distribuídos; §8.1→regra do
+  Step 4 da Task 7; §8.2→`ownSlot` idempotente + teste de reatribuição.
+  Fases 1.5/2 ficam explicitamente fora (spec §5).
+- **Riscos apontados no plano:** spawn é o único ponto com retain/registro
+  separados (comentário obrigatório); `chan_recv` release antes do bind
+  seguinte deixa o valor em trânsito com count reduzido — seguro (+0 em
+  trânsito, mutação sempre via slot).
+- **Consistência de nomes:** `Retain/Release/OwnersCount/ownersOf`
+  (value), `Owned`/`ownSlot` (frame), `OP_OWN_LOCAL` (chunk) — usados
+  uniformemente nas tasks.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -118,17 +118,29 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
   justamente o retain do campo `proximo: ref Node` que sustenta a contagem de
   uma lista encadeada — remover esse inc para "uniformizar com `ref`" abriria
   dec a menos em toda a estrutura.
-- **A pergunta certa é "este slot RETÉM o que guarda?", não "o tipo declarado é
-  `ref T`?".** Não-possuidor é estritamente mais largo: além dos slots `ref`,
-  dois vínculos colocam um valor no slot **sem inc e sem tipo declarado** — a
-  variável de `for ... in` e o binding de `case` do `select`/`when`. Tratá-los
-  como possuidores faz o caminho MUT soltar um objeto que o slot nunca reteve
-  (dec a menos, o elemento do contêiner passa a parecer único). O compilador
-  carrega um flag `Owns` por vínculo local, marcado **exatamente onde o inc é
-  emitido** (`OP_OWN_LOCAL` do `let`; retain de parâmetro sem `ref` no bind da
-  chamada), e é esse flag — não o tipo — que escolhe o gêmeo. Default `false`:
-  a direção segura para o caminho MUT (no máximo deixa um dono a mais, custando
-  uma cópia).
+- **A pergunta certa é "este slot RETÉM o que guarda?", e TODO vínculo local
+  nomeado sem `ref` retém — inclusive a variável de `for ... in` e o binding de
+  `case` do `select`/`when`.** A linha "slot de local" da tabela sempre cobriu
+  esses binds ("TODO composto"); deixá-los sem inc era violação da tabela, não
+  design, e abria as duas direções de erro: servi-los pelos gêmeos possuidores
+  solta um objeto que o slot nunca reteve (dec a menos no elemento do
+  contêiner), e servi-los pelos gêmeos de empréstimo deixa o slot segurando
+  duravelmente um valor com um dono a menos — o rebind (`item = outro`,
+  `setit(ref item, ...)`, case do select) muta depois "no lugar" e vaza para o
+  dono real. O `OP_OWN_LOCAL` desses binds roda **a cada iteração/entrada**:
+  cada elemento recebe exatamente um retain no bind e um release no bind
+  seguinte do mesmo slot (o vínculo anterior morreu — índices são reusados) ou
+  no fim do frame. O compilador continua carregando o flag `Owns` por vínculo,
+  marcado **exatamente onde o inc é emitido**, e é esse flag — não o tipo — que
+  escolhe o gêmeo; com a classe fechada, `Owns == (tipo declarado não é
+  ref T)` vale para todo local nomeado, o que torna correta por construção a
+  marca de empréstimo da caixa de upvalue (que é por tipo). Os únicos slots
+  não-possuidores restantes são os `ref` (empréstimo) e os slots **ocultos** da
+  maquinaria (`$collection`/`$map`/`$sel_*`): esses emprestam de propósito —
+  possuir a coleção iterada faria `arr[i] = x` dentro do laço clonar e a
+  iteração continuar no array velho, divergindo do contrato — e o empréstimo
+  neles é sound porque nenhum funil de escrita, captura ou `ref` os alcança
+  (nomes com espaço são inalcançáveis por identificador).
 - **A condição de empréstimo é ESTÁTICA — decidida pelo compilador, nunca
   inferida em runtime.** Cada funil que trocaria posse tem um gêmeo de
   empréstimo emitido pelo lowering (`OP_SET_LOCAL_BORROW`,
@@ -151,7 +163,11 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
   frame o solta uma segunda vez (**dec a mais** — o objeto velho, ainda vivo em
   outro dono, passa a parecer único). A entrada é reapontada para o valor novo
   na própria escrita, de modo que o velho é pago pelo funil e o novo pelo fim do
-  frame.
+  frame. **A mesma regra vale para a caixa de upvalue ABERTA**: enquanto aberta,
+  `OP_SET_UPVALUE` e `OP_GET_UPVALUE_MUT` (caixa possuidora) escrevem num slot
+  de pilha possuído — são o store contado daquele slot — e reapontam a entrada
+  do frame dono do mesmo jeito; caixa fechada guarda o valor em si mesma e não
+  tem entrada a reapontar.
 - Natives da allowlist só-leitura (`cow_natives.go`): empréstimo puro.
 - Natives **com** assinatura: cópia ansiosa mantida (spec CoW §4.6) — fora
   do RC.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -95,7 +95,7 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
 | global (`Environment`) | `SetLocal` | sobrescrita |
 | upvalue (box) | captura/store | sobrescrita; box coletado é irrelevante (GC) |
 | elemento de contêiner | `OP_ARRAY`/`OP_MAP`/`OP_SET_INDEX`/`append`/campo de struct (constructor e `OP_SET_PROPERTY`) | sobrescrita do elemento, `delete`, `pop` |
-| buffer de canal | `chan_send` | `chan_recv` (o valor sai do buffer) |
+| buffer de canal | `chan_send`; `OP_SELECT` com case de send disparado (segundo funil do mesmo par — retain especulativo antes do select, desfeito nos sends não disparados) | `chan_recv`; `OP_SELECT` com case de recv (o valor sai do buffer) |
 | captura de task (`spawn`/`spawn_task`) | preparação dos args | handoff para os slots de parâmetro da task (que fazem seu próprio inc) |
 | captura de `defer` | captura | após execução do defer |
 

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -1,0 +1,240 @@
+# Posse Única por Contagem de Referências Duráveis (RC-uniqueness)
+
+**Data:** 2026-08-17 · **Branch:** `perf/cow-uniqueness-rc` · **Status:** proposta
+**Relação:** evolução da implementação da spec
+`2026-08-16-cow-value-semantics-design.md` (CoW 0.4.0). O contrato semântico
+daquela spec permanece integralmente válido; esta spec troca só o mecanismo
+que decide *quando clonar*.
+
+## 1. Objetivo
+
+Eliminar por construção os O(N²) do CoW causados por **compartilhamento
+morto** — clones pagos quando o alias que motivou a marca já não existe.
+Hoje o bit `Shared` é sticky (só liga, nunca desliga): qualquer passagem por
+valor condena o contêiner a clonar na próxima mutação, para sempre.
+
+Caso emblemático (NoxyDB, reproduzido e medido): helper `database_file(db)`
+por valor chamado em laço de puts → 3 clones por put (instância, state e o
+map de payloads inteiro) → O(N²). Medido no repro `struct→struct→map`:
+N=4000 puts em 4.658ms com curva quadrática (pós-PR #31, que removeu o outro
+quadrático — a validação de tipos), contra ~130ms flat da variante sem a
+passagem por valor. Contador de clones confirma: 3N clones na variante por
+valor, 3 no total nas demais.
+
+**Meta:** nenhum clone jamais acontece por compartilhamento morto. Clones
+passam a ocorrer somente quando existe **outro dono vivo** no momento da
+mutação.
+
+**Não-meta:** reduzir o custo de snapshots genuinamente vivos (programa que
+de fato consome N cópias paga O(rodadas×n) em qualquer linguagem de semântica
+de valor, inclusive Swift — o remédio seria estrutura persistente, fora de
+escopo, ver §9).
+
+## 2. Modelo de referência: Swift
+
+O desenho é o do CoW do Swift, adaptado de compilador AOT com ARC para
+interpretador bytecode com GC:
+
+| Swift | noxy (esta spec) |
+|---|---|
+| refcount do ARC no buffer | contador `Owners` no composto |
+| `isKnownUniquelyReferenced()` antes de mutar | `Owners == 1` → in-place; `> 1` → clona |
+| parâmetro normal `+0 guaranteed` (empréstimo) | temporário de pilha não conta |
+| retain quando o callee armazena | incremento só em vínculo durável |
+| releases inseridos pelo compilador | fase 1: dec central no fim do frame; fases seguintes: drops emitidos pelo compilador |
+
+Diferença estrutural a nosso favor: o ARC também gerencia memória, então
+errar release corrompe. Aqui a memória é do GC do Go — o contador é **apenas
+oráculo de unicidade**. Contar a mais (ex.: dec pulado por unwind, ciclos)
+degrada para uma cópia extra, nunca corrompe. O único erro grave é contar a
+menos (mutação in-place com alias vivo); todo o desenho e o plano de testes
+giram em torno de impedir essa direção.
+
+## 3. Contrato semântico (visível ao usuário): INALTERADO
+
+Nenhuma mudança observável. Valem todos os itens da spec CoW §2:
+independência de cópias em qualquer vínculo sem `ref`, `ref` como único
+mecanismo de compartilhamento, igualdade estrutural, semântica de canais e
+tasks. A fronteira do snapshot continua sendo o momento do **vínculo**
+(chamada/atribuição/inserção), não o momento do push na pilha — paridade
+exata com hoje, onde a marcação ocorre em `vm.call` após avaliar os
+argumentos.
+
+Critério operacional de paridade: o corpus de exemplos
+(`benchmarks/compare_examples.ps1`, 130 programas) e a suíte de
+caracterização (`internal/vm/value_semantics_test.go`) devem produzir os
+mesmos resultados. Testes que ancoram **contagem exata de clones** podem
+mudar para menos clones — cada mudança dessas é revisada uma a uma como
+melhoria esperada, nunca aceita em lote.
+
+## 4. Design
+
+### 4.1 O contador `Owners`
+
+Em `ObjArray`, `ObjMap` e `ObjInstance`: `Shared atomic.Bool` é substituído
+por `Owners atomic.Int32`. Escalares e strings (imutáveis) ficam fora, como
+hoje.
+
+- `IsShared(v)` → `Owners.Load() > 1`.
+- `unicize`/opcodes `*_MUT`/builtins mutantes: inalterados na lógica — só o
+  predicado muda. Clona quando compartilhado; agora "compartilhado" é
+  preciso.
+- Contador atômico porque tasks são paralelas (mesmo requisito do ARC).
+
+### 4.2 A regra única: vínculo durável conta, empréstimo não
+
+**Incrementa** quando o composto entra num lugar que sobrevive à expressão
+corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
+
+| lugar durável | inc | dec |
+|---|---|---|
+| slot de parâmetro (sem `ref`) | bind na chamada (`vm.call`, onde hoje há `MarkShared`) | fim do frame (retorno E unwind, funil único em `finishFrame`) |
+| slot de local (`let`, reatribuição) | no vínculo (sites de `emitMarkSharedForStore`, generalizados: **todo** composto, fresco ou alias) | sobrescrita do slot; fim do frame; fim de bloco (fase 1.5) |
+| global (`Environment`) | `SetLocal` | sobrescrita |
+| upvalue (box) | captura/store | sobrescrita; box coletado é irrelevante (GC) |
+| elemento de contêiner | `OP_ARRAY`/`OP_MAP`/`OP_SET_INDEX`/`append`/campo de struct (constructor e `OP_SET_PROPERTY`) | sobrescrita do elemento, `delete`, `pop` |
+| buffer de canal | `chan_send` | `chan_recv` (o valor sai do buffer) |
+| captura de task (`spawn`/`spawn_task`) | preparação dos args | handoff para os slots de parâmetro da task (que fazem seu próprio inc) |
+| captura de `defer` | captura | após execução do defer |
+
+**Não conta (empréstimo, +0):**
+
+- Temporários da pilha de operandos (push/pop) — nunca.
+- `ref`: um `VAL_REF` aliasa um *slot*, não cria dono novo do objeto; o slot
+  já conta. Escrita através do ref = sobrescrita do slot (dec velho, inc
+  novo).
+- Natives da allowlist só-leitura (`cow_natives.go`): empréstimo puro.
+- Natives **com** assinatura: cópia ansiosa mantida (spec CoW §4.6) — fora
+  do RC.
+- Natives **sem** assinatura fora da allowlist: inc permanente sem dec
+  (tradução fiel do sticky de hoje: "assuma retenção"). Mesma perf de hoje,
+  nunca pior.
+
+Consequência de simplificação: a distinção fresco/alias do
+`emitMarkSharedForStore` (cow_lowering) desaparece — todo vínculo de
+composto incrementa, e um literal fresco vinculado a um `let` simplesmente
+nasce com `Owners == 1` (dono único, mutação in-place), que é o
+comportamento desejado sem caso especial.
+
+### 4.3 Mutação e clone
+
+- `Owners > 1` na mutação: clona no slot mutante (como hoje). O slot solta o
+  objeto antigo (**dec 1** nele) e passa a dono único do clone
+  (`Owners = 1`). Cada filho imediato do clone ganha **+1** (o clone é um
+  novo dono durável deles) — substitui o `MarkShared` dos filhos que o
+  `copyValue` faz hoje, dentro do O(n) que o clone já custa.
+- `Owners <= 1`: muta in-place. (`0` ocorre só em valores em trânsito puro
+  na pilha; mutação sempre passa por slot, que incrementou antes.)
+
+### 4.4 Retorno de função
+
+`OP_RETURN` entrega o resultado como temporário (+0). Se o resultado é um
+local do frame, o dec do fim do frame o leva a `Owners-1` enquanto em
+trânsito — correto: o vínculo do frame morreu; o caller incrementa ao
+vincular. Não há promoção especial: o caso "retornei meu próprio parâmetro"
+resolve por aritmética (caller: 1 do slot original + 1 do novo vínculo = 2 →
+primeira mutação de qualquer lado clona — independência preservada).
+
+### 4.5 O que morre com esta spec
+
+- `MarkShared`/bit sticky e toda a classe de auditoria "esqueceram de marcar
+  no caminho X" — os sites viram inc/dec da tabela §4.2, e a allowlist de
+  natives vira só a lista de empréstimos.
+- `OP_MARK_SHARED`/`OP_COPY` como marcadores de compartilhamento (o
+  lowering emite os incs nos mesmos pontos).
+
+### 4.6 Observabilidade
+
+`cloneCount` (spec CoW §4.9) permanece — é a âncora dos testes de regressão
+de perf. Adicional para testes: leitura de `Owners` de um valor
+(test-only/interno), permitindo ancorar "após o retorno, `Owners == 1`".
+
+## 5. Fases de implementação
+
+A ordem ataca primeiro a forma de compartilhamento morto que causou o bug
+real, com a propriedade de segurança de que **dec faltante nunca é unsound**
+(só custa uma cópia):
+
+- **Fase 1 — granularidade de frame (o alvo real).** Incs completos da
+  tabela §4.2; decs centralizados em `finishFrame` (retorno e unwind)
+  varrendo os slots de locais do frame (requer metadado de contagem de
+  locais por função no compilador — hoje o frame não sabe onde os locais
+  terminam e os temporários começam). Elimina o caso `database_file(db)` e
+  todo dead-share em forma de chamada, inclusive cross-module.
+- **Fase 1.5 — escopo de bloco.** Compilador emite drops (dec) na saída de
+  blocos para locais compostos que morrem ali (ele conhece tipos e escopos).
+  Elimina `do let b = a end; a[i] = x` em laço.
+- **Fase 2 — último uso (Perceus-lite).** Drops movidos do fim do escopo
+  para o último uso. Elimina a forma restante: `let b = a; a[i] = x` com `b`
+  nunca lido depois. Otimização pura sobre a mesma arquitetura.
+
+Fases 1.5 e 2 só mexem em *onde* o compilador emite decs; o modelo de
+runtime não muda mais depois da fase 1.
+
+## 6. Performance: previsões e critérios de aceitação
+
+Benchmarks novos (entram na suíte e no RESULTS.md):
+
+- `bench_value_call_mutate.nx`: helper **por valor** em laço de mutação com
+  map crescendo (espelho do `bench_typed_call_map`, que usa `ref`). Hoje:
+  quadrático (~4,7s @ N=4000). **Aceite fase 1: flat, no nível da variante
+  sem helper (~130ms), e `cloneCount` O(1) no laço.**
+- `bench_alias_scope_dies.nx`: `do let b = a end` + mutação de `a` em laço.
+  **Aceite fase 1.5: flat.**
+- (fase 2) variante com `let b = a` sem bloco e `b` não lido. **Aceite: flat.**
+
+Critérios globais (mesmo arnês do PR #31):
+
+1. Suíte intercalada (`interleaved_compare.ps1`): benches que não são alvo
+   ficam **≤ ~5%** (o overhead novo é inc/dec O(aridade/locais compostos)
+   por chamada — é aqui que ele é julgado).
+2. Corpus de exemplos: **saídas idênticas** binário antigo × novo.
+3. `go test ./...` verde; testes de caracterização de independência
+   inalterados; mudanças de contagem de clones revisadas caso a caso (§3).
+
+## 7. Testes
+
+- **Red tests da fase 1 (TDD):** laço chamada-por-valor + mutação com
+  `cloneCount` ancorado em O(1); `Owners` volta a 1 após retorno; retorno do
+  próprio parâmetro mantém independência (§4.4); passagem aninhada do mesmo
+  objeto por valor em profundidade k decrementa corretamente no unwind das
+  k chamadas.
+- **Semântica preservada:** mutação de global que aliasa o argumento durante
+  a chamada (o argumento continua contando o slot do caller → clone
+  acontece); canais entregam valor independente; `defer` vê o valor da
+  captura.
+- **Unwind:** erro no meio da chamada passa pelo funil de dec
+  (`finishFrame`); teste com erro + retry em laço não acumula clones.
+- **Concorrência:** os testes existentes de tasks/canais + `-race` (contador
+  atômico).
+
+## 8. Riscos
+
+1. **Dec a mais (unsound).** Mitigação: direção segura por desenho (incs
+   completos primeiro; decs só nos funis centrais da fase 1), arnês de
+   independência já existente, corpus de 130 programas com diff de saída, e
+   revisão caso-a-caso de qualquer teste de clones que mude.
+2. **Metadado de locais.** O frame precisa saber a fronteira locais/
+   temporários para o dec central. Trabalho de compilador (contagem de
+   locais por função) — pré-requisito da fase 1.
+3. **Overhead do inc/dec.** O(compostos vinculados) por chamada; julgado
+   pelo critério ≤ ~5% nos benches neutros. Se estourar, fase 2 (drops
+   precisos) e elisão de pares inc/dec no mesmo bytecode são as válvulas.
+4. **Contenção atômica.** Contadores quentes compartilhados entre tasks são
+   raros (travessia de fronteira já copia por semântica); `-race` + bench
+   `spawn_sum` cobrem.
+5. **Inflação por unwind (fases 1.5/2).** Drops emitidos pelo compilador são
+   pulados por unwind → contador inflado → cópias extras, nunca corrupção.
+   Aceito e documentado; o funil da fase 1 minimiza a janela.
+
+## 9. Fora de escopo
+
+- **Estruturas persistentes (HAMT):** atacam snapshots *vivos* (outra
+  família de custo), ao preço de piorar constantes do caso comum. Só com
+  evidência de workload real.
+- **Inferência estática de borrow:** com RC preciso ela vira só elisão de
+  inc/dec (otimização de fase 2+), não mecanismo de correção.
+- **Gerência de memória:** o contador não libera nada; GC do Go permanece o
+  dono da memória.
+- **Mudanças de linguagem:** nenhuma sintaxe nova (`borrowing`/`consuming` à
+  la Swift ficam como possibilidade futura, não necessidade).

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -156,11 +156,15 @@ real, com a propriedade de segurança de que **dec faltante nunca é unsound**
 (só custa uma cópia):
 
 - **Fase 1 — granularidade de frame (o alvo real).** Incs completos da
-  tabela §4.2; decs centralizados em `finishFrame` (retorno e unwind)
-  varrendo os slots de locais do frame (requer metadado de contagem de
-  locais por função no compilador — hoje o frame não sabe onde os locais
-  terminam e os temporários começam). Elimina o caso `database_file(db)` e
-  todo dead-share em forma de chamada, inclusive cross-module.
+  tabela §4.2; decs centralizados em `finalizeCurrentFrame` (funil único de
+  retorno normal E unwind, após os defers). O frame mantém uma lista dos
+  **slots que ele reteve** (`Owned []int`: parâmetros no bind, locais via
+  novo opcode de posse no `let`); o release percorre só essa lista. Varrer a
+  região de slots do frame seria unsound no unwind (temporários nunca
+  retidos seriam liberados — dec a menos); a lista elimina esse risco e
+  dispensa metadado de contagem de locais no compilador. Elimina o caso
+  `database_file(db)` e todo dead-share em forma de chamada, inclusive
+  cross-module.
 - **Fase 1.5 — escopo de bloco.** Compilador emite drops (dec) na saída de
   blocos para locais compostos que morrem ali (ele conhece tipos e escopos).
   Elimina `do let b = a end; a[i] = x` em laço.
@@ -214,9 +218,10 @@ Critérios globais (mesmo arnês do PR #31):
    completos primeiro; decs só nos funis centrais da fase 1), arnês de
    independência já existente, corpus de 130 programas com diff de saída, e
    revisão caso-a-caso de qualquer teste de clones que mude.
-2. **Metadado de locais.** O frame precisa saber a fronteira locais/
-   temporários para o dec central. Trabalho de compilador (contagem de
-   locais por função) — pré-requisito da fase 1.
+2. **Slots duplicados na lista `Owned`.** O mesmo slot listado duas vezes
+   causaria release dobrado do ocupante final (dec a menos — unsound).
+   Mitigação: inserção com verificação de presença (lista é pequena,
+   varredura linear) e teste dedicado de reatribuição sobre slot possuído.
 3. **Overhead do inc/dec.** O(compostos vinculados) por chamada; julgado
    pelo critério ≤ ~5% nos benches neutros. Se estourar, fase 2 (drops
    precisos) e elisão de pares inc/dec no mesmo bytecode são as válvulas.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -103,6 +103,21 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
 - `ref`: um `VAL_REF` aliasa um *slot*, não cria dono novo do objeto; o slot
   já conta. Escrita através do ref = sobrescrita do slot (dec velho, inc
   novo).
+- **Slot de variável de tipo `ref` (empréstimo) — atenção à assimetria:** o
+  empréstimo vale para *slots de variável* — parâmetro `ref`, `let x: ref T`
+  local, global de tipo `ref`, e a **caixa de upvalue aberta sobre um desses
+  slots** (a caixa herda o empréstimo). Nenhum deles é dono: não incrementam
+  ao vincular e, principalmente, **não podem decrementar** ao serem
+  sobrescritos ou ao serem mutados via caminho MUT — soltar o que nunca se
+  reteve é *dec a menos*, que faz um composto realmente compartilhado parecer
+  único e a mutação seguinte acontecer no lugar (escrita vazando para os
+  outros donos). Um **campo de struct de tipo `ref T`**, por outro lado, **é
+  lugar durável e RETÉM** normalmente (linha "elemento de contêiner":
+  construtor e `OP_SET_PROPERTY`): a distinção é *slot de variável* (empresta)
+  × *campo/elemento* (possui), não a presença da palavra `ref` no tipo. É
+  justamente o retain do campo `proximo: ref Node` que sustenta a contagem de
+  uma lista encadeada — remover esse inc para "uniformizar com `ref`" abriria
+  dec a menos em toda a estrutura.
 - Natives da allowlist só-leitura (`cow_natives.go`): empréstimo puro.
 - Natives **com** assinatura: cópia ansiosa mantida (spec CoW §4.6) — fora
   do RC.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -118,10 +118,21 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
   justamente o retain do campo `proximo: ref Node` que sustenta a contagem de
   uma lista encadeada — remover esse inc para "uniformizar com `ref`" abriria
   dec a menos em toda a estrutura.
-- **A condição de empréstimo é ESTÁTICA — decidida pelo compilador a partir do
-  tipo declarado do slot, nunca inferida em runtime.** Cada funil que trocaria
-  posse num slot `ref` tem um gêmeo de empréstimo emitido pelo lowering
-  (`OP_SET_LOCAL_BORROW`, `OP_SET_GLOBAL_BORROW`, `OP_GET_LOCAL_MUT_BORROW`, e
+- **A pergunta certa é "este slot RETÉM o que guarda?", não "o tipo declarado é
+  `ref T`?".** Não-possuidor é estritamente mais largo: além dos slots `ref`,
+  dois vínculos colocam um valor no slot **sem inc e sem tipo declarado** — a
+  variável de `for ... in` e o binding de `case` do `select`/`when`. Tratá-los
+  como possuidores faz o caminho MUT soltar um objeto que o slot nunca reteve
+  (dec a menos, o elemento do contêiner passa a parecer único). O compilador
+  carrega um flag `Owns` por vínculo local, marcado **exatamente onde o inc é
+  emitido** (`OP_OWN_LOCAL` do `let`; retain de parâmetro sem `ref` no bind da
+  chamada), e é esse flag — não o tipo — que escolhe o gêmeo. Default `false`:
+  a direção segura para o caminho MUT (no máximo deixa um dono a mais, custando
+  uma cópia).
+- **A condição de empréstimo é ESTÁTICA — decidida pelo compilador, nunca
+  inferida em runtime.** Cada funil que trocaria posse tem um gêmeo de
+  empréstimo emitido pelo lowering (`OP_SET_LOCAL_BORROW`,
+  `OP_SET_GLOBAL_BORROW`, `OP_GET_LOCAL_MUT_BORROW`, `OP_REF_LOCAL_BORROW` e
   `OP_MARK_UPVALUE_BORROW` para a caixa de upvalue). Tentar deduzir "este slot
   é empréstimo?" perguntando à lista de slots possuídos do frame erra nas duas
   direções: (i) um slot **possuído** cujo ocupante era `null`/escalar no
@@ -133,6 +144,14 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
   genuinamente emprestado parecer possuído — o dec indevido volta (**dec a
   menos**). A lista de possuídos serve para o release de fim de frame, não como
   oráculo de tipo.
+- **Escrita através de ref para um slot possuído tem de reapontar a entrada de
+  posse do frame.** O funil de escrita via ref faz retain(novo)/release(velho)
+  porque o slot passa a possuir o valor novo; se a entrada `(slot, objeto)` do
+  frame continuar nomeando o objeto **velho**, o release em massa do fim do
+  frame o solta uma segunda vez (**dec a mais** — o objeto velho, ainda vivo em
+  outro dono, passa a parecer único). A entrada é reapontada para o valor novo
+  na própria escrita, de modo que o velho é pago pelo funil e o novo pelo fim do
+  frame.
 - Natives da allowlist só-leitura (`cow_natives.go`): empréstimo puro.
 - Natives **com** assinatura: cópia ansiosa mantida (spec CoW §4.6) — fora
   do RC.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -158,13 +158,15 @@ real, com a propriedade de segurança de que **dec faltante nunca é unsound**
 - **Fase 1 — granularidade de frame (o alvo real).** Incs completos da
   tabela §4.2; decs centralizados em `finalizeCurrentFrame` (funil único de
   retorno normal E unwind, após os defers). O frame mantém uma lista dos
-  **slots que ele reteve** (`Owned []int`: parâmetros no bind, locais via
-  novo opcode de posse no `let`); o release percorre só essa lista. Varrer a
-  região de slots do frame seria unsound no unwind (temporários nunca
-  retidos seriam liberados — dec a menos); a lista elimina esse risco e
-  dispensa metadado de contagem de locais no compilador. Elimina o caso
-  `database_file(db)` e todo dead-share em forma de chamada, inclusive
-  cross-module.
+  **slots que ele reteve** (lista de pares slot→objeto retido: parâmetros no
+  bind, locais via opcode de posse no let; o release libera o OBJETO
+  GRAVADO — liberar o ocupante atual do slot seria unsound sob reuso de slot
+  por temporários após a morte de locais de bloco); o release percorre só
+  essa lista. Varrer a região de slots do frame seria unsound no unwind
+  (temporários nunca retidos seriam liberados — dec a menos); a lista
+  elimina esse risco e dispensa metadado de contagem de locais no
+  compilador. Elimina o caso `database_file(db)` e todo dead-share em forma
+  de chamada, inclusive cross-module.
 - **Fase 1.5 — escopo de bloco.** Compilador emite drops (dec) na saída de
   blocos para locais compostos que morrem ali (ele conhece tipos e escopos).
   Elimina `do let b = a end; a[i] = x` em laço.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -118,6 +118,21 @@ corrente; **decrementa** quando esse lugar morre ou é sobrescrito.
   justamente o retain do campo `proximo: ref Node` que sustenta a contagem de
   uma lista encadeada — remover esse inc para "uniformizar com `ref`" abriria
   dec a menos em toda a estrutura.
+- **A condição de empréstimo é ESTÁTICA — decidida pelo compilador a partir do
+  tipo declarado do slot, nunca inferida em runtime.** Cada funil que trocaria
+  posse num slot `ref` tem um gêmeo de empréstimo emitido pelo lowering
+  (`OP_SET_LOCAL_BORROW`, `OP_SET_GLOBAL_BORROW`, `OP_GET_LOCAL_MUT_BORROW`, e
+  `OP_MARK_UPVALUE_BORROW` para a caixa de upvalue). Tentar deduzir "este slot
+  é empréstimo?" perguntando à lista de slots possuídos do frame erra nas duas
+  direções: (i) um slot **possuído** cujo ocupante era `null`/escalar no
+  momento em que a lista foi consultada nunca chegou a ser registrado (o
+  `Retain` falha em não-composto) e seria tratado como empréstimo — o inc
+  devido é pulado (**under-count**, quebra a independência do vínculo por
+  valor); (ii) índices de slot são **reusados entre blocos irmãos** e a lista
+  não é podada no fim do escopo, então a entrada morta de um irmão faz um slot
+  genuinamente emprestado parecer possuído — o dec indevido volta (**dec a
+  menos**). A lista de possuídos serve para o release de fim de frame, não como
+  oráculo de tipo.
 - Natives da allowlist só-leitura (`cow_natives.go`): empréstimo puro.
 - Natives **com** assinatura: cópia ansiosa mantida (spec CoW §4.6) — fora
   do RC.

--- a/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
+++ b/docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md
@@ -1,10 +1,12 @@
 # Posse Única por Contagem de Referências Duráveis (RC-uniqueness)
 
-**Data:** 2026-08-17 · **Branch:** `perf/cow-uniqueness-rc` · **Status:** proposta
+**Data:** 2026-08-17 · **Branch:** `perf/cow-uniqueness-rc` · **Status:** implementada (fase 1)
 **Relação:** evolução da implementação da spec
 `2026-08-16-cow-value-semantics-design.md` (CoW 0.4.0). O contrato semântico
 daquela spec permanece integralmente válido; esta spec troca só o mecanismo
 que decide *quando clonar*.
+**Resultados:** `benchmarks/RESULTS.md`, seção "develop (fac7542) ×
+RC-uniqueness fase 1 (perf/cow-uniqueness-rc)".
 
 ## 1. Objetivo
 

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -101,6 +101,16 @@ const (
 	// (escrita perdida). Espelha o skip de params IsRef em callPreparedClosure.
 	OP_SET_LOCAL_BORROW  // [slot]
 	OP_SET_GLOBAL_BORROW // [const_hi, const_lo]; mesma regra para globais ref
+	// RC: gêmeos de EMPRÉSTIMO dos funis que trocariam posse. O compilador
+	// decide qual emitir pelo TIPO DECLARADO do slot (`ref T` = empréstimo) —
+	// a resposta é estática. Nunca inferir empréstimo em runtime a partir da
+	// lista de slots possuídos do frame: um slot possuído cujo ocupante era
+	// null/escalar na captura não aparece nela (Retain falha em não-composto)
+	// e índices de slot são reusados entre blocos irmãos sem poda da lista, de
+	// modo que a resposta dinâmica erra nas duas direções.
+	OP_GET_LOCAL_MUT_BORROW // [slot]; uniciza sem contar posse (slot ref)
+	OP_MARK_UPVALUE_BORROW  // [upvalue_index]; marca a caixa de peek(0) como
+	// emprestada (emitido logo após OP_CLOSURE, um por upvalue de tipo ref)
 )
 
 func (op OpCode) String() string {
@@ -165,6 +175,10 @@ func (op OpCode) String() string {
 		return "OP_SET_LOCAL_BORROW"
 	case OP_SET_GLOBAL_BORROW:
 		return "OP_SET_GLOBAL_BORROW"
+	case OP_GET_LOCAL_MUT_BORROW:
+		return "OP_GET_LOCAL_MUT_BORROW"
+	case OP_MARK_UPVALUE_BORROW:
+		return "OP_MARK_UPVALUE_BORROW"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -378,6 +392,10 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.byteInstruction("OP_SET_LOCAL_BORROW", offset)
 	case OP_SET_GLOBAL_BORROW:
 		return c.constantLongInstruction("OP_SET_GLOBAL_BORROW", offset)
+	case OP_GET_LOCAL_MUT_BORROW:
+		return c.byteInstruction("OP_GET_LOCAL_MUT_BORROW", offset)
+	case OP_MARK_UPVALUE_BORROW:
+		return c.byteInstruction("OP_MARK_UPVALUE_BORROW", offset)
 	case OP_EQUAL:
 		return c.simpleInstruction("OP_EQUAL", offset)
 	case OP_GREATER:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -111,6 +111,7 @@ const (
 	OP_GET_LOCAL_MUT_BORROW // [slot]; uniciza sem contar posse (slot ref)
 	OP_MARK_UPVALUE_BORROW  // [upvalue_index]; marca a caixa de peek(0) como
 	// emprestada (emitido logo após OP_CLOSURE, um por upvalue de tipo ref)
+	OP_REF_LOCAL_BORROW // [slot]; ref para slot não-possuidor (caixa emprestada)
 )
 
 func (op OpCode) String() string {
@@ -179,6 +180,8 @@ func (op OpCode) String() string {
 		return "OP_GET_LOCAL_MUT_BORROW"
 	case OP_MARK_UPVALUE_BORROW:
 		return "OP_MARK_UPVALUE_BORROW"
+	case OP_REF_LOCAL_BORROW:
+		return "OP_REF_LOCAL_BORROW"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -396,6 +399,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.byteInstruction("OP_GET_LOCAL_MUT_BORROW", offset)
 	case OP_MARK_UPVALUE_BORROW:
 		return c.byteInstruction("OP_MARK_UPVALUE_BORROW", offset)
+	case OP_REF_LOCAL_BORROW:
+		return c.byteInstruction("OP_REF_LOCAL_BORROW", offset)
 	case OP_EQUAL:
 		return c.simpleInstruction("OP_EQUAL", offset)
 	case OP_GREATER:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -95,6 +95,12 @@ const (
 	OP_DEREF_MUT       // pops ref; uniciza através do slot
 	OP_MARK_SHARED     // marca peek(0) como Shared
 	OP_OWN_LOCAL       // retem peek(0) e registra o slot no frame corrente (RC)
+	// RC: rebind de local de tipo ref — grava no slot SEM contar posse. Um
+	// vínculo `ref` é empréstimo (borrow), não dono: contá-lo daria um dono a
+	// mais ao objeto emprestado e faria a mutação através do empréstimo clonar
+	// (escrita perdida). Espelha o skip de params IsRef em callPreparedClosure.
+	OP_SET_LOCAL_BORROW  // [slot]
+	OP_SET_GLOBAL_BORROW // [const_hi, const_lo]; mesma regra para globais ref
 )
 
 func (op OpCode) String() string {
@@ -155,6 +161,10 @@ func (op OpCode) String() string {
 		return "OP_MARK_SHARED"
 	case OP_OWN_LOCAL:
 		return "OP_OWN_LOCAL"
+	case OP_SET_LOCAL_BORROW:
+		return "OP_SET_LOCAL_BORROW"
+	case OP_SET_GLOBAL_BORROW:
+		return "OP_SET_GLOBAL_BORROW"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -364,6 +374,10 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_MARK_SHARED", offset)
 	case OP_OWN_LOCAL:
 		return c.simpleInstruction("OP_OWN_LOCAL", offset)
+	case OP_SET_LOCAL_BORROW:
+		return c.byteInstruction("OP_SET_LOCAL_BORROW", offset)
+	case OP_SET_GLOBAL_BORROW:
+		return c.constantLongInstruction("OP_SET_GLOBAL_BORROW", offset)
 	case OP_EQUAL:
 		return c.simpleInstruction("OP_EQUAL", offset)
 	case OP_GREATER:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -93,7 +93,7 @@ const (
 	OP_GET_INDEX_MUT   // pops index + container
 	OP_GET_PROP_MUT    // [const_hi, const_lo]; pops container
 	OP_DEREF_MUT       // pops ref; uniciza através do slot
-	OP_MARK_SHARED     // marca peek(0) como Shared
+	OP_MARK_SHARED     // morto pos-RC (Task 8), mantido para nao renumerar; compilador nao emite mais
 	OP_OWN_LOCAL       // vinculo novo: retem peek(0), registra o slot no frame e paga a entrada anterior do indice, se houver (RC)
 	// RC: rebind de local de tipo ref — grava no slot SEM contar posse. Um
 	// vínculo `ref` é empréstimo (borrow), não dono: contá-lo daria um dono a

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -94,6 +94,7 @@ const (
 	OP_GET_PROP_MUT    // [const_hi, const_lo]; pops container
 	OP_DEREF_MUT       // pops ref; uniciza através do slot
 	OP_MARK_SHARED     // marca peek(0) como Shared
+	OP_OWN_LOCAL       // retem peek(0) e registra o slot no frame corrente (RC)
 )
 
 func (op OpCode) String() string {
@@ -152,6 +153,8 @@ func (op OpCode) String() string {
 		return "OP_DEREF_MUT"
 	case OP_MARK_SHARED:
 		return "OP_MARK_SHARED"
+	case OP_OWN_LOCAL:
+		return "OP_OWN_LOCAL"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -359,6 +362,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_DEREF_MUT", offset)
 	case OP_MARK_SHARED:
 		return c.simpleInstruction("OP_MARK_SHARED", offset)
+	case OP_OWN_LOCAL:
+		return c.simpleInstruction("OP_OWN_LOCAL", offset)
 	case OP_EQUAL:
 		return c.simpleInstruction("OP_EQUAL", offset)
 	case OP_GREATER:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -94,7 +94,7 @@ const (
 	OP_GET_PROP_MUT    // [const_hi, const_lo]; pops container
 	OP_DEREF_MUT       // pops ref; uniciza através do slot
 	OP_MARK_SHARED     // marca peek(0) como Shared
-	OP_OWN_LOCAL       // retem peek(0) e registra o slot no frame corrente (RC)
+	OP_OWN_LOCAL       // vinculo novo: retem peek(0), registra o slot no frame e paga a entrada anterior do indice, se houver (RC)
 	// RC: rebind de local de tipo ref — grava no slot SEM contar posse. Um
 	// vínculo `ref` é empréstimo (borrow), não dono: contá-lo daria um dono a
 	// mais ao objeto emprestado e faria a mutação através do empréstimo clonar
@@ -102,12 +102,15 @@ const (
 	OP_SET_LOCAL_BORROW  // [slot]
 	OP_SET_GLOBAL_BORROW // [const_hi, const_lo]; mesma regra para globais ref
 	// RC: gêmeos de EMPRÉSTIMO dos funis que trocariam posse. O compilador
-	// decide qual emitir pelo TIPO DECLARADO do slot (`ref T` = empréstimo) —
-	// a resposta é estática. Nunca inferir empréstimo em runtime a partir da
-	// lista de slots possuídos do frame: um slot possuído cujo ocupante era
-	// null/escalar na captura não aparece nela (Retain falha em não-composto)
-	// e índices de slot são reusados entre blocos irmãos sem poda da lista, de
-	// modo que a resposta dinâmica erra nas duas direções.
+	// decide qual emitir pela POSSE do vínculo (Local.Owns, marcado exatamente
+	// onde o inc é emitido) — resposta estática. Com todo local não-ref
+	// possuidor desde o nascimento (let, parâmetro sem ref, variável de
+	// for-each, binding de case do select), Owns coincide com "tipo declarado
+	// não é `ref T`" para locais nomeados. Nunca inferir empréstimo em runtime
+	// a partir da lista de slots possuídos do frame: um slot possuído cujo
+	// ocupante era null/escalar na captura não aparece nela (Retain falha em
+	// não-composto) e índices de slot são reusados entre blocos irmãos sem
+	// poda da lista, de modo que a resposta dinâmica erra nas duas direções.
 	OP_GET_LOCAL_MUT_BORROW // [slot]; uniciza sem contar posse (slot ref)
 	OP_MARK_UPVALUE_BORROW  // [upvalue_index]; marca a caixa de peek(0) como
 	// emprestada (emitido logo após OP_CLOSURE, um por upvalue de tipo ref)

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -410,9 +410,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						return nil, nil, err
 					}
 					// RC: mesma pergunta do gemeo MUT — so slot POSSUIDOR troca
-					// posse. Um slot nao-possuidor sem tipo `ref` existe (ex.:
-					// `item = outro` dentro de um for-each): contar ali soltaria
-					// o elemento do contêiner, que este slot nunca reteve.
+					// posse. Com for-each e select possuidores desde o
+					// nascimento, os nao-possuidores nomeados sao exatamente os
+					// slots `ref`; o flag Owns segue decidindo.
 					if c.localOwns(arg) {
 						c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
 					} else {
@@ -1215,6 +1215,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		}
 
 		if isMap {
+			// RC: o slot oculto $map EMPRESTA (sem OP_OWN_LOCAL) — ver a nota
+			// do $collection abaixo; a mesma paridade vale para mutar o map
+			// durante a iteracao pelas chaves.
 			c.addLocal(" $map", colType) // Consumes Map from stack
 
 			// Get 'keys' global
@@ -1230,6 +1233,16 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		}
 
 		// 3. Store Collection in Local ($collection)
+		// RC: decisao deliberada — $collection (e $map) EMPRESTAM, nao possuem.
+		// Possuir daria Owners+1 a colecao durante o laco, e `arr[i] = x` no
+		// corpo passaria a CLONAR: a iteracao continuaria no array VELHO,
+		// divergindo do merge-base (conferido no binario: a mutacao durante a
+		// iteracao E observada pelos itens seguintes). O emprestimo aqui e
+		// sound: slots ocultos (nome com espaco) sao inalcancaveis por
+		// identificador do usuario — nenhum funil de escrita, captura ou `ref`
+		// os alcanca, entao nunca ha release sobre eles (a maquinaria do laco
+		// so LE estes slots). Escalares ($index/$len) seriam indiferentes
+		// (Retain e no-op), mas ficam no mesmo regime por consistencia.
 		c.addLocal(" $collection", nil)
 
 		// 4. Init Index ($index = 0)
@@ -1262,7 +1275,17 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		// Body Scope
 		c.beginScope()
-		c.addLocal(n.Identifier, nil) // User variable (consumes Item from stack)
+		// RC (spec §4.2): TODO vinculo local de composto retem — a variavel de
+		// for-each nao e excecao. O bind roda DENTRO do corpo, entao o
+		// OP_OWN_LOCAL executa a cada iteracao: cada elemento recebe exatamente
+		// um retain aqui, e o release e pago pelo bind da iteracao seguinte
+		// (bindOwnedSlot solta o objeto da entrada anterior do slot) ou pelo
+		// fim do frame (ultimo elemento). Colecao vazia: o bind nunca roda —
+		// nem retain, nem entrada, nem release. Com o slot possuidor desde o
+		// nascimento, a captura por closure produz caixa possuidora e o rebind
+		// usa o store contado — Owns volta a coincidir com "tipo nao-ref".
+		c.emitByte(byte(chunk.OP_OWN_LOCAL))
+		c.addOwnedLocal(n.Identifier, nil) // User variable (consumes Item from stack)
 
 		// 9. Compile Body
 		_, _, err = c.Compile(n.Body)
@@ -1394,6 +1417,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		c.beginScope()
 		// Determine types? Dynamic.
+		// RC: slots ocultos do select EMPRESTAM (mesma nota do $collection do
+		// for-each): inalcancaveis pelo usuario, apenas lidos pela maquinaria.
+		// O binding de case (visivel) e quem retem, via OP_OWN_LOCAL abaixo.
 		c.addLocal(" $sel_idx", &ast.PrimitiveType{Name: "int"}) // Stack[-3] -> local 0
 		c.addLocal(" $sel_val", nil)                             // Stack[-2] -> local 1
 		c.addLocal(" $sel_ok", &ast.PrimitiveType{Name: "bool"}) // Stack[-1] -> local 2
@@ -1421,7 +1447,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				ident := assign.Target.(*ast.Identifier)
 				// Create local with value from $sel_val
 				c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(valSlot))
-				c.addLocal(ident.Value, nil) // Bind local
+				// RC (spec §4.2): o binding de case retem como qualquer let —
+				// um `when` dentro de laco reexecuta o bind, e o bindOwnedSlot
+				// paga a entrada anterior do slot (mesma mecanica do for-each).
+				c.emitByte(byte(chunk.OP_OWN_LOCAL))
+				c.addOwnedLocal(ident.Value, nil) // Bind local
 			}
 
 			// Compile Block
@@ -1882,9 +1912,9 @@ func (c *Compiler) compileReferenceArgumentValue(expression ast.Expression) (ast
 				return ref.ElementType, nil
 			}
 			// RC: a caixa aberta sobre o slot herda a condicao do slot. Slot
-			// nao-possuidor (variavel de for-each, binding de case do select)
-			// produz caixa EMPRESTADA, para que a escrita via esse ref nao solte
-			// o que o slot nunca reteve (dec a menos no elemento do contêiner).
+			// nao-possuidor (hoje, apenas os de tipo `ref`) produz caixa
+			// EMPRESTADA, para que a escrita via esse ref nao solte o que o
+			// slot nunca reteve (dec a menos).
 			if c.localOwns(slot) {
 				c.emitBytes(byte(chunk.OP_REF_LOCAL), byte(slot))
 			} else {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -212,11 +212,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 		}
 
-		// CoW: inicializador não-fresco compartilha o composto com a origem
-		if n.Value != nil {
-			c.emitMarkSharedForStore(n.Value, valType)
-		}
-
 		if c.scopeDepth > 0 {
 			// Local variable
 			// RC: o let e um vinculo duravel do frame (spec §4.2) — exceto
@@ -335,9 +330,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				return nil, nil, err
 			}
 
-			// CoW: o valor gravado através do ref passa a ter mais de um dono
-			c.emitMarkSharedForStore(n.Value, valType)
-
 			// 4. Emit Store
 			// Stack: [Ref, Val]
 			// OP_STORE_REF consumes both (Val -> *Ref).
@@ -352,9 +344,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if err != nil {
 				return nil, nil, err
 			}
-
-			// CoW: reatribuição com RHS não-fresco compartilha o composto
-			c.emitMarkSharedForStore(n.Value, valType)
 
 			// 2. Check and Set Variable
 			if arg, localType := c.resolveLocal(ident.Value); arg != -1 {
@@ -513,9 +502,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				return nil, nil, err
 			}
 
-			// CoW: valor composto não-fresco guardado no contêiner
-			c.emitMarkSharedForStore(n.Value, valType)
-
 			// Unwrap RefType
 			if ref, ok := leftType.(*ast.RefType); ok {
 				leftType = ref.ElementType
@@ -594,9 +580,6 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if err != nil {
 				return nil, nil, err
 			}
-
-			// CoW: valor composto não-fresco guardado no campo
-			c.emitMarkSharedForStore(n.Value, valType)
 
 			// RESOLVE FIELD TYPE:
 			var fieldType ast.NoxyType

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -205,8 +205,18 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		if c.scopeDepth > 0 {
 			// Local variable
-			// RC: o let e um vinculo duravel do frame (spec §4.2)
-			c.emitByte(byte(chunk.OP_OWN_LOCAL))
+			// RC: o let e um vinculo duravel do frame (spec §4.2) — exceto
+			// quando o tipo declarado e `ref T`. Um vinculo ref e EMPRESTIMO
+			// (borrow), nunca dono: conta-lo daria um dono a mais ao objeto
+			// emprestado e a mutacao atraves do emprestimo clonaria (escrita
+			// perdida). Mesma regra dos parametros IsRef, que
+			// callPreparedClosure ja pula. A condicao aqui e exatamente a que
+			// resolveLocal enxerga depois (addLocal guarda este n.Type), entao
+			// o rebind — OP_SET_LOCAL_BORROW — decide igual, e um mesmo slot
+			// nunca mistura escrita contada com escrita emprestada.
+			if _, isRefBinding := n.Type.(*ast.RefType); !isRefBinding {
+				c.emitByte(byte(chunk.OP_OWN_LOCAL))
+			}
 			c.addLocal(n.Name.Value, n.Type)
 			// Do NOT pop. The value stays on stack and becomes the local variable.
 		} else {
@@ -215,7 +225,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			c.globals[n.Name.Value] = n.Type
 
 			nameConstant := c.makeConstant(value.NewString(n.Name.Value))
-			c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL, nameConstant)
+			// RC: mesma regra do let local — global de tipo `ref T` e
+			// emprestimo, nao dono (ver OP_SET_LOCAL_BORROW). O tipo do global
+			// fica registrado em c.globals, entao o rebind adiante decide
+			// igual e o slot nunca mistura escrita contada com emprestada.
+			if _, isRefBinding := n.Type.(*ast.RefType); isRefBinding {
+				c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL_BORROW, nameConstant)
+			} else {
+				c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL, nameConstant)
+			}
 			c.emitByte(byte(chunk.OP_POP))
 		}
 		return c.currentChunk, nil, nil
@@ -353,7 +371,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						if err := c.emitRuntimeValueType(localType); err != nil {
 							return nil, nil, err
 						}
-						c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
+						// RC: rebind de local `ref` e troca de EMPRESTIMO, nao
+						// de posse — grava no slot sem retain/release (o dono
+						// real e o campo/global/slot do chamador apontado).
+						// Contar aqui daria um dono a mais ao objeto e faria a
+						// mutacao atraves do emprestimo clonar.
+						c.emitBytes(byte(chunk.OP_SET_LOCAL_BORROW), byte(arg))
 						c.emitByte(byte(chunk.OP_POP))
 						return c.currentChunk, nil, nil
 					}
@@ -410,7 +433,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							if err := c.emitRuntimeValueType(globalType); err != nil {
 								return nil, nil, err
 							}
-							c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL, nameConstant)
+							// RC: rebind de global `ref` e troca de
+							// emprestimo, nao de posse (ver
+							// OP_SET_LOCAL_BORROW).
+							c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL_BORROW, nameConstant)
 							c.emitByte(byte(chunk.OP_POP))
 						} else {
 							// User tried `ref = val`. Explicitly FORBID update via name.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -17,12 +17,13 @@ type Local struct {
 	IsParam    bool
 	// Owns diz que o SLOT deste vinculo RETEM o composto que guarda — ou seja,
 	// que existe um inc pareado com o release de fim de frame (OP_OWN_LOCAL no
-	// `let`, ou o retain de parametro sem `ref` em callPreparedClosure). E a
-	// unica pergunta que os funis de escrita precisam responder, e ela e mais
-	// estreita do que "o tipo declarado e `ref T`?": ha vinculos que colocam um
-	// valor no slot SEM reter e SEM tipo declarado (variavel de for-each,
-	// binding de case do select). Tratar esses como possuidores fazia o caminho
-	// MUT soltar um objeto que o slot nunca reteve (dec a menos).
+	// `let`, na variavel de for-each e no binding de case do select, ou o
+	// retain de parametro sem `ref` em callPreparedClosure). E a unica pergunta
+	// que os funis de escrita precisam responder. Com todo local nomeado
+	// nao-`ref` possuidor desde o nascimento (spec §4.2), Owns coincide com "o
+	// tipo declarado nao e `ref T`" — os nao-possuidores restantes sao os slots
+	// `ref` (emprestimo) e os slots ocultos da maquinaria ($collection/$map/
+	// $sel_*, que emprestam de proposito e sao inalcancaveis pelos funis).
 	//
 	// O default e false — a direcao segura para o gemeo MUT (no maximo deixa um
 	// dono a mais, custando uma copia; nunca solta o que nao reteve). Marque

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1566,16 +1566,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		funcIndex := c.makeConstant(fnObj)
 		c.emitOpWithConstantIndex(chunk.OP_CLOSURE, funcIndex)
-
-		// Emit upvalue bytes
-		for _, up := range fnCompiler.upvalues {
-			isLocal := byte(0)
-			if up.IsLocal {
-				isLocal = 1
-			}
-			c.emitByte(isLocal)
-			c.emitByte(up.Index)
-		}
+		c.emitClosureUpvalues(fnCompiler)
 
 		nameConst := c.makeConstant(value.NewString(n.Name))
 		c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL, nameConst)
@@ -1601,15 +1592,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		funcIndex := c.makeConstant(fnObj)
 		c.emitOpWithConstantIndex(chunk.OP_CLOSURE, funcIndex)
-
-		for _, up := range fnCompiler.upvalues {
-			isLocal := byte(0)
-			if up.IsLocal {
-				isLocal = 1
-			}
-			c.emitByte(isLocal)
-			c.emitByte(up.Index)
-		}
+		c.emitClosureUpvalues(fnCompiler)
 
 		return c.currentChunk, newFunctionType(n.Parameters, n.ReturnType), nil
 
@@ -2254,6 +2237,37 @@ func (c *Compiler) addUpvalue(index uint8, isLocal bool, upvalueType ast.NoxyTyp
 
 	c.upvalues = append(c.upvalues, Upvalue{Index: index, IsLocal: isLocal, Type: upvalueType})
 	return len(c.upvalues) - 1
+}
+
+// emitClosureUpvalues emite a tabela de descritores de upvalue do OP_CLOSURE
+// (pares [is_local, index], encoding intocado) e, em seguida, um
+// OP_MARK_UPVALUE_BORROW para cada upvalue cujo TIPO DECLARADO e `ref T`.
+//
+// RC: a caixa de um upvalue aberto sobre um slot `ref` empresta — nao possui —
+// o que guarda, e essa condicao tem de vir do compilador (estatica), nunca de
+// uma inspecao da lista de slots possuidos do frame em runtime: um slot
+// possuido cujo ocupante era null/escalar na hora da captura nao esta na lista
+// (Retain falha em nao-composto) e seria marcado emprestado por engano (retain
+// devido pulado = under-count), e indices de slot sao reusados entre blocos
+// irmaos sem poda da lista, entao a entrada morta de um irmao faria um slot
+// realmente emprestado parecer possuido (release indevido = dec a menos).
+// As marcas saem depois dos descritores e antes de qualquer uso do valor: o
+// corpo da closure so roda quando ela e chamada, e o fechamento da caixa
+// acontece no fim do escopo/frame — os dois depois daqui.
+func (c *Compiler) emitClosureUpvalues(fnCompiler *Compiler) {
+	for _, up := range fnCompiler.upvalues {
+		isLocal := byte(0)
+		if up.IsLocal {
+			isLocal = 1
+		}
+		c.emitByte(isLocal)
+		c.emitByte(up.Index)
+	}
+	for i, up := range fnCompiler.upvalues {
+		if _, isRefBinding := up.Type.(*ast.RefType); isRefBinding {
+			c.emitBytes(byte(chunk.OP_MARK_UPVALUE_BORROW), byte(i))
+		}
+	}
 }
 
 func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *ast.BlockStatement, returnType ast.NoxyType) (value.Value, *Compiler, error) {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -205,6 +205,8 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		if c.scopeDepth > 0 {
 			// Local variable
+			// RC: o let e um vinculo duravel do frame (spec §4.2)
+			c.emitByte(byte(chunk.OP_OWN_LOCAL))
 			c.addLocal(n.Name.Value, n.Type)
 			// Do NOT pop. The value stays on stack and becomes the local variable.
 		} else {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -15,6 +15,19 @@ type Local struct {
 	Type       ast.NoxyType
 	IsCaptured bool
 	IsParam    bool
+	// Owns diz que o SLOT deste vinculo RETEM o composto que guarda — ou seja,
+	// que existe um inc pareado com o release de fim de frame (OP_OWN_LOCAL no
+	// `let`, ou o retain de parametro sem `ref` em callPreparedClosure). E a
+	// unica pergunta que os funis de escrita precisam responder, e ela e mais
+	// estreita do que "o tipo declarado e `ref T`?": ha vinculos que colocam um
+	// valor no slot SEM reter e SEM tipo declarado (variavel de for-each,
+	// binding de case do select). Tratar esses como possuidores fazia o caminho
+	// MUT soltar um objeto que o slot nunca reteve (dec a menos).
+	//
+	// O default e false — a direcao segura para o gemeo MUT (no maximo deixa um
+	// dono a mais, custando uma copia; nunca solta o que nao reteve). Marque
+	// true exatamente onde o inc e emitido.
+	Owns bool
 }
 
 type Loop struct {
@@ -216,8 +229,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			// nunca mistura escrita contada com escrita emprestada.
 			if _, isRefBinding := n.Type.(*ast.RefType); !isRefBinding {
 				c.emitByte(byte(chunk.OP_OWN_LOCAL))
+				c.addOwnedLocal(n.Name.Value, n.Type)
+			} else {
+				c.addLocal(n.Name.Value, n.Type)
 			}
-			c.addLocal(n.Name.Value, n.Type)
 			// Do NOT pop. The value stays on stack and becomes the local variable.
 		} else {
 			// Global
@@ -394,7 +409,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					if err := c.emitRuntimeValueType(localType); err != nil {
 						return nil, nil, err
 					}
-					c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
+					// RC: mesma pergunta do gemeo MUT — so slot POSSUIDOR troca
+					// posse. Um slot nao-possuidor sem tipo `ref` existe (ex.:
+					// `item = outro` dentro de um for-each): contar ali soltaria
+					// o elemento do contêiner, que este slot nunca reteve.
+					if c.localOwns(arg) {
+						c.emitBytes(byte(chunk.OP_SET_LOCAL), byte(arg))
+					} else {
+						c.emitBytes(byte(chunk.OP_SET_LOCAL_BORROW), byte(arg))
+					}
 					c.emitByte(byte(chunk.OP_POP))
 				}
 			} else if arg, upvalueType := c.resolveUpvalue(ident.Value); arg != -1 {
@@ -1858,7 +1881,15 @@ func (c *Compiler) compileReferenceArgumentValue(expression ast.Expression) (ast
 				c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(slot))
 				return ref.ElementType, nil
 			}
-			c.emitBytes(byte(chunk.OP_REF_LOCAL), byte(slot))
+			// RC: a caixa aberta sobre o slot herda a condicao do slot. Slot
+			// nao-possuidor (variavel de for-each, binding de case do select)
+			// produz caixa EMPRESTADA, para que a escrita via esse ref nao solte
+			// o que o slot nunca reteve (dec a menos no elemento do contêiner).
+			if c.localOwns(slot) {
+				c.emitBytes(byte(chunk.OP_REF_LOCAL), byte(slot))
+			} else {
+				c.emitBytes(byte(chunk.OP_REF_LOCAL_BORROW), byte(slot))
+			}
 			c.locals[slot].IsCaptured = true
 			return declared, nil
 		}
@@ -2070,8 +2101,26 @@ func (c *Compiler) endScope() {
 	}
 }
 
+// addLocal declara um vinculo local que NAO retem o que guarda (Owns=false — o
+// default seguro). Vinculos que retem devem usar addOwnedLocal.
 func (c *Compiler) addLocal(name string, t ast.NoxyType) {
 	c.locals = append(c.locals, Local{Name: name, Depth: c.scopeDepth, Type: t})
+}
+
+// addOwnedLocal declara um vinculo local cujo slot RETEM o composto que guarda
+// — usar somente onde o inc correspondente e de fato emitido (OP_OWN_LOCAL) ou
+// feito pelo runtime (retain de parametro sem `ref`).
+func (c *Compiler) addOwnedLocal(name string, t ast.NoxyType) {
+	c.locals = append(c.locals, Local{Name: name, Depth: c.scopeDepth, Type: t, Owns: true})
+}
+
+// localOwns responde a pergunta que os funis de escrita fazem: este slot retem
+// o que guarda? Indice fora de faixa responde false (direcao segura).
+func (c *Compiler) localOwns(index int) bool {
+	if index < 0 || index >= len(c.locals) {
+		return false
+	}
+	return c.locals[index].Owns
 }
 
 func (c *Compiler) emitDefaultInit(t ast.NoxyType) error {
@@ -2283,12 +2332,19 @@ func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *a
 
 	paramsInfo := []value.ParamInfo{}
 	for _, param := range params {
-		fnCompiler.addLocal(param.Name, param.Type)
-		fnCompiler.locals[len(fnCompiler.locals)-1].IsParam = true // Mark as param
 		isRef := false
 		if _, ok := param.Type.(*ast.RefType); ok {
 			isRef = true
 		}
+		// RC: callPreparedClosure retem (e registra em frame.Owned) o slot de
+		// cada parametro SEM `ref`; parametro `ref` e emprestimo e e pulado la.
+		// O flag Owns aqui espelha exatamente essa decisao do runtime.
+		if isRef {
+			fnCompiler.addLocal(param.Name, param.Type)
+		} else {
+			fnCompiler.addOwnedLocal(param.Name, param.Type)
+		}
+		fnCompiler.locals[len(fnCompiler.locals)-1].IsParam = true // Mark as param
 		paramsInfo = append(paramsInfo, value.ParamInfo{
 			IsRef:    isRef,
 			TypeName: param.Type.String(),

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -19,14 +19,16 @@ func (c *Compiler) compileLValueBase(expr ast.Expression) (ast.NoxyType, bool, e
 	case *ast.Identifier:
 		var t ast.NoxyType
 		if arg, localType := c.resolveLocal(n.Value); arg != -1 {
-			// RC: slot de tipo `ref` e EMPRESTIMO — a unicizacao no caminho de
-			// mutacao nao pode trocar posse ali (nem retain do clone, nem
-			// release do velho: o slot nunca reteve nada). A decisao e estatica,
-			// pelo tipo declarado, igual a do OP_SET_LOCAL_BORROW.
-			if _, isRefBinding := localType.(*ast.RefType); isRefBinding {
-				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT_BORROW), byte(arg))
-			} else {
+			// RC: a pergunta e "este slot RETEM o que guarda?" (Local.Owns), nao
+			// "o tipo declarado e `ref T`?". Nao-possuidor e estritamente mais
+			// largo: alem dos slots `ref`, a variavel de for-each e o binding de
+			// case do select recebem um valor sem inc e sem tipo declarado.
+			// Emitir o gemeo possuidor neles fazia o caminho MUT soltar um
+			// objeto que o slot nunca reteve (dec a menos).
+			if c.localOwns(arg) {
 				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT), byte(arg))
+			} else {
+				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT_BORROW), byte(arg))
 			}
 			t = localType
 		} else if arg, upvalueType := c.resolveUpvalue(n.Value); arg != -1 {

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -19,12 +19,13 @@ func (c *Compiler) compileLValueBase(expr ast.Expression) (ast.NoxyType, bool, e
 	case *ast.Identifier:
 		var t ast.NoxyType
 		if arg, localType := c.resolveLocal(n.Value); arg != -1 {
-			// RC: a pergunta e "este slot RETEM o que guarda?" (Local.Owns), nao
-			// "o tipo declarado e `ref T`?". Nao-possuidor e estritamente mais
-			// largo: alem dos slots `ref`, a variavel de for-each e o binding de
-			// case do select recebem um valor sem inc e sem tipo declarado.
-			// Emitir o gemeo possuidor neles fazia o caminho MUT soltar um
-			// objeto que o slot nunca reteve (dec a menos).
+			// RC: a pergunta e "este slot RETEM o que guarda?" (Local.Owns),
+			// marcado exatamente onde o inc e emitido. Com todo local nao-ref
+			// possuidor desde o nascimento (let, parametro sem ref, variavel de
+			// for-each, binding de case do select — spec §4.2), Owns coincide
+			// com "tipo declarado nao e `ref T`" para locais nomeados; o flag
+			// continua sendo a fonte de verdade para nao reabrir o dec a menos
+			// se um bind site futuro esquecer o inc.
 			if c.localOwns(arg) {
 				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT), byte(arg))
 			} else {

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -19,7 +19,15 @@ func (c *Compiler) compileLValueBase(expr ast.Expression) (ast.NoxyType, bool, e
 	case *ast.Identifier:
 		var t ast.NoxyType
 		if arg, localType := c.resolveLocal(n.Value); arg != -1 {
-			c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT), byte(arg))
+			// RC: slot de tipo `ref` e EMPRESTIMO — a unicizacao no caminho de
+			// mutacao nao pode trocar posse ali (nem retain do clone, nem
+			// release do velho: o slot nunca reteve nada). A decisao e estatica,
+			// pelo tipo declarado, igual a do OP_SET_LOCAL_BORROW.
+			if _, isRefBinding := localType.(*ast.RefType); isRefBinding {
+				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT_BORROW), byte(arg))
+			} else {
+				c.emitBytes(byte(chunk.OP_GET_LOCAL_MUT), byte(arg))
+			}
 			t = localType
 		} else if arg, upvalueType := c.resolveUpvalue(n.Value); arg != -1 {
 			c.emitBytes(byte(chunk.OP_GET_UPVALUE_MUT), byte(arg))

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -101,44 +101,10 @@ func (c *Compiler) derefMutIfRef(t ast.NoxyType) (ast.NoxyType, bool) {
 	return t, false
 }
 
-// isFreshComposite reconhece expressões que produzem um composto novo em
-// folha — literais e zeros — cujo resultado não precisa de OP_MARK_SHARED
-// ao ser armazenado.
-func isFreshComposite(expr ast.Expression) bool {
-	switch expr.(type) {
-	case *ast.ArrayLiteral, *ast.MapLiteral, *ast.ZerosLiteral:
-		return true
-	}
-	return false
-}
-
-// typeNeedsSharedMark decide se um valor do tipo estático dado pode ser um
-// composto CoW (array, map, struct ou desconhecido/any) e portanto precisa
-// de OP_MARK_SHARED ao ser armazenado em um slot.
-func (c *Compiler) typeNeedsSharedMark(t ast.NoxyType) bool {
-	switch tt := t.(type) {
-	case nil:
-		return true // desconhecido: conservador
-	case *ast.ArrayType, *ast.MapType:
-		return true
-	case *ast.PrimitiveType:
-		if _, isStruct := c.structs[tt.Name]; isStruct {
-			return true
-		}
-		return tt.Name == "any"
-	default:
-		return false
-	}
-}
-
-// emitMarkSharedForStore emite OP_MARK_SHARED para o valor no topo da pilha
-// quando ele pode ser um composto que passa a ter mais de um dono.
-func (c *Compiler) emitMarkSharedForStore(valueExpr ast.Expression, valType ast.NoxyType) {
-	if valueExpr != nil && isFreshComposite(valueExpr) {
-		return
-	}
-	if !c.typeNeedsSharedMark(valType) {
-		return
-	}
-	c.emitByte(byte(chunk.OP_MARK_SHARED))
-}
+// NOTA (Task 8): havia aqui um trio de funções (reconhecimento de composto
+// fresco, checagem de tipo marcável e emissão condicional) que decidia
+// quando emitir OP_MARK_SHARED, o antigo opcode de marcação sticky. A
+// unicidade agora é decidida em runtime pelo contador Owners (RC) — o
+// compilador não emite mais esse opcode. Removidas junto com as 5 call
+// sites em compiler.go; o opcode segue definido em chunk.go só para não
+// renumerar.

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -132,34 +132,10 @@ end`)
 	}
 }
 
-func TestMarkSharedOnAliasingLet(t *testing.T) {
-	code := compileSource(t, `func f()
-    let a: int[] = [1]
-    let b: int[] = a
-end`)
-	ops := collectOpcodes(t, code)
-	if ops[chunk.OP_MARK_SHARED] == 0 {
-		t.Fatal("let b = a deve emitir OP_MARK_SHARED")
-	}
-}
-
-func TestNoMarkSharedOnFreshLiteralLet(t *testing.T) {
-	code := compileSource(t, `func f()
-    let b: int[] = [1, 2]
-end`)
-	ops := collectOpcodes(t, code)
-	if ops[chunk.OP_MARK_SHARED] != 0 {
-		t.Fatal("let b = [literal] não deve emitir OP_MARK_SHARED")
-	}
-}
-
-func TestNoMarkSharedOnScalarAssignment(t *testing.T) {
-	code := compileSource(t, `func f()
-    let i: int = 0
-    i = i + 1
-end`)
-	ops := collectOpcodes(t, code)
-	if ops[chunk.OP_MARK_SHARED] != 0 {
-		t.Fatal("atribuição escalar não deve emitir OP_MARK_SHARED (custo em hot loop)")
-	}
-}
+// NOTA (Task 8): havia aqui três testes que auditavam quando o compilador
+// emitia (ou deixava de emitir) o antigo opcode de marcação sticky —
+// aliasing de let devia emitir, literal fresco e atribuição escalar não
+// deviam. O compilador não emite mais esse opcode em nenhum caso (a
+// unicidade é decidida em runtime pelo contador Owners), então os três
+// testes ficaram sem objeto: testavam a emissão de uma máquina removida,
+// não um comportamento observável. Removidos junto com a Task 8.

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -46,7 +46,7 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				// opcode e dessincroniza, perdendo a contagem dos opcodes
 				// seguintes.
 				chunk.OP_SET_LOCAL_BORROW, chunk.OP_GET_LOCAL_MUT_BORROW,
-				chunk.OP_MARK_UPVALUE_BORROW:
+				chunk.OP_MARK_UPVALUE_BORROW, chunk.OP_REF_LOCAL_BORROW:
 				offset++
 			case chunk.OP_CONSTANT_LONG:
 				offset += 3

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -40,7 +40,13 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				chunk.OP_GET_UPVALUE, chunk.OP_SET_UPVALUE, chunk.OP_CALL,
 				chunk.OP_DEFER, chunk.OP_REF_LOCAL, chunk.OP_REF_UPVALUE,
 				chunk.OP_GET_LOCAL_MUT, chunk.OP_GET_UPVALUE_MUT,
-				chunk.OP_SET_PROPERTY_DEREF, chunk.OP_INVOKE:
+				chunk.OP_SET_PROPERTY_DEREF, chunk.OP_INVOKE,
+				// RC (Task 7): gemeos de emprestimo e a marca de upvalue —
+				// operando de 1 byte. Sem eles aqui o walker le o operando como
+				// opcode e dessincroniza, perdendo a contagem dos opcodes
+				// seguintes.
+				chunk.OP_SET_LOCAL_BORROW, chunk.OP_GET_LOCAL_MUT_BORROW,
+				chunk.OP_MARK_UPVALUE_BORROW:
 				offset++
 			case chunk.OP_CONSTANT_LONG:
 				offset += 3
@@ -50,7 +56,8 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				chunk.OP_REF_GLOBAL, chunk.OP_REF_PROPERTY, chunk.OP_CONTEXT_REF_PROPERTY,
 				chunk.OP_IMPORT, chunk.OP_IMPORT_FROM_ALL, chunk.OP_SELECT,
 				chunk.OP_GET_GLOBAL_MUT, chunk.OP_GET_PROP_MUT,
-				chunk.OP_MARK_REF_TARGET_TYPE, chunk.OP_MARK_RUNTIME_VALUE_TYPE:
+				chunk.OP_MARK_REF_TARGET_TYPE, chunk.OP_MARK_RUNTIME_VALUE_TYPE,
+				chunk.OP_SET_GLOBAL_BORROW:
 				offset += 2
 			case chunk.OP_CLOSURE:
 				// [const_index] [upvalue_count] ([is_local, index])*

--- a/internal/value/cow.go
+++ b/internal/value/cow.go
@@ -5,27 +5,10 @@ import (
 	"sync/atomic"
 )
 
-// MarkShared liga o bit sticky de compartilhamento em compostos (CoW).
-// No-op para escalares e demais tipos.
-func MarkShared(v Value) {
-	if v.Type != VAL_OBJ {
-		return
-	}
-	switch obj := v.Obj.(type) {
-	case *ObjArray:
-		obj.Shared.Store(true)
-	case *ObjMap:
-		obj.Shared.Store(true)
-	case *ObjInstance:
-		obj.Shared.Store(true)
-	}
-}
-
 // IsShared informa se o composto tem mais de um dono durável vivo — a
-// unicidade agora é decidida pelo contador Owners, não pelo bit sticky
-// (spec §3: "posse única por contagem de referências duráveis"). O bit
-// Shared continua sendo escrito por MarkShared, mas ninguém mais o lê:
-// virou dead-weight até a Task 8 removê-lo.
+// unicidade é decidida pelo contador Owners (spec §3: "posse única por
+// contagem de referências duráveis"). O antigo bit sticky Shared foi
+// removido na Task 8; Owners é a única fonte de verdade.
 func IsShared(v Value) bool {
 	owners := ownersOf(v)
 	return owners != nil && owners.Load() > 1

--- a/internal/value/cow.go
+++ b/internal/value/cow.go
@@ -21,20 +21,14 @@ func MarkShared(v Value) {
 	}
 }
 
-// IsShared informa se o composto está marcado como compartilhado.
+// IsShared informa se o composto tem mais de um dono durável vivo — a
+// unicidade agora é decidida pelo contador Owners, não pelo bit sticky
+// (spec §3: "posse única por contagem de referências duráveis"). O bit
+// Shared continua sendo escrito por MarkShared, mas ninguém mais o lê:
+// virou dead-weight até a Task 8 removê-lo.
 func IsShared(v Value) bool {
-	if v.Type != VAL_OBJ {
-		return false
-	}
-	switch obj := v.Obj.(type) {
-	case *ObjArray:
-		return obj.Shared.Load()
-	case *ObjMap:
-		return obj.Shared.Load()
-	case *ObjInstance:
-		return obj.Shared.Load()
-	}
-	return false
+	owners := ownersOf(v)
+	return owners != nil && owners.Load() > 1
 }
 
 // ownersSaturation impede overflow do contador; acima disso o valor se

--- a/internal/value/cow.go
+++ b/internal/value/cow.go
@@ -1,5 +1,10 @@
 package value
 
+import (
+	"math"
+	"sync/atomic"
+)
+
 // MarkShared liga o bit sticky de compartilhamento em compostos (CoW).
 // No-op para escalares e demais tipos.
 func MarkShared(v Value) {
@@ -30,4 +35,63 @@ func IsShared(v Value) bool {
 		return obj.Shared.Load()
 	}
 	return false
+}
+
+// ownersSaturation impede overflow do contador; acima disso o valor se
+// comporta como permanentemente compartilhado (equivalente ao sticky).
+const ownersSaturation = math.MaxInt32 / 2
+
+func ownersOf(v Value) *atomic.Int32 {
+	if v.Type != VAL_OBJ {
+		return nil
+	}
+	switch obj := v.Obj.(type) {
+	case *ObjArray:
+		return &obj.Owners
+	case *ObjMap:
+		return &obj.Owners
+	case *ObjInstance:
+		return &obj.Owners
+	}
+	return nil
+}
+
+// Retain registra um dono durável novo. Retorna true se o valor é um
+// composto rastreável (chamador decide se registra o slot para release).
+func Retain(v Value) bool {
+	owners := ownersOf(v)
+	if owners == nil {
+		return false
+	}
+	if owners.Load() < ownersSaturation {
+		owners.Add(1)
+	}
+	return true
+}
+
+// Release solta um dono durável. Nunca desce abaixo de zero (dec a mais é
+// proibido por design; o clamp protege contra funis duplicados).
+func Release(v Value) {
+	owners := ownersOf(v)
+	if owners == nil {
+		return
+	}
+	for {
+		current := owners.Load()
+		if current <= 0 || current >= ownersSaturation {
+			return
+		}
+		if owners.CompareAndSwap(current, current-1) {
+			return
+		}
+	}
+}
+
+// OwnersCount é introspecção para testes; -1 para não-compostos.
+func OwnersCount(v Value) int32 {
+	owners := ownersOf(v)
+	if owners == nil {
+		return -1
+	}
+	return owners.Load()
 }

--- a/internal/value/owners_test.go
+++ b/internal/value/owners_test.go
@@ -1,0 +1,58 @@
+package value
+
+import "testing"
+
+func TestRetainReleaseCountsComposites(t *testing.T) {
+	arr := NewArray([]Value{NewInt(1)})
+	if OwnersCount(arr) != 0 {
+		t.Fatalf("array novo deve nascer com Owners=0, veio %d", OwnersCount(arr))
+	}
+	if !Retain(arr) {
+		t.Fatal("Retain de array deve retornar true")
+	}
+	if !Retain(arr) {
+		t.Fatal("segundo Retain deve retornar true")
+	}
+	if OwnersCount(arr) != 2 {
+		t.Fatalf("esperado Owners=2, veio %d", OwnersCount(arr))
+	}
+	Release(arr)
+	if OwnersCount(arr) != 1 {
+		t.Fatalf("esperado Owners=1 apos Release, veio %d", OwnersCount(arr))
+	}
+}
+
+func TestRetainIgnoresScalarsAndStrings(t *testing.T) {
+	if Retain(NewInt(7)) {
+		t.Fatal("Retain de int deve retornar false")
+	}
+	if Retain(NewString("s")) {
+		t.Fatal("Retain de string deve retornar false")
+	}
+	if OwnersCount(NewInt(7)) != -1 {
+		t.Fatal("OwnersCount de escalar deve ser -1")
+	}
+	Release(NewInt(7)) // nao deve entrar em panico
+}
+
+func TestReleaseClampsAtZero(t *testing.T) {
+	m := NewMap()
+	Release(m)
+	Release(m)
+	if OwnersCount(m) != 0 {
+		t.Fatalf("Release nao pode ir abaixo de 0, veio %d", OwnersCount(m))
+	}
+}
+
+func TestMapAndInstanceAlsoCount(t *testing.T) {
+	m := NewMap()
+	Retain(m)
+	if OwnersCount(m) != 1 {
+		t.Fatalf("map: esperado 1, veio %d", OwnersCount(m))
+	}
+	inst := Value{Type: VAL_OBJ, Obj: &ObjInstance{Fields: map[string]Value{}}}
+	Retain(inst)
+	if OwnersCount(inst) != 1 {
+		t.Fatalf("instance: esperado 1, veio %d", OwnersCount(inst))
+	}
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -285,9 +285,9 @@ func (oc *ObjClosure) Format(f fmt.State, verb rune) {
 type ObjArray struct {
 	Elements    []Value
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
-	Shared      atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
-	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
+	// é a única fonte de unicidade — o antigo bit sticky Shared foi
+	// removido na Task 8.
 	Owners atomic.Int32
 }
 
@@ -328,9 +328,9 @@ type ObjMap struct {
 	store       *bindingStore
 	storeOnce   sync.Once
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
-	Shared      atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
-	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
+	// é a única fonte de unicidade — o antigo bit sticky Shared foi
+	// removido na Task 8.
 	Owners atomic.Int32
 }
 
@@ -385,9 +385,9 @@ func (os *ObjStruct) Format(f fmt.State, verb rune) {
 type ObjInstance struct {
 	Struct *ObjStruct
 	Fields map[string]Value
-	Shared atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
-	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
+	// é a única fonte de unicidade — o antigo bit sticky Shared foi
+	// removido na Task 8.
 	Owners atomic.Int32
 }
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -258,6 +258,9 @@ type ObjArray struct {
 	Elements    []Value
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
 	Shared      atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
+	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	Owners atomic.Int32
 }
 
 func (oa *ObjArray) String() string {
@@ -298,6 +301,9 @@ type ObjMap struct {
 	storeOnce   sync.Once
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
 	Shared      atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
+	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	Owners atomic.Int32
 }
 
 func (om *ObjMap) String() string {
@@ -352,6 +358,9 @@ type ObjInstance struct {
 	Struct *ObjStruct
 	Fields map[string]Value
 	Shared atomic.Bool // CoW: sticky, ligado quando existe mais de um dono
+	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17).
+	// Durante a migração convive com Shared; a chave vira no fim da fase 1.
+	Owners atomic.Int32
 }
 
 func (oi *ObjInstance) String() string {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -147,10 +147,38 @@ type ObjUpvalue struct {
 	location *Value
 	closed   Value
 	next     *ObjUpvalue
+	// borrowed marca que a caixa foi aberta sobre um slot EMPRESTADO (slot de
+	// tipo `ref`, que nunca é dono durável — spec §4.2). Uma caixa emprestada
+	// não retém o que guarda, então os funis de escrita que trocam o conteúdo
+	// (OP_SET_UPVALUE, OP_GET_UPVALUE_MUT) também não podem soltar o valor
+	// velho: soltar o que nunca se reteve é dec a menos e faria o objeto
+	// parecer único, mutando no lugar algo compartilhado.
+	borrowed bool
 }
 
 func NewOpenUpvalue(location *Value, next *ObjUpvalue) *ObjUpvalue {
 	return &ObjUpvalue{location: location, next: next}
+}
+
+// MarkBorrowed registra que a caixa empresta (não possui) o que guarda. É
+// idempotente: capturas repetidas do mesmo slot chegam à mesma conclusão.
+func (upvalue *ObjUpvalue) MarkBorrowed() {
+	if upvalue == nil {
+		return
+	}
+	upvalue.mu.Lock()
+	defer upvalue.mu.Unlock()
+	upvalue.borrowed = true
+}
+
+// IsBorrowed informa se a caixa empresta o valor em vez de possuí-lo.
+func (upvalue *ObjUpvalue) IsBorrowed() bool {
+	if upvalue == nil {
+		return false
+	}
+	upvalue.mu.RLock()
+	defer upvalue.mu.RUnlock()
+	return upvalue.borrowed
 }
 
 func (upvalue *ObjUpvalue) IsValid() bool {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.4.0"
+const Version = "v0.5.0"

--- a/internal/vm/builtins_collections.go
+++ b/internal/vm/builtins_collections.go
@@ -85,7 +85,14 @@ func (vm *VM) defineCollectionBuiltins() {
 					}
 				}
 				if key != nil {
+					// RC: busca o valor velho antes de remover; so libera se
+					// a chave de fato existia (chave ausente nao mexe em
+					// Owners).
+					old, existed := m.Get(key)
 					m.Delete(key)
+					if existed {
+						value.Release(old)
+					}
 				}
 			}
 		}
@@ -118,6 +125,7 @@ func (vm *VM) defineCollectionBuiltins() {
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
 				value.MarkShared(item) // o chamador ainda segura um ponteiro para o item
+				value.Retain(item)     // RC: o array e dono duravel do item anexado
 				arr.Elements = append(arr.Elements, item)
 			}
 		}
@@ -149,6 +157,7 @@ func (vm *VM) defineCollectionBuiltins() {
 				}
 				val := arr.Elements[len(arr.Elements)-1]
 				arr.Elements = arr.Elements[:len(arr.Elements)-1]
+				value.Release(val) // RC: o array solta a posse duravel do elemento removido
 				return val, nil
 			}
 		}

--- a/internal/vm/builtins_collections.go
+++ b/internal/vm/builtins_collections.go
@@ -124,8 +124,7 @@ func (vm *VM) defineCollectionBuiltins() {
 		}
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
-				value.MarkShared(item) // o chamador ainda segura um ponteiro para o item
-				value.Retain(item)     // RC: o array e dono duravel do item anexado
+				value.Retain(item) // RC: o array e dono duravel do item anexado
 				arr.Elements = append(arr.Elements, item)
 			}
 		}

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -56,8 +56,11 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		// Push Args
 		// CoW: a exceção legada do spawn (encaminhar identidade) foi removida;
 		// args compostos são valores como em qualquer outra fronteira.
+		// RC: retain aqui, sincrono, antes do goroutine ser lançado — a nova
+		// thread passa a ser dona durável de cada composto empurrado.
 		for _, arg := range threadArgs {
 			value.MarkShared(arg)
+			value.Retain(arg)
 			threadVM.push(arg)
 		}
 
@@ -68,6 +71,18 @@ func (vm *VM) defineConcurrencyBuiltins() {
 			StackBase:   0,
 			LocalBase:   0,
 			Environment: closure.Environment,
+		}
+
+		// RC: registra os slots retidos acima no frame manual (spawn não passa
+		// por callPreparedClosure, que faria isso via frame.ownSlot — aqui é o
+		// ÚNICO lugar onde retain e registro ficam separados: o retain já
+		// aconteceu no loop de push; aqui só registramos o slot para que
+		// finalizeCurrentFrame libere quando o frame da thread terminar. NÃO
+		// usar ownSlot aqui — ele retém de novo (double-retain).
+		for i := range threadArgs {
+			if value.OwnersCount(threadArgs[i]) >= 0 {
+				frame.Owned = append(frame.Owned, 1+i)
+			}
 		}
 
 		threadVM.frames[0] = frame
@@ -109,6 +124,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		}
 		ch := args[0].Obj.(*value.ObjChannel).Chan
 		value.MarkShared(args[1]) // CoW: canal transporta valor, não identidade
+		value.Retain(args[1])     // RC: o buffer do canal é dono durável enquanto o valor está nele
 		ch <- args[1]
 		return args[1]
 	})
@@ -157,8 +173,11 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		ch := args[0].Obj.(*value.ObjChannel).Chan
 		val, ok := <-ch
 		if !ok {
+			// canal fechado e vazio: nao ha valor recebido, entao nao ha o
+			// que liberar aqui.
 			return value.NewNull()
 		}
+		value.Release(val) // RC: o valor saiu do buffer do canal (que era dono durável)
 		return val
 	})
 

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -81,7 +81,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		// usar ownSlot aqui — ele retém de novo (double-retain).
 		for i := range threadArgs {
 			if value.OwnersCount(threadArgs[i]) >= 0 {
-				frame.Owned = append(frame.Owned, 1+i)
+				frame.Owned = append(frame.Owned, ownedEntry{slot: 1 + i, obj: threadArgs[i]})
 			}
 		}
 

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -59,7 +59,6 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		// RC: retain aqui, sincrono, antes do goroutine ser lançado — a nova
 		// thread passa a ser dona durável de cada composto empurrado.
 		for _, arg := range threadArgs {
-			value.MarkShared(arg)
 			value.Retain(arg)
 			threadVM.push(arg)
 		}
@@ -123,8 +122,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 			return value.NewNull()
 		}
 		ch := args[0].Obj.(*value.ObjChannel).Chan
-		value.MarkShared(args[1]) // CoW: canal transporta valor, não identidade
-		value.Retain(args[1])     // RC: o buffer do canal é dono durável enquanto o valor está nele
+		value.Retain(args[1]) // RC: o buffer do canal é dono durável enquanto o valor está nele
 		ch <- args[1]
 		return args[1]
 	})

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -121,6 +121,10 @@ func stopAndDrainTaskTimer(timer *time.Timer) {
 func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			// RC: espelha o release de invokePreparedCall (defer.go) — a
+			// captura feita em prepareTaskCall sai de escopo aqui tambem no
+			// caminho de panico, antes de sinalizar conclusao da task.
+			vm.releasePreparedArguments(call.Arguments, call.Closure.Function.Params)
 			task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
 				Kind:    "panic",
 				Message: fmt.Sprint(recovered),
@@ -130,6 +134,11 @@ func (vm *VM) startSupervisedTask(task *value.ObjTask, call preparedTaskCall) {
 	}()
 
 	result, err := vm.executePreparedTaskCall(call)
+	// RC: solta a retencao de captura de prepareTaskCall assim que a
+	// execucao termina (sucesso ou erro) — espelha o release pos-invocacao
+	// de invokePreparedCall (defer.go). Chamado antes de task.Complete para
+	// que quem sincroniza via task_await ja veja o release feito.
+	vm.releasePreparedArguments(call.Arguments, call.Closure.Function.Params)
 	if err != nil {
 		task.Complete(value.TaskOutcome{Failure: &value.TaskFailure{
 			Kind:    "runtime",

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -55,6 +55,7 @@ func (vm *VM) callPreparedValue(callee value.Value, argCount int, c *chunk.Chunk
 			for i := 0; i < argCount; i++ {
 				arg := vm.peek(argCount - 1 - i)
 				value.MarkShared(arg) // CoW: o chamador ainda referencia o arg
+				value.Retain(arg)     // RC: campo e dono duravel
 				instObj.Fields[structDef.Fields[i]] = arg
 			}
 			vm.stackTop -= argCount + 1
@@ -156,6 +157,7 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		copy(newElems, obj.Elements)
 		for _, el := range newElems {
 			value.MarkShared(el)
+			value.Retain(el) // RC: filho ganha dono duravel no clone
 		}
 		copied := value.NewArray(newElems)
 		copied.Obj.(*value.ObjArray).RuntimeType.Store(obj.RuntimeType.Load())
@@ -165,6 +167,7 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		newData := obj.Snapshot()
 		for _, val := range newData {
 			value.MarkShared(val)
+			value.Retain(val) // RC: filho ganha dono duravel no clone
 		}
 		copied := value.NewMap()
 		copiedMap := copied.Obj.(*value.ObjMap)
@@ -176,6 +179,7 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		newFields := make(map[string]value.Value)
 		for k, val := range obj.Fields {
 			value.MarkShared(val)
+			value.Retain(val) // RC: filho ganha dono duravel no clone
 			newFields[k] = val
 		}
 		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjInstance{Struct: obj.Struct, Fields: newFields}}

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -36,13 +36,12 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 			vm.copyPreparedArguments(callArgs, params)
 			args = callArgs
 		} else if !native.ReadonlyArgs {
-			// CoW: native sem assinatura pode reter/mutar args — marca todos
-			// os compostos (conservador; allowlist só-leitura pula isto)
-			// RC: retenção permanente e conservadora — não sabemos se o
-			// native guarda o valor além da chamada, então assumimos que sim
-			// e nunca soltamos (sem release em lugar nenhum; até a Task 8).
+			// RC: native sem assinatura pode reter/mutar args — retém todos
+			// os compostos (conservador; allowlist só-leitura pula isto).
+			// Retenção permanente e conservadora — não sabemos se o native
+			// guarda o valor além da chamada, então assumimos que sim e
+			// nunca soltamos (sem release em lugar nenhum).
 			for i := range args {
-				value.MarkShared(args[i])
 				value.Retain(args[i])
 			}
 		}
@@ -58,8 +57,7 @@ func (vm *VM) callPreparedValue(callee value.Value, argCount int, c *chunk.Chunk
 			instObj := instance.Obj.(*value.ObjInstance)
 			for i := 0; i < argCount; i++ {
 				arg := vm.peek(argCount - 1 - i)
-				value.MarkShared(arg) // CoW: o chamador ainda referencia o arg
-				value.Retain(arg)     // RC: campo e dono duravel
+				value.Retain(arg) // RC: campo e dono duravel
 				instObj.Fields[structDef.Fields[i]] = arg
 			}
 			vm.stackTop -= argCount + 1
@@ -106,16 +104,9 @@ func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip i
 	if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
 		return false, vm.runtimeError(c, ip, "%s", err)
 	}
-	for i := 0; i < argCount; i++ {
-		if i < len(fn.Params) {
-			param := fn.Params[i]
-			if !param.IsRef {
-				// CoW: fronteira de valor — marca em vez de copiar; a cópia
-				// só acontece se alguém mutar (unicize)
-				value.MarkShared(vm.stack[baseArgs+i])
-			}
-		}
-	}
+	// RC: fronteira de valor para parametros nao-ref nao precisa de marcacao
+	// aqui — a copia so acontece se alguem mutar (unicize), e a posse do
+	// slot novo e decidida por ownSlot/Retain dentro de callPreparedClosure.
 	return vm.callPreparedClosure(closure, argCount, c, ip)
 }
 
@@ -148,8 +139,8 @@ func (vm *VM) callPreparedClosure(closure *value.ObjClosure, argCount int, c *ch
 	return true, nil
 }
 
-// copyValue é o clone raso do CoW: o contêiner novo nasce unshared, e os
-// filhos imediatos compostos ficam marcados Shared (passam a ter dois donos).
+// copyValue é o clone raso do CoW: o contêiner novo nasce com Owners=0, e os
+// filhos imediatos compostos ganham Retain (passam a ter dois donos duráveis).
 func (vm *VM) copyValue(v value.Value) value.Value {
 	if v.Type != value.VAL_OBJ {
 		return v
@@ -160,7 +151,6 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		newElems := make([]value.Value, len(obj.Elements))
 		copy(newElems, obj.Elements)
 		for _, el := range newElems {
-			value.MarkShared(el)
 			value.Retain(el) // RC: filho ganha dono duravel no clone
 		}
 		copied := value.NewArray(newElems)
@@ -170,7 +160,6 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		cloneCount.Add(1)
 		newData := obj.Snapshot()
 		for _, val := range newData {
-			value.MarkShared(val)
 			value.Retain(val) // RC: filho ganha dono duravel no clone
 		}
 		copied := value.NewMap()
@@ -182,7 +171,6 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		cloneCount.Add(1)
 		newFields := make(map[string]value.Value)
 		for k, val := range obj.Fields {
-			value.MarkShared(val)
 			value.Retain(val) // RC: filho ganha dono duravel no clone
 			newFields[k] = val
 		}

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -126,6 +126,16 @@ func (vm *VM) callPreparedClosure(closure *value.ObjClosure, argCount int, c *ch
 		LocalBase:   vm.stackTop - argCount - 1,
 		Environment: closure.Environment,
 	}
+
+	// RC: parametros sem ref sao vinculos duraveis do frame novo
+	params := closure.Function.Params
+	for i := 0; i < argCount; i++ {
+		if i < len(params) && params[i].IsRef {
+			continue
+		}
+		frame.ownSlot(vm, frame.LocalBase+1+i)
+	}
+
 	// Push new frame
 	vm.frames[vm.frameCount] = frame
 	vm.frameCount++

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -38,8 +38,12 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 		} else if !native.ReadonlyArgs {
 			// CoW: native sem assinatura pode reter/mutar args — marca todos
 			// os compostos (conservador; allowlist só-leitura pula isto)
+			// RC: retenção permanente e conservadora — não sabemos se o
+			// native guarda o valor além da chamada, então assumimos que sim
+			// e nunca soltamos (sem release em lugar nenhum; até a Task 8).
 			for i := range args {
 				value.MarkShared(args[i])
+				value.Retain(args[i])
 			}
 		}
 		return vm.callNative(native, args, argCount, c, ip)

--- a/internal/vm/cow.go
+++ b/internal/vm/cow.go
@@ -36,6 +36,10 @@ func (vm *VM) unicizeThroughRefValue(refArg value.Value) (value.Value, error) {
 	}
 	v, changed := vm.unicize(stored)
 	if changed {
+		// RC: o clone substitui o ocupante velho no destino apontado pelo
+		// ref; retain-antes-de-release em torno da troca.
+		value.Retain(v)
+		value.Release(stored)
 		store(v)
 	}
 	return v, nil

--- a/internal/vm/cow.go
+++ b/internal/vm/cow.go
@@ -41,6 +41,10 @@ func (vm *VM) unicizeThroughRefValue(refArg value.Value) (value.Value, error) {
 		// empresta (caixa de upvalue emprestada) troca sem contar posse.
 		if !refStorageBorrows(ref) {
 			value.Retain(v)
+			// mesma correcao do storeReferenceValue: a entrada de posse do frame
+			// passa a nomear o clone, senao o fim do frame soltaria o valor
+			// velho uma segunda vez (dec a mais).
+			vm.retargetOwnedSlot(ref, v)
 			value.Release(stored)
 		}
 		store(v)

--- a/internal/vm/cow.go
+++ b/internal/vm/cow.go
@@ -37,9 +37,12 @@ func (vm *VM) unicizeThroughRefValue(refArg value.Value) (value.Value, error) {
 	v, changed := vm.unicize(stored)
 	if changed {
 		// RC: o clone substitui o ocupante velho no destino apontado pelo
-		// ref; retain-antes-de-release em torno da troca.
-		value.Retain(v)
-		value.Release(stored)
+		// ref; retain-antes-de-release em torno da troca. Lugar que apenas
+		// empresta (caixa de upvalue emprestada) troca sem contar posse.
+		if !refStorageBorrows(ref) {
+			value.Retain(v)
+			value.Release(stored)
+		}
 		store(v)
 	}
 	return v, nil

--- a/internal/vm/cow_builtins_test.go
+++ b/internal/vm/cow_builtins_test.go
@@ -6,15 +6,16 @@ import (
 	"noxy-vm/internal/value"
 )
 
-// newMarkingVM registra um native test_mark_shared que marca o composto como
-// Shared (simulando um segundo dono) e captura o ponteiro original.
+// newMarkingVM registra um native test_mark_shared que retém o composto
+// (spec §3: Owners > 1 é a unicidade — simula um segundo dono durável) e
+// captura o ponteiro original.
 func newMarkingVM() (*VM, *value.Value) {
 	machine := New()
 	captured := &value.Value{}
 	machine.DefineNative("test_mark_shared", func(args []value.Value) value.Value {
 		if len(args) == 1 {
 			*captured = args[0]
-			value.MarkShared(args[0])
+			value.Retain(args[0])
 		}
 		return value.NewNull()
 	})

--- a/internal/vm/cow_mut_opcodes_test.go
+++ b/internal/vm/cow_mut_opcodes_test.go
@@ -15,7 +15,7 @@ func TestGetLocalMutClonesSharedAndWritesBack(t *testing.T) {
 	machine := New()
 	arr := value.NewArray([]value.Value{value.NewInt(10)})
 	// spec §3: a precondição "compartilhado" é Owners > 1 (dois donos
-	// duráveis), não mais o bit sticky que value.MarkShared liga.
+	// duráveis), não mais o antigo bit sticky (removido na Task 8).
 	shareByOwners(arr)
 
 	code := &chunk.Chunk{}
@@ -161,27 +161,10 @@ func TestDerefMutUnicizesThroughGlobalSlot(t *testing.T) {
 	}
 }
 
-func TestMarkSharedOpcode(t *testing.T) {
-	machine := New()
-	arr := value.NewArray([]value.Value{value.NewInt(1)})
-
-	code := &chunk.Chunk{}
-	constIdx := code.AddConstant(arr)
-	code.Write(byte(chunk.OP_CONSTANT), 1)
-	code.Write(byte(constIdx), 1)
-	code.Write(byte(chunk.OP_MARK_SHARED), 1)
-
-	if err := machine.Interpret(code); err != nil {
-		t.Fatalf("vm error: %v", err)
-	}
-	// spec §3: depois da chave, value.IsShared lê Owners — o bit sticky virou
-	// dead-weight (ninguém mais o lê) e só será removido na Task 8. Enquanto o
-	// opcode existir, auditamos exatamente o que ele ainda faz: ligar o bit no
-	// objeto do topo da pilha.
-	if !arr.Obj.(*value.ObjArray).Shared.Load() {
-		t.Fatal("OP_MARK_SHARED deve ligar o bit do topo da pilha")
-	}
-	if value.IsShared(arr) {
-		t.Fatal("o bit não decide mais unicidade: sem donos duráveis, o valor é único")
-	}
-}
+// NOTA (Task 8): havia aqui um teste que auditava o antigo bit sticky de
+// compartilhamento que OP_MARK_SHARED ligava no composto, e confirmava que
+// value.IsShared já não o lia mais. O bit sticky foi removido do struct e o
+// compilador não emite mais o opcode (case removido do switch do executor —
+// vira no-op se algum bytecode antigo o contiver). Não há mais bit para
+// auditar; a cobertura de unicidade por Owners segue nos testes de unicize
+// em cow_test.go (via shareByOwners) e em rc_uniqueness_test.go.

--- a/internal/vm/cow_mut_opcodes_test.go
+++ b/internal/vm/cow_mut_opcodes_test.go
@@ -14,7 +14,9 @@ import (
 func TestGetLocalMutClonesSharedAndWritesBack(t *testing.T) {
 	machine := New()
 	arr := value.NewArray([]value.Value{value.NewInt(10)})
-	value.MarkShared(arr)
+	// spec §3: a precondição "compartilhado" é Owners > 1 (dois donos
+	// duráveis), não mais o bit sticky que value.MarkShared liga.
+	shareByOwners(arr)
 
 	code := &chunk.Chunk{}
 	constIdx := code.AddConstant(arr)
@@ -29,10 +31,10 @@ func TestGetLocalMutClonesSharedAndWritesBack(t *testing.T) {
 
 	slotVal := machine.stack[1]
 	if slotVal.Obj == arr.Obj {
-		t.Fatal("slot deveria conter o clone, não o original Shared")
+		t.Fatal("slot deveria conter o clone, não o original compartilhado")
 	}
 	if value.IsShared(slotVal) {
-		t.Fatal("clone no slot deve estar unshared")
+		t.Fatal("clone no slot deve ter um único dono (o próprio slot)")
 	}
 	if machine.stack[2].Obj != slotVal.Obj {
 		t.Fatal("valor empilhado deve ser o mesmo clone gravado no slot")
@@ -61,8 +63,10 @@ func TestGetLocalMutLeavesUnsharedAlone(t *testing.T) {
 func TestGetIndexMutClonesSharedChild(t *testing.T) {
 	machine := New()
 	child := value.NewArray([]value.Value{value.NewInt(5)})
-	value.MarkShared(child)
 	parent := value.NewArray([]value.Value{child})
+	// spec §3: dois donos duráveis (o elemento de parent, que o OP_ARRAY real
+	// teria retido, mais um alias qualquer) em vez do bit sticky.
+	shareByOwners(child)
 
 	code := &chunk.Chunk{}
 	parentIdx := code.AddConstant(parent)
@@ -79,23 +83,25 @@ func TestGetIndexMutClonesSharedChild(t *testing.T) {
 
 	parentObj := parent.Obj.(*value.ObjArray)
 	if parentObj.Elements[0].Obj == child.Obj {
-		t.Fatal("filho Shared deveria ter sido clonado e gravado de volta em Elements[0]")
+		t.Fatal("filho compartilhado deveria ter sido clonado e gravado de volta em Elements[0]")
 	}
 	if machine.stack[1].Obj != parentObj.Elements[0].Obj {
 		t.Fatal("valor empilhado deve ser o clone gravado no pai")
 	}
 	if value.IsShared(parentObj.Elements[0]) {
-		t.Fatal("clone deve estar unshared")
+		t.Fatal("clone deve ter um único dono (o elemento do pai)")
 	}
 }
 
 func TestGetPropMutClonesSharedField(t *testing.T) {
 	machine := New()
 	field := value.NewArray([]value.Value{value.NewInt(5)})
-	value.MarkShared(field)
 	structDef := &value.ObjStruct{Name: "Box", Fields: []string{"data"}}
 	inst := value.NewInstance(structDef)
 	inst.Obj.(*value.ObjInstance).Fields["data"] = field
+	// spec §3: dois donos duráveis (o campo da instância, que o construtor
+	// real teria retido, mais um alias qualquer) em vez do bit sticky.
+	shareByOwners(field)
 
 	code := &chunk.Chunk{}
 	instIdx := code.AddConstant(inst)
@@ -112,7 +118,7 @@ func TestGetPropMutClonesSharedField(t *testing.T) {
 
 	instObj := inst.Obj.(*value.ObjInstance)
 	if instObj.Fields["data"].Obj == field.Obj {
-		t.Fatal("campo Shared deveria ter sido clonado e gravado de volta")
+		t.Fatal("campo compartilhado deveria ter sido clonado e gravado de volta")
 	}
 	if machine.stack[1].Obj != instObj.Fields["data"].Obj {
 		t.Fatal("valor empilhado deve ser o clone gravado no campo")
@@ -122,9 +128,11 @@ func TestGetPropMutClonesSharedField(t *testing.T) {
 func TestDerefMutUnicizesThroughGlobalSlot(t *testing.T) {
 	machine := New()
 	arr := value.NewArray([]value.Value{value.NewInt(3)})
-	value.MarkShared(arr)
 	env := machine.shared.Root
 	env.SetLocal("g", arr)
+	// spec §3: dois donos duráveis (o slot global g, que o OP_SET_GLOBAL real
+	// teria retido, mais um alias qualquer) em vez do bit sticky.
+	shareByOwners(arr)
 	refVal := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{
 		RefType:     value.REF_GLOBAL,
 		Name:        "g",
@@ -146,7 +154,7 @@ func TestDerefMutUnicizesThroughGlobalSlot(t *testing.T) {
 		t.Fatal("global g sumiu")
 	}
 	if stored.Obj == arr.Obj {
-		t.Fatal("composto Shared atrás do ref deveria ter sido clonado no slot")
+		t.Fatal("composto compartilhado atrás do ref deveria ter sido clonado no slot")
 	}
 	if machine.stack[1].Obj != stored.Obj {
 		t.Fatal("valor empilhado deve ser o clone gravado no slot global")
@@ -166,7 +174,14 @@ func TestMarkSharedOpcode(t *testing.T) {
 	if err := machine.Interpret(code); err != nil {
 		t.Fatalf("vm error: %v", err)
 	}
-	if !value.IsShared(arr) {
+	// spec §3: depois da chave, value.IsShared lê Owners — o bit sticky virou
+	// dead-weight (ninguém mais o lê) e só será removido na Task 8. Enquanto o
+	// opcode existir, auditamos exatamente o que ele ainda faz: ligar o bit no
+	// objeto do topo da pilha.
+	if !arr.Obj.(*value.ObjArray).Shared.Load() {
 		t.Fatal("OP_MARK_SHARED deve ligar o bit do topo da pilha")
+	}
+	if value.IsShared(arr) {
+		t.Fatal("o bit não decide mais unicidade: sem donos duráveis, o valor é único")
 	}
 }

--- a/internal/vm/cow_natives.go
+++ b/internal/vm/cow_natives.go
@@ -12,8 +12,9 @@ func stampReadonlyArgs(v value.Value) value.Value {
 }
 
 // readonlyNatives lista natives sem assinatura que comprovadamente não retêm
-// nem mutam seus argumentos: seus args compostos não precisam de MarkShared.
-// Só entra aqui native auditado — o default conservador é marcar.
+// nem mutam seus argumentos: seus args compostos não precisam do Retain
+// conservador em callValue. Só entra aqui native auditado — o default
+// conservador é reter (RC: assume posse durável indefinida).
 var readonlyNatives = map[string]bool{
 	"length":      true,
 	"to_str":      true,
@@ -21,7 +22,7 @@ var readonlyNatives = map[string]bool{
 	"to_float":    true,
 	"fmt":         true,
 	"typeof":      true,
-	"chan_recv":   true, // recebe o canal; o payload foi marcado no send
+	"chan_recv":   true, // recebe o canal; o payload foi retido no send
 	"test_report": true, // harness de teste: apenas observa
 	"has_key":     true, // só consulta o mapa; devolve bool novo
 	"keys":        true, // Snapshot + array novo; não compartilha estrutura

--- a/internal/vm/cow_test.go
+++ b/internal/vm/cow_test.go
@@ -6,18 +6,18 @@ import (
 	"noxy-vm/internal/value"
 )
 
-// shareByOwners estabelece a precondição "compartilhado" pelo mecanismo novo
-// (spec docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md §3): a
-// unicidade passou a ser decidida por Owners > 1, não mais pelo bit sticky
-// Shared. Os testes de mecanismo abaixo antes forjavam o estado com
-// value.MarkShared; agora registram os dois donos duráveis que o bytecode
-// real registraria (ex.: slot de um `let` + elemento de um contêiner).
+// shareByOwners estabelece a precondição "compartilhado" pelo mecanismo de
+// posse por contagem (spec docs/superpowers/specs/
+// 2026-08-17-cow-rc-uniqueness-design.md §3): a unicidade é decidida por
+// Owners > 1. Os testes de mecanismo abaixo registram os dois donos
+// duráveis que o bytecode real registraria (ex.: slot de um `let` +
+// elemento de um contêiner).
 func shareByOwners(v value.Value) {
 	value.Retain(v)
 	value.Retain(v)
 }
 
-func TestMarkSharedAndUnicize(t *testing.T) {
+func TestShareByOwnersAndUnicize(t *testing.T) {
 	machine := New()
 	inner := value.NewArray([]value.Value{value.NewInt(1)})
 	outer := value.NewArray([]value.Value{inner})
@@ -55,11 +55,15 @@ func TestMarkSharedAndUnicize(t *testing.T) {
 	}
 }
 
-func TestMarkSharedIgnoresScalars(t *testing.T) {
+// NOTA (Task 8): havia aqui um teste que confirmava que a função de marcação
+// (bit sticky, aposentada nesta task) era no-op em escalares. O mesmo
+// invariante para escalares — IsShared sempre false — segue coberto abaixo;
+// Retain/Release/OwnersCount também são no-op/-1 em escalares (ver
+// rc_uniqueness_test.go).
+func TestIsSharedFalseForScalars(t *testing.T) {
 	n := value.NewInt(7)
-	value.MarkShared(n) // não deve entrar em pânico
 	if value.IsShared(n) {
-		t.Fatal("escalares nunca são Shared")
+		t.Fatal("escalares nunca são compartilhados (sem contador de donos)")
 	}
 }
 

--- a/internal/vm/cow_test.go
+++ b/internal/vm/cow_test.go
@@ -6,10 +6,25 @@ import (
 	"noxy-vm/internal/value"
 )
 
+// shareByOwners estabelece a precondição "compartilhado" pelo mecanismo novo
+// (spec docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md §3): a
+// unicidade passou a ser decidida por Owners > 1, não mais pelo bit sticky
+// Shared. Os testes de mecanismo abaixo antes forjavam o estado com
+// value.MarkShared; agora registram os dois donos duráveis que o bytecode
+// real registraria (ex.: slot de um `let` + elemento de um contêiner).
+func shareByOwners(v value.Value) {
+	value.Retain(v)
+	value.Retain(v)
+}
+
 func TestMarkSharedAndUnicize(t *testing.T) {
 	machine := New()
 	inner := value.NewArray([]value.Value{value.NewInt(1)})
 	outer := value.NewArray([]value.Value{inner})
+	// inner é elemento durável de outer — o OP_ARRAY real teria retido
+	// (Task 5); aqui o array foi montado fora do bytecode, então contamos à
+	// mão para que o clone raso de outer o leve de 1 para 2 donos.
+	value.Retain(inner)
 
 	if value.IsShared(outer) {
 		t.Fatal("array novo não deve nascer Shared")
@@ -19,17 +34,18 @@ func TestMarkSharedAndUnicize(t *testing.T) {
 		t.Fatal("unicize de objeto não-Shared deve devolver o mesmo objeto sem clonar")
 	}
 
-	value.MarkShared(outer)
+	// spec §3: dois donos duráveis (aqui: o alias de teste) em vez do bit.
+	shareByOwners(outer)
 	ResetCloneCount()
 	v, cloned = machine.unicize(outer)
 	if !cloned || v.Obj == outer.Obj {
 		t.Fatal("unicize de objeto Shared deve clonar")
 	}
 	if value.IsShared(v) {
-		t.Fatal("clone deve nascer com Shared desligado")
+		t.Fatal("clone deve nascer sem donos (não compartilhado)")
 	}
 	if !value.IsShared(inner) {
-		t.Fatal("clone raso deve marcar os filhos compostos como Shared")
+		t.Fatal("clone raso deve dar um dono a mais aos filhos compostos (ficam compartilhados)")
 	}
 	if CloneCountValue() != 1 {
 		t.Fatalf("esperado 1 clone, contador = %d", CloneCountValue())
@@ -52,14 +68,17 @@ func TestUnicizeMapMarksValues(t *testing.T) {
 	inner := value.NewArray([]value.Value{value.NewInt(1)})
 	m := value.NewMap()
 	m.Obj.(*value.ObjMap).Set("k", inner)
-	value.MarkShared(m)
+	// dono durável do valor guardado no map (OP_MAP real faria isso).
+	value.Retain(inner)
+	// spec §3: "compartilhado" agora é Owners > 1, não o bit sticky.
+	shareByOwners(m)
 
 	v, cloned := machine.unicize(m)
 	if !cloned {
-		t.Fatal("map Shared deve clonar")
+		t.Fatal("map com mais de um dono deve clonar")
 	}
 	if !value.IsShared(inner) {
-		t.Fatal("valores do map clonado devem ficar Shared")
+		t.Fatal("valores do map clonado devem ganhar um dono (ficam compartilhados)")
 	}
 	got, ok := v.Obj.(*value.ObjMap).Get("k")
 	if !ok || got.Obj != inner.Obj {
@@ -73,14 +92,17 @@ func TestUnicizeInstanceMarksFields(t *testing.T) {
 	structDef := &value.ObjStruct{Name: "Box", Fields: []string{"data"}}
 	inst := value.NewInstance(structDef)
 	inst.Obj.(*value.ObjInstance).Fields["data"] = inner
-	value.MarkShared(inst)
+	// dono durável do campo (o construtor real faria isso — Task 5).
+	value.Retain(inner)
+	// spec §3: "compartilhado" agora é Owners > 1, não o bit sticky.
+	shareByOwners(inst)
 
 	v, cloned := machine.unicize(inst)
 	if !cloned {
-		t.Fatal("instância Shared deve clonar")
+		t.Fatal("instância com mais de um dono deve clonar")
 	}
 	if !value.IsShared(inner) {
-		t.Fatal("campos compostos do clone devem ficar Shared")
+		t.Fatal("campos compostos do clone devem ganhar um dono (ficam compartilhados)")
 	}
 	if v.Obj.(*value.ObjInstance).Fields["data"].Obj != inner.Obj {
 		t.Fatal("clone raso de instância deve compartilhar os campos (mesmo ponteiro)")

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -32,7 +32,7 @@ func (vm *VM) prepareDeferredCall(callee value.Value, args []value.Value, regist
 		if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
 			return PreparedCall{}, err
 		}
-		vm.markPreparedArguments(prepared.Arguments, fn.Params)
+		vm.retainPreparedArguments(prepared.Arguments, fn.Params)
 		return prepared, nil
 
 	case value.VAL_NATIVE:
@@ -91,27 +91,26 @@ func nativeParameters(native *value.ObjNative, argCount int) ([]value.ParamInfo,
 	return params, nil
 }
 
-// markPreparedArguments implementa a fronteira de valor do CoW para código
-// Noxy (closures, tasks): em vez de copiar ansiosamente, marca os compostos
-// não-ref como Shared — a cópia só acontece se alguém mutar (unicize).
-// RC: também retém — a captura (PreparedCall.Arguments) é uma posse durável
-// entre o registro do defer e sua invocação (janela em que os args ficam
-// "guardados" fora da pilha); releasePreparedArguments desfaz isso depois
-// que a invocação roda.
-func (vm *VM) markPreparedArguments(args []value.Value, params []value.ParamInfo) {
+// retainPreparedArguments implementa a fronteira de valor do CoW para código
+// Noxy (closures, tasks): em vez de copiar ansiosamente, retém os compostos
+// não-ref — a cópia só acontece se alguém mutar (unicize). A captura
+// (PreparedCall.Arguments, ou o array espelho em preparedTaskCall) é uma
+// posse durável entre o registro (defer/task) e a invocação (janela em que
+// os args ficam "guardados" fora da pilha); releasePreparedArguments desfaz
+// isso depois que a invocação roda.
+func (vm *VM) retainPreparedArguments(args []value.Value, params []value.ParamInfo) {
 	for i, param := range params {
 		if i >= len(args) {
 			break
 		}
 		if !param.IsRef {
-			value.MarkShared(args[i])
 			value.Retain(args[i])
 		}
 	}
 }
 
 // releasePreparedArguments desfaz exatamente o retain de captura feito por
-// markPreparedArguments, usando a mesma condição (!IsRef) para não soltar
+// retainPreparedArguments, usando a mesma condição (!IsRef) para não soltar
 // argumentos ref que nunca foram retidos aqui. Chamado depois que a
 // invocação preparada (defer ou task) já rodou — a posse durável passou a
 // ser a do binding de parâmetro do frame instanciado pela chamada.
@@ -156,13 +155,13 @@ func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 		}
 		vm.stackTop = base
 
-		// RC: solta a retenção de captura feita em markPreparedArguments — a
-		// invocação já rodou (sucesso ou erro, este é um defer do Go: sempre
+		// RC: solta a retenção de captura feita em retainPreparedArguments —
+		// a invocação já rodou (sucesso ou erro, este é um defer do Go: sempre
 		// executa) e já retomou posse durável via callPreparedClosure (frame
 		// próprio da closure chamada). Só se aplica a callee VAL_FUNCTION,
-		// que é o único caso em que markPreparedArguments reteve na captura
+		// que é o único caso em que retainPreparedArguments reteve na captura
 		// (native usa cópia ansiosa via copyPreparedArguments; struct não
-		// marca nada aqui).
+		// retém nada aqui).
 		if call.Callee.Type == value.VAL_FUNCTION {
 			if closure, ok := call.Callee.Obj.(*value.ObjClosure); ok && closure != nil && closure.Function != nil {
 				vm.releasePreparedArguments(call.Arguments, closure.Function.Params)

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -94,6 +94,10 @@ func nativeParameters(native *value.ObjNative, argCount int) ([]value.ParamInfo,
 // markPreparedArguments implementa a fronteira de valor do CoW para código
 // Noxy (closures, tasks): em vez de copiar ansiosamente, marca os compostos
 // não-ref como Shared — a cópia só acontece se alguém mutar (unicize).
+// RC: também retém — a captura (PreparedCall.Arguments) é uma posse durável
+// entre o registro do defer e sua invocação (janela em que os args ficam
+// "guardados" fora da pilha); releasePreparedArguments desfaz isso depois
+// que a invocação roda.
 func (vm *VM) markPreparedArguments(args []value.Value, params []value.ParamInfo) {
 	for i, param := range params {
 		if i >= len(args) {
@@ -101,6 +105,23 @@ func (vm *VM) markPreparedArguments(args []value.Value, params []value.ParamInfo
 		}
 		if !param.IsRef {
 			value.MarkShared(args[i])
+			value.Retain(args[i])
+		}
+	}
+}
+
+// releasePreparedArguments desfaz exatamente o retain de captura feito por
+// markPreparedArguments, usando a mesma condição (!IsRef) para não soltar
+// argumentos ref que nunca foram retidos aqui. Chamado depois que a
+// invocação preparada (defer ou task) já rodou — a posse durável passou a
+// ser a do binding de parâmetro do frame instanciado pela chamada.
+func (vm *VM) releasePreparedArguments(args []value.Value, params []value.ParamInfo) {
+	for i, param := range params {
+		if i >= len(args) {
+			break
+		}
+		if !param.IsRef {
+			value.Release(args[i])
 		}
 	}
 }
@@ -134,6 +155,19 @@ func (vm *VM) invokePreparedCall(call PreparedCall) (err error) {
 			vm.stack[i] = value.Value{}
 		}
 		vm.stackTop = base
+
+		// RC: solta a retenção de captura feita em markPreparedArguments — a
+		// invocação já rodou (sucesso ou erro, este é um defer do Go: sempre
+		// executa) e já retomou posse durável via callPreparedClosure (frame
+		// próprio da closure chamada). Só se aplica a callee VAL_FUNCTION,
+		// que é o único caso em que markPreparedArguments reteve na captura
+		// (native usa cópia ansiosa via copyPreparedArguments; struct não
+		// marca nada aqui).
+		if call.Callee.Type == value.VAL_FUNCTION {
+			if closure, ok := call.Callee.Obj.(*value.ObjClosure); ok && closure != nil && closure.Function != nil {
+				vm.releasePreparedArguments(call.Arguments, closure.Function.Params)
+			}
+		}
 	}()
 
 	ownerFrameCount := vm.frameCount

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -186,11 +186,20 @@ func TestPrepareDeferredCallUsesCallableCaptureSemantics(t *testing.T) {
 	closureValue := value.NewFunction("cleanup", 1, 0, []value.ParamInfo{{TypeName: "int[]"}}, chunk.New(), machine.shared.Root)
 	closure := &value.ObjClosure{Function: closureValue.Obj.(*value.ObjFunction), Environment: machine.shared.Root}
 
-	// Contrato CoW: closure defer captura por valor via marcação Shared —
-	// mesmo ponteiro, cópia adiada para a primeira mutação (unicize).
+	// Contrato CoW: closure defer captura por valor sem copiar — mesmo
+	// ponteiro, cópia adiada para a primeira mutação (unicize). Depois da
+	// chave (spec §3), o que registra a captura é o contador de donos, não o
+	// bit sticky: aqui `array` nasce sem dono nenhum (montado fora do
+	// bytecode), então a captura o leva de 0 para 1 — em código real o dono do
+	// chamador já estaria contado e o total passaria de 1, disparando o CoW na
+	// primeira mutação.
+	ownersBefore := value.OwnersCount(array)
 	prepared, err := machine.prepareDeferredCall(value.Value{Type: value.VAL_FUNCTION, Obj: closure}, []value.Value{array}, SourceLocation{})
-	if err != nil || prepared.Arguments[0].Obj != array.Obj || !value.IsShared(prepared.Arguments[0]) {
-		t.Fatalf("closure defer deve marcar o arg composto como Shared (captura CoW)")
+	if err != nil || prepared.Arguments[0].Obj != array.Obj {
+		t.Fatalf("closure defer deve capturar o arg composto sem copiar: err=%v", err)
+	}
+	if got := value.OwnersCount(prepared.Arguments[0]); got != ownersBefore+1 {
+		t.Fatalf("captura do defer deve contar um dono durável: esperado %d, veio %d", ownersBefore+1, got)
 	}
 
 	reference := value.Value{Type: value.VAL_REF, Obj: &value.ObjRef{RefType: value.REF_GLOBAL, Name: "items", GlobalOwner: machine.shared.Root}}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -252,7 +252,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			slot := int(c.Code[ip])
 			ip++
 			// Reference to a stack slot - Capture it!
-			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot])
+			// RC: a caixa herda a condicao do slot (possuido x emprestado).
+			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot], frame.ownsSlotIndex(frame.LocalBase+slot))
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
@@ -959,7 +960,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				ip++
 
 				if isLocal == 1 {
-					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[frame.LocalBase+int(index)])
+					// RC: a caixa herda a condicao do slot capturado — slot
+					// `ref` e emprestimo, e a caixa nao passa a possuir.
+					localSlot := frame.LocalBase + int(index)
+					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[localSlot], frame.ownsSlotIndex(localSlot))
 				} else {
 					closure.Upvalues[i] = frame.Closure.Upvalues[index]
 				}
@@ -983,12 +987,21 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return vm.runtimeError(c, ip, "invalid upvalue")
 			}
 			updated := vm.peek(0)
-			// RC: retain-antes-de-release (auto-atribuicao via upvalue)
-			value.Retain(updated)
-			if !frame.Closure.Upvalues[slot].Store(updated) {
-				return vm.runtimeError(c, ip, "invalid upvalue")
+			// RC: retain-antes-de-release (auto-atribuicao via upvalue). Caixa
+			// emprestada (slot `ref` capturado) troca sem contar posse: quem
+			// responde pelo objeto e o dono real, e soltar o velho aqui seria
+			// soltar o que a caixa nunca reteve (dec a menos).
+			if frame.Closure.Upvalues[slot].IsBorrowed() {
+				if !frame.Closure.Upvalues[slot].Store(updated) {
+					return vm.runtimeError(c, ip, "invalid upvalue")
+				}
+			} else {
+				value.Retain(updated)
+				if !frame.Closure.Upvalues[slot].Store(updated) {
+					return vm.runtimeError(c, ip, "invalid upvalue")
+				}
+				value.Release(old)
 			}
-			value.Release(old)
 
 		case chunk.OP_CLOSE_UPVALUE:
 			// RC: a posse so migra para o box se o slot era possuido pelo
@@ -1331,10 +1344,18 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				old := v
 				v = vm.copyValue(v)
 				vm.stack[idx] = v
-				// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
-				// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
-				frame.ownSlot(vm, idx)
-				value.Release(old)
+				// RC: so o slot POSSUIDO troca de dono. Um slot de tipo `ref` e
+				// emprestimo (nunca esta em frame.Owned): soltar o velho ali
+				// seria soltar o que este slot nunca reteve (dec a menos), e o
+				// objeto compartilhado passaria a parecer unico. O clone fica
+				// no slot emprestado sem dono — como no comportamento antigo.
+				if frame.ownsSlotIndex(idx) {
+					// ownSlot (nao Retain cru) mantem o slot registrado em
+					// frame.Owned apontando o objeto novo — mesmo padrao do
+					// OP_SET_LOCAL.
+					frame.ownSlot(vm, idx)
+					value.Release(old)
+				}
 			}
 			vm.push(v)
 
@@ -1374,10 +1395,16 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			v, changed := vm.unicize(stored)
 			if changed {
 				// RC: o clone substitui o valor compartilhado no box do
-				// upvalue; retain-antes-de-release em torno da troca.
-				value.Retain(v)
-				value.Release(stored)
-				upv.Store(v)
+				// upvalue; retain-antes-de-release em torno da troca. Caixa
+				// emprestada (slot `ref` capturado) nao possui o que guarda:
+				// soltar o velho ali seria dec a menos.
+				if upv.IsBorrowed() {
+					upv.Store(v)
+				} else {
+					value.Retain(v)
+					value.Release(stored)
+					upv.Store(v)
+				}
 			}
 			vm.push(v)
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -248,15 +248,19 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_OWN_LOCAL:
 			frame.ownSlot(vm, vm.stackTop-1)
 
-		case chunk.OP_REF_LOCAL:
+		case chunk.OP_REF_LOCAL, chunk.OP_REF_LOCAL_BORROW:
 			slot := int(c.Code[ip])
 			ip++
 			// Reference to a stack slot - Capture it!
-			// RC: a caixa nasce possuidora, e aqui isso e sempre correto: o
-			// compilador so emite OP_REF_LOCAL para local de tipo NAO-ref (o
-			// caso `ref T` sai antes, reempilhando o proprio ref com
-			// OP_GET_LOCAL). Nada de consultar frame.Owned.
+			// RC: a caixa nasce possuidora; o gemeo _BORROW (emitido quando o
+			// slot capturado NAO retem o que guarda — variavel de for-each,
+			// binding de case do select) a marca como emprestada, e os funis de
+			// escrita via ref param de contar posse nela. Decisao estatica: nada
+			// de consultar frame.Owned.
 			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot])
+			if instruction == chunk.OP_REF_LOCAL_BORROW {
+				upvalue.MarkBorrowed()
+			}
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1062,9 +1062,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			elements := make([]value.Value, count)
 			for i := count - 1; i >= 0; i-- {
 				elements[i] = vm.pop()
-				// CoW: o elemento pode continuar referenciado pela origem
-				value.MarkShared(elements[i]) // sticky: sai na Task 8
-				value.Retain(elements[i])     // RC: elemento e dono duravel
+				// RC: elemento pode continuar referenciado pela origem
+				value.Retain(elements[i]) // elemento e dono duravel
 			}
 			vm.push(value.NewArray(elements))
 
@@ -1092,9 +1091,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				} else {
 					return vm.runtimeError(c, ip, "map key must be int or string")
 				}
-				// CoW: o valor pode continuar referenciado pela origem
-				value.MarkShared(val) // sticky: sai na Task 8
-				value.Retain(val)     // RC: elemento e dono duravel
+				// RC: valor pode continuar referenciado pela origem
+				value.Retain(val) // elemento e dono duravel
 				mapping.Set(key, val)
 			}
 			vm.push(mapObj)
@@ -1564,8 +1562,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 			vm.push(v)
 
-		case chunk.OP_MARK_SHARED:
-			value.MarkShared(vm.peek(0))
+		// OP_MARK_SHARED morto pos-RC (Task 8): compilador nao emite mais;
+		// case removido do switch (sem default, opcode nao tratado e no-op).
 
 		case chunk.OP_SWAP:
 			// Swap top two stack elements: [a, b] -> [b, a]
@@ -1575,9 +1573,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			vm.push(a)
 
 		case chunk.OP_COPY:
-			// CoW: deref para contexto de valor marca em vez de copiar
+			// CoW: deref para contexto de valor passa o valor adiante sem
+			// copiar; unicidade e decidida por Owners (RC), nao por marcacao.
 			val := vm.pop()
-			value.MarkShared(val)
 			vm.push(val)
 		}
 	}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1002,7 +1002,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			for i := count - 1; i >= 0; i-- {
 				elements[i] = vm.pop()
 				// CoW: o elemento pode continuar referenciado pela origem
-				value.MarkShared(elements[i])
+				value.MarkShared(elements[i]) // sticky: sai na Task 8
+				value.Retain(elements[i])     // RC: elemento e dono duravel
 			}
 			vm.push(value.NewArray(elements))
 
@@ -1031,7 +1032,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					return vm.runtimeError(c, ip, "map key must be int or string")
 				}
 				// CoW: o valor pode continuar referenciado pela origem
-				value.MarkShared(val)
+				value.MarkShared(val) // sticky: sai na Task 8
+				value.Retain(val)     // RC: elemento e dono duravel
 				mapping.Set(key, val)
 			}
 			vm.push(mapObj)
@@ -1150,7 +1152,11 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					if idx < 0 || idx >= len(arr.Elements) {
 						return vm.runtimeError(c, ip, "array index out of bounds")
 					}
+					// RC: retain-antes-de-release (elemento e dono duravel)
+					old := arr.Elements[idx]
+					value.Retain(val)
 					arr.Elements[idx] = val
+					value.Release(old)
 					vm.push(val) // Assignment expression result
 					continue
 				} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
@@ -1166,7 +1172,16 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					} else {
 						return vm.runtimeError(c, ip, "map key must be int or string")
 					}
-					mapObj.Set(key, val)
+					// RC: so libera o velho se a chave ja existia (dec a
+					// menos e proibido); retain-antes-de-release quando existe.
+					if old, exists := mapObj.Get(key); exists {
+						value.Retain(val)
+						mapObj.Set(key, val)
+						value.Release(old)
+					} else {
+						value.Retain(val)
+						mapObj.Set(key, val)
+					}
 					vm.push(val)
 					continue
 				}
@@ -1238,7 +1253,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return vm.runtimeError(c, ip, "only instances have properties")
 			}
 
+			// RC: retain-antes-de-release (campo e dono duravel); Release
+			// em campo inexistente (Value{} zero) e no-op (nao e VAL_OBJ)
+			old := instance.Fields[name]
+			value.Retain(val)
 			instance.Fields[name] = val
+			value.Release(old)
 			vm.push(val)
 
 		case chunk.OP_SET_PROPERTY_DEREF:
@@ -1287,8 +1307,13 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			idx := frame.LocalBase + int(slot)
 			v := vm.stack[idx]
 			if value.IsShared(v) {
+				old := v
 				v = vm.copyValue(v)
 				vm.stack[idx] = v
+				// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
+				// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
+				frame.ownSlot(vm, idx)
+				value.Release(old)
 			}
 			vm.push(v)
 
@@ -1356,8 +1381,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					}
 					v := arr.Elements[idx]
 					if value.IsShared(v) {
+						old := v
 						v = vm.copyValue(v)
+						// RC: retain-antes-de-release em torno da troca
+						value.Retain(v)
 						arr.Elements[idx] = v
+						value.Release(old)
 					}
 					vm.push(v)
 					continue
@@ -1373,7 +1402,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					}
 					v, changed := vm.unicize(stored)
 					if changed {
+						// RC: retain-antes-de-release em torno da troca
+						value.Retain(v)
 						mapObj.Set(key, v)
+						value.Release(stored)
 					}
 					vm.push(v)
 					continue
@@ -1402,8 +1434,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					return vm.runtimeError(c, ip, "undefined property '%s'", name)
 				}
 				if value.IsShared(fieldVal) {
+					old := fieldVal
 					fieldVal = vm.copyValue(fieldVal)
+					// RC: retain-antes-de-release em torno da troca
+					value.Retain(fieldVal)
 					instance.Fields[name] = fieldVal
+					value.Release(old)
 				}
 				vm.push(fieldVal)
 			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
@@ -1414,7 +1450,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				}
 				v, changed := vm.unicize(stored)
 				if changed {
+					// RC: retain-antes-de-release em torno da troca
+					value.Retain(v)
 					mapObj.Set(name, v)
+					value.Release(stored)
 				}
 				vm.push(v)
 			} else {

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -255,10 +255,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			ip++
 			// Reference to a stack slot - Capture it!
 			// RC: a caixa nasce possuidora; o gemeo _BORROW (emitido quando o
-			// slot capturado NAO retem o que guarda — variavel de for-each,
-			// binding de case do select) a marca como emprestada, e os funis de
-			// escrita via ref param de contar posse nela. Decisao estatica: nada
-			// de consultar frame.Owned.
+			// slot capturado NAO retem o que guarda — hoje, apenas slot de tipo
+			// `ref`) a marca como emprestada, e os funis de escrita via ref
+			// param de contar posse nela. Decisao estatica: nada de consultar
+			// frame.Owned.
 			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot])
 			if instruction == chunk.OP_REF_LOCAL_BORROW {
 				upvalue.MarkBorrowed()

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -199,6 +199,15 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			ip += 2
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
+			// RC: troca contada no ambiente (retain-antes-de-release; slots
+			// globais nunca sao liberados por finalizeCurrentFrame, entao a
+			// bookkeeping precisa acontecer aqui, no proprio funil de escrita).
+			if old, ok := frame.Environment.GetLocal(name); ok {
+				value.Retain(vm.peek(0))
+				value.Release(old)
+			} else {
+				value.Retain(vm.peek(0))
+			}
 			frame.Environment.SetLocal(name, vm.peek(0))
 
 		case chunk.OP_GET_LOCAL:
@@ -950,9 +959,17 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_SET_UPVALUE:
 			slot := c.Code[ip]
 			ip++
-			if !frame.Closure.Upvalues[slot].Store(vm.peek(0)) {
+			old, ok := frame.Closure.Upvalues[slot].Load()
+			if !ok {
 				return vm.runtimeError(c, ip, "invalid upvalue")
 			}
+			updated := vm.peek(0)
+			// RC: retain-antes-de-release (auto-atribuicao via upvalue)
+			value.Retain(updated)
+			if !frame.Closure.Upvalues[slot].Store(updated) {
+				return vm.runtimeError(c, ip, "invalid upvalue")
+			}
+			value.Release(old)
 
 		case chunk.OP_CLOSE_UPVALUE:
 			vm.closeUpvalue(&vm.stack[vm.stackTop-1])
@@ -1289,6 +1306,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 			v, changed := vm.unicize(stored)
 			if changed {
+				// RC: o clone substitui o valor compartilhado no global;
+				// retain-antes-de-release em torno da troca.
+				value.Retain(v)
+				value.Release(stored)
 				owner.SetLocal(name, v)
 			}
 			vm.push(v)
@@ -1306,6 +1327,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 			v, changed := vm.unicize(stored)
 			if changed {
+				// RC: o clone substitui o valor compartilhado no box do
+				// upvalue; retain-antes-de-release em torno da troca.
+				value.Retain(v)
+				value.Release(stored)
 				upv.Store(v)
 			}
 			vm.push(v)

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -210,6 +210,17 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 			frame.Environment.SetLocal(name, vm.peek(0))
 
+		case chunk.OP_SET_GLOBAL_BORROW:
+			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			nameVal := c.Constants[index]
+			name := nameVal.Obj.(string)
+			// RC: global de tipo `ref` — empréstimo, não posse. Sem
+			// retain/release: quem responde pelo objeto é o dono real
+			// (campo, outro global, slot do chamador…). Contar aqui daria um
+			// dono a mais e a mutação através do empréstimo clonaria.
+			frame.Environment.SetLocal(name, vm.peek(0))
+
 		case chunk.OP_GET_LOCAL:
 			slot := c.Code[ip]
 			ip++
@@ -225,6 +236,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// RC: retain-antes-de-release (auto-atribuicao x = x)
 			frame.ownSlot(vm, idx)
 			value.Release(old)
+
+		case chunk.OP_SET_LOCAL_BORROW:
+			slot := c.Code[ip]
+			ip++
+			// RC: rebind de local `ref` — empréstimo, não posse. Nada de
+			// retain/release e nada registrado em frame.Owned: quem responde
+			// pelo objeto é o dono real (campo, global, slot do chamador…).
+			vm.stack[frame.LocalBase+int(slot)] = vm.peek(0)
 
 		case chunk.OP_OWN_LOCAL:
 			frame.ownSlot(vm, vm.stackTop-1)
@@ -972,7 +991,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			value.Release(old)
 
 		case chunk.OP_CLOSE_UPVALUE:
-			vm.closeUpvalue(&vm.stack[vm.stackTop-1])
+			// RC: a posse so migra para o box se o slot era possuido pelo
+			// frame; slots `ref` sao emprestimos (ver closeUpvalue).
+			vm.closeUpvalue(&vm.stack[vm.stackTop-1], frame.ownsSlotIndex(vm.stackTop-1))
 			vm.pop()
 
 		case chunk.OP_RETURN:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -210,7 +210,15 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_SET_LOCAL:
 			slot := c.Code[ip]
 			ip++
-			vm.stack[frame.LocalBase+int(slot)] = vm.peek(0)
+			idx := frame.LocalBase + int(slot)
+			old := vm.stack[idx]
+			vm.stack[idx] = vm.peek(0)
+			// RC: retain-antes-de-release (auto-atribuicao x = x)
+			frame.ownSlot(vm, idx)
+			value.Release(old)
+
+		case chunk.OP_OWN_LOCAL:
+			frame.ownSlot(vm, vm.stackTop-1)
 
 		case chunk.OP_REF_LOCAL:
 			slot := int(c.Code[ip])

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -638,6 +638,17 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			count := int(c.Code[ip])
 			ip++
 			cases := make([]reflect.SelectCase, count)
+			// RC: OP_SELECT e o segundo funil do par do buffer de canal (spec
+			// §4.2): um send que dispara aqui precisa do MESMO retain que
+			// chan_send faz, senao o chan_recv (ou o braco de recv de outro
+			// select) do outro lado libera uma retencao que nunca existiu (dec
+			// a menos). O retain e feito ANTES do reflect.Select — especulativo,
+			// para todos os cases de send — porque um receptor concorrente pode
+			// consumir e liberar o valor assim que o send dispara; retain
+			// tardio abriria janela de contagem furada. Os sends que NAO
+			// dispararem sao desfeitos logo apos o select (retain-antes-de-
+			// release: a contagem nunca passa por zero).
+			sendVals := make([]value.Value, count)
 			// Stack layout: [... Case0_Chan, Case0_Val, Case0_Mode ... CaseN_Chan, CaseN_Val, CaseN_Mode]
 			// Top is CaseN_Mode.
 			// Iterating i from count-1 down to 0:
@@ -653,6 +664,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 						return vm.runtimeError(c, ip, "select case expects channel")
 					}
 					ch := chVal.Obj.(*value.ObjChannel).Chan
+					value.Retain(val) // RC: espelha chan_send (ver comentario acima)
+					sendVals[i] = val
 					cases[i] = reflect.SelectCase{Dir: reflect.SelectSend, Chan: reflect.ValueOf(ch), Send: reflect.ValueOf(val)}
 				} else { // Recv
 					if chVal.Type != value.VAL_CHANNEL {
@@ -665,11 +678,24 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 			chosenIndex, recvVal, recvOK := reflect.Select(cases)
 
+			// RC: desfaz o retain especulativo dos cases de send que nao
+			// dispararam. O do case escolhido (se for send) permanece: o buffer
+			// do canal agora e dono duravel, e quem tirar o valor de la
+			// (chan_recv ou recv de select) faz o release espelhado.
+			for i := range cases {
+				if i != chosenIndex && cases[i].Dir == reflect.SelectSend {
+					value.Release(sendVals[i])
+				}
+			}
+
 			vm.push(value.NewInt(int64(chosenIndex)))
 
 			var valToPush value.Value
 			if recvOK {
 				if v, ok := recvVal.Interface().(value.Value); ok {
+					// RC: espelha chan_recv — o valor saiu do buffer do canal,
+					// que era dono duravel dele.
+					value.Release(v)
 					valToPush = v
 				} else {
 					valToPush = value.NewNull()

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -252,8 +252,11 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			slot := int(c.Code[ip])
 			ip++
 			// Reference to a stack slot - Capture it!
-			// RC: a caixa herda a condicao do slot (possuido x emprestado).
-			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot], frame.ownsSlotIndex(frame.LocalBase+slot))
+			// RC: a caixa nasce possuidora, e aqui isso e sempre correto: o
+			// compilador so emite OP_REF_LOCAL para local de tipo NAO-ref (o
+			// caso `ref T` sai antes, reempilhando o proprio ref com
+			// OP_GET_LOCAL). Nada de consultar frame.Owned.
+			upvalue := vm.captureUpvalue(&vm.stack[frame.LocalBase+slot])
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
@@ -960,15 +963,28 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				ip++
 
 				if isLocal == 1 {
-					// RC: a caixa herda a condicao do slot capturado — slot
-					// `ref` e emprestimo, e a caixa nao passa a possuir.
-					localSlot := frame.LocalBase + int(index)
-					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[localSlot], frame.ownsSlotIndex(localSlot))
+					// RC: a caixa nasce possuidora; os
+					// OP_MARK_UPVALUE_BORROW que o compilador emite logo
+					// depois desta tabela marcam as de slot `ref`.
+					closure.Upvalues[i] = vm.captureUpvalue(&vm.stack[frame.LocalBase+int(index)])
 				} else {
 					closure.Upvalues[i] = frame.Closure.Upvalues[index]
 				}
 			}
 			vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: closure})
+
+		case chunk.OP_MARK_UPVALUE_BORROW:
+			upvalueIndex := int(c.Code[ip])
+			ip++
+			// RC: marca estatica emitida pelo compilador logo apos o
+			// OP_CLOSURE — a caixa deste upvalue foi aberta sobre um slot de
+			// tipo `ref` e portanto EMPRESTA o que guarda (nao retem ao fechar,
+			// nao solta ao ser sobrescrita).
+			marked, ok := vm.peek(0).Obj.(*value.ObjClosure)
+			if !ok || marked == nil || upvalueIndex >= len(marked.Upvalues) {
+				return vm.runtimeError(c, ip, "invalid upvalue")
+			}
+			marked.Upvalues[upvalueIndex].MarkBorrowed()
 
 		case chunk.OP_GET_UPVALUE:
 			slot := c.Code[ip]
@@ -1004,9 +1020,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 
 		case chunk.OP_CLOSE_UPVALUE:
-			// RC: a posse so migra para o box se o slot era possuido pelo
-			// frame; slots `ref` sao emprestimos (ver closeUpvalue).
-			vm.closeUpvalue(&vm.stack[vm.stackTop-1], frame.ownsSlotIndex(vm.stackTop-1))
+			// RC: a propria caixa sabe se empresta (marca estatica); a posse
+			// so migra para ela quando nao empresta (ver closeUpvalue).
+			vm.closeUpvalue(&vm.stack[vm.stackTop-1])
 			vm.pop()
 
 		case chunk.OP_RETURN:
@@ -1344,18 +1360,27 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				old := v
 				v = vm.copyValue(v)
 				vm.stack[idx] = v
-				// RC: so o slot POSSUIDO troca de dono. Um slot de tipo `ref` e
-				// emprestimo (nunca esta em frame.Owned): soltar o velho ali
-				// seria soltar o que este slot nunca reteve (dec a menos), e o
-				// objeto compartilhado passaria a parecer unico. O clone fica
-				// no slot emprestado sem dono — como no comportamento antigo.
-				if frame.ownsSlotIndex(idx) {
-					// ownSlot (nao Retain cru) mantem o slot registrado em
-					// frame.Owned apontando o objeto novo — mesmo padrao do
-					// OP_SET_LOCAL.
-					frame.ownSlot(vm, idx)
-					value.Release(old)
-				}
+				// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
+				// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
+				frame.ownSlot(vm, idx)
+				value.Release(old)
+			}
+			vm.push(v)
+
+		case chunk.OP_GET_LOCAL_MUT_BORROW:
+			slot := c.Code[ip]
+			ip++
+			// RC: gemeo de EMPRESTIMO do acima, emitido quando o tipo declarado
+			// do local e `ref T`. O slot nao possui o que guarda: nao pode
+			// reter o clone nem soltar o velho (soltar o que nunca se reteve e
+			// dec a menos, e faria o objeto compartilhado parecer unico). O
+			// clone fica no slot emprestado sem dono — a mutacao adiante vai
+			// para o clone, exatamente como no comportamento pre-RC.
+			idx := frame.LocalBase + int(slot)
+			v := vm.stack[idx]
+			if value.IsShared(v) {
+				v = vm.copyValue(v)
+				vm.stack[idx] = v
 			}
 			vm.push(v)
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -246,7 +246,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			vm.stack[frame.LocalBase+int(slot)] = vm.peek(0)
 
 		case chunk.OP_OWN_LOCAL:
-			frame.ownSlot(vm, vm.stackTop-1)
+			// RC: vinculo NOVO no slot — paga a entrada anterior do indice, se
+			// houver (reuso entre iteracoes/blocos irmaos); ver bindOwnedSlot.
+			frame.bindOwnedSlot(vm, vm.stackTop-1)
 
 		case chunk.OP_REF_LOCAL, chunk.OP_REF_LOCAL_BORROW:
 			slot := int(c.Code[ip])
@@ -1017,6 +1019,11 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				}
 			} else {
 				value.Retain(updated)
+				// Caixa ABERTA escreve num slot de pilha possuido: a entrada
+				// (slot, objeto) do frame dono tem de passar a nomear o valor
+				// novo — o velho e pago aqui pelo funil, o novo pelo fim do
+				// frame (spec §4.2, mesma regra da escrita via ref).
+				vm.retargetOwnedSlotForUpvalue(frame.Closure.Upvalues[slot], updated)
 				if !frame.Closure.Upvalues[slot].Store(updated) {
 					return vm.runtimeError(c, ip, "invalid upvalue")
 				}
@@ -1431,6 +1438,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					upv.Store(v)
 				} else {
 					value.Retain(v)
+					// Mesma regra do OP_SET_UPVALUE: caixa aberta alcanca um
+					// slot de pilha possuido — reaponta a entrada do frame dono
+					// antes de soltar o velho (spec §4.2).
+					vm.retargetOwnedSlotForUpvalue(upv, v)
 					value.Release(stored)
 					upv.Store(v)
 				}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -891,12 +891,29 @@ end`); err != nil {
 
 // Task 6 (Step 1): spawn_task retem o argumento na preparacao (captura,
 // sincrona, antes do goroutine da task rodar) e libera quando a task
-// termina (mirror do padrao de defer) — a asserção "durante" tambem nao
-// precisa de sincronizacao porque o retain acontece antes do "go".
+// termina (mirror do padrao de defer) — a asserção pos-Invoke nao precisa
+// de sincronizacao porque o retain de captura acontece antes do "go".
+//
+// Review final (Critical 1): a medida "durante" subiu de before+1 para
+// before+2 — o frame da task passou a fazer o bind de posse dos parametros
+// por valor (ownSlot em executePreparedTaskCall, espelho de
+// callPreparedClosure; spec §4.2, linha da captura de task: os slots de
+// parametro "fazem seu proprio inc"). Captura (+1) e bind do slot de
+// parametro (+1) coexistem enquanto o corpo roda; o gate bloqueia o corpo
+// para a leitura ser deterministica.
 func TestSpawnTaskCapturesArgSynchronouslyAndReleasesWhenTaskCompletes(t *testing.T) {
 	machine := New()
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	machine.DefineNative("task_gate", func(args []value.Value) value.Value {
+		close(started)
+		<-unblock
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "task_gate")
 	if err := interpretVMSource(t, machine, `
 func worker(m: int[])
+    task_gate()
 end`); err != nil {
 		t.Fatal(err)
 	}
@@ -914,9 +931,23 @@ end`); err != nil {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := value.OwnersCount(m); got != before+1 {
-		t.Fatalf("esperado Owners=%d logo apos spawn_task (captura sincrona em prepareTaskCall), veio %d", before+1, got)
+	// Captura sincrona: pelo menos +1 ja aqui; o bind do parametro (+1)
+	// acontece no goroutine da task e pode ou nao ter rodado ainda.
+	if got := value.OwnersCount(m); got < before+1 || got > before+2 {
+		t.Fatalf("esperado Owners entre %d e %d logo apos spawn_task (captura sincrona em prepareTaskCall), veio %d", before+1, before+2, got)
 	}
+
+	select {
+	case <-started:
+	case <-time.After(statefulBuiltinTimeout):
+		t.Fatal("worker da task nao chegou ao gate")
+	}
+	// Corpo da task parado no gate: captura (+1) e bind do slot de
+	// parametro (+1) estao ambos vivos — leitura deterministica.
+	if got := value.OwnersCount(m); got != before+2 {
+		t.Fatalf("esperado Owners=%d com a task rodando (captura +1, bind do parametro +1), veio %d", before+2, got)
+	}
+	close(unblock)
 
 	taskAwait := requireBuiltin(t, machine, "task_await")
 	if _, err := taskAwait.Invoke(machine, []value.Value{handle}); err != nil {
@@ -931,7 +962,7 @@ end`); err != nil {
 		time.Sleep(time.Millisecond)
 	}
 	if got := value.OwnersCount(m); got != before {
-		t.Fatalf("esperado Owners=%d apos a task terminar (release da captura), veio %d", before, got)
+		t.Fatalf("esperado Owners=%d apos a task terminar (release do bind do frame e da captura), veio %d", before, got)
 	}
 }
 
@@ -2476,5 +2507,410 @@ main()`
 	const want = "1|1|1|1"
 	if reported.Type != value.VAL_OBJ || reported.Obj != want {
 		t.Fatalf("entrada fantasma apos rebind nao-retivel (dec a mais): esperado %q (n1|n2|n3|n4), veio %#v", want, reported.Obj)
+	}
+}
+
+// defineWaitOwnersProbe registra o native de sonda `wait_owners(v, n) -> bool`:
+// espera OwnersCount(v) atingir n E ficar estavel por uma janela curta (o alvo
+// dos testes e sempre um valor TERMINAL da aritmetica correta; a janela de
+// estabilidade descarta coincidencias transitorias de uma aritmetica furada
+// que passa por n a caminho de um valor menor). E a sincronizacao usada pelos
+// testes de `defer spawn_task`, onde o handle da task e descartado pelo defer
+// e nao ha task_await para ancorar a conclusao.
+func defineWaitOwnersProbe(t *testing.T, machine *VM) {
+	t.Helper()
+	machine.DefineNative("wait_owners", func(args []value.Value) value.Value {
+		if len(args) != 2 || args[1].Type != value.VAL_INT {
+			return value.NewBool(false)
+		}
+		want := int32(args[1].AsInt)
+		const hold = 50 * time.Millisecond
+		deadline := time.Now().Add(statefulBuiltinTimeout)
+		for time.Now().Before(deadline) {
+			if value.OwnersCount(args[0]) != want {
+				time.Sleep(time.Millisecond)
+				continue
+			}
+			stable := true
+			holdUntil := time.Now().Add(hold)
+			for time.Now().Before(holdUntil) {
+				if value.OwnersCount(args[0]) != want {
+					stable = false
+					break
+				}
+				time.Sleep(time.Millisecond)
+			}
+			if stable {
+				return value.NewBool(true)
+			}
+		}
+		return value.NewBool(false)
+	})
+	markProbeReadonly(t, machine, "wait_owners")
+}
+
+// Review final (Critical 1, aritmetica direta): o frame da task deve reter os
+// parametros por valor (ownSlot em executePreparedTaskCall), como
+// callPreparedClosure faz em qualquer chamada. Sem isso, o rebind
+// (OP_SET_LOCAL) do parametro dentro do corpo da task libera uma retencao que
+// nunca aconteceu (dec a menos) e releasePreparedArguments desconta a captura
+// DE NOVO na conclusao — o composto do chamador perde um dono. Invoca
+// spawn_task direto do Go (rota host, sem o Retain conservador de callValue
+// que mascara a rota de bytecode direta) e usa task_await como ancora: o
+// release da captura roda antes de task.Complete, entao depois do await a
+// aritmetica ja fechou, sem polling.
+func TestTaskFrameParamRebindKeepsCallerOwnersBalanced(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(m: int[]) -> int
+    m = [2]
+    return 0
+end`); err != nil {
+		t.Fatal(err)
+	}
+	workerFn, _ := machine.GetGlobal("worker")
+	m := value.NewArray([]value.Value{value.NewInt(1)})
+	// Dono duravel simulado do chamador (ex.: um global). Sem ele o clamp de
+	// Release em zero mascararia o deficit que este teste fixa.
+	value.Retain(m)
+	before := value.OwnersCount(m)
+
+	spawnTask := requireBuiltin(t, machine, "spawn_task")
+	handle, err := spawnTask.Invoke(machine, []value.Value{workerFn, m})
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskAwait := requireBuiltin(t, machine, "task_await")
+	if _, err := taskAwait.Invoke(machine, []value.Value{handle}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := value.OwnersCount(m); got != before {
+		t.Fatalf("rebind do parametro dentro da task roubou dono do chamador (dec a menos): esperado Owners=%d apos a task, veio %d", before, got)
+	}
+}
+
+// Review final (Critical 1, variante MUT): mesmo cenario, mas o corpo da task
+// muta o parametro (caminho OP_GET_LOCAL_MUT): com mais de um dono o MUT clona
+// e libera o ocupante velho do slot — release que so e pareado se o frame da
+// task tiver feito o bind de posse do parametro.
+func TestTaskFrameParamMutKeepsCallerOwnersBalanced(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(m: int[]) -> int
+    m[0] = 5
+    return 0
+end`); err != nil {
+		t.Fatal(err)
+	}
+	workerFn, _ := machine.GetGlobal("worker")
+	m := value.NewArray([]value.Value{value.NewInt(1)})
+	value.Retain(m) // dono duravel simulado do chamador; ver teste acima
+	before := value.OwnersCount(m)
+
+	spawnTask := requireBuiltin(t, machine, "spawn_task")
+	handle, err := spawnTask.Invoke(machine, []value.Value{workerFn, m})
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskAwait := requireBuiltin(t, machine, "task_await")
+	if _, err := taskAwait.Invoke(machine, []value.Value{handle}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := value.OwnersCount(m); got != before {
+		t.Fatalf("clone MUT do parametro dentro da task roubou dono do chamador (dec a menos): esperado Owners=%d apos a task, veio %d", before, got)
+	}
+	// O MUT clonou (havia mais de um dono): a mutacao nao pode vazar para o
+	// array do chamador.
+	if got := m.Obj.(*value.ObjArray).Elements[0].AsInt; got != 1 {
+		t.Fatalf("mutacao dentro da task vazou para o chamador: esperado m[0]=1, veio %d", got)
+	}
+}
+
+// Review final (Critical 1, oraculo E2E): `defer spawn_task(...)` roteia por
+// callPreparedValue (branch de native), que NAO faz o Retain conservador de
+// callValue — a rota onde o bug ficava exposto em programa real. Oraculo do
+// baseline (noxy_merged): 1 — a mutacao de gb depois da task ve o composto
+// compartilhado com arr e clona. Com o deficit (sem o bind de parametro no
+// frame da task), gb parecia unico e a escrita vazava para arr[0] (99).
+// wait_owners ancora a conclusao da task (o defer descarta o handle): 2 =
+// global gb + elemento de arr e o valor TERMINAL apos o release da captura.
+func TestDeferredSpawnTaskParamRebindDoesNotStealCallerOwnership(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("report_probe", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "report_probe")
+	defineWaitOwnersProbe(t, machine)
+	src := `
+struct Box
+    v: int
+end
+
+let gb: Box = Box(1)
+let arr: Box[] = [gb]
+let ch: any = make_chan(1)
+
+func worker(m: Box) -> int
+    m = Box(2)
+    chan_send(ch, 1)
+    return 0
+end
+
+func run() -> int
+    defer spawn_task(worker, gb)
+    return 0
+end
+
+func main()
+    let r: int = run()
+    let d: any = chan_recv(ch)
+    if wait_owners(gb, 2) then
+        gb.v = 99
+        report_probe(arr[0].v)
+    else
+        report_probe(0 - 1)
+    end
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+		t.Fatalf("rebind de parametro em task defer'd roubou dono de gb (-1 = wait_owners nao estabilizou em 2; 99 = mutacao vazou para arr): esperado 1, veio %#v", reported)
+	}
+}
+
+// Review final (Critical 1, oraculo E2E — variante MUT): igual ao teste acima,
+// mas o corpo da task muta o parametro (m.v = 5, caminho MUT com clone) em vez
+// de rebindar. Oraculo do baseline: 1.
+func TestDeferredSpawnTaskParamMutDoesNotStealCallerOwnership(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("report_probe", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "report_probe")
+	defineWaitOwnersProbe(t, machine)
+	src := `
+struct Box
+    v: int
+end
+
+let gb: Box = Box(1)
+let arr: Box[] = [gb]
+let ch: any = make_chan(1)
+
+func worker(m: Box) -> int
+    m.v = 5
+    chan_send(ch, 1)
+    return 0
+end
+
+func run() -> int
+    defer spawn_task(worker, gb)
+    return 0
+end
+
+func main()
+    let r: int = run()
+    let d: any = chan_recv(ch)
+    if wait_owners(gb, 2) then
+        gb.v = 99
+        report_probe(arr[0].v)
+    else
+        report_probe(0 - 1)
+    end
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+		t.Fatalf("clone MUT de parametro em task defer'd roubou dono de gb (-1 = wait_owners nao estabilizou em 2; 99 = mutacao vazou para arr): esperado 1, veio %#v", reported)
+	}
+}
+
+// Review final (Critical 1, controle): a rota DIRETA de bytecode
+// (`spawn_task(...)` sem defer) passa por callValue, cujo Retain conservador
+// de native sem assinatura mascarava o deficit. O controle fixa que essa rota
+// imprime 1 tanto antes quanto depois da correcao — e protege contra uma
+// futura auditoria de spawn_task na allowlist readonly reabrir o buraco sem o
+// bind de parametro no frame da task. task_await ancora a conclusao.
+func TestDirectSpawnTaskParamRebindControlKeepsCoW(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("report_probe", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "report_probe")
+	src := `
+struct Box
+    v: int
+end
+
+let gb: Box = Box(1)
+let arr: Box[] = [gb]
+
+func worker(m: Box) -> int
+    m = Box(2)
+    return 0
+end
+
+func main()
+    let t: any = spawn_task(worker, gb)
+    let r: any = task_await(t)
+    gb.v = 99
+    report_probe(arr[0].v)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+		t.Fatalf("controle da rota direta de spawn_task regrediu: esperado 1 (mutacao de gb clona, arr preservado), veio %#v", reported)
+	}
+}
+
+// Review final (Critical 2, direcao send): OP_SELECT e o segundo funil do par
+// do buffer de canal (spec §4.2). Um send disparado pelo select precisa do
+// mesmo Retain de chan_send — senao o chan_recv do outro lado libera uma
+// retencao que nunca existiu (dec a menos) e a mutacao seguinte vaza para o
+// alias. Programa 100% sincrono (canal bufferizado): deterministico nos dois
+// lados. O case do canal morto (unbuffered, sem receptor: nunca pronto) cobre
+// o desfazer do retain especulativo dos sends nao disparados. Oraculo do
+// baseline: report=1; probe_b = probe_a+1 (buffer possui apos o send do
+// select); probe_c = probe_a (chan_recv devolveu a posse).
+func TestSelectSendRetainsForChannelBufferLikeChanSend(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	var ownersA, ownersB, ownersC int32
+	machine.DefineNative("report_probe", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_a", func(args []value.Value) value.Value {
+		ownersA = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_b", func(args []value.Value) value.Value {
+		ownersB = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_c", func(args []value.Value) value.Value {
+		ownersC = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "report_probe")
+	markProbeReadonly(t, machine, "probe_a")
+	markProbeReadonly(t, machine, "probe_b")
+	markProbeReadonly(t, machine, "probe_c")
+	src := `
+struct Box
+    v: int
+end
+
+func main()
+    let b: Box = Box(1)
+    let keep: Box[] = [b]
+    let ch: any = make_chan(1)
+    let dead: any = make_chan()
+    probe_a(b)
+    when
+        case chan_send(dead, b) then
+            let y: int = 1
+        case chan_send(ch, b) then
+            let x: int = 1
+    end
+    probe_b(b)
+    chan_recv(ch)
+    probe_c(b)
+    b.v = 99
+    report_probe(keep[0].v)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersB != ownersA+1 {
+		t.Fatalf("send do select nao deixou o buffer do canal como dono (esperado Owners=%d apos o select, veio %d)", ownersA+1, ownersB)
+	}
+	if ownersC != ownersA {
+		t.Fatalf("par send-do-select/chan_recv nao fechou (esperado Owners=%d apos chan_recv, veio %d)", ownersA, ownersC)
+	}
+	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+		t.Fatalf("send do select sem retain: chan_recv descontou dono alheio e a mutacao vazou para keep: esperado 1, veio %#v", reported)
+	}
+}
+
+// Review final (Critical 2, direcao recv): o braco de recv do select precisa
+// do mesmo Release de chan_recv — o valor sai do buffer do canal, que era dono
+// duravel. Sem ele o buffer "fantasma" segue contando para sempre (leak:
+// direcao segura, mas quebra o par da spec §4.2 e infla a contagem que os
+// demais funis leem). Asserto relativo: o bind do case (got, OP_OWN_LOCAL,
+// +1) substitui exatamente a posse do buffer (-1), entao durante o case a
+// contagem volta ao valor pre-select.
+func TestSelectRecvReleasesChannelBufferOwnership(t *testing.T) {
+	machine := New()
+	var ownersBefore, ownersDuring, ownersAfter int32
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		ownersBefore = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		ownersDuring = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		ownersAfter = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_during")
+	markProbeReadonly(t, machine, "probe_after")
+	src := `
+struct Box
+    v: int
+end
+
+func main()
+    let b: Box = Box(1)
+    let keep: Box[] = [b]
+    let ch: any = make_chan(1)
+    chan_send(ch, b)
+    probe_before(b)
+    when
+        case got = chan_recv(ch) then
+            probe_during(got)
+    end
+    probe_after(b)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersDuring != ownersBefore {
+		t.Fatalf("recv do select nao liberou a posse do buffer (bind do case +1 deveria repor o release -1): esperado Owners=%d durante o case, veio %d", ownersBefore, ownersDuring)
+	}
+	if ownersAfter != ownersBefore {
+		t.Fatalf("recv do select deixou posse fantasma do buffer: esperado Owners=%d apos o select, veio %d", ownersBefore, ownersAfter)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -177,3 +177,74 @@ main()`
 		t.Fatalf("apos os dois retornos esperado %d, veio %d", during-2, after)
 	}
 }
+
+// O let e um vinculo duravel do frame (spec §4.2): o slot local retem o
+// composto assim que e criado. probe roda ainda dentro do frame de main,
+// entao Owners deve refletir exatamente o retain do OP_OWN_LOCAL do let.
+func TestLetBindRetainsComposite(t *testing.T) {
+	machine := New()
+	var count int32
+	machine.DefineNative("probe", func(args []value.Value) value.Value {
+		count = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe")
+
+	src := `
+func main()
+    let m: map[string, int] = {"a": 1}
+    probe(m)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("esperado Owners=1 (slot do let), veio %d", count)
+	}
+}
+
+// a = b deve soltar o objeto que ocupava o slot de "a" e reter o objeto de
+// "b" (que passa a ter dois donos: os slots de "a" e "b"). Captura-se o
+// value.Value velho de "a" via native de sonda para medir seu OwnersCount
+// depois da reatribuicao, quando o slot ja nao aponta mais para ele.
+func TestAssignReleasesOldRetainsNew(t *testing.T) {
+	machine := New()
+	var oldA value.Value
+	var ownersA1, ownersA2 int32
+	machine.DefineNative("probe_a1", func(args []value.Value) value.Value {
+		oldA = args[0]
+		ownersA1 = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_a2", func(args []value.Value) value.Value {
+		ownersA2 = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_a1")
+	markProbeReadonly(t, machine, "probe_a2")
+
+	src := `
+func main()
+    let a: map[string, int] = {"x": 1}
+    let b: map[string, int] = {"y": 2}
+    probe_a1(a)
+    a = b
+    probe_a2(a)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersA1 != 1 {
+		t.Fatalf("esperado Owners(a)=1 antes da reatribuicao, veio %d", ownersA1)
+	}
+	if ownersA2 != 2 {
+		t.Fatalf("esperado Owners(b)=2 apos a=b (slots a e b), veio %d", ownersA2)
+	}
+	if got := value.OwnersCount(oldA); got != 0 {
+		t.Fatalf("esperado Owners(objeto velho de a)=0 apos a reatribuicao, veio %d", got)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -687,10 +687,19 @@ main()`
 }
 
 // Task 5 (Step 1): caminho MUT (OP_GET_INDEX_MUT, branch array) — quando
-// a[0] esta Shared (marcado pelo proprio OP_ARRAY), a mutacao a[0].x=9
-// clona o elemento, grava o clone de volta em Elements[0] com retain, e
-// libera a instancia velha. Auditado por contagem na instancia velha
-// (capturada antes da mutacao) e na nova (lida depois).
+// a[0] esta compartilhado, a mutacao a[0].x=9 clona o elemento, grava o clone
+// de volta em Elements[0] com retain, e libera a instancia velha. Auditado
+// por contagem na instancia velha (capturada antes da mutacao) e na nova
+// (lida depois).
+//
+// Task 7: antes da chave bastava `let a: P[] = [P(1)]` — o MarkShared que o
+// OP_ARRAY faz no elemento era suficiente para o caminho de clone disparar.
+// Depois da chave (spec docs/superpowers/specs/
+// 2026-08-17-cow-rc-uniqueness-design.md §3), "compartilhado" e Owners > 1, e
+// um elemento com um unico dono (o proprio array) e unico por definicao —
+// mutar em lugar e correto e nao clona. Para continuar exercitando o caminho
+// de clone, o programa agora da DOIS donos duraveis a instancia: o slot do
+// `let p` e o elemento de `a`.
 func TestMutIndexClonePathRetainsWriteBackReleasesOld(t *testing.T) {
 	machine := New()
 	var oldInst value.Value
@@ -713,7 +722,8 @@ struct P
 end
 
 func main()
-    let a: P[] = [P(1)]
+    let p: P = P(1)
+    let a: P[] = [p]
     probe_before(a[0])
     a[0].x = 9
     probe_after(a[0])
@@ -723,8 +733,8 @@ main()`
 	if err := interpretVMSource(t, machine, src); err != nil {
 		t.Fatalf("programa falhou: %v", err)
 	}
-	if ownersOldBefore != 1 {
-		t.Fatalf("esperado Owners(a[0])=1 antes da mutacao (retain do elemento no OP_ARRAY), veio %d", ownersOldBefore)
+	if ownersOldBefore != 2 {
+		t.Fatalf("esperado Owners(a[0])=2 antes da mutacao (slot do let p + elemento retido no OP_ARRAY), veio %d", ownersOldBefore)
 	}
 	if got := value.OwnersCount(oldInst); got != 0 {
 		t.Fatalf("esperado Owners(instancia velha)=0 apos o clone gravado de volta em OP_GET_INDEX_MUT, veio %d", got)
@@ -1051,5 +1061,204 @@ test_observe_rc(g)`
 	// permanente do native sem assinatura.
 	if got := value.OwnersCount(captured); got != 2 {
 		t.Fatalf("esperado Owners=2 (1 do global + 1 da retencao permanente do native), veio %d", got)
+	}
+}
+
+// Task 7 (Step 1): teste de aceite da CHAVE — com a unicidade decidida pelo
+// contador de donos (spec §3), um laco que passa um composto POR VALOR a um
+// helper nao pode mais clonar por iteracao. Antes da chave, o bit sticky
+// Shared ligado pelo bind do parametro por valor ficava para sempre: cada
+// put() reclonava db/state/payloads (3 clones por iteracao, ~600 no total, e
+// o clone do map cresce com N => quadratico). Depois da chave, o retain do
+// parametro e liberado no fim do frame do helper, os donos voltam a 1 e as
+// mutacoes seguintes mutam no lugar: O(1) clones no laco inteiro.
+func TestByValueCallLoopClonesO1AfterFlip(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	ResetCloneCount()
+	src := `
+struct State
+    payloads: map[string, string]
+end
+
+struct Db
+    state: State
+end
+
+func helper(db: Db) -> int
+    return 1
+end
+
+func put(db: ref Db, key: string, val: string) -> void
+    let x: int = helper(db)
+    db.state.payloads[key] = val
+end
+
+func main()
+    let payloads: map[string, string] = {}
+    let db: Db = Db(State(payloads))
+    let i: int = 0
+    while i < 200 do
+        put(ref db, f"k{i}", "v")
+        i = i + 1
+    end
+    test_report(length(keys(db.state.payloads)))
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if reported.Type != value.VAL_INT || reported.AsInt != 200 {
+		t.Fatalf("programa incorreto: %#v", reported)
+	}
+	if n := CloneCountValue(); n > 8 {
+		t.Fatalf("laco por-valor deveria clonar O(1); clonou %d", n)
+	}
+}
+
+// Task 7 (fallout da chave): um vinculo de tipo `ref` e um EMPRESTIMO
+// (borrow), nunca um dono duravel. Parametros ref ja eram pulados no bind
+// (callPreparedClosure), mas o `let x: ref T` e o rebind `x = y` de um local
+// ref contavam posse — over-count que so ficou observavel depois da chave: um
+// no de lista alcancado por `current = current.proximo` passava a ter 2 donos
+// (o campo `proximo` do no anterior + o slot ref emprestado), IsShared virava
+// true e a mutacao `current.proximo = null` clonava o no em vez de muta-lo no
+// lugar, perdendo a escrita (noxy_examples/stack.nx e linked_list.nx
+// divergiam do baseline). Este teste e de SEMANTICA: a mutacao atraves do
+// emprestimo tem de ser visivel na lista original.
+func TestRefLocalBindingIsBorrowNotOwner(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+func pop(node: ref Node) -> int
+    let current: ref Node = node
+    while current.proximo.proximo != null do
+        current = current.proximo
+    end
+    let valor: int = current.proximo.valor
+    current.proximo = null
+    return valor
+end
+
+func count(node: ref Node) -> int
+    let n: int = 0
+    let current: ref Node = node
+    while current != null do
+        n = n + 1
+        current = current.proximo
+    end
+    return n
+end
+
+func main()
+    let head: Node = Node(0, null)
+    _append(head, 20)
+    _append(head, 30)
+    let popped: int = pop(head)
+    test_report(count(head) * 100 + popped)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// 2 nos restantes (0, 20) * 100 + valor removido (30).
+	if reported.Type != value.VAL_INT || reported.AsInt != 230 {
+		t.Fatalf("mutacao atraves do emprestimo ref se perdeu (clone indevido): esperado 230, veio %#v", reported)
+	}
+}
+
+// Task 7 (fallout da chave): mesma regra do teste acima nos outros dois
+// funis de vinculo ref — global de tipo ref (OP_SET_GLOBAL_BORROW) e local
+// ref capturado por uma closure que escapa do frame (closeUpvalue so migra a
+// posse quando o slot era possuido). Sem os dois, o objeto emprestado ganhava
+// um dono a mais e a mutacao atraves do emprestimo clonava, perdendo a
+// escrita. Teste de SEMANTICA: a lista original tem de encolher.
+func TestRefGlobalAndCapturedRefLocalAreBorrows(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+func count(node: ref Node) -> int
+    let n: int = 0
+    let cur: ref Node = node
+    while cur != null do
+        n = n + 1
+        cur = cur.proximo
+    end
+    return n
+end
+
+func make_dropper(node: ref Node) -> func() -> int
+    let u: ref Node = node.proximo
+    return func() -> int
+        u.proximo = null
+        return 1
+    end
+end
+
+let head_a: Node = Node(0, null)
+_append(head_a, 20)
+_append(head_a, 30)
+let g: ref Node = head_a.proximo
+g.proximo = null
+
+let head_b: Node = Node(0, null)
+_append(head_b, 20)
+_append(head_b, 30)
+let dropper: func() -> int = make_dropper(head_b)
+let done: int = dropper()
+
+test_report(count(head_a) * 10 + count(head_b))`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// as duas listas encolhem de 3 para 2 nos: 2*10 + 2 = 22.
+	if reported.Type != value.VAL_INT || reported.AsInt != 22 {
+		t.Fatalf("mutacao atraves de emprestimo ref (global / capturado) se perdeu: esperado 22, veio %#v", reported)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1432,11 +1432,17 @@ main()`
 	}
 }
 
-// Task 7 (fallout, round 2 — Important 4): teste Go direto do ramo FALSO do
-// contrato de posse da caixa. Um slot emprestado (nao registrado em
-// frame.Owned) produz uma caixa marcada como emprestada, e fechar essa caixa
-// NAO pode reter — e o que impede o par retain/release da caixa de existir e,
-// por consequencia, o dec a menos nos funis de escrita dela.
+// Task 7 (fallout, round 2 — Important 4): teste Go direto dos DOIS ramos do
+// contrato de posse da caixa. Toda caixa nasce POSSUIDORA; so o
+// OP_MARK_UPVALUE_BORROW (marca estatica emitida pelo compilador para slot de
+// tipo `ref`) a torna emprestada, e fechar uma caixa emprestada NAO pode reter
+// — e o que impede o par retain/release da caixa de existir e, por
+// consequencia, o dec a menos nos funis de escrita dela.
+//
+// Round 3: a condicao NAO vem mais de frame.Owned. Ela errava nas duas
+// direcoes — slot possuido com ocupante null/escalar na captura nao aparece na
+// lista (retain devido pulado) e indice de slot reusado entre blocos irmaos
+// deixa entrada morta (release indevido).
 func TestBorrowedUpvalueBoxDoesNotRetainOnClose(t *testing.T) {
 	machine := New()
 
@@ -1446,24 +1452,29 @@ func TestBorrowedUpvalueBoxDoesNotRetainOnClose(t *testing.T) {
 	machine.stack[0] = owned
 	ownedSlot := &machine.stack[0]
 
-	// emprestado: idem, mas o slot nao e dono.
+	// emprestado: idem, mas o slot so empresta.
 	borrowed := value.NewMap()
 	value.Retain(borrowed)
 	machine.stack[1] = borrowed
 	borrowedSlot := &machine.stack[1]
 
-	ownedBox := machine.captureUpvalue(ownedSlot, true)
-	borrowedBox := machine.captureUpvalue(borrowedSlot, false)
+	ownedBox := machine.captureUpvalue(ownedSlot)
+	borrowedBox := machine.captureUpvalue(borrowedSlot)
 
-	if ownedBox.IsBorrowed() {
-		t.Fatal("caixa aberta sobre slot possuido nao pode nascer emprestada")
+	if ownedBox.IsBorrowed() || borrowedBox.IsBorrowed() {
+		t.Fatal("toda caixa nasce possuidora — o emprestimo e marcado explicitamente")
 	}
+	// o que o OP_MARK_UPVALUE_BORROW faz, pelo tipo declarado do slot:
+	borrowedBox.MarkBorrowed()
 	if !borrowedBox.IsBorrowed() {
-		t.Fatal("caixa aberta sobre slot emprestado tem de nascer emprestada")
+		t.Fatal("a marca de emprestimo deveria ter pegado")
+	}
+	if ownedBox.IsBorrowed() {
+		t.Fatal("marcar uma caixa nao pode contaminar a outra")
 	}
 
-	machine.closeUpvalue(ownedSlot, true)
-	machine.closeUpvalue(borrowedSlot, false)
+	machine.closeUpvalue(ownedSlot)
+	machine.closeUpvalue(borrowedSlot)
 
 	// ramo verdadeiro: a posse migra do slot para a caixa (+1; o release do
 	// slot e responsabilidade do frame).
@@ -1473,5 +1484,250 @@ func TestBorrowedUpvalueBoxDoesNotRetainOnClose(t *testing.T) {
 	// ramo falso: a caixa empresta — nada de retain.
 	if got := value.OwnersCount(borrowed); got != 1 {
 		t.Fatalf("caixa emprestada nao pode reter ao fechar: esperado Owners=1, veio %d", got)
+	}
+}
+
+// Task 7 (fallout da chave, round 3 — CRITICO achado em review): a condicao de
+// EMPRESTIMO tem de ser ESTATICA (tipo declarado do slot, decidida pelo
+// compilador). O round 2 a inferia em runtime varrendo frame.Owned
+// (ownsSlotIndex), e essa resposta erra nas DUAS direcoes:
+//
+//   (a) under-count: um slot POSSUIDO (`let x: Node = null`) cujo ocupante era
+//       null/escalar na hora da captura nunca entrou em frame.Owned (Retain
+//       falha em nao-composto) — a caixa do upvalue era marcada emprestada por
+//       engano e o retain que ela devia ao fechar/gravar era PULADO. O no ficava
+//       com um dono a menos, parecia unico, e `picked.valor = 99` mutava no
+//       lugar: a escrita vazava para head.proximo, quebrando a independencia do
+//       vinculo por valor.
+//   (b) dec a menos: indices de slot sao REUSADOS entre blocos irmaos e
+//       frame.Owned nao e podado no fim do escopo — a entrada morta de um irmao
+//       fazia um slot realmente emprestado parecer possuido, e o guard do
+//       OP_GET_LOCAL_MUT era derrotado (release indevido, o bug original).
+//
+// Agora quem decide e o compilador: OP_GET_LOCAL_MUT_BORROW para local `ref` e
+// OP_MARK_UPVALUE_BORROW (emitido apos o OP_CLOSURE) para upvalue `ref`.
+// Oraculo dos dois cenarios, conferido no binario do merge-base: 20.
+func TestBorrowConditionIsStaticNotInferredFromOwnedList(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+func get_second(h: ref Node) -> Node
+    return h.proximo
+end
+
+// (a) slot POSSUIDO que estava null na captura, escrito de dentro da closure
+// por OP_SET_UPVALUE. A caixa possui: o retain e devido.
+func repro_e(head: ref Node) -> int
+    let picked: Node = null
+    let f: func() -> int = func() -> int
+        picked = get_second(head)
+        return 1
+    end
+    let ignored: int = f()
+    picked.valor = 99
+    return head.proximo.valor
+end
+
+// (a2) controle: mesmo cenario com o slot ja composto na captura (entrada em
+// frame.Owned existe). Antes e depois da correcao responde 20 — isola a causa.
+func repro_e2(head: ref Node) -> int
+    let picked: Node = Node(1, null)
+    let f: func() -> int = func() -> int
+        picked = get_second(head)
+        return 1
+    end
+    let ignored: int = f()
+    picked.valor = 99
+    return head.proximo.valor
+end
+
+// (b) reuso de indice de slot entre blocos irmaos: o primeiro bloco registra o
+// indice em frame.Owned, o segundo reaproveita o MESMO indice para um
+// emprestimo (let u: ref Node).
+func repro_f(head: ref Node) -> int
+    let second: Node = head.proximo
+    if 1 == 1 then
+        let dead: Node = Node(7, null)
+        let touch: int = dead.valor
+    end
+    if 1 == 1 then
+        let u: ref Node = head.proximo
+        u.valor = 77
+    end
+    second.valor = 99
+    return head.proximo.valor
+end
+
+// (b2) controle: sem o bloco irmao morto, o indice nunca foi possuido.
+func repro_f2(head: ref Node) -> int
+    let second: Node = head.proximo
+    if 1 == 1 then
+        let u: ref Node = head.proximo
+        u.valor = 77
+    end
+    second.valor = 99
+    return head.proximo.valor
+end
+
+func main()
+    let ha: Node = Node(0, null)
+    _append(ha, 20)
+    _append(ha, 30)
+    let a: int = repro_e(ha)
+
+    let hb: Node = Node(0, null)
+    _append(hb, 20)
+    _append(hb, 30)
+    let b: int = repro_e2(hb)
+
+    let hc: Node = Node(0, null)
+    _append(hc, 20)
+    _append(hc, 30)
+    let c: int = repro_f(hc)
+
+    let hd: Node = Node(0, null)
+    _append(hd, 20)
+    _append(hd, 30)
+    let d: int = repro_f2(hd)
+
+    test_report(a * 1000000 + b * 10000 + c * 100 + d)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// 20 / 20 / 20 / 20 — os quatro cenarios respondem o oraculo do merge-base.
+	if reported.Type != value.VAL_INT || reported.AsInt != 20202020 {
+		t.Fatalf("condicao de emprestimo saiu errada (esperado 20202020 = e/e2/f/f2 todos 20), veio %#v", reported)
+	}
+}
+
+// Task 7 (round 3): contrapartida do teste acima — a escrita ATRAVES DE UM REF
+// para um no com um UNICO dono duravel acontece NO LUGAR, e nao num clone. E o
+// mesmo principio que torna as escritas via `ref Db` visiveis para o chamador
+// (bench_typed_call_map / NoxyDB) e que faz o `pop` de lista encadeada
+// funcionar; clonar ali seria justamente a escrita perdida corrigida nos
+// rounds anteriores.
+//
+// Este teste ancora o RASTRO DE CONTAGEM, que e a invariante defensavel:
+//
+//   p1 = 1  o campo `proximo` do no anterior e o unico dono
+//   p2 = 2  `*n = v` grava o no no slot por valor `x` — dois donos reais
+//   p3 = 1  `x.valor = 99` clona por independencia (CoW): `x` passa a apontar o
+//           clone e o no volta a ter um dono
+//   p4 = 1  `u.valor = 77` atravessa um emprestimo e muta no lugar; nenhum dono
+//           entra ou sai
+//
+// NOTA DE DIVERGENCIA CONSCIENTE: o binario pre-chave responde 50 aqui (soma
+// 0+20+30), porque o `*n = v` ligava o bit sticky do no PARA SEMPRE e a
+// mutacao via `u` clonava, perdendo a escrita. Com a unicidade por contagem o
+// resultado e 107 (0+77+30). Nao e bug de contagem — o rastro acima foi medido
+// e esta correto em todos os pontos; e exatamente o dead-share que a spec §3
+// se propoe a eliminar (a mesma razao do ganho de 13x no
+// bench_value_call_mutate). Nenhum exemplo do corpus muda (130/130).
+func TestRefWriteToUniquelyOwnedNodeMutatesInPlace(t *testing.T) {
+	machine := New()
+	counts := map[string]int32{}
+	for _, name := range []string{"p1", "p2", "p3", "p4"} {
+		probeName := name
+		machine.DefineNative("probe_"+probeName, func(args []value.Value) value.Value {
+			counts[probeName] = value.OwnersCount(args[0])
+			return value.NewNull()
+		})
+		markProbeReadonly(t, machine, "probe_"+probeName)
+	}
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+func get_second(h: ref Node) -> Node
+    return h.proximo
+end
+
+func setit(n: ref Node, v: Node)
+    *n = v
+end
+
+func sum_list(head: ref Node) -> int
+    let total: int = 0
+    let cur: ref Node = head
+    while cur != null do
+        total = total + cur.valor
+        cur = cur.proximo
+    end
+    return total
+end
+
+func run(head: ref Node) -> int
+    let x: Node = null
+    probe_p1(head.proximo)
+    setit(ref x, get_second(head))
+    probe_p2(head.proximo)
+    x.valor = 99
+    probe_p3(head.proximo)
+    let u: ref Node = head.proximo
+    u.valor = 77
+    probe_p4(head.proximo)
+    return sum_list(head)
+end
+
+func main()
+    let h: Node = Node(0, null)
+    _append(h, 20)
+    _append(h, 30)
+    test_report(run(h))
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	want := map[string]int32{"p1": 1, "p2": 2, "p3": 1, "p4": 1}
+	for _, name := range []string{"p1", "p2", "p3", "p4"} {
+		if counts[name] != want[name] {
+			t.Fatalf("rastro de donos errado: %s=%d, esperado %d (rastro completo: p1=%d p2=%d p3=%d p4=%d)",
+				name, counts[name], want[name], counts["p1"], counts["p2"], counts["p3"], counts["p4"])
+		}
+	}
+	// 0 + 77 + 30: a escrita via ref alcancou o no da lista.
+	if reported.Type != value.VAL_INT || reported.AsInt != 107 {
+		t.Fatalf("escrita via ref para no de dono unico deveria mutar no lugar (soma 107), veio %#v", reported)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -368,3 +368,295 @@ main()`
 		t.Fatalf("esperado Owners(capturado) >= 1 apos retorno do frame externo (box retem), veio %d", owners)
 	}
 }
+
+// Task 5 (Step 1): OP_ARRAY retem cada elemento como dono duravel (ao lado
+// do MarkShared existente, que fica ate a Task 8). x tem dois donos apos
+// virar elemento de arr: o slot do let e o elemento do array.
+func TestArrayLiteralRetainsSharedElement(t *testing.T) {
+	machine := New()
+	var owners int32
+	machine.DefineNative("probe", func(args []value.Value) value.Value {
+		owners = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe")
+
+	src := `
+func main()
+    let x: map[string, int] = {"a": 1}
+    let arr: map[string, int][] = [x]
+    probe(x)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if owners != 2 {
+		t.Fatalf("esperado Owners(x)=2 (slot de x + elemento do array), veio %d", owners)
+	}
+}
+
+// Task 5 (Step 1): OP_SET_INDEX (array) libera o elemento velho e retem o
+// novo. arr nao esta compartilhado (literal fresco), entao OP_GET_LOCAL_MUT
+// nao clona — o teste isola exatamente o par retain/release do proprio
+// OP_SET_INDEX.
+func TestArraySetIndexReleasesOldRetainsNew(t *testing.T) {
+	machine := New()
+	var oldVal value.Value
+	var ownersOldBefore, ownersNewAfter int32
+	machine.DefineNative("probe_old", func(args []value.Value) value.Value {
+		oldVal = args[0]
+		ownersOldBefore = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_new", func(args []value.Value) value.Value {
+		ownersNewAfter = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_old")
+	markProbeReadonly(t, machine, "probe_new")
+
+	src := `
+func main()
+    let x: map[string, int] = {"a": 1}
+    let y: map[string, int] = {"b": 2}
+    let arr: map[string, int][] = [x]
+    probe_old(x)
+    arr[0] = y
+    probe_new(y)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersOldBefore != 2 {
+		t.Fatalf("esperado Owners(x)=2 antes de arr[0]=y (slot x + elemento), veio %d", ownersOldBefore)
+	}
+	if got := value.OwnersCount(oldVal); got != 1 {
+		t.Fatalf("esperado Owners(x)=1 apos arr[0]=y (elemento liberado, slot x permanece), veio %d", got)
+	}
+	if ownersNewAfter != 2 {
+		t.Fatalf("esperado Owners(y)=2 apos arr[0]=y (slot y + elemento), veio %d", ownersNewAfter)
+	}
+}
+
+// Task 5 (Step 1): OP_SET_INDEX (map) sobre chave existente libera o valor
+// velho e retem o novo. m nao esta compartilhado, entao GET_LOCAL_MUT nao
+// clona — isola o par retain/release do proprio OP_SET_INDEX (branch map).
+func TestMapSetIndexReleasesOldOnExistingKey(t *testing.T) {
+	machine := New()
+	var oldVal value.Value
+	var ownersOldBefore, ownersNewAfter int32
+	machine.DefineNative("probe_old", func(args []value.Value) value.Value {
+		oldVal = args[0]
+		ownersOldBefore = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_new", func(args []value.Value) value.Value {
+		ownersNewAfter = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_old")
+	markProbeReadonly(t, machine, "probe_new")
+
+	src := `
+func main()
+    let x: map[string, int] = {"a": 1}
+    let y: map[string, int] = {"b": 2}
+    let m: map[string, map[string, int]] = {"k": x}
+    probe_old(x)
+    m["k"] = y
+    probe_new(y)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersOldBefore != 2 {
+		t.Fatalf(`esperado Owners(x)=2 antes de m["k"]=y (slot x + valor no map), veio %d`, ownersOldBefore)
+	}
+	if got := value.OwnersCount(oldVal); got != 1 {
+		t.Fatalf(`esperado Owners(x)=1 apos m["k"]=y (valor liberado do map, slot x permanece), veio %d`, got)
+	}
+	if ownersNewAfter != 2 {
+		t.Fatalf(`esperado Owners(y)=2 apos m["k"]=y (slot y + valor no map), veio %d`, ownersNewAfter)
+	}
+}
+
+// Task 5 (Step 1): OP_SET_PROPERTY libera o campo velho e retem o novo. A
+// 1a atribuicao clona box (Box(x) nao e reconhecido como "fresco" pelo
+// compilador — so array/map/zeros literal sao — entao o let marca o
+// resultado do construtor Shared, e a base "box" e clonada via
+// OP_GET_LOCAL_MUT). A 2a atribuicao roda com box ja unshared (o clone
+// nasce sem o bit ligado), isolando o par retain/release do proprio
+// OP_SET_PROPERTY sem a clonagem do caminho MUT interferir na contagem.
+func TestSetPropertyReleasesOldRetainsNew(t *testing.T) {
+	machine := New()
+	var oldFieldVal value.Value
+	var ownersOldBefore, ownersNewAfter int32
+	machine.DefineNative("probe_old", func(args []value.Value) value.Value {
+		oldFieldVal = args[0]
+		ownersOldBefore = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_new", func(args []value.Value) value.Value {
+		ownersNewAfter = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_old")
+	markProbeReadonly(t, machine, "probe_new")
+
+	src := `
+struct Box
+    value: map[string, int]
+end
+
+func main()
+    let x: map[string, int] = {"a": 1}
+    let y1: map[string, int] = {"y1": 1}
+    let y2: map[string, int] = {"y2": 2}
+    let box: Box = Box(x)
+    box.value = y1
+    probe_old(y1)
+    box.value = y2
+    probe_new(y2)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersOldBefore != 2 {
+		t.Fatalf("esperado Owners(y1)=2 apos a 1a atribuicao (slot + campo), veio %d", ownersOldBefore)
+	}
+	if got := value.OwnersCount(oldFieldVal); got != 1 {
+		t.Fatalf("esperado Owners(y1)=1 apos a 2a atribuicao liberar o campo, veio %d", got)
+	}
+	if ownersNewAfter != 2 {
+		t.Fatalf("esperado Owners(y2)=2 apos a 2a atribuicao (slot + campo), veio %d", ownersNewAfter)
+	}
+}
+
+// Task 5 (Step 1): construtor de struct (callPreparedValue) retem cada
+// argumento ao lado do MarkShared existente — o campo e um slot duravel.
+func TestStructConstructorRetainsFieldArgument(t *testing.T) {
+	machine := New()
+	var owners int32
+	machine.DefineNative("probe", func(args []value.Value) value.Value {
+		owners = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe")
+
+	src := `
+struct Box
+    value: map[string, int]
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    let box: Box = Box(m)
+    probe(m)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if owners != 2 {
+		t.Fatalf("esperado Owners(m)=2 (slot de m + campo do struct), veio %d", owners)
+	}
+}
+
+// Task 5 (Step 1): copyValue retem cada filho clonado (ao lado do
+// MarkShared existente). arr e compartilhado via alias; arr[1]=repl forca o
+// clone de arr (OP_GET_LOCAL_MUT) mas so sobrescreve o indice 1 — "child"
+// (indice 0) fica intocado e deve ganhar exatamente +1 dono vindo do clone.
+func TestCloneOnMutationRetainsUntouchedChild(t *testing.T) {
+	machine := New()
+	var before, after int32
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		before = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+func main()
+    let child: map[string, int] = {"a": 1}
+    let other: map[string, int] = {"b": 2}
+    let arr: map[string, int][] = [child, other]
+    let alias: map[string, int][] = arr
+    probe_before(child)
+    let repl: map[string, int] = {"c": 3}
+    arr[1] = repl
+    probe_after(child)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if before != 2 {
+		t.Fatalf("esperado Owners(child)=2 antes do clone (slot + elemento), veio %d", before)
+	}
+	if after != before+1 {
+		t.Fatalf("esperado Owners(child) crescer +1 apos o clone de arr (filho intocado herda dono do clone), before=%d after=%d", before, after)
+	}
+}
+
+// Task 5 (Step 1): caminho MUT (OP_GET_INDEX_MUT, branch array) — quando
+// a[0] esta Shared (marcado pelo proprio OP_ARRAY), a mutacao a[0].x=9
+// clona o elemento, grava o clone de volta em Elements[0] com retain, e
+// libera a instancia velha. Auditado por contagem na instancia velha
+// (capturada antes da mutacao) e na nova (lida depois).
+func TestMutIndexClonePathRetainsWriteBackReleasesOld(t *testing.T) {
+	machine := New()
+	var oldInst value.Value
+	var ownersOldBefore, ownersNewAfter int32
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		oldInst = args[0]
+		ownersOldBefore = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		ownersNewAfter = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+struct P
+    x: int
+end
+
+func main()
+    let a: P[] = [P(1)]
+    probe_before(a[0])
+    a[0].x = 9
+    probe_after(a[0])
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersOldBefore != 1 {
+		t.Fatalf("esperado Owners(a[0])=1 antes da mutacao (retain do elemento no OP_ARRAY), veio %d", ownersOldBefore)
+	}
+	if got := value.OwnersCount(oldInst); got != 0 {
+		t.Fatalf("esperado Owners(instancia velha)=0 apos o clone gravado de volta em OP_GET_INDEX_MUT, veio %d", got)
+	}
+	if ownersNewAfter != 1 {
+		t.Fatalf("esperado Owners(clone gravado em a[0])=1 apos a mutacao, veio %d", ownersNewAfter)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -248,3 +248,123 @@ main()`
 		t.Fatalf("esperado Owners(objeto velho de a)=0 apos a reatribuicao, veio %d", got)
 	}
 }
+
+// Task 4 (Step 1): let global de composto retem 1 dono; reatribuicao do
+// global (g = h, ambos globais) solta o velho e o novo passa a ter 2 donos
+// (os slots globais g e h).
+func TestGlobalLetRetainsCompositeAndReassignmentSwaps(t *testing.T) {
+	machine := New()
+	var ownersG1, ownersG2 int32
+	var oldG value.Value
+	machine.DefineNative("probe_g1", func(args []value.Value) value.Value {
+		oldG = args[0]
+		ownersG1 = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_g2", func(args []value.Value) value.Value {
+		ownersG2 = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_g1")
+	markProbeReadonly(t, machine, "probe_g2")
+
+	src := `
+let g: map[string, int] = {"a": 1}
+probe_g1(g)
+let h: map[string, int] = {"b": 2}
+g = h
+probe_g2(g)`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if ownersG1 != 1 {
+		t.Fatalf("esperado Owners(g)=1 apos let global, veio %d", ownersG1)
+	}
+	if ownersG2 != 2 {
+		t.Fatalf("esperado Owners(g)=2 apos g=h (globais g e h), veio %d", ownersG2)
+	}
+	if got := value.OwnersCount(oldG); got != 0 {
+		t.Fatalf("esperado Owners(objeto velho de g)=0 apos a reatribuicao, veio %d", got)
+	}
+}
+
+// Task 4 (Step 1): funcao com parametro ref escreve no composto do
+// chamador via *target = novo. O velho deve ser liberado, o novo retido.
+func TestWriteViaRefReleasesOldRetainsNew(t *testing.T) {
+	machine := New()
+	var before, after int32
+	var oldM value.Value
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		oldM = args[0]
+		before = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+func write_via_ref(target: ref map[string, int]) -> void
+    *target = {"z": 9}
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    probe_before(m)
+    write_via_ref(ref m)
+    probe_after(m)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if before != 1 {
+		t.Fatalf("esperado Owners(m)=1 antes da escrita via ref, veio %d", before)
+	}
+	if got := value.OwnersCount(oldM); got != 0 {
+		t.Fatalf("esperado Owners(objeto velho de m)=0 apos escrita via ref, veio %d", got)
+	}
+	if after != 1 {
+		t.Fatalf("esperado Owners(novo valor de m)=1 apos escrita via ref, veio %d", after)
+	}
+}
+
+// Task 4 (Step 1): closure que captura um composto local sobrevive ao
+// retorno do frame externo — o box do upvalue precisa reter o valor ao
+// fechar (closeUpvalue), senao o retorno do frame externo (que solta o
+// slot local) deixaria Owners em 0 enquanto a closure ainda vive.
+func TestClosureCaptureSurvivesFrameReturn(t *testing.T) {
+	machine := New()
+	var owners int32
+	machine.DefineNative("probe", func(args []value.Value) value.Value {
+		owners = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe")
+
+	src := `
+func make_holder() -> func() -> map[string, int]
+    let m: map[string, int] = {"a": 1}
+    return func() -> map[string, int]
+        probe(m)
+        return m
+    end
+end
+
+func main()
+    let holder: func() -> map[string, int] = make_holder()
+    holder()
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if owners < 1 {
+		t.Fatalf("esperado Owners(capturado) >= 1 apos retorno do frame externo (box retem), veio %d", owners)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1731,3 +1731,201 @@ main()`
 		t.Fatalf("escrita via ref para no de dono unico deveria mutar no lugar (soma 107), veio %#v", reported)
 	}
 }
+
+// Task 7 (fallout da chave, round 4 — CRITICO achado em review): o predicado
+// estatico do round 3 perguntava "o tipo declarado do slot e `ref T`?", mas a
+// pergunta que os funis de escrita precisam responder e "este slot RETEM o que
+// guarda?". Nao-possuidor e ESTRITAMENTE MAIS LARGO: dois bind sites do
+// compilador colocam um valor no slot sem inc, sem entrada em frame.Owned e com
+// tipo declarado NIL — a variavel de for-each (addLocal(ident, nil) depois de um
+// OP_GET_INDEX, sem OP_OWN_LOCAL) e o binding de case do select (valor vindo do
+// $sel_val). Com tipo nil o teste antigo escolhia o gemeo POSSUIDOR, e
+// `item.v = 99` fazia ownSlot + Release(velho) sobre um objeto que aquele slot
+// nunca reteve: dec a menos, o elemento do array passava a parecer unico e a
+// escrita seguinte em `b` vazava para arr[0].
+//
+// Agora o compilador carrega Local.Owns, marcado exatamente onde o inc e
+// emitido (OP_OWN_LOCAL do let / retain de parametro sem ref no
+// callPreparedClosure), e os tres consumidores decidem por ele:
+// OP_GET_LOCAL_MUT(_BORROW), OP_SET_LOCAL(_BORROW) e OP_REF_LOCAL(_BORROW).
+//
+// Oraculo de todos os cenarios, conferido no binario do merge-base: 1.
+func TestNonOwningLocalBindsNeverReleaseWhatTheyNeverRetained(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+func setit(n: ref Box, w: Box)
+    *n = w
+end
+
+// A: variavel de for-each no caminho MUT (o cenario do review).
+func a_foreach_mut() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    for item in arr do
+        item.v = 99
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+// B: controle — o loop existe mas so le a variavel.
+func b_foreach_readonly() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    let acc: int = 0
+    for item in arr do
+        acc = acc + item.v
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+// C: controle — sem loop nenhum.
+func c_no_loop() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    b.v = 55
+    return arr[0].v
+end
+
+// D: rebind da propria variavel de for-each (OP_SET_LOCAL sobre slot
+// nao-possuidor soltaria o elemento do array).
+func d_foreach_rebind() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    let other: Box = Box(2)
+    for item in arr do
+        item = other
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+// E: ref para a variavel de for-each, escrito via *n = w (a caixa aberta sobre
+// um slot nao-possuidor tem de nascer emprestada).
+func e_ref_to_foreach_var() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    for item in arr do
+        setit(ref item, Box(9))
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+// F: binding de case do select mutado no corpo do case.
+func f_select_binding_mut() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    let ch: any = make_chan(1)
+    chan_send(ch, arr[0])
+    when
+        case got = chan_recv(ch) then
+            got.v = 99
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+func main()
+    let a: string = to_str(a_foreach_mut())
+    let b: string = to_str(b_foreach_readonly())
+    let c: string = to_str(c_no_loop())
+    let d: string = to_str(d_foreach_rebind())
+    let e: string = to_str(e_ref_to_foreach_var())
+    let f: string = to_str(f_select_binding_mut())
+    test_report(a + "|" + b + "|" + c + "|" + d + "|" + e + "|" + f)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1|1|1|1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("independencia quebrada por dec a menos em slot nao-possuidor: esperado %q (a|b|c|d|e|f), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 4 — CRITICO 2, pre-existente e confirmado observavel): a escrita
+// ATRAVES DE UM REF para um slot de pilha POSSUIDO soltava o ocupante velho no
+// funil (references.go) mas deixava a entrada (slot, objeto) do frame nomeando o
+// objeto VELHO — o release em massa do fim do frame o soltava DE NOVO. Dec a
+// mais e a direcao insegura: o objeto velho, ainda vivo em outro dono (aqui dois
+// globais), passava a parecer unico e a mutacao seguinte acontecia no lugar,
+// vazando para o outro dono.
+//
+// Correcao (opcao (a) do review): retargetOwnedSlot reaponta a entrada do frame
+// para o valor novo, entao o release do velho e pago agora pelo funil e o do
+// novo pelo fim do frame — conta fechada, sem inflacao.
+//
+// Oraculo do merge-base: 1 (a escrita em ga[0] nao pode aparecer em gb[0]).
+func TestRefWriteToOwnedSlotRetargetsFrameOwnedEntry(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+let ga: Box[] = []
+let gb: Box[] = []
+let ha: Box[] = []
+let hb: Box[] = []
+
+func setit(n: ref Box, w: Box)
+    *n = w
+end
+
+// escreve via ref no slot possuido de y depois de compartilhar y com dois
+// globais: a entrada de posse do frame precisa passar a nomear o valor novo.
+func build_with_ref_write()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    setit(ref y, Box(9))
+end
+
+// controle: mesmo compartilhamento, sem a escrita via ref.
+func build_plain()
+    let y: Box = Box(1)
+    ha = [y]
+    hb = [y]
+end
+
+func main()
+    build_with_ref_write()
+    ga[0].v = 55
+
+    build_plain()
+    ha[0].v = 55
+
+    test_report(to_str(gb[0].v) + "|" + to_str(hb[0].v))
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("dec a mais pela entrada de posse obsoleta: esperado %q (com escrita via ref | controle), veio %#v", want, reported.Obj)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -420,9 +420,9 @@ main()`
 	}
 }
 
-// Task 5 (Step 1): OP_ARRAY retem cada elemento como dono duravel (ao lado
-// do MarkShared existente, que fica ate a Task 8). x tem dois donos apos
-// virar elemento de arr: o slot do let e o elemento do array.
+// Task 5 (Step 1): OP_ARRAY retem cada elemento como dono duravel (a antiga
+// marcacao sticky que rodava ao lado foi removida na Task 8). x tem dois
+// donos apos virar elemento de arr: o slot do let e o elemento do array.
 func TestArrayLiteralRetainsSharedElement(t *testing.T) {
 	machine := New()
 	var owners int32
@@ -614,7 +614,7 @@ main()`
 }
 
 // Task 5 (Step 1): construtor de struct (callPreparedValue) retem cada
-// argumento ao lado do MarkShared existente — o campo e um slot duravel.
+// argumento — o campo e um slot duravel.
 func TestStructConstructorRetainsFieldArgument(t *testing.T) {
 	machine := New()
 	var owners int32
@@ -644,10 +644,10 @@ main()`
 	}
 }
 
-// Task 5 (Step 1): copyValue retem cada filho clonado (ao lado do
-// MarkShared existente). arr e compartilhado via alias; arr[1]=repl forca o
-// clone de arr (OP_GET_LOCAL_MUT) mas so sobrescreve o indice 1 — "child"
-// (indice 0) fica intocado e deve ganhar exatamente +1 dono vindo do clone.
+// Task 5 (Step 1): copyValue retem cada filho clonado. arr e compartilhado
+// via alias; arr[1]=repl forca o clone de arr (OP_GET_LOCAL_MUT) mas so
+// sobrescreve o indice 1 — "child" (indice 0) fica intocado e deve ganhar
+// exatamente +1 dono vindo do clone.
 func TestCloneOnMutationRetainsUntouchedChild(t *testing.T) {
 	machine := New()
 	var before, after int32
@@ -692,8 +692,9 @@ main()`
 // por contagem na instancia velha (capturada antes da mutacao) e na nova
 // (lida depois).
 //
-// Task 7: antes da chave bastava `let a: P[] = [P(1)]` — o MarkShared que o
-// OP_ARRAY faz no elemento era suficiente para o caminho de clone disparar.
+// Task 7: antes da chave bastava `let a: P[] = [P(1)]` — a marcacao sticky
+// que o OP_ARRAY fazia no elemento era suficiente para o caminho de clone
+// disparar.
 // Depois da chave (spec docs/superpowers/specs/
 // 2026-08-17-cow-rc-uniqueness-design.md §3), "compartilhado" e Owners > 1, e
 // um elemento com um unico dono (o proprio array) e unico por definicao —
@@ -744,8 +745,8 @@ main()`
 	}
 }
 
-// Task 6 (Step 1): append retem o item ao lado do MarkShared existente; pop
-// libera o elemento removido depois de tira-lo do array.
+// Task 6 (Step 1): append retem o item; pop libera o elemento removido
+// depois de tira-lo do array.
 func TestAppendRetainsItemPopReleasesRemoved(t *testing.T) {
 	machine := New()
 	item := value.NewMap()
@@ -800,9 +801,8 @@ func TestDeleteReleasesValueOnlyWhenKeyExisted(t *testing.T) {
 	}
 }
 
-// Task 6 (Step 1): chan_send retem o valor ao lado do MarkShared existente
-// (o buffer e durave); chan_recv libera apos um recebimento bem-sucedido —
-// o valor saiu do buffer.
+// Task 6 (Step 1): chan_send retem o valor (o buffer e durave); chan_recv
+// libera apos um recebimento bem-sucedido — o valor saiu do buffer.
 func TestChanSendRetainsChanRecvReleasesOnSuccess(t *testing.T) {
 	machine := New()
 	item := value.NewMap()
@@ -905,7 +905,7 @@ end`); err != nil {
 	// assinatura da funcao, e um value.NewMap() cru nao carrega o
 	// RuntimeType que o checker exige para map[K,V]; um array construido
 	// fora do bytecode passa nessa validacao (mesmo padrao usado em
-	// TestPreparedTaskCallMarksValueParameterShared).
+	// TestPreparedTaskCallRetainsValueParameter).
 	m := value.NewArray([]value.Value{value.NewInt(1)})
 	before := value.OwnersCount(m)
 

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1732,22 +1732,17 @@ main()`
 	}
 }
 
-// Task 7 (fallout da chave, round 4 — CRITICO achado em review): o predicado
-// estatico do round 3 perguntava "o tipo declarado do slot e `ref T`?", mas a
-// pergunta que os funis de escrita precisam responder e "este slot RETEM o que
-// guarda?". Nao-possuidor e ESTRITAMENTE MAIS LARGO: dois bind sites do
-// compilador colocam um valor no slot sem inc, sem entrada em frame.Owned e com
-// tipo declarado NIL — a variavel de for-each (addLocal(ident, nil) depois de um
-// OP_GET_INDEX, sem OP_OWN_LOCAL) e o binding de case do select (valor vindo do
-// $sel_val). Com tipo nil o teste antigo escolhia o gemeo POSSUIDOR, e
-// `item.v = 99` fazia ownSlot + Release(velho) sobre um objeto que aquele slot
-// nunca reteve: dec a menos, o elemento do array passava a parecer unico e a
-// escrita seguinte em `b` vazava para arr[0].
-//
-// Agora o compilador carrega Local.Owns, marcado exatamente onde o inc e
-// emitido (OP_OWN_LOCAL do let / retain de parametro sem ref no
-// callPreparedClosure), e os tres consumidores decidem por ele:
-// OP_GET_LOCAL_MUT(_BORROW), OP_SET_LOCAL(_BORROW) e OP_REF_LOCAL(_BORROW).
+// Task 7 (fallout da chave, rounds 3-4): a pergunta dos funis de escrita e
+// "este slot RETEM o que guarda?" (Local.Owns, marcado exatamente onde o inc e
+// emitido), e os tres consumidores decidem por ela: OP_GET_LOCAL_MUT(_BORROW),
+// OP_SET_LOCAL(_BORROW) e OP_REF_LOCAL(_BORROW). No round 3 a variavel de
+// for-each e o binding de case do select eram slots NAO-possuidores servidos
+// pelos gemeos de emprestimo; o round 4 fechou a classe: esses binds agora
+// RETEM desde o nascimento (OP_OWN_LOCAL por iteracao, spec §4.2 — "TODO
+// composto"), e os nao-possuidores nomeados voltaram a ser exatamente os slots
+// `ref`. Estes cenarios permanecem como ancoras de INDEPENDENCIA: nenhum
+// caminho pode soltar o elemento do array que o slot nao retem (round 3) nem
+// deixar de reter o que o slot guarda duravelmente (round 4).
 //
 // Oraculo de todos os cenarios, conferido no binario do merge-base: 1.
 func TestNonOwningLocalBindsNeverReleaseWhatTheyNeverRetained(t *testing.T) {
@@ -1812,8 +1807,8 @@ func d_foreach_rebind() -> int
     return arr[0].v
 end
 
-// E: ref para a variavel de for-each, escrito via *n = w (a caixa aberta sobre
-// um slot nao-possuidor tem de nascer emprestada).
+// E: ref para a variavel de for-each, escrito via *n = w (round 4: o slot
+// possui, a caixa nasce possuidora e o funil reaponta a entrada do frame).
 func e_ref_to_foreach_var() -> int
     let b: Box = Box(1)
     let arr: Box[] = [b]
@@ -1927,5 +1922,307 @@ main()`
 	const want = "1|1"
 	if reported.Type != value.VAL_OBJ || reported.Obj != want {
 		t.Fatalf("dec a mais pela entrada de posse obsoleta: esperado %q (com escrita via ref | controle), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 4 — CRITICO 2 do re-review): os binds de for-each e de case do
+// select agora RETEM (spec §4.2: "slot de local ... TODO composto"), entao o
+// rebind durável do slot passa pelo store CONTADO. Antes, `item = other` (e as
+// formas via ref e via select) gravava o objeto de `other` no slot SEM inc
+// (gemeo de emprestimo): o slot segurava o objeto duravelmente com um dono a
+// menos, a mutacao seguinte via Owners==1 e escrevia NO LUGAR — vazando para o
+// dono real (candidato respondia 7; o merge-base e o proprio `let` respondem 2).
+//
+// Oraculo do merge-base para os cinco cenarios: 2 (independencia por valor).
+func TestForEachAndSelectBindingsOwnFromBirth(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+func setit(n: ref Box, w: Box)
+    *n = w
+end
+
+// U1: rebind da variavel de for-each com valor de outro dono vivo + mutacao.
+func u1_rebind_then_mut() -> int
+    let other: Box = Box(2)
+    let arr: Box[] = [Box(1)]
+    for item in arr do
+        item = other
+        item.v = 7
+    end
+    return other.v
+end
+
+// U2: escrita via ref para a variavel de for-each + mutacao.
+func u2_refwrite_then_mut() -> int
+    let other: Box = Box(2)
+    let arr: Box[] = [Box(1)]
+    for item in arr do
+        setit(ref item, other)
+        item.v = 7
+    end
+    return other.v
+end
+
+// U3: o mesmo padrao no binding de case do select.
+func u3_select_rebind_then_mut() -> int
+    let other: Box = Box(2)
+    let ch: any = make_chan(1)
+    chan_send(ch, Box(1))
+    when
+        case got = chan_recv(ch) then
+            got = other
+            got.v = 7
+    end
+    return other.v
+end
+
+// W1: referencia de semantica — o MESMO padrao num let (sempre respondeu 2).
+func w1_let_rebind_then_mut() -> int
+    let other: Box = Box(2)
+    let x: Box = Box(1)
+    x = other
+    x.v = 7
+    return other.v
+end
+
+// W3: o valor rebindado tambem vive num terceiro dono (elemento de array).
+func w3_foreach_rebind_leak_to_array() -> int
+    let other: Box = Box(2)
+    let keep: Box[] = [other]
+    let arr: Box[] = [Box(1)]
+    for item in arr do
+        item = other
+        item.v = 7
+    end
+    return keep[0].v
+end
+
+func main()
+    let u1: string = to_str(u1_rebind_then_mut())
+    let u2: string = to_str(u2_refwrite_then_mut())
+    let u3: string = to_str(u3_select_rebind_then_mut())
+    let w1: string = to_str(w1_let_rebind_then_mut())
+    let w3: string = to_str(w3_foreach_rebind_leak_to_array())
+    test_report(u1 + "|" + u2 + "|" + u3 + "|" + w1 + "|" + w3)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "2|2|2|2|2"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("rebind duravel sem retain (under-count) em bind de for-each/select: esperado %q (u1|u2|u3|w1|w3), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 4 — CRITICO 1 do re-review): a marca de emprestimo da caixa de
+// upvalue e por TIPO DECLARADO (emitClosureUpvalues), e a variavel de for-each
+// tem tipo nil — a caixa nasce POSSUIDORA. Enquanto o slot nao retinha, a
+// closure que o capturava soltava (OP_SET_UPVALUE) ou trocava com release
+// (OP_GET_UPVALUE_MUT) um elemento de array que ninguem reteve: dec a menos, o
+// elemento parecia unico e a escrita em `b` vazava para arr[0] (candidato
+// respondia 55|55). Com o slot possuidor desde o nascimento a marca por tipo
+// fica correta POR CONSTRUCAO — sem mecanismo novo.
+//
+// Oraculo do merge-base: 1|1.
+func TestCapturedForEachItemKeepsContainerElementIndependent(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+// A: closure captura a variavel de for-each e muta via OP_GET_UPVALUE_MUT.
+func a_closure_mut_foreach() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    for item in arr do
+        let f: func = func() -> void
+            item.v = 99
+        end
+        f()
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+// B: closure captura a variavel de for-each e REBINDA via OP_SET_UPVALUE.
+func b_closure_rebind_foreach() -> int
+    let b: Box = Box(1)
+    let arr: Box[] = [b]
+    let other: Box = Box(2)
+    for item in arr do
+        let f: func = func() -> void
+            item = other
+        end
+        f()
+    end
+    b.v = 55
+    return arr[0].v
+end
+
+func main()
+    test_report(to_str(a_closure_mut_foreach()) + "|" + to_str(b_closure_rebind_foreach()))
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("caixa possuidora sobre slot de for-each soltou o que ninguem reteve: esperado %q (mut|rebind), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 4): escrita ATRAVES DA CAIXA DE UPVALUE ABERTA sobre um slot
+// possuido e um store contado no slot — a entrada (slot, objeto) do frame dono
+// tem de passar a nomear o valor novo, exatamente como na escrita via ref
+// (retargetOwnedSlot). Sem o reaponte, o fim do frame soltava o objeto velho
+// uma SEGUNDA vez (dec a mais): vivo em dois globais, ele parecia unico e a
+// mutacao seguinte vazava de ga[0] para gb[0] (candidato respondia 55|55 —
+// bug PRE-EXISTENTE em `let` capturado, exposto de vez pelos itens de for-each
+// possuidores e capturaveis).
+//
+// Oraculo do merge-base: 1|1.
+func TestOpenUpvalueWriteRetargetsFrameOwnedEntry(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+let ga: Box[] = []
+let gb: Box[] = []
+let ha: Box[] = []
+let hb: Box[] = []
+
+// V1: rebind de um let possuidor pela caixa ABERTA (OP_SET_UPVALUE).
+func v1_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let f: func = func() -> void
+        y = Box(9)
+    end
+    f()
+end
+
+// V2: mutacao do let possuidor pela caixa ABERTA (OP_GET_UPVALUE_MUT).
+func v2_build()
+    let y: Box = Box(1)
+    ha = [y]
+    hb = [y]
+    let f: func = func() -> void
+        y.v = 3
+    end
+    f()
+end
+
+func main()
+    v1_build()
+    ga[0].v = 55
+    v2_build()
+    ha[0].v = 55
+    test_report(to_str(gb[0].v) + "|" + to_str(hb[0].v))
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("entrada de posse obsoleta apos escrita pela caixa aberta (dec a mais): esperado %q (set_upvalue|get_upvalue_mut), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 4): aritmetica exata do laco — cada elemento recebe UM retain
+// no bind da iteracao (OP_OWN_LOCAL roda dentro do corpo) e UM release no bind
+// da iteracao seguinte (bindOwnedSlot paga a entrada anterior do slot) ou no
+// fim do frame (ultimo elemento). O mesmo objeto em tres posicoes: durante o
+// laco Owners sobe exatamente 1 (o vinculo do item), e depois do retorno da
+// funcao que iterou volta EXATAMENTE ao valor de antes — sem o pagamento da
+// entrada anterior o replace vazaria um retain por iteracao (Owners inflaria
+// para before+2 aqui).
+func TestForEachItemRetainReleasePairsPerElement(t *testing.T) {
+	machine := New()
+	var before, during, after int32
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		before = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		during = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_during")
+	markProbeReadonly(t, machine, "probe_after")
+	src := `
+struct Box
+    v: int
+end
+
+func loop_over(arr: Box[])
+    for item in arr do
+        probe_during(item)
+    end
+end
+
+func main()
+    let b: Box = Box(1)
+    let arr: Box[] = [b, b, b]
+    probe_before(b)
+    loop_over(arr)
+    probe_after(b)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// slot do let b (1) + tres elementos do array (3)
+	if before != 4 {
+		t.Fatalf("precondicao: esperado Owners 4 antes do laco (let + 3 elementos), veio %d", before)
+	}
+	// dentro do laco: +1 do vinculo do item — em TODAS as iteracoes (o release
+	// da entrada anterior acompanha o retain da seguinte)
+	if during != before+1 {
+		t.Fatalf("durante o laco esperado Owners %d (bind do item retem), veio %d", before+1, during)
+	}
+	// depois do retorno: conta fechada, um release por retain
+	if after != before {
+		t.Fatalf("apos o retorno esperado Owners %d (cada elemento: 1 retain, 1 release), veio %d", before, after)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -2226,3 +2226,255 @@ main()`
 		t.Fatalf("apos o retorno esperado Owners %d (cada elemento: 1 retain, 1 release), veio %d", before, after)
 	}
 }
+
+// Task 7 (round 5 — CRITICO 1, pre-existente): os dois helpers de reaponte
+// varriam os frames de FORA PARA DENTRO e devolviam o primeiro match por
+// endereco. Indices absolutos de slot sao reusados: a regiao de pilha do frame
+// chamado sobrepoe os indices onde um bloco irmao MORTO do chamador deixou
+// entradas nunca podadas — a entrada morta do chamador casava primeiro, era
+// reapontada no lugar da entrada VIVA do frame interno, e o fim do frame
+// soltava o objeto velho uma segunda vez (dec a mais: vivo em dois globais,
+// parecia unico, a mutacao seguinte vazava). O alinhamento depende do offset do
+// bloco morto (rr_alias: D0/D1 escapavam, D2+ mordiam). Correcao: varrer de
+// DENTRO PARA FORA — entradas de um frame interno sao todas >= seu LocalBase,
+// entao nenhuma entrada interna pode aliasar um slot vivo de frame externo.
+//
+// Cobre os DOIS funis: caixa de upvalue aberta (retargetOwnedSlotForUpvalue,
+// cenarios A*) e escrita via ref (retargetOwnedSlot, cenarios B*), cada um com
+// controle sem bloco morto. Oraculo do merge-base: 1 em todos.
+func TestRetargetScansFramesInnermostFirst(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+let ga: Box[] = []
+let gb: Box[] = []
+
+func setit(n: ref Box, w: Box)
+    *n = w
+end
+
+// funil da caixa de upvalue aberta (OP_SET_UPVALUE)
+func upv_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let f: func = func() -> void
+        y = Box(9)
+    end
+    f()
+end
+
+// funil da escrita via ref (storeReferenceValue)
+func ref_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    setit(ref y, Box(9))
+end
+
+// A0/B0: controles sem bloco morto no chamador.
+func a0() -> int
+    upv_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+func b0() -> int
+    ref_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+// A2/B2: bloco irmao morto deixa entradas possuidoras do CHAMADOR em indices
+// que o frame chamado reusa (o offset 2 e o primeiro que morde no rr_alias).
+func a2() -> int
+    if true then
+        let d0: Box = Box(90)
+        let d1: Box = Box(91)
+        d0.v = d1.v
+    end
+    upv_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+func b2() -> int
+    if true then
+        let d0: Box = Box(90)
+        let d1: Box = Box(91)
+        d0.v = d1.v
+    end
+    ref_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+// A3/B3: um slot morto a mais (outro alinhamento que mordia).
+func a3() -> int
+    if true then
+        let d0: Box = Box(90)
+        let d1: Box = Box(91)
+        let d2: Box = Box(92)
+        d0.v = d1.v + d2.v
+    end
+    upv_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+func b3() -> int
+    if true then
+        let d0: Box = Box(90)
+        let d1: Box = Box(91)
+        let d2: Box = Box(92)
+        d0.v = d1.v + d2.v
+    end
+    ref_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+func main()
+    let ra0: string = to_str(a0())
+    let ra2: string = to_str(a2())
+    let ra3: string = to_str(a3())
+    let rb0: string = to_str(b0())
+    let rb2: string = to_str(b2())
+    let rb3: string = to_str(b3())
+    test_report(ra0 + "|" + ra2 + "|" + ra3 + "|" + rb0 + "|" + rb2 + "|" + rb3)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1|1|1|1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("reaponte casou entrada morta do chamador (dec a mais): esperado %q (a0|a2|a3|b0|b2|b3), veio %#v", want, reported.Obj)
+	}
+}
+
+// Task 7 (round 5 — CRITICO 2, pre-existente): quando o valor novo de um
+// OP_SET_LOCAL nao e retivel (ex.: `z = null` num slot possuidor), o site ja
+// liberou o ocupante velho, mas o ownSlot fazia early-return no Retain falho e
+// a entrada (slot, objeto) continuava nomeando o objeto JA PAGO — entrada
+// fantasma. Quem a honrasse (fim do frame, ou o bindOwnedSlot da iteracao
+// seguinte) soltava o objeto de novo: dec a mais, vivo em dois globais ele
+// parecia unico e a mutacao vazava. Correcao: ownSlot remove a entrada do slot
+// (swap-remove) quando o ocupante novo nao e retivel — mesma disciplina do
+// bindOwnedSlot.
+//
+// Oraculo do merge-base: 1 em todos (N4 e o controle sem rebind para null;
+// N3 cobre o rebind para null da variavel de for-each).
+func TestOwnSlotDropsEntryOnNonRetainableRebind(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Box
+    v: int
+end
+
+let ga: Box[] = []
+let gb: Box[] = []
+
+// N1: rebind de slot possuidor para null; a entrada fantasma seria honrada
+// pelo release em massa do fim do frame.
+func n1_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let z: Box = y
+    z = null
+end
+
+func n1() -> int
+    n1_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+// N2: o mesmo dentro de um laco — a entrada fantasma seria honrada pelo
+// bindOwnedSlot da iteracao seguinte, antes do fim do frame.
+func n2_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let i: int = 0
+    while i < 3 do
+        let z: Box = y
+        z = null
+        i = i + 1
+    end
+end
+
+func n2() -> int
+    n2_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+// N3: variavel de for-each rebindada para null.
+func n3_build(arr: Box[])
+    for item in arr do
+        item = null
+    end
+end
+
+func n3() -> int
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let arr: Box[] = [y, y, y]
+    n3_build(arr)
+    ga[0].v = 55
+    return gb[0].v
+end
+
+// N4: controle — sem rebind para null.
+func n4_build()
+    let y: Box = Box(1)
+    ga = [y]
+    gb = [y]
+    let z: Box = y
+    z.v = z.v
+end
+
+func n4() -> int
+    n4_build()
+    ga[0].v = 55
+    return gb[0].v
+end
+
+func main()
+    let r1: string = to_str(n1())
+    let r2: string = to_str(n2())
+    let r3: string = to_str(n3())
+    let r4: string = to_str(n4())
+    test_report(r1 + "|" + r2 + "|" + r3 + "|" + r4)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	const want = "1|1|1|1"
+	if reported.Type != value.VAL_OBJ || reported.Obj != want {
+		t.Fatalf("entrada fantasma apos rebind nao-retivel (dec a mais): esperado %q (n1|n2|n3|n4), veio %#v", want, reported.Obj)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1,0 +1,179 @@
+package vm
+
+import (
+	"fmt"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// markProbeReadonly estampa ReadonlyArgs=true no native de sonda registrado
+// via DefineNative. DefineNative usa stampReadonlyArgs, que só liga o flag
+// para nomes na allowlist de cow_natives.go — nossos probes não estão lá, e
+// por padrão ficariam com ReadonlyArgs=false (native "sem assinatura fora da
+// allowlist": marca Shared nos args, mas nesta fase isso não mexe em
+// Owners). Ligamos explicitamente porque uma tarefa futura fará natives sem
+// assinatura reterem permanentemente seus args por padrão — sem isso aqui,
+// essa mudança futura destabilizaria a aritmética medida por estes testes,
+// que auditam apenas o retain do parâmetro de valor da função Noxy chamada
+// (reader/inner/outer), não qualquer retain feito pelo próprio native de
+// sonda.
+func markProbeReadonly(t *testing.T, machine *VM, name string) {
+	t.Helper()
+	requireBuiltin(t, machine, name).ReadonlyArgs = true
+}
+
+// O programa passa um map por valor a um helper e reporta depois do
+// retorno. O teste intercepta o valor via native de teste para medir Owners
+// em tres momentos.
+func TestParamRetainReleasedAfterReturn(t *testing.T) {
+	machine := New()
+	var during, after int32
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		during = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_during")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+func reader(m: map[string, int]) -> int
+    probe_during(m)
+    return 1
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    reader(m)
+    probe_after(m)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// during: slot do parametro de reader retido => >= 1
+	if during < 1 {
+		t.Fatalf("durante a chamada esperado Owners >= 1, veio %d", during)
+	}
+	// after: o retain do parametro foi liberado no fim do frame => o valor
+	// caiu em exatamente 1 em relacao ao pico medido durante
+	if after != during-1 {
+		t.Fatalf("apos o retorno esperado %d, veio %d", during-1, after)
+	}
+}
+
+// boom() aborta com erro de indice fora dos limites. O runtime desenrola
+// (unwind) todos os frames ate o topo — inclusive o de main() — entao
+// probe_after nunca chega a rodar dentro deste programa; o que resta
+// auditavel aqui e que o erro realmente ocorre (nao silenciosamente ignora o
+// unwind, nao entra em panico). A asserção real de que o release aconteceu
+// durante o unwind está em TestParamReleaseOnUnwindDirect (Step 1b), que
+// monta o frame a mao e inspeciona Owners diretamente.
+func TestParamReleaseRunsOnUnwind(t *testing.T) {
+	machine := New()
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_after")
+	src := `
+func boom(m: map[string, int]) -> int
+    let arr: int[] = [1]
+    return arr[99]
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    boom(m)
+    probe_after(m)
+end
+
+main()`
+	err := interpretVMSource(t, machine, src)
+	if err == nil {
+		t.Fatalf("esperado erro de indice fora dos limites, veio nil")
+	}
+}
+
+// Step 1b: teste Go direto do caminho de unwind. Monta um frame a mao via
+// callPreparedClosure com um map como argumento por valor, forca um
+// unwindTo com erro (sem passar pelo retorno normal OP_RETURN) e confere
+// que o release do parametro aconteceu mesmo assim.
+func TestParamReleaseOnUnwindDirect(t *testing.T) {
+	machine := New()
+	m := value.NewMap()
+
+	fn := &value.ObjFunction{
+		Name:   "boom",
+		Arity:  1,
+		Params: []value.ParamInfo{{IsRef: false, TypeName: "map[string, int]"}},
+	}
+	closure := &value.ObjClosure{Function: fn}
+
+	// Monta a pilha manualmente: [callee, arg] como um OP_CALL deixaria.
+	machine.push(value.Value{Type: value.VAL_FUNCTION, Obj: closure})
+	machine.push(m)
+
+	if ok, err := machine.callPreparedClosure(closure, 1, nil, 0); !ok {
+		t.Fatalf("callPreparedClosure falhou: %v", err)
+	}
+
+	if got := value.OwnersCount(m); got != 1 {
+		t.Fatalf("apos a chamada esperado Owners=1, veio %d", got)
+	}
+
+	machine.unwindTo(0, frameOutcome{Err: fmt.Errorf("erro forcado para testar unwind")})
+
+	if got := value.OwnersCount(m); got != 0 {
+		t.Fatalf("apos unwind esperado Owners=0 (release rodou), veio %d", got)
+	}
+}
+
+// f(m) chama g(m) chama probe_during(m); apos tudo, probe_after. during >= 2
+// (dois frames retendo, um por chamada aninhada); after == during - 2.
+func TestNestedByValueCallsStackAndUnstack(t *testing.T) {
+	machine := New()
+	var during, after int32
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		during = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_during")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+func inner(m: map[string, int]) -> int
+    probe_during(m)
+    return 1
+end
+
+func outer(m: map[string, int]) -> int
+    inner(m)
+    return 1
+end
+
+func main()
+    let m: map[string, int] = {"a": 1}
+    outer(m)
+    probe_after(m)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if during < 2 {
+		t.Fatalf("durante a chamada aninhada esperado Owners >= 2, veio %d", during)
+	}
+	if after != during-2 {
+		t.Fatalf("apos os dois retornos esperado %d, veio %d", during-2, after)
+	}
+}

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"noxy-vm/internal/value"
 )
@@ -658,5 +659,323 @@ main()`
 	}
 	if ownersNewAfter != 1 {
 		t.Fatalf("esperado Owners(clone gravado em a[0])=1 apos a mutacao, veio %d", ownersNewAfter)
+	}
+}
+
+// Task 6 (Step 1): append retem o item ao lado do MarkShared existente; pop
+// libera o elemento removido depois de tira-lo do array.
+func TestAppendRetainsItemPopReleasesRemoved(t *testing.T) {
+	machine := New()
+	item := value.NewMap()
+	storedArray := value.NewArray(nil)
+	arrayRef := pointerReference(&storedArray)
+
+	before := value.OwnersCount(item)
+	callBuiltin(t, machine, "append", arrayRef, item)
+	if got := value.OwnersCount(item); got != before+1 {
+		t.Fatalf("esperado Owners=%d apos append, veio %d", before+1, got)
+	}
+
+	popped := callBuiltin(t, machine, "pop", arrayRef)
+	if popped.Obj != item.Obj {
+		t.Fatalf("pop retornou objeto diferente do item empilhado")
+	}
+	if got := value.OwnersCount(item); got != before {
+		t.Fatalf("esperado Owners=%d apos pop remover o elemento, veio %d", before, got)
+	}
+}
+
+// Task 6 (Step 1): delete busca o valor velho antes de remover a chave e so
+// libera se a chave de fato existia (chave ausente nao mexe em Owners).
+func TestDeleteReleasesValueOnlyWhenKeyExisted(t *testing.T) {
+	machine := New()
+	oldVal := value.NewMap()
+	// simula a retencao duravel que o proprio mapa ja teria feito ao guardar
+	// oldVal (Task 5 / OP_MAP) — aqui construimos o mapa via helper de teste
+	// (fora do bytecode), entao retemos manualmente para ter algo para o
+	// delete soltar.
+	value.Retain(oldVal)
+
+	storedMap := value.NewMap()
+	mapObject := storedMap.Obj.(*value.ObjMap)
+	setTestMap(mapObject, "k", oldVal)
+	mapRef := pointerReference(&storedMap)
+
+	before := value.OwnersCount(oldVal)
+	callBuiltin(t, machine, "delete", mapRef, value.NewString("k"))
+	if got := value.OwnersCount(oldVal); got != before-1 {
+		t.Fatalf("esperado Owners=%d apos delete da chave existente, veio %d", before-1, got)
+	}
+
+	missing := value.NewMap()
+	value.Retain(missing)
+	beforeMissing := value.OwnersCount(missing)
+	setTestMap(mapObject, "other", missing)
+	afterSet := value.OwnersCount(missing)
+	callBuiltin(t, machine, "delete", mapRef, value.NewString("chave-inexistente"))
+	if got := value.OwnersCount(missing); got != afterSet {
+		t.Fatalf("delete de chave ausente nao deveria alterar Owners de outro valor: antes=%d depois=%d", beforeMissing, got)
+	}
+}
+
+// Task 6 (Step 1): chan_send retem o valor ao lado do MarkShared existente
+// (o buffer e durave); chan_recv libera apos um recebimento bem-sucedido —
+// o valor saiu do buffer.
+func TestChanSendRetainsChanRecvReleasesOnSuccess(t *testing.T) {
+	machine := New()
+	item := value.NewMap()
+	ch := value.NewChannel(1)
+
+	before := value.OwnersCount(item)
+	callBuiltin(t, machine, "chan_send", ch, item)
+	if got := value.OwnersCount(item); got != before+1 {
+		t.Fatalf("esperado Owners=%d apos chan_send, veio %d", before+1, got)
+	}
+
+	got := callBuiltin(t, machine, "chan_recv", ch)
+	if got.Obj != item.Obj {
+		t.Fatalf("chan_recv retornou valor diferente do enviado")
+	}
+	if got := value.OwnersCount(item); got != before {
+		t.Fatalf("esperado Owners=%d apos chan_recv receber com sucesso, veio %d", before, got)
+	}
+}
+
+// Task 6 (Step 1): o caminho !ok de chan_recv (canal fechado e vazio) nao
+// pode liberar nada — nao ha valor recebido para soltar.
+func TestChanRecvOnClosedEmptyChannelDoesNotRelease(t *testing.T) {
+	machine := New()
+	item := value.NewMap()
+	ch := value.NewChannel(1)
+	callBuiltin(t, machine, "chan_send", ch, item)
+	first := callBuiltin(t, machine, "chan_recv", ch)
+	if first.Obj != item.Obj {
+		t.Fatalf("primeiro recv nao retornou o item esperado")
+	}
+	afterFirstRecv := value.OwnersCount(item)
+
+	chObj := ch.Obj.(*value.ObjChannel)
+	chObj.Lock.Lock()
+	close(chObj.Chan)
+	chObj.Closed = true
+	chObj.Lock.Unlock()
+
+	second := callBuiltin(t, machine, "chan_recv", ch)
+	if second.Type != value.VAL_NULL {
+		t.Fatalf("esperado null ao receber de canal fechado e vazio, veio %#v", second)
+	}
+	if got := value.OwnersCount(item); got != afterFirstRecv {
+		t.Fatalf("recv em canal fechado/vazio nao deveria alterar Owners: antes=%d depois=%d", afterFirstRecv, got)
+	}
+}
+
+// Task 6 (Step 1): spawn e a excecao onde retain e registro no frame.Owned
+// ficam em pontos separados do codigo (o retain acontece no loop de push,
+// sincrono, antes do goroutine ser lancado; o registro no frame manual da
+// thread e o que causa o release quando aquele frame termina). Como o
+// retain+registro sao sincronos (rodam dentro do proprio native "spawn",
+// antes do "go func(){...}()"), medimos logo apos spawn.Invoke retornar —
+// sem precisar sincronizar com a goroutine para a medida "durante".
+func TestSpawnRetainsArgSynchronouslyAndReleasesWhenThreadFrameEnds(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(m: map[string, int])
+end`); err != nil {
+		t.Fatal(err)
+	}
+	workerFn, _ := machine.GetGlobal("worker")
+	m := value.NewMap()
+	before := value.OwnersCount(m)
+
+	spawn := requireBuiltin(t, machine, "spawn")
+	if _, err := spawn.Invoke(machine, []value.Value{workerFn, m}); err != nil {
+		t.Fatal(err)
+	}
+	if got := value.OwnersCount(m); got != before+1 {
+		t.Fatalf("esperado Owners=%d logo apos spawn (retain sincrono no push), veio %d", before+1, got)
+	}
+
+	deadline := time.Now().Add(statefulBuiltinTimeout)
+	for time.Now().Before(deadline) {
+		if value.OwnersCount(m) == before {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := value.OwnersCount(m); got != before {
+		t.Fatalf("esperado Owners=%d apos a thread da spawn terminar (frame.Owned liberado), veio %d", before, got)
+	}
+}
+
+// Task 6 (Step 1): spawn_task retem o argumento na preparacao (captura,
+// sincrona, antes do goroutine da task rodar) e libera quando a task
+// termina (mirror do padrao de defer) — a asserção "durante" tambem nao
+// precisa de sincronizacao porque o retain acontece antes do "go".
+func TestSpawnTaskCapturesArgSynchronouslyAndReleasesWhenTaskCompletes(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func worker(m: int[])
+end`); err != nil {
+		t.Fatal(err)
+	}
+	workerFn, _ := machine.GetGlobal("worker")
+	// array (nao map): prepareTaskCall valida RuntimeType contra a
+	// assinatura da funcao, e um value.NewMap() cru nao carrega o
+	// RuntimeType que o checker exige para map[K,V]; um array construido
+	// fora do bytecode passa nessa validacao (mesmo padrao usado em
+	// TestPreparedTaskCallMarksValueParameterShared).
+	m := value.NewArray([]value.Value{value.NewInt(1)})
+	before := value.OwnersCount(m)
+
+	spawnTask := requireBuiltin(t, machine, "spawn_task")
+	handle, err := spawnTask.Invoke(machine, []value.Value{workerFn, m})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := value.OwnersCount(m); got != before+1 {
+		t.Fatalf("esperado Owners=%d logo apos spawn_task (captura sincrona em prepareTaskCall), veio %d", before+1, got)
+	}
+
+	taskAwait := requireBuiltin(t, machine, "task_await")
+	if _, err := taskAwait.Invoke(machine, []value.Value{handle}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(statefulBuiltinTimeout)
+	for time.Now().Before(deadline) {
+		if value.OwnersCount(m) == before {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := value.OwnersCount(m); got != before {
+		t.Fatalf("esperado Owners=%d apos a task terminar (release da captura), veio %d", before, got)
+	}
+}
+
+// Task 6 (Step 1): defer captura o composto (+1) ao preparar a chamada
+// adiada; depois que o defer roda (fim da funcao externa, invokePreparedCall
+// completo), a captura e liberada (-1) — teste direto e isolado, sem
+// misturar com o retain do proprio frame da funcao externa.
+func TestDeferCapturesCompositeThenReleasesAfterInvocation(t *testing.T) {
+	machine := New()
+	if err := interpretVMSource(t, machine, `
+func cleanup(m: map[string, int]) -> void
+end`); err != nil {
+		t.Fatal(err)
+	}
+	callee, ok := machine.GetGlobal("cleanup")
+	if !ok {
+		t.Fatal("global 'cleanup' nao encontrado")
+	}
+	m := value.NewMap()
+	before := value.OwnersCount(m)
+
+	prepared, err := machine.prepareDeferredCall(callee, []value.Value{m}, SourceLocation{})
+	if err != nil {
+		t.Fatalf("prepareDeferredCall: %v", err)
+	}
+	if got := value.OwnersCount(m); got != before+1 {
+		t.Fatalf("esperado Owners=%d apos a captura do defer, veio %d", before+1, got)
+	}
+
+	if err := machine.invokePreparedCall(prepared); err != nil {
+		t.Fatalf("invokePreparedCall: %v", err)
+	}
+	if got := value.OwnersCount(m); got != before {
+		t.Fatalf("esperado Owners=%d apos o defer rodar (release da captura), veio %d", before, got)
+	}
+}
+
+// Task 6 (Step 1): mesmo cenario acima, mas de ponta a ponta via programa
+// Noxy real — confirma que o release da captura acontece junto com o
+// unwind normal do frame externo (defer registrado, funcao externa
+// retorna, defer roda, captura e liberada).
+func TestDeferCaptureEndToEndReleasesAfterOuterFunctionReturns(t *testing.T) {
+	machine := New()
+	var capturedM value.Value
+	var duringOwners int32
+	machine.DefineNative("probe_during", func(args []value.Value) value.Value {
+		capturedM = args[0]
+		duringOwners = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_during")
+
+	src := `
+func cleanup(m: map[string, int]) -> void
+    probe_during(m)
+end
+
+func outer() -> void
+    let m: map[string, int] = {"a": 1}
+    defer cleanup(m)
+end
+
+func main()
+    outer()
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// durante a execucao do defer: slot do let em outer (ainda vivo — o
+	// Deferred roda antes do release do frame.Owned de outer) + captura do
+	// defer + parametro de cleanup (proprio frame retido via
+	// callPreparedClosure) = 3.
+	if duringOwners != 3 {
+		t.Fatalf("esperado Owners=3 durante o defer, veio %d", duringOwners)
+	}
+	// Apos outer() retornar totalmente, o par do defer (captura +1 / release
+	// -1) ja fechou em zero. Mas sobra 1: o proprio "let m" de outer nunca
+	// solta seu retain original, porque o OP_POP de fim de bloco que o
+	// compilador emite para locais (BlockStatement.endScope) roda ANTES do
+	// release em massa de frame.Owned em finalizeCurrentFrame — o slot ja
+	// nao esta mais "vivo" (stackTop) quando o loop de release olha para
+	// ele, entao o release e pulado. Isso e um gap pre-existente da Task 3
+	// (locais), fora do escopo desta tarefa (fronteiras); nao mexemos em
+	// endScope()/frame.Owned aqui. O que este teste isola e exatamente que o
+	// PAR do defer em si fecha em zero: o total final e so esse +1 preso do
+	// let de outer, nada alem disso.
+	if got := value.OwnersCount(capturedM); got != 1 {
+		t.Fatalf("esperado Owners=1 (so o let de outer preso pelo gap pre-existente da Task 3; o par do defer fecha em zero), veio %d", got)
+	}
+}
+
+// Task 6 (Step 1): native sem assinatura fora da allowlist retem
+// permanentemente (conservador) — sem release em lugar nenhum. Diferente de
+// TestUnlistedNativeStillMarksArgs (que audita so o Shared bit/clone), este
+// teste audita o contador Owners.
+//
+// Usamos um GLOBAL (nao um "let" local) de proposito: um "let" local dentro
+// de uma funcao e liberado por dois mecanismos concorrentes — o OP_POP de
+// fim de bloco que o compilador emite (BlockStatement.endScope, sem RC) e o
+// release em massa de frame.Owned em finalizeCurrentFrame (Task 3, com RC).
+// O OP_POP roda ANTES do finalizeCurrentFrame (fora do escopo desta tarefa,
+// gap pre-existente da Task 3), entao o retain original do "let" fica preso
+// e contaminaria a leitura "so a retencao do native". Um global evita isso:
+// seu retain nunca passa por frame.Owned (funil proprio via OP_SET_GLOBAL,
+// Task 4), entao o baseline e estavel e conhecido (1, igual
+// TestGlobalLetRetainsCompositeAndReassignmentSwaps).
+func TestUnlistedNativeRetainsArgPermanently(t *testing.T) {
+	machine := New()
+	var captured value.Value
+	machine.DefineNative("test_observe_rc", func(args []value.Value) value.Value {
+		captured = args[0]
+		return value.NewNull()
+	})
+	// Sem markProbeReadonly de proposito: queremos o comportamento default
+	// (native fora da allowlist, ReadonlyArgs=false).
+	src := `
+let g: map[string, int] = {"a": 1}
+test_observe_rc(g)`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// 1 do retain do global (permanece pelo programa todo) + 1 da retencao
+	// permanente do native sem assinatura.
+	if got := value.OwnersCount(captured); got != 2 {
+		t.Fatalf("esperado Owners=2 (1 do global + 1 da retencao permanente do native), veio %d", got)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -134,6 +134,56 @@ func TestParamReleaseOnUnwindDirect(t *testing.T) {
 	}
 }
 
+// TestFrameReleaseTargetsRecordedObjectNotSlotOccupant reproduz o cenario
+// unsound do desenho por indice (Owned []int + release lendo vm.stack[slot]):
+// um local de bloco possuido "morre" sem drop (OP_POP simples no fim do
+// while/if) e o slot e reusado por um temporario NUNCA retido (ex.:
+// OP_GET_LOCAL de outra variavel). O release do fim do frame nao pode tocar
+// o ocupante atual do slot — so o objeto que ele de fato reteve.
+func TestFrameReleaseTargetsRecordedObjectNotSlotOccupant(t *testing.T) {
+	machine := New()
+	blockLocal := value.NewArray([]value.Value{value.NewInt(1)})
+	bystander := value.NewMap()
+	value.Retain(bystander) // dono duravel em outro lugar (ex.: global)
+
+	fn := &value.ObjFunction{
+		Name:   "boom",
+		Arity:  1,
+		Params: []value.ParamInfo{{IsRef: false, TypeName: "int[]"}},
+	}
+	closure := &value.ObjClosure{Function: fn}
+
+	// Monta a pilha manualmente: [callee, arg] como um OP_CALL deixaria.
+	// O param bind chama ownSlot internamente (callPreparedClosure), que
+	// registra blockLocal como o objeto possuido no slot do parametro —
+	// exatamente como um `let` de bloco registraria via OP_OWN_LOCAL.
+	machine.push(value.Value{Type: value.VAL_FUNCTION, Obj: closure})
+	machine.push(blockLocal)
+
+	if ok, err := machine.callPreparedClosure(closure, 1, nil, 0); !ok {
+		t.Fatalf("callPreparedClosure falhou: %v", err)
+	}
+
+	if got := value.OwnersCount(blockLocal); got != 1 {
+		t.Fatalf("apos o bind esperado Owners=1 para blockLocal, veio %d", got)
+	}
+
+	// Simula o fim do bloco (OP_POP sem drop) seguido de reuso do slot por
+	// um temporario nunca retido — sobrescrita crua de vm.stack, sem passar
+	// por ownSlot (e assim sem atualizar/duplicar a entrada em Owned).
+	slot := machine.currentFrame.LocalBase + 1
+	machine.stack[slot] = bystander
+
+	machine.unwindTo(0, frameOutcome{Err: fmt.Errorf("erro forcado para testar unwind")})
+
+	if got := value.OwnersCount(bystander); got != 1 {
+		t.Fatalf("temporario nunca retido foi liberado (dec a menos): Owners=%d, esperado 1", got)
+	}
+	if got := value.OwnersCount(blockLocal); got != 0 {
+		t.Fatalf("objeto gravado deveria ter sido liberado no fim do frame: Owners=%d", got)
+	}
+}
+
 // f(m) chama g(m) chama probe_during(m); apos tudo, probe_after. during >= 2
 // (dois frames retendo, um por chamada aninhada); after == during - 2.
 func TestNestedByValueCallsStackAndUnstack(t *testing.T) {
@@ -435,8 +485,15 @@ main()`
 	if ownersOldBefore != 2 {
 		t.Fatalf("esperado Owners(x)=2 antes de arr[0]=y (slot x + elemento), veio %d", ownersOldBefore)
 	}
-	if got := value.OwnersCount(oldVal); got != 1 {
-		t.Fatalf("esperado Owners(x)=1 apos arr[0]=y (elemento liberado, slot x permanece), veio %d", got)
+	// Task 2b: esta leitura acontece apos interpretVMSource retornar, ou
+	// seja, apos main() ja ter retornado e seu frame ja ter sido liberado.
+	// Antes da Task 2b, o slot do "let x" ficava preso (guard `slot <
+	// vm.stackTop` pulava o release por indice apos o OP_POP de fim de
+	// escopo do compilador) — agora o release e do objeto gravado, sem esse
+	// guard, entao o slot de x tambem libera no fim do frame e so resta o
+	// release do elemento (ja contado acima): total 0.
+	if got := value.OwnersCount(oldVal); got != 0 {
+		t.Fatalf("esperado Owners(x)=0 apos arr[0]=y liberar o elemento E main() retornar (Task 2b libera o slot do let no fim do frame), veio %d", got)
 	}
 	if ownersNewAfter != 2 {
 		t.Fatalf("esperado Owners(y)=2 apos arr[0]=y (slot y + elemento), veio %d", ownersNewAfter)
@@ -479,8 +536,12 @@ main()`
 	if ownersOldBefore != 2 {
 		t.Fatalf(`esperado Owners(x)=2 antes de m["k"]=y (slot x + valor no map), veio %d`, ownersOldBefore)
 	}
-	if got := value.OwnersCount(oldVal); got != 1 {
-		t.Fatalf(`esperado Owners(x)=1 apos m["k"]=y (valor liberado do map, slot x permanece), veio %d`, got)
+	// Task 2b: mesma observacao de TestArraySetIndexReleasesOldRetainsNew —
+	// esta leitura acontece apos main() ja ter retornado; o slot do "let x"
+	// tambem libera no fim do frame agora (sem o guard de stackTop), entao
+	// so resta o release do valor do map (ja contado acima): total 0.
+	if got := value.OwnersCount(oldVal); got != 0 {
+		t.Fatalf(`esperado Owners(x)=0 apos m["k"]=y liberar o valor E main() retornar (Task 2b libera o slot do let no fim do frame), veio %d`, got)
 	}
 	if ownersNewAfter != 2 {
 		t.Fatalf(`esperado Owners(y)=2 apos m["k"]=y (slot y + valor no map), veio %d`, ownersNewAfter)
@@ -533,8 +594,19 @@ main()`
 	if ownersOldBefore != 2 {
 		t.Fatalf("esperado Owners(y1)=2 apos a 1a atribuicao (slot + campo), veio %d", ownersOldBefore)
 	}
-	if got := value.OwnersCount(oldFieldVal); got != 1 {
-		t.Fatalf("esperado Owners(y1)=1 apos a 2a atribuicao liberar o campo, veio %d", got)
+	// Task 2b: esta leitura acontece apos interpretVMSource retornar, ou
+	// seja, apos main() ja ter retornado por completo — o release em massa
+	// de finalizeCurrentFrame ja rodou para o frame de main. Antes da Task
+	// 2b, o guard `slot < vm.stackTop` fazia esse release pular TODOS os
+	// locais de main (o epilogo de fim de escopo do compilador ja tinha
+	// poppado x/y1/y2/box do stack antes do OP_RETURN, entao seus slots
+	// pareciam "mortos" para o guard) — o retain do "let y1" ficava preso
+	// para sempre (Owners=1 residual). A Task 2b libera por OBJETO GRAVADO,
+	// sem esse guard, entao o slot do "let y1" agora e devidamente liberado
+	// no fim do frame de main: so resta o release do campo (ja contado
+	// acima), e o total cai a 0.
+	if got := value.OwnersCount(oldFieldVal); got != 0 {
+		t.Fatalf("esperado Owners(y1)=0 apos a 2a atribuicao liberar o campo E main() retornar (Task 2b libera o slot do let no fim do frame), veio %d", got)
 	}
 	if ownersNewAfter != 2 {
 		t.Fatalf("esperado Owners(y2)=2 apos a 2a atribuicao (slot + campo), veio %d", ownersNewAfter)
@@ -928,18 +1000,20 @@ main()`
 		t.Fatalf("esperado Owners=3 durante o defer, veio %d", duringOwners)
 	}
 	// Apos outer() retornar totalmente, o par do defer (captura +1 / release
-	// -1) ja fechou em zero. Mas sobra 1: o proprio "let m" de outer nunca
-	// solta seu retain original, porque o OP_POP de fim de bloco que o
-	// compilador emite para locais (BlockStatement.endScope) roda ANTES do
-	// release em massa de frame.Owned em finalizeCurrentFrame — o slot ja
-	// nao esta mais "vivo" (stackTop) quando o loop de release olha para
-	// ele, entao o release e pulado. Isso e um gap pre-existente da Task 3
-	// (locais), fora do escopo desta tarefa (fronteiras); nao mexemos em
-	// endScope()/frame.Owned aqui. O que este teste isola e exatamente que o
-	// PAR do defer em si fecha em zero: o total final e so esse +1 preso do
-	// let de outer, nada alem disso.
-	if got := value.OwnersCount(capturedM); got != 1 {
-		t.Fatalf("esperado Owners=1 (so o let de outer preso pelo gap pre-existente da Task 3; o par do defer fecha em zero), veio %d", got)
+	// -1) ja fechou em zero. Antes da Task 2b, sobrava 1: o proprio "let m"
+	// de outer nunca soltava seu retain original, porque o OP_POP de fim de
+	// bloco que o compilador emite para locais (BlockStatement.endScope)
+	// roda ANTES do release em massa de finalizeCurrentFrame — sob o desenho
+	// antigo (guard `slot < vm.stackTop`, release por INDICE), o slot ja nao
+	// estava mais "vivo" quando o loop de release olhava para ele, entao o
+	// release era pulado (gap pre-existente da Task 3, documentado como fora
+	// do escopo daquela tarefa). A Task 2b fecha esse gap como consequencia
+	// direta de trocar o release por indice por release do OBJETO GRAVADO
+	// (sem guard de stackTop): o slot do "let m" de outer agora libera
+	// normalmente no fim do frame, entao o total final e 0 — nao sobra mais
+	// nada preso.
+	if got := value.OwnersCount(capturedM); got != 0 {
+		t.Fatalf("esperado Owners=0 (Task 2b libera o slot do let de outer no fim do frame, fechando o gap pre-existente da Task 3; o par do defer tambem fecha em zero), veio %d", got)
 	}
 }
 
@@ -948,16 +1022,16 @@ main()`
 // TestUnlistedNativeStillMarksArgs (que audita so o Shared bit/clone), este
 // teste audita o contador Owners.
 //
-// Usamos um GLOBAL (nao um "let" local) de proposito: um "let" local dentro
-// de uma funcao e liberado por dois mecanismos concorrentes — o OP_POP de
-// fim de bloco que o compilador emite (BlockStatement.endScope, sem RC) e o
-// release em massa de frame.Owned em finalizeCurrentFrame (Task 3, com RC).
-// O OP_POP roda ANTES do finalizeCurrentFrame (fora do escopo desta tarefa,
-// gap pre-existente da Task 3), entao o retain original do "let" fica preso
-// e contaminaria a leitura "so a retencao do native". Um global evita isso:
-// seu retain nunca passa por frame.Owned (funil proprio via OP_SET_GLOBAL,
-// Task 4), entao o baseline e estavel e conhecido (1, igual
-// TestGlobalLetRetainsCompositeAndReassignmentSwaps).
+// Usamos um GLOBAL (nao um "let" local) de proposito: um global nunca passa
+// por frame.Owned (funil proprio via OP_SET_GLOBAL, Task 4), entao o
+// baseline e estavel e conhecido (1, igual
+// TestGlobalLetRetainsCompositeAndReassignmentSwaps) sem depender de quando
+// a funcao ao redor retorna. (Ate a Task 2b, um "let" local tambem exigia
+// esse cuidado: o OP_POP de fim de bloco emitido pelo compilador rodava
+// ANTES do release em massa de finalizeCurrentFrame, e o guard por indice
+// entao vigente pulava o release do slot — gap pre-existente da Task 3,
+// fechado pela Task 2b ao trocar o release por indice por release do objeto
+// gravado.)
 func TestUnlistedNativeRetainsArgPermanently(t *testing.T) {
 	machine := New()
 	var captured value.Value

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1262,3 +1262,216 @@ test_report(count(head_a) * 10 + count(head_b))`
 		t.Fatalf("mutacao atraves de emprestimo ref (global / capturado) se perdeu: esperado 22, veio %#v", reported)
 	}
 }
+
+// Task 7 (fallout da chave, round 2 — CRITICO achado em review): um slot `ref`
+// capturado por closure empresta, e a CAIXA do upvalue herda o emprestimo. Sem
+// isso, os funis de escrita da caixa soltavam um objeto que ela nunca reteve
+// (dec a menos): OP_SET_UPVALUE (rebind `u = u.proximo`) e OP_GET_UPVALUE_MUT
+// (mutacao `u.valor = 77`). O mesmo furo existia no OP_GET_LOCAL_MUT sobre um
+// slot local `ref` emprestado.
+//
+// A forma exige DOIS donos reais vivos no no mutado — o campo `proximo` do no
+// anterior E um vinculo por valor (`let second: Node = head.proximo`). Com um
+// dono so, o Release a mais e absorvido pelo clamp em zero de value.Release e
+// o bug fica invisivel (foi exatamente o ponto cego de
+// TestRefGlobalAndCapturedRefLocalAreBorrows). Com dois, o dec a menos leva
+// 2 -> 1, o no passa a parecer unico, `second.valor = 99` muta no lugar em vez
+// de clonar (CoW) e a escrita vaza para head.proximo.
+//
+// Oraculo: o binario do merge-base responde 20 nos tres cenarios (o valor
+// original do no 20 nunca e alterado, porque toda mutacao passa por clone).
+func TestCapturedAndBorrowedRefSlotsNeverReleaseWhatTheyDoNotOwn(t *testing.T) {
+	machine := New()
+	reported := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+// A: rebind do upvalue ref (OP_SET_UPVALUE sobre caixa emprestada).
+func repro_a(head: ref Node) -> int
+    let second: Node = head.proximo
+    let u: ref Node = head.proximo
+    let f: func() -> int = func() -> int
+        u = u.proximo
+        return 1
+    end
+    let ignored: int = f()
+    second.valor = 99
+    return head.proximo.valor
+end
+
+// B: mutacao atraves do upvalue ref (OP_GET_UPVALUE_MUT sobre caixa
+// emprestada).
+func repro_b(head: ref Node) -> int
+    let second: Node = head.proximo
+    let u: ref Node = head.proximo
+    let f: func() -> int = func() -> int
+        u.valor = 77
+        return 1
+    end
+    let ignored: int = f()
+    second.valor = 99
+    return head.proximo.valor
+end
+
+// C: mutacao atraves de um local ref emprestado (OP_GET_LOCAL_MUT).
+func repro_c(head: ref Node) -> int
+    let second: Node = head.proximo
+    let u: ref Node = head.proximo
+    u.valor = 77
+    second.valor = 99
+    return head.proximo.valor
+end
+
+func main()
+    let ha: Node = Node(0, null)
+    _append(ha, 20)
+    _append(ha, 30)
+    let a: int = repro_a(ha)
+
+    let hb: Node = Node(0, null)
+    _append(hb, 20)
+    _append(hb, 30)
+    let b: int = repro_b(hb)
+
+    let hc: Node = Node(0, null)
+    _append(hc, 20)
+    _append(hc, 30)
+    let c: int = repro_c(hc)
+
+    test_report(a * 10000 + b * 100 + c)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// 20 / 20 / 20 — exatamente o que o binario do merge-base responde.
+	if reported.Type != value.VAL_INT || reported.AsInt != 202020 {
+		t.Fatalf("escrita vazou por dec a menos em slot/caixa emprestada: esperado 202020 (A=20 B=20 C=20), veio %#v", reported)
+	}
+}
+
+// Task 7 (fallout, round 2): mesma invariante auditada por CONTAGEM, nao por
+// saida — o no compartilhado tem de continuar com os seus dois donos reais
+// depois de um rebind do upvalue emprestado. Antes da correcao caia para 1.
+func TestBorrowedUpvalueRebindKeepsOwnersOfSharedNode(t *testing.T) {
+	machine := New()
+	var before, after int32
+	machine.DefineNative("probe_before", func(args []value.Value) value.Value {
+		before = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	machine.DefineNative("probe_after", func(args []value.Value) value.Value {
+		after = value.OwnersCount(args[0])
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_before")
+	markProbeReadonly(t, machine, "probe_after")
+
+	src := `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+
+func _append(node: ref Node, valor: int)
+    if node.proximo == null then
+        node.proximo = Node(valor, null)
+    else
+        _append(node.proximo, valor)
+    end
+end
+
+func run(head: ref Node) -> int
+    let second: Node = head.proximo
+    probe_before(head.proximo)
+    let u: ref Node = head.proximo
+    let f: func() -> int = func() -> int
+        u = u.proximo
+        return 1
+    end
+    let ignored: int = f()
+    probe_after(head.proximo)
+    return 1
+end
+
+func main()
+    let head: Node = Node(0, null)
+    _append(head, 20)
+    _append(head, 30)
+    let ok: int = run(head)
+end
+
+main()`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	// campo proximo de head + slot do `let second` = 2 donos reais.
+	if before != 2 {
+		t.Fatalf("esperado Owners(no compartilhado)=2 antes da closure, veio %d", before)
+	}
+	if after != before {
+		t.Fatalf("rebind de upvalue emprestado soltou o que a caixa nunca reteve: Owners %d -> %d", before, after)
+	}
+}
+
+// Task 7 (fallout, round 2 — Important 4): teste Go direto do ramo FALSO do
+// contrato de posse da caixa. Um slot emprestado (nao registrado em
+// frame.Owned) produz uma caixa marcada como emprestada, e fechar essa caixa
+// NAO pode reter — e o que impede o par retain/release da caixa de existir e,
+// por consequencia, o dec a menos nos funis de escrita dela.
+func TestBorrowedUpvalueBoxDoesNotRetainOnClose(t *testing.T) {
+	machine := New()
+
+	// possuido: um dono real em outro lugar (campo, global, slot do chamador).
+	owned := value.NewMap()
+	value.Retain(owned)
+	machine.stack[0] = owned
+	ownedSlot := &machine.stack[0]
+
+	// emprestado: idem, mas o slot nao e dono.
+	borrowed := value.NewMap()
+	value.Retain(borrowed)
+	machine.stack[1] = borrowed
+	borrowedSlot := &machine.stack[1]
+
+	ownedBox := machine.captureUpvalue(ownedSlot, true)
+	borrowedBox := machine.captureUpvalue(borrowedSlot, false)
+
+	if ownedBox.IsBorrowed() {
+		t.Fatal("caixa aberta sobre slot possuido nao pode nascer emprestada")
+	}
+	if !borrowedBox.IsBorrowed() {
+		t.Fatal("caixa aberta sobre slot emprestado tem de nascer emprestada")
+	}
+
+	machine.closeUpvalue(ownedSlot, true)
+	machine.closeUpvalue(borrowedSlot, false)
+
+	// ramo verdadeiro: a posse migra do slot para a caixa (+1; o release do
+	// slot e responsabilidade do frame).
+	if got := value.OwnersCount(owned); got != 2 {
+		t.Fatalf("caixa possuida deveria reter ao fechar: esperado Owners=2, veio %d", got)
+	}
+	// ramo falso: a caixa empresta — nada de retain.
+	if got := value.OwnersCount(borrowed); got != 1 {
+		t.Fatalf("caixa emprestada nao pode reter ao fechar: esperado Owners=1, veio %d", got)
+	}
+}

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -66,7 +66,7 @@ func TestModuleGlobalReferenceRetainsResolvedEnvironment(t *testing.T) {
 	machine := New()
 	machine.shared.Root = root
 	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "module", GlobalOwner: module}
-	if err := machine.storeGlobalReferenceValue(ref, value.NewInt(3)); err != nil {
+	if err := machine.storeReferenceValue(value.Value{Type: value.VAL_REF, Obj: ref}, value.NewInt(3)); err != nil {
 		t.Fatal(err)
 	}
 	got, _ := module.GetLocal("module")

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -135,13 +135,12 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 // refStorageBorrows informa que o lugar apontado pelo ref NAO possui o que
 // guarda, e portanto a troca ali nao pode contar posse (soltar o que nunca se
 // reteve e dec a menos). Hoje o unico lugar assim e a caixa de upvalue marcada
-// como emprestada — caixa aberta sobre um slot de tipo `ref`.
+// como emprestada — caixa aberta sobre um slot que nao retem o que guarda.
 //
-// Defesa em profundidade: pelo caminho do compilador esse caso e inalcancavel,
-// porque OP_REF_LOCAL (o unico produtor de REF_UPVALUE) so e emitido para
-// local de tipo NAO-ref — um `ref u` com u ja de tipo `ref T` reempilha o
-// proprio ref via OP_GET_LOCAL, sem capturar nada. O consulta fica aqui para
-// que uma mudanca futura no lowering nao reabra o dec a menos em silencio.
+// Caminho VIVO desde o OP_REF_LOCAL_BORROW: `ref` para um slot nao-possuidor
+// (hoje, slot de tipo `ref T`) cria uma caixa REF_UPVALUE marcada emprestada,
+// e a escrita atraves dela cai exatamente aqui. E a consulta que impede
+// `setit(ref x, ...)` de soltar um objeto que o slot x nunca reteve.
 func refStorageBorrows(ref *value.ObjRef) bool {
 	return ref != nil && ref.RefType == value.REF_UPVALUE && ref.Upvalue.IsBorrowed()
 }
@@ -182,6 +181,40 @@ func (vm *VM) retargetOwnedSlot(ref *value.ObjRef, updated value.Value) bool {
 					continue
 				}
 			} else if ref.Ptr != occupant {
+				continue
+			}
+			frame.Owned[j].obj = updated
+			return true
+		}
+	}
+	return false
+}
+
+// retargetOwnedSlotForUpvalue e o mesmo reaponte do retargetOwnedSlot para os
+// funis que escrevem ATRAVES DA CAIXA DE UPVALUE (OP_SET_UPVALUE e
+// OP_GET_UPVALUE_MUT em caixa possuidora): enquanto a caixa esta ABERTA a
+// escrita alcanca um slot de pilha, e se aquele slot e possuido a entrada
+// (slot, objeto) do frame dono tem de passar a nomear o valor novo — senao o
+// release em massa do fim do frame solta o velho uma SEGUNDA vez (dec a mais,
+// direcao insegura: o velho, ainda vivo em outro dono, passa a parecer unico).
+// Caixa fechada: PointsTo e falso para qualquer slot de pilha (o valor mora no
+// proprio box) e nao ha entrada a reapontar. O guard de openUpvalues zera o
+// custo no caso comum (nenhuma captura aberta).
+func (vm *VM) retargetOwnedSlotForUpvalue(upv *value.ObjUpvalue, updated value.Value) bool {
+	if upv == nil || vm.openUpvalues == nil {
+		return false
+	}
+	for i := 0; i < vm.frameCount; i++ {
+		frame := vm.frames[i]
+		if frame == nil {
+			continue
+		}
+		for j := range frame.Owned {
+			slot := frame.Owned[j].slot
+			if slot < 0 || slot >= len(vm.stack) {
+				continue
+			}
+			if !upv.PointsTo(&vm.stack[slot]) {
 				continue
 			}
 			frame.Owned[j].obj = updated

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -132,6 +132,20 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 	}
 }
 
+// refStorageBorrows informa que o lugar apontado pelo ref NAO possui o que
+// guarda, e portanto a troca ali nao pode contar posse (soltar o que nunca se
+// reteve e dec a menos). Hoje o unico lugar assim e a caixa de upvalue marcada
+// como emprestada — caixa aberta sobre um slot de tipo `ref`.
+//
+// Defesa em profundidade: pelo caminho do compilador esse caso e inalcancavel,
+// porque OP_REF_LOCAL (o unico produtor de REF_UPVALUE) so e emitido para
+// local de tipo NAO-ref — um `ref u` com u ja de tipo `ref T` reempilha o
+// proprio ref via OP_GET_LOCAL, sem capturar nada. O consulta fica aqui para
+// que uma mudanca futura no lowering nao reabra o dec a menos em silencio.
+func refStorageBorrows(ref *value.ObjRef) bool {
+	return ref != nil && ref.RefType == value.REF_UPVALUE && ref.Upvalue.IsBorrowed()
+}
+
 func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
 	stored, _, _, err := vm.referenceStorage(ref)
 	return stored, err
@@ -164,9 +178,12 @@ func (vm *VM) storeReferenceValue(input value.Value, updated value.Value) error 
 		return err
 	}
 	// RC: funil unico para OP_STORE_REF / OP_STORE_VIA_REF /
-	// OP_SET_PROPERTY_DEREF - retain-antes-de-release em torno da troca.
-	value.Retain(updated)
-	value.Release(stored)
+	// OP_SET_PROPERTY_DEREF - retain-antes-de-release em torno da troca. Lugar
+	// que apenas empresta (caixa de upvalue emprestada) troca sem contar.
+	if !refStorageBorrows(ref) {
+		value.Retain(updated)
+		value.Release(stored)
+	}
 	store(updated)
 	return nil
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -159,10 +159,14 @@ func (vm *VM) storeReferenceValue(input value.Value, updated value.Value) error 
 	if err != nil {
 		return err
 	}
-	_, _, store, err := vm.referenceStorage(ref)
+	stored, _, store, err := vm.referenceStorage(ref)
 	if err != nil {
 		return err
 	}
+	// RC: funil unico para OP_STORE_REF / OP_STORE_VIA_REF /
+	// OP_SET_PROPERTY_DEREF - retain-antes-de-release em torno da troca.
+	value.Retain(updated)
+	value.Release(stored)
 	store(updated)
 	return nil
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -146,6 +146,51 @@ func refStorageBorrows(ref *value.ObjRef) bool {
 	return ref != nil && ref.RefType == value.REF_UPVALUE && ref.Upvalue.IsBorrowed()
 }
 
+// retargetOwnedSlot mantém honesta a lista de posse do frame quando uma escrita
+// ATRAVÉS DE UM REF troca o ocupante de um slot de pilha POSSUÍDO.
+//
+// O funil de escrita faz retain(novo)/release(velho) porque o slot passa a
+// possuir o valor novo — mas a entrada (slot, objeto) do frame continuava
+// nomeando o objeto VELHO, e o release em massa do fim do frame o soltava DE
+// NOVO: dec a mais, direção insegura (o objeto velho, ainda vivo em outro dono,
+// passava a parecer único e a mutação seguinte acontecia no lugar). Reapontar a
+// entrada para o valor novo fecha a conta: o release do velho é pago agora pelo
+// funil, e o do novo pelo fim do frame.
+//
+// Devolve true quando encontrou (e reapontou) a entrada. Só varre as listas de
+// posse dos frames vivos — pequenas — e só para refs que apontam para slot de
+// pilha; os demais tipos de ref saem no primeiro teste.
+func (vm *VM) retargetOwnedSlot(ref *value.ObjRef, updated value.Value) bool {
+	if ref == nil || (ref.RefType != value.REF_UPVALUE && ref.RefType != value.REF_PTR) {
+		return false
+	}
+	for i := 0; i < vm.frameCount; i++ {
+		frame := vm.frames[i]
+		if frame == nil {
+			continue
+		}
+		for j := range frame.Owned {
+			slot := frame.Owned[j].slot
+			if slot < 0 || slot >= len(vm.stack) {
+				continue
+			}
+			occupant := &vm.stack[slot]
+			if ref.RefType == value.REF_UPVALUE {
+				// PointsTo é falso para caixa já fechada — nesse caso o valor não
+				// mora mais no slot e não há entrada a reapontar.
+				if !ref.Upvalue.PointsTo(occupant) {
+					continue
+				}
+			} else if ref.Ptr != occupant {
+				continue
+			}
+			frame.Owned[j].obj = updated
+			return true
+		}
+	}
+	return false
+}
+
 func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
 	stored, _, _, err := vm.referenceStorage(ref)
 	return stored, err
@@ -182,6 +227,10 @@ func (vm *VM) storeReferenceValue(input value.Value, updated value.Value) error 
 	// que apenas empresta (caixa de upvalue emprestada) troca sem contar.
 	if !refStorageBorrows(ref) {
 		value.Retain(updated)
+		// Se o destino e um slot de pilha possuido, a entrada de posse do frame
+		// tem de passar a nomear o valor novo — senao o fim do frame soltaria o
+		// velho uma segunda vez (dec a mais).
+		vm.retargetOwnedSlot(ref, updated)
 		value.Release(stored)
 	}
 	store(updated)

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -236,20 +236,6 @@ func (vm *VM) retargetOwnedSlotForUpvalue(upv *value.ObjUpvalue, updated value.V
 	return false
 }
 
-func (vm *VM) lookupGlobalReferenceValue(ref *value.ObjRef) (value.Value, error) {
-	stored, _, _, err := vm.referenceStorage(ref)
-	return stored, err
-}
-
-func (vm *VM) storeGlobalReferenceValue(ref *value.ObjRef, updated value.Value) error {
-	_, _, store, err := vm.referenceStorage(ref)
-	if err != nil {
-		return err
-	}
-	store(updated)
-	return nil
-}
-
 func (vm *VM) lookupReferenceValue(ref *value.ObjRef) (value.Value, error) {
 	stored, _, _, err := vm.referenceStorage(ref)
 	return stored, err

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -159,11 +159,20 @@ func refStorageBorrows(ref *value.ObjRef) bool {
 // Devolve true quando encontrou (e reapontou) a entrada. Só varre as listas de
 // posse dos frames vivos — pequenas — e só para refs que apontam para slot de
 // pilha; os demais tipos de ref saem no primeiro teste.
+//
+// A varredura é de DENTRO PARA FORA (frame mais interno primeiro): índices
+// absolutos de slot são reusados — a região de pilha de um frame chamado
+// sobrepõe os índices onde blocos irmãos mortos do CHAMADOR deixaram entradas
+// nunca podadas. Varrer de fora para dentro casava a entrada MORTA do chamador
+// (mesmo endereço) e deixava a entrada VIVA do frame interno nomeando o objeto
+// velho — solto duas vezes no fim do frame (dec a mais). A direção inversa é
+// segura: as entradas de um frame interno são todas >= seu LocalBase, então
+// nenhuma entrada interna pode aliasar um slot vivo de um frame externo.
 func (vm *VM) retargetOwnedSlot(ref *value.ObjRef, updated value.Value) bool {
 	if ref == nil || (ref.RefType != value.REF_UPVALUE && ref.RefType != value.REF_PTR) {
 		return false
 	}
-	for i := 0; i < vm.frameCount; i++ {
+	for i := vm.frameCount - 1; i >= 0; i-- {
 		frame := vm.frames[i]
 		if frame == nil {
 			continue
@@ -199,12 +208,15 @@ func (vm *VM) retargetOwnedSlot(ref *value.ObjRef, updated value.Value) bool {
 // direcao insegura: o velho, ainda vivo em outro dono, passa a parecer unico).
 // Caixa fechada: PointsTo e falso para qualquer slot de pilha (o valor mora no
 // proprio box) e nao ha entrada a reapontar. O guard de openUpvalues zera o
-// custo no caso comum (nenhuma captura aberta).
+// custo no caso comum (nenhuma captura aberta). Varredura de DENTRO PARA FORA
+// pela mesma razao do retargetOwnedSlot: uma entrada morta do chamador num
+// indice reusado casaria primeiro e deixaria a entrada viva do frame interno
+// obsoleta (dec a mais no fim do frame).
 func (vm *VM) retargetOwnedSlotForUpvalue(upv *value.ObjUpvalue, updated value.Value) bool {
 	if upv == nil || vm.openUpvalues == nil {
 		return false
 	}
-	for i := 0; i < vm.frameCount; i++ {
+	for i := vm.frameCount - 1; i >= 0; i-- {
 		frame := vm.frames[i]
 		if frame == nil {
 			continue

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -107,14 +107,14 @@ func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
 	ref := &value.ObjRef{RefType: value.REF_GLOBAL, Name: "answer", GlobalOwner: environment}
 	machine := New()
 
-	got, err := machine.lookupGlobalReferenceValue(ref)
+	got, err := machine.lookupReferenceValue(ref)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Type != value.VAL_INT || got.AsInt != 41 {
 		t.Fatalf("lookup=%v, want 41", got)
 	}
-	if err := machine.storeGlobalReferenceValue(ref, value.NewInt(42)); err != nil {
+	if err := machine.storeReferenceValue(value.Value{Type: value.VAL_REF, Obj: ref}, value.NewInt(42)); err != nil {
 		t.Fatal(err)
 	}
 	if got, _ := environment.GetLocal("answer"); got.Type != value.VAL_INT || got.AsInt != 42 {
@@ -138,10 +138,10 @@ func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := machine.lookupGlobalReferenceValue(tt.ref); err == nil || err.Error() != tt.want {
+			if _, err := machine.lookupReferenceValue(tt.ref); err == nil || err.Error() != tt.want {
 				t.Fatalf("lookup error=%v, want %q", err, tt.want)
 			}
-			if err := machine.storeGlobalReferenceValue(tt.ref, value.NewInt(42)); err == nil || err.Error() != tt.want {
+			if err := machine.storeReferenceValue(value.Value{Type: value.VAL_REF, Obj: tt.ref}, value.NewInt(42)); err == nil || err.Error() != tt.want {
 				t.Fatalf("store error=%v, want %q", err, tt.want)
 			}
 		})

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -160,20 +160,32 @@ func (vm *VM) peek(distance int) value.Value {
 // nunca o ocupante atual do slot no momento do release — reuso de slot por
 // temporários nunca retidos (locais de bloco mortos, ex.: OP_POP sem drop)
 // tornaria o release por índice unsound (dec a menos, proibido pela spec).
+//
+// Ocupante novo NÃO-retível (null/escalar): a entrada do slot, se existir, é
+// REMOVIDA — o site já liberou o ocupante velho (é o contrato deste helper),
+// então mantê-la seria uma reivindicação FANTASMA sobre um objeto já pago, e
+// o fim do frame (ou o bindOwnedSlot de uma iteração seguinte) o soltaria uma
+// segunda vez (dec a mais, direção insegura).
 func (f *CallFrame) ownSlot(vm *VM, slot int) {
 	v := vm.stack[slot]
-	if !value.Retain(v) {
-		return
-	}
+	retained := value.Retain(v)
 	for i := range f.Owned {
 		if f.Owned[i].slot == slot {
-			// Sobrescrita do slot: o site ja liberou o ocupante velho; a
-			// entrada passa a apontar o objeto novo (retido acima).
-			f.Owned[i].obj = v
+			if retained {
+				// Sobrescrita do slot: o site ja liberou o ocupante velho; a
+				// entrada passa a apontar o objeto novo (retido acima).
+				f.Owned[i].obj = v
+			} else {
+				last := len(f.Owned) - 1
+				f.Owned[i] = f.Owned[last]
+				f.Owned = f.Owned[:last]
+			}
 			return
 		}
 	}
-	f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
+	if retained {
+		f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
+	}
 }
 
 // bindOwnedSlot e o OP_OWN_LOCAL: um vinculo NOVO nasce no slot (let, variavel

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -176,26 +176,15 @@ func (f *CallFrame) ownSlot(vm *VM, slot int) {
 	f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
 }
 
-// ownsSlotIndex informa se o slot e um vinculo POSSUIDO deste frame. Slots de
-// tipo `ref` (params IsRef, `let x: ref T`, rebind de ref) sao emprestimos e
-// nunca aparecem em Owned — e por isso que a posse nao migra para o box do
-// upvalue quando um deles e capturado (ver closeUpvalue).
-func (f *CallFrame) ownsSlotIndex(slot int) bool {
-	for i := range f.Owned {
-		if f.Owned[i].slot == slot {
-			return true
-		}
-	}
-	return false
-}
-
 // captureUpvalue finds or creates an open upvalue for the given stack slot.
-// frameOwnedSlot diz se o slot e um vinculo POSSUIDO do frame; quando nao e
-// (slot de tipo `ref` — empréstimo), a caixa herda a condicao de emprestimo e
-// os funis de escrita dela param de contar posse (ver value.ObjUpvalue.
-// borrowed). A condicao e estatica por slot — decidida pelo tipo declarado, ja
-// resolvida antes de qualquer captura — entao decidir aqui e estavel.
-func (vm *VM) captureUpvalue(local *value.Value, frameOwnedSlot bool) *value.ObjUpvalue {
+//
+// RC: a caixa nasce POSSUIDORA. Quem a marca como emprestada e exclusivamente
+// o OP_MARK_UPVALUE_BORROW que o compilador emite depois do OP_CLOSURE, pelo
+// TIPO DECLARADO do slot capturado — a condicao e estatica. Inferi-la aqui a
+// partir de frame.Owned seria errado nas duas direcoes (slot possuido com
+// ocupante null/escalar na captura nao esta na lista; indice de slot reusado
+// entre blocos irmaos deixa entrada morta na lista).
+func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 	// var prevUpvalue *value.ObjUpvalue // Unused for now
 	upvalue := vm.openUpvalues
 
@@ -205,27 +194,23 @@ func (vm *VM) captureUpvalue(local *value.Value, frameOwnedSlot bool) *value.Obj
 		upvalue = upvalue.Next()
 	}
 
-	if upvalue == nil {
-		upvalue = value.NewOpenUpvalue(local, vm.openUpvalues)
-		vm.openUpvalues = upvalue
+	if upvalue != nil {
+		return upvalue
 	}
 
-	if !frameOwnedSlot {
-		upvalue.MarkBorrowed()
-	}
+	createdUpvalue := value.NewOpenUpvalue(local, vm.openUpvalues)
+	vm.openUpvalues = createdUpvalue
 
-	return upvalue
+	return createdUpvalue
 }
 
-// closeUpvalue fecha o box do upvalue aberto sobre o slot. frameOwnedSlot diz
-// se o slot era um vinculo POSSUIDO do frame (registrado em frame.Owned): so
-// nesse caso a posse migra do slot para o box. Um slot de tipo `ref` e
-// EMPRESTIMO (nunca entra em frame.Owned) — reter ao fechar daria um dono a
-// mais ao objeto emprestado e faria a mutacao atraves do empréstimo clonar,
-// perdendo a escrita. A caixa fica marcada como emprestada para que os funis
-// de escrita dela (OP_SET_UPVALUE, OP_GET_UPVALUE_MUT) tambem nao soltem o que
-// ela nunca reteve (dec a menos).
-func (vm *VM) closeUpvalue(slot *value.Value, frameOwnedSlot bool) {
+// closeUpvalue fecha o box do upvalue aberto sobre o slot. A decisao de posse
+// vem da PROPRIA CAIXA (marcada estaticamente pelo compilador via
+// OP_MARK_UPVALUE_BORROW quando o slot capturado tem tipo `ref`): caixa
+// possuidora assume a posse que o slot tinha; caixa emprestada nao retem —
+// reter daria um dono a mais ao objeto emprestado e faria a mutacao atraves do
+// empréstimo clonar, perdendo a escrita.
+func (vm *VM) closeUpvalue(slot *value.Value) {
 	var prev *value.ObjUpvalue
 	curr := vm.openUpvalues
 
@@ -235,10 +220,8 @@ func (vm *VM) closeUpvalue(slot *value.Value, frameOwnedSlot bool) {
 			// finalizeCurrentFrame) para o box do upvalue, que passa a ser
 			// dono duravel independente do frame. So retem aqui - nunca
 			// libera (o release do slot e responsabilidade do frame).
-			if frameOwnedSlot {
+			if !curr.IsBorrowed() {
 				value.Retain(*slot)
-			} else {
-				curr.MarkBorrowed()
 			}
 			next := curr.Next()
 			if prev == nil {

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -176,6 +176,19 @@ func (f *CallFrame) ownSlot(vm *VM, slot int) {
 	f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
 }
 
+// ownsSlotIndex informa se o slot e um vinculo POSSUIDO deste frame. Slots de
+// tipo `ref` (params IsRef, `let x: ref T`, rebind de ref) sao emprestimos e
+// nunca aparecem em Owned — e por isso que a posse nao migra para o box do
+// upvalue quando um deles e capturado (ver closeUpvalue).
+func (f *CallFrame) ownsSlotIndex(slot int) bool {
+	for i := range f.Owned {
+		if f.Owned[i].slot == slot {
+			return true
+		}
+	}
+	return false
+}
+
 // captureUpvalue finds or creates an open upvalue for the given stack slot.
 func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 	// var prevUpvalue *value.ObjUpvalue // Unused for now
@@ -197,7 +210,13 @@ func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 	return createdUpvalue
 }
 
-func (vm *VM) closeUpvalue(slot *value.Value) {
+// closeUpvalue fecha o box do upvalue aberto sobre o slot. frameOwnedSlot diz
+// se o slot era um vinculo POSSUIDO do frame (registrado em frame.Owned): so
+// nesse caso a posse migra do slot para o box. Um slot de tipo `ref` e
+// EMPRESTIMO (nunca entra em frame.Owned) — reter ao fechar daria um dono a
+// mais ao objeto emprestado e faria a mutacao atraves do empréstimo clonar,
+// perdendo a escrita.
+func (vm *VM) closeUpvalue(slot *value.Value, frameOwnedSlot bool) {
 	var prev *value.ObjUpvalue
 	curr := vm.openUpvalues
 
@@ -207,7 +226,9 @@ func (vm *VM) closeUpvalue(slot *value.Value) {
 			// finalizeCurrentFrame) para o box do upvalue, que passa a ser
 			// dono duravel independente do frame. So retem aqui - nunca
 			// libera (o release do slot e responsabilidade do frame).
-			value.Retain(*slot)
+			if frameOwnedSlot {
+				value.Retain(*slot)
+			}
 			next := curr.Next()
 			if prev == nil {
 				vm.openUpvalues = next

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -176,6 +176,40 @@ func (f *CallFrame) ownSlot(vm *VM, slot int) {
 	f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
 }
 
+// bindOwnedSlot e o OP_OWN_LOCAL: um vinculo NOVO nasce no slot (let, variavel
+// de for-each, binding de case do select). Retem o ocupante e, se o frame ja
+// tinha entrada para este indice, o vinculo que a criou MORREU (indices de slot
+// sao reusados entre iteracoes de laco e blocos irmaos, e a lista nao e podada
+// no fim do escopo) — o objeto gravado nela e pago AGORA, fechando o par
+// retain/release daquele vinculo: e assim que cada elemento de um for-each
+// recebe exatamente um retain (no bind da iteracao) e um release (no bind da
+// iteracao seguinte, ou no fim do frame para o ultimo). Retain-antes-de-
+// release: rebind do mesmo objeto (elemento repetido) nao passa por zero.
+// Ocupante nao-composto (Retain falha) com entrada anterior: a entrada e
+// removida depois de paga — deixa-la nomearia um objeto que um proximo
+// OP_SET_LOCAL substituiria sem release (retain orfao, over-count).
+func (f *CallFrame) bindOwnedSlot(vm *VM, slot int) {
+	v := vm.stack[slot]
+	retained := value.Retain(v)
+	for i := range f.Owned {
+		if f.Owned[i].slot != slot {
+			continue
+		}
+		value.Release(f.Owned[i].obj)
+		if retained {
+			f.Owned[i].obj = v
+		} else {
+			last := len(f.Owned) - 1
+			f.Owned[i] = f.Owned[last]
+			f.Owned = f.Owned[:last]
+		}
+		return
+	}
+	if retained {
+		f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
+	}
+}
+
 // captureUpvalue finds or creates an open upvalue for the given stack slot.
 //
 // RC: a caixa nasce POSSUIDORA. Quem a marca como emprestada e exclusivamente

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -155,6 +155,25 @@ func (vm *VM) peek(distance int) value.Value {
 	return vm.stack[vm.stackTop-1-distance]
 }
 
+// ownSlot retém o composto no slot e o registra para release no fim do
+// frame. Idempotente por slot: duplicata causaria release dobrado (dec a
+// menos — proibido pela spec §8.2).
+func (f *CallFrame) ownSlot(vm *VM, slot int) {
+	v := vm.stack[slot]
+	if !value.Retain(v) {
+		return
+	}
+	for _, existing := range f.Owned {
+		if existing == slot {
+			// Slot ja possuido: o retain acima cobre o ocupante novo; o
+			// release do ocupante velho e responsabilidade do site que
+			// sobrescreveu (Task 3+). Nao registrar de novo.
+			return
+		}
+	}
+	f.Owned = append(f.Owned, slot)
+}
+
 // captureUpvalue finds or creates an open upvalue for the given stack slot.
 func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 	// var prevUpvalue *value.ObjUpvalue // Unused for now

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -155,23 +155,25 @@ func (vm *VM) peek(distance int) value.Value {
 	return vm.stack[vm.stackTop-1-distance]
 }
 
-// ownSlot retém o composto no slot e o registra para release no fim do
-// frame. Idempotente por slot: duplicata causaria release dobrado (dec a
-// menos — proibido pela spec §8.2).
+// ownSlot retém o composto no slot e o registra (slot, objeto) para release
+// no fim do frame. O release do fim do frame libera o objeto GRAVADO aqui,
+// nunca o ocupante atual do slot no momento do release — reuso de slot por
+// temporários nunca retidos (locais de bloco mortos, ex.: OP_POP sem drop)
+// tornaria o release por índice unsound (dec a menos, proibido pela spec).
 func (f *CallFrame) ownSlot(vm *VM, slot int) {
 	v := vm.stack[slot]
 	if !value.Retain(v) {
 		return
 	}
-	for _, existing := range f.Owned {
-		if existing == slot {
-			// Slot ja possuido: o retain acima cobre o ocupante novo; o
-			// release do ocupante velho e responsabilidade do site que
-			// sobrescreveu (Task 3+). Nao registrar de novo.
+	for i := range f.Owned {
+		if f.Owned[i].slot == slot {
+			// Sobrescrita do slot: o site ja liberou o ocupante velho; a
+			// entrada passa a apontar o objeto novo (retido acima).
+			f.Owned[i].obj = v
 			return
 		}
 	}
-	f.Owned = append(f.Owned, slot)
+	f.Owned = append(f.Owned, ownedEntry{slot: slot, obj: v})
 }
 
 // captureUpvalue finds or creates an open upvalue for the given stack slot.

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -190,7 +190,12 @@ func (f *CallFrame) ownsSlotIndex(slot int) bool {
 }
 
 // captureUpvalue finds or creates an open upvalue for the given stack slot.
-func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
+// frameOwnedSlot diz se o slot e um vinculo POSSUIDO do frame; quando nao e
+// (slot de tipo `ref` — empréstimo), a caixa herda a condicao de emprestimo e
+// os funis de escrita dela param de contar posse (ver value.ObjUpvalue.
+// borrowed). A condicao e estatica por slot — decidida pelo tipo declarado, ja
+// resolvida antes de qualquer captura — entao decidir aqui e estavel.
+func (vm *VM) captureUpvalue(local *value.Value, frameOwnedSlot bool) *value.ObjUpvalue {
 	// var prevUpvalue *value.ObjUpvalue // Unused for now
 	upvalue := vm.openUpvalues
 
@@ -200,14 +205,16 @@ func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 		upvalue = upvalue.Next()
 	}
 
-	if upvalue != nil {
-		return upvalue
+	if upvalue == nil {
+		upvalue = value.NewOpenUpvalue(local, vm.openUpvalues)
+		vm.openUpvalues = upvalue
 	}
 
-	createdUpvalue := value.NewOpenUpvalue(local, vm.openUpvalues)
-	vm.openUpvalues = createdUpvalue
+	if !frameOwnedSlot {
+		upvalue.MarkBorrowed()
+	}
 
-	return createdUpvalue
+	return upvalue
 }
 
 // closeUpvalue fecha o box do upvalue aberto sobre o slot. frameOwnedSlot diz
@@ -215,7 +222,9 @@ func (vm *VM) captureUpvalue(local *value.Value) *value.ObjUpvalue {
 // nesse caso a posse migra do slot para o box. Um slot de tipo `ref` e
 // EMPRESTIMO (nunca entra em frame.Owned) — reter ao fechar daria um dono a
 // mais ao objeto emprestado e faria a mutacao atraves do empréstimo clonar,
-// perdendo a escrita.
+// perdendo a escrita. A caixa fica marcada como emprestada para que os funis
+// de escrita dela (OP_SET_UPVALUE, OP_GET_UPVALUE_MUT) tambem nao soltem o que
+// ela nunca reteve (dec a menos).
 func (vm *VM) closeUpvalue(slot *value.Value, frameOwnedSlot bool) {
 	var prev *value.ObjUpvalue
 	curr := vm.openUpvalues
@@ -228,6 +237,8 @@ func (vm *VM) closeUpvalue(slot *value.Value, frameOwnedSlot bool) {
 			// libera (o release do slot e responsabilidade do frame).
 			if frameOwnedSlot {
 				value.Retain(*slot)
+			} else {
+				curr.MarkBorrowed()
 			}
 			next := curr.Next()
 			if prev == nil {

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -201,6 +201,11 @@ func (vm *VM) closeUpvalue(slot *value.Value) {
 
 	for curr != nil {
 		if curr.Close(slot) {
+			// RC: o valor migra do slot do frame (liberado por
+			// finalizeCurrentFrame) para o box do upvalue, que passa a ser
+			// dono duravel independente do frame. So retem aqui - nunca
+			// libera (o release do slot e responsabilidade do frame).
+			value.Retain(*slot)
 			next := curr.Next()
 			if prev == nil {
 				vm.openUpvalues = next

--- a/internal/vm/stack_characterization_test.go
+++ b/internal/vm/stack_characterization_test.go
@@ -81,15 +81,14 @@ func TestUpvalueCaptureAndClose(t *testing.T) {
 	machine.stack[0] = value.NewInt(7)
 	slot := &machine.stack[0]
 
-	// slot possuido pelo frame (true): a caixa passa a possuir ao fechar.
-	first := machine.captureUpvalue(slot, true)
-	second := machine.captureUpvalue(slot, true)
+	first := machine.captureUpvalue(slot)
+	second := machine.captureUpvalue(slot)
 	if first != second {
 		t.Fatal("capturing the same slot returned distinct upvalues")
 	}
 
-	// slot possuido pelo frame (true): a posse migra do slot para o box.
-	machine.closeUpvalue(slot, true)
+	// caixa nao marcada como emprestada: a posse migra do slot para ela.
+	machine.closeUpvalue(slot)
 	machine.stack[0] = value.NewInt(42)
 	if first.PointsTo(slot) {
 		t.Fatal("closed upvalue still points to its former stack slot")

--- a/internal/vm/stack_characterization_test.go
+++ b/internal/vm/stack_characterization_test.go
@@ -81,8 +81,9 @@ func TestUpvalueCaptureAndClose(t *testing.T) {
 	machine.stack[0] = value.NewInt(7)
 	slot := &machine.stack[0]
 
-	first := machine.captureUpvalue(slot)
-	second := machine.captureUpvalue(slot)
+	// slot possuido pelo frame (true): a caixa passa a possuir ao fechar.
+	first := machine.captureUpvalue(slot, true)
+	second := machine.captureUpvalue(slot, true)
 	if first != second {
 		t.Fatal("capturing the same slot returned distinct upvalues")
 	}

--- a/internal/vm/stack_characterization_test.go
+++ b/internal/vm/stack_characterization_test.go
@@ -87,7 +87,8 @@ func TestUpvalueCaptureAndClose(t *testing.T) {
 		t.Fatal("capturing the same slot returned distinct upvalues")
 	}
 
-	machine.closeUpvalue(slot)
+	// slot possuido pelo frame (true): a posse migra do slot para o box.
+	machine.closeUpvalue(slot, true)
 	machine.stack[0] = value.NewInt(42)
 	if first.PointsTo(slot) {
 		t.Fatal("closed upvalue still points to its former stack slot")

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -74,6 +74,11 @@ func (vm *VM) prepareTaskCall(callable value.Value, arguments []value.Value) (pr
 		if !parameter.IsRef {
 			// CoW: fronteira de valor — marca em vez de copiar
 			value.MarkShared(preparedArguments[i])
+			// RC: retain de captura (mesmo padrao do defer/markPreparedArguments)
+			// — a preparacao roda sincrona, antes do goroutine da task ser
+			// lancado; os args ficam "guardados" em preparedTaskCall.Arguments
+			// ate a task terminar. Release espelhado em startSupervisedTask.
+			value.Retain(preparedArguments[i])
 		}
 	}
 	return preparedTaskCall{Callable: callable, Closure: closure, Arguments: preparedArguments}, nil

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -67,20 +67,11 @@ func (vm *VM) prepareTaskCall(callable value.Value, arguments []value.Value) (pr
 
 	preparedArguments := make([]value.Value, len(arguments))
 	copy(preparedArguments, arguments)
-	for i, parameter := range function.Params {
-		if i >= len(preparedArguments) {
-			break
-		}
-		if !parameter.IsRef {
-			// CoW: fronteira de valor — marca em vez de copiar
-			value.MarkShared(preparedArguments[i])
-			// RC: retain de captura (mesmo padrao do defer/markPreparedArguments)
-			// — a preparacao roda sincrona, antes do goroutine da task ser
-			// lancado; os args ficam "guardados" em preparedTaskCall.Arguments
-			// ate a task terminar. Release espelhado em startSupervisedTask.
-			value.Retain(preparedArguments[i])
-		}
-	}
+	// RC: retain de captura, mesmo padrao/funcao do defer (retainPreparedArguments)
+	// — a preparacao roda sincrona, antes do goroutine da task ser lancado; os
+	// args ficam "guardados" em preparedTaskCall.Arguments ate a task terminar.
+	// Release espelhado em startSupervisedTask.
+	vm.retainPreparedArguments(preparedArguments, function.Params)
 	return preparedTaskCall{Callable: callable, Closure: closure, Arguments: preparedArguments}, nil
 }
 

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -88,6 +88,21 @@ func (vm *VM) executePreparedTaskCall(call preparedTaskCall) (value.Value, error
 		LocalBase:   0,
 		Environment: call.Closure.Environment,
 	}
+	// RC: parametros sem ref sao vinculos duraveis do frame da task — mesmo
+	// bind que callPreparedClosure faz (spec §4.2, linha da captura de task:
+	// os slots de parametro da task "fazem seu proprio inc"). Sem isto, um
+	// rebind (OP_SET_LOCAL) ou o clone do caminho MUT dentro do corpo da task
+	// dispararia Release(velho) sem retain correspondente (dec a menos), e
+	// releasePreparedArguments em startSupervisedTask soltaria a captura DE
+	// NOVO. O release espelhado destes binds e o funil unico do frame
+	// (finalizeCurrentFrame), tanto no retorno normal quanto no unwind.
+	params := call.Closure.Function.Params
+	for i := range call.Arguments {
+		if i < len(params) && params[i].IsRef {
+			continue
+		}
+		frame.ownSlot(vm, frame.LocalBase+1+i)
+	}
 	vm.frames[0], vm.frameCount, vm.currentFrame = frame, 1, frame
 	if err := vm.run(1, &result); err != nil {
 		return value.NewNull(), err

--- a/internal/vm/task_execution_test.go
+++ b/internal/vm/task_execution_test.go
@@ -64,8 +64,14 @@ func TestRuntimeErrorRemainsTypedThroughImportFailure(t *testing.T) {
 	}
 }
 
-// Contrato CoW: parâmetro por valor de task é marcado Shared — mesmo
+// Contrato CoW: parâmetro por valor de task é capturado sem copiar — mesmo
 // ponteiro, cópia adiada para a primeira mutação (unicize) no bytecode.
+// Depois da chave (spec docs/superpowers/specs/
+// 2026-08-17-cow-rc-uniqueness-design.md §3), o que registra a captura é o
+// contador de donos e não o bit sticky: `outer` é montado fora do bytecode e
+// nasce sem dono, então a captura o leva de 0 para 1 (em código real o dono do
+// chamador já estaria contado, o total passaria de 1 e a primeira mutação
+// dentro da task clonaria).
 func TestPreparedTaskCallMarksValueParameterShared(t *testing.T) {
 	machine := New()
 	if err := interpretVMSource(t, machine, `
@@ -77,6 +83,7 @@ end`); err != nil {
 	callable, _ := machine.GetGlobal("worker")
 	nested := value.NewArray([]value.Value{value.NewInt(7)})
 	outer := value.NewArray([]value.Value{nested})
+	ownersBefore := value.OwnersCount(outer)
 
 	call, err := machine.prepareTaskCall(callable, []value.Value{outer})
 	if err != nil {
@@ -87,8 +94,8 @@ end`); err != nil {
 	if gotOuter != wantOuter {
 		t.Fatal("CoW: o arg deve manter o ponteiro (cópia adiada)")
 	}
-	if !value.IsShared(call.Arguments[0]) {
-		t.Fatal("CoW: o arg composto por valor deve estar marcado Shared")
+	if got := value.OwnersCount(call.Arguments[0]); got != ownersBefore+1 {
+		t.Fatalf("CoW: a captura do arg composto por valor deve contar um dono durável: esperado %d, veio %d", ownersBefore+1, got)
 	}
 	if gotOuter.Elements[0].Obj != nested.Obj {
 		t.Fatal("marcação não pode clonar o aninhado")

--- a/internal/vm/task_execution_test.go
+++ b/internal/vm/task_execution_test.go
@@ -72,7 +72,7 @@ func TestRuntimeErrorRemainsTypedThroughImportFailure(t *testing.T) {
 // nasce sem dono, então a captura o leva de 0 para 1 (em código real o dono do
 // chamador já estaria contado, o total passaria de 1 e a primeira mutação
 // dentro da task clonaria).
-func TestPreparedTaskCallMarksValueParameterShared(t *testing.T) {
+func TestPreparedTaskCallRetainsValueParameter(t *testing.T) {
 	machine := New()
 	if err := interpretVMSource(t, machine, `
 func worker(values: int[][]) -> int

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -42,10 +42,14 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	// precisa saber se o slot era possuido (frame.Owned ainda intacto) para
 	// decidir se a posse migra para ele, e retain-antes-de-release mantem a
 	// contagem sem passar por zero. Slots `ref` sao emprestimos e nunca estao
-	// em Owned: o box tambem so os empresta (ver closeUpvalue).
+	// em Owned: o box tambem so os empresta (ver closeUpvalue). O guard de
+	// openUpvalues evita a varredura por slot no caso comum (frame sem nenhuma
+	// captura aberta), que e a esmagadora maioria dos retornos.
 	ownedTop := vm.stackTop
-	for index := frame.StackBase; index < ownedTop; index++ {
-		vm.closeUpvalue(&vm.stack[index], frame.ownsSlotIndex(index))
+	if vm.openUpvalues != nil {
+		for index := frame.StackBase; index < ownedTop; index++ {
+			vm.closeUpvalue(&vm.stack[index], frame.ownsSlotIndex(index))
+		}
 	}
 
 	// RC: solta os vinculos duraveis do frame (retorno normal e unwind

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -38,6 +38,16 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 		}
 	}
 
+	// RC: fecha os upvalues ANTES de soltar os vinculos do frame — o box
+	// precisa saber se o slot era possuido (frame.Owned ainda intacto) para
+	// decidir se a posse migra para ele, e retain-antes-de-release mantem a
+	// contagem sem passar por zero. Slots `ref` sao emprestimos e nunca estao
+	// em Owned: o box tambem so os empresta (ver closeUpvalue).
+	ownedTop := vm.stackTop
+	for index := frame.StackBase; index < ownedTop; index++ {
+		vm.closeUpvalue(&vm.stack[index], frame.ownsSlotIndex(index))
+	}
+
 	// RC: solta os vinculos duraveis do frame (retorno normal e unwind
 	// passam ambos por aqui). Libera o OBJETO GRAVADO em cada entrada —
 	// nunca o ocupante atual do slot, que apos reuso de slot por um
@@ -50,9 +60,7 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	}
 	frame.Owned = nil
 
-	ownedTop := vm.stackTop
 	for index := frame.StackBase; index < ownedTop; index++ {
-		vm.closeUpvalue(&vm.stack[index])
 		vm.stack[index] = value.Value{}
 	}
 

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -39,12 +39,14 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	}
 
 	// RC: solta os vinculos duraveis do frame (retorno normal e unwind
-	// passam ambos por aqui). Le o ocupante ATUAL do slot: sobrescritas
-	// durante a vida do frame ja fizeram seu proprio release/retain.
-	for _, slot := range frame.Owned {
-		if slot < vm.stackTop {
-			value.Release(vm.stack[slot])
-		}
+	// passam ambos por aqui). Libera o OBJETO GRAVADO em cada entrada —
+	// nunca o ocupante atual do slot, que apos reuso de slot por um
+	// temporario nunca retido (locais de bloco mortos sem drop) poderia ser
+	// um valor diferente do que foi retido. Sites de sobrescrita ja liberam
+	// o velho e atualizam a entrada (ownSlot); nao ha guard de stackTop
+	// porque o release agora e por objeto, nao por leitura de vm.stack.
+	for _, entry := range frame.Owned {
+		value.Release(entry.obj)
 	}
 	frame.Owned = nil
 

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -38,17 +38,16 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 		}
 	}
 
-	// RC: fecha os upvalues ANTES de soltar os vinculos do frame — o box
-	// precisa saber se o slot era possuido (frame.Owned ainda intacto) para
-	// decidir se a posse migra para ele, e retain-antes-de-release mantem a
-	// contagem sem passar por zero. Slots `ref` sao emprestimos e nunca estao
-	// em Owned: o box tambem so os empresta (ver closeUpvalue). O guard de
-	// openUpvalues evita a varredura por slot no caso comum (frame sem nenhuma
+	// RC: fecha os upvalues ANTES de soltar os vinculos do frame —
+	// retain-antes-de-release mantem a contagem sem passar por zero na
+	// migracao slot -> caixa. Cada caixa decide sozinha se assume a posse
+	// (ela sabe, estaticamente, se empresta; ver closeUpvalue). O guard de
+	// openUpvalues evita percorrer os slots no caso comum (frame sem nenhuma
 	// captura aberta), que e a esmagadora maioria dos retornos.
 	ownedTop := vm.stackTop
 	if vm.openUpvalues != nil {
 		for index := frame.StackBase; index < ownedTop; index++ {
-			vm.closeUpvalue(&vm.stack[index], frame.ownsSlotIndex(index))
+			vm.closeUpvalue(&vm.stack[index])
 		}
 	}
 

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -38,6 +38,16 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 		}
 	}
 
+	// RC: solta os vinculos duraveis do frame (retorno normal e unwind
+	// passam ambos por aqui). Le o ocupante ATUAL do slot: sobrescritas
+	// durante a vida do frame ja fizeram seu proprio release/retain.
+	for _, slot := range frame.Owned {
+		if slot < vm.stackTop {
+			value.Release(vm.stack[slot])
+		}
+	}
+	frame.Owned = nil
+
 	ownedTop := vm.stackTop
 	for index := frame.StackBase; index < ownedTop; index++ {
 		vm.closeUpvalue(&vm.stack[index])

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -22,6 +22,10 @@ type CallFrame struct {
 	LocalBase   int // Offset in stack where this frame's locals start
 	Deferred    []PreparedCall
 	Environment *value.GlobalEnvironment
+
+	// Owned: slots absolutos de vm.stack retidos por este frame
+	// (parametros e lets). Liberados em finalizeCurrentFrame.
+	Owned []int
 }
 
 type SharedState struct {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -23,9 +23,18 @@ type CallFrame struct {
 	Deferred    []PreparedCall
 	Environment *value.GlobalEnvironment
 
-	// Owned: slots absolutos de vm.stack retidos por este frame
+	// Owned: vinculos duraveis (slot, objeto) retidos por este frame
 	// (parametros e lets). Liberados em finalizeCurrentFrame.
-	Owned []int
+	Owned []ownedEntry
+}
+
+// ownedEntry registra um vínculo durável do frame: o slot e o OBJETO retido
+// naquele momento. O release do fim do frame libera o objeto gravado — nunca
+// o ocupante atual do slot, que após reuso de slot pode ser um temporário
+// jamais retido (liberá-lo seria dec a menos, proibido pela spec).
+type ownedEntry struct {
+	slot int
+	obj  value.Value
 }
 
 type SharedState struct {

--- a/noxy.mod
+++ b/noxy.mod
@@ -1,6 +1,6 @@
 module noxy
 
-noxy v0.4.0
+noxy v0.5.0
 
 require github.com/estevaofon/quicksort v0.1.0
 require github.com/estevaofon/noxy_dynamodb v0.1.0


### PR DESCRIPTION
## Summary
- Substitui o bit sticky `Shared` do CoW por um contador `Owners` de referências duráveis (modelo do CoW do Swift adaptado a interpretador com GC): mutação clona apenas quando existe outro dono vivo no momento — `IsShared = Owners > 1`.
- Elimina por construção os O(N²) de **compartilhamento morto** (o caso `database_file(db)` do NoxyDB e toda a classe de padrão): o benchmark novo `bench_value_call_mutate.nx` (helper por valor em laço de mutação) sai de ~1,5s quadrático para ~100ms flat (**−93,5%** na intercalada; a N=5000, 10.412ms → 157ms = 66x), e `TestByValueCallLoopClonesO1AfterFlip` prova O(1) clones no laço (600 → ≤8 em 200 puts).
- Contrato semântico da spec CoW 0.4.0 permanece intacto: corpus de 130 exemplos com saídas idênticas em toda verificação, `go test ./...` verde, `-race` verde (`internal/value` completo + `internal/vm` completo sem filtro).
- Implementação faseada com rastreamento duplo (bit sticky + contador convivem até a chave virar), TDD em toda tarefa, 9 tarefas do plano + 1 correção estrutural intermediária + 5 rounds de fix na tarefa da chave + 1 fix wave na review final de branch — histórico completo no CHANGELOG e nos commits.
- Uma única divergência comportamental (deliberada, documentada como correção): escrita através de `ref` para um nó com exatamente um dono durável agora acontece in-place e é visível — antes o bit sticky podia clonar e **perder a escrita**, de forma dependente da sintaxe. Ver entrada `Fixed` no CHANGELOG.
- **Corta a release v0.5.0**: bump em `version.go`/`noxy.mod`/README e o `[Unreleased]` do CHANGELOG vira `[0.5.0] - 2026-08-17`.

## Components
- `internal/value/value.go`, `internal/value/cow.go`: contador `Owners atomic.Int32` substitui `Shared atomic.Bool`; `Retain`/`Release`/`OwnersCount`; `IsShared` lê o contador.
- `internal/vm/stack.go`, `internal/vm/unwind.go`, `internal/vm/vm.go`: posse por frame — `CallFrame.Owned` como pares (slot, objeto retido), release central em `finalizeCurrentFrame` (retorno e unwind); `retargetOwnedSlot(ForUpvalue)` mantém as entradas corretas sob escrita via `ref` (varredura innermost-first).
- `internal/compiler/compiler.go`, `internal/compiler/cow_lowering.go`, `internal/chunk/chunk.go`: `OP_OWN_LOCAL` (vínculo de posse) e os opcodes de **empréstimo estático** para `ref` de variável (`OP_SET_LOCAL_BORROW`, `OP_SET_GLOBAL_BORROW`, `OP_GET_LOCAL_MUT_BORROW`, `OP_REF_LOCAL_BORROW`, `OP_MARK_UPVALUE_BORROW`) — decididos pelo tipo declarado no compilador, nunca inferidos em runtime. Campo `ref T` de struct retém (assimetria documentada na spec §4.2).
- `internal/vm/executor.go`, `internal/vm/calls.go`, `internal/vm/references.go`, `internal/vm/task_execution.go`, `internal/vm/builtins_concurrency.go`, `internal/vm/builtins_collections.go`, `internal/vm/builtins_tasks.go`, `internal/vm/defer.go`: posse contada em todos os vínculos duráveis (globais, upvalues, contêineres, construtor, `append`/`pop`/`delete`, canais incluindo `OP_SELECT`, `spawn`/`spawn_task` incluindo o frame da task, `defer`, natives sem assinatura).
- `internal/vm/rc_uniqueness_test.go` (novo): suíte extensa fixando o contrato (empréstimo estático, posse desde o nascimento em for-each/select, reaponte innermost-first, balanço de defer/tasks/`OP_SELECT`, oráculos contra o binário do merge-base).
- `benchmarks/bench_value_call_mutate.nx` (novo); `benchmarks/RESULTS.md` e `CHANGELOG.md` atualizados (seção nova de resultados; entradas `Performance` e `Fixed`; release 0.5.0).
- `docs/superpowers/specs/2026-08-17-cow-rc-uniqueness-design.md`, `docs/superpowers/plans/2026-08-17-cow-rc-uniqueness-fase1.md`: spec (implementada fase 1) e plano.
- `internal/version/version.go`, `noxy.mod`, `README.md`: versão v0.5.0.

## Test Plan
- [x] TDD em toda tarefa (RED verificado antes de cada implementação)
- [x] `go test ./...` verde na árvore final
- [x] `go vet ./internal/...` limpo
- [x] `-race`: `internal/value` completo e `internal/vm` completo sem filtro, ambos verdes
- [x] Corpus de exemplos (130 programas): saídas idênticas em toda verificação relevante
- [x] Suíte intercalada de benchmarks: sem regressões fora do gate documentado (`map_churn` +10,9% e `spawn_sum` +10,4% aceitos e justificados no RESULTS.md como preço do bookkeeping RC, com válvulas de otimização futura nomeadas)
- [x] Review final de branch inteira (18 commits) com 1 fix wave (2 Criticals nas costuras task/canal, corrigidos e re-verificados)
- [x] Validar no workload real do NoxyDB (re-rodar o benchmark de puts do refactor v0.4 com o binário desta branch)
- [x] Atualizar o site (`docs/index.html`) com seção "What's New in v0.5.0" (badge do hero ainda aponta a v0.4.0 — tarefa de conteúdo separada)
- [x] Issue separada para o bug pré-existente encontrado: `break` dentro de `for...in` não funciona no `develop` atual (compilador nunca resolve os jumps de break) — não introduzido por esta branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)