### PR TITLE
fix/break-in-for-each - break dentro de for...in não sai do laço (compilador + parser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `break` dentro de `for ... in` voltou a sair do laço. O branch do
+  `ForStatement` em `internal/compiler/compiler.go` empilhava o laço em
+  `c.loops` mas nunca fazia o pareamento que o `while` já fazia: não patchava
+  os `loop.BreakJumps` nem desempilhava o laço no fim. O jump do `break`
+  ficava com o operando de placeholder (`0xffff`), o `ip` saltava para fora do
+  chunk e o laço principal do executor (`internal/vm/executor.go`, guarda
+  `ip >= len(c.Code)`) retornava sucesso — o programa terminava em silêncio,
+  com exit 0 e saída truncada, em vez de continuar depois do laço. Como o laço
+  também nunca era desempilhado, um `break` posterior mirava o `for` já
+  encerrado (mesmo jump nunca patchado) e `break` fora de qualquer laço deixava
+  de ser erro de compilação. Bug pré-existente (reproduz em 0.4.0 e 0.5.0),
+  descoberto na verificação final do PR #33. `#compiler` @estevaofon
+
+- `if cond then break end` na mesma linha voltou a fechar no `end` correto.
+  `parseBreakStatement` (`internal/parser/parser.go`) avançava um token depois
+  do `break`, violando o contrato dos laços de statement
+  (`ParseProgram`/`parseBlockStatement`/`parseCaseBody` esperam `curToken` no
+  último token do statement e fazem o `nextToken` eles mesmos). Na forma
+  multilinha o `NEWLINE` absorvia o excesso e o bug não aparecia; na forma
+  inline o `end` do `if` era engolido e o bloco só terminava no `end` do laço
+  externo — `SyntaxError: expected 'end' after for loop, found EOF`. Afetava
+  também `while` (o idioma usado nos exemplos de `docs/concurrency.md`).
+  `#parser` @estevaofon
+
 ## [0.5.0] - 2026-08-17
 
 ### Performance

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1293,6 +1293,23 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		c.patchJump(jumpToExit)
 		c.emitByte(byte(chunk.OP_POP)) // Pop condition at exit
 
+		// 13. Patch Break Jumps (mesmo tratamento do while)
+		// O alvo tem de ficar DEPOIS do pop da condicao e ANTES do endScope: no
+		// break a condicao nao esta na pilha (o BreakStmt so estoura os locais
+		// alem de EnclosingLocals, isto e, a variavel do laco e o que o corpo
+		// declarou), entao o break chega aqui com a mesma pilha da saida normal
+		// — [$collection, $index, $len] — e paga os pops do escopo wrapper
+		// junto com ela.
+		for _, jump := range loop.BreakJumps {
+			c.patchJump(jump)
+		}
+
+		// 14. Pop Loop — sem isto o for continua sendo o laco "corrente" depois
+		// do seu fim: um break posterior miraria este laco ja encerrado (jump
+		// nunca patchado, operando 0xffff) e `break` fora de laco deixaria de
+		// ser erro de compilacao.
+		c.loops = c.loops[:len(c.loops)-1]
+
 		c.endScope() // Close Wrapper Scope ($collection, $index, $len)
 
 		return c.currentChunk, nil, nil

--- a/internal/compiler/loop_break_test.go
+++ b/internal/compiler/loop_break_test.go
@@ -1,0 +1,16 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Depois que o for termina ele nao pode continuar sendo o laco corrente: um
+// break solto depois dele tem de ser rejeitado como qualquer break fora de
+// laco (antes o laco ficava empilhado e o break gerava um jump nunca patchado).
+func TestCompileBreakAfterForLoopIsRejectedOutsideLoop(t *testing.T) {
+	_, _, err := New().Compile(parse("for item in [1, 2] do\n    print(item)\nend\nbreak\n"))
+	if err == nil || !strings.Contains(err.Error(), "break outside of loop") {
+		t.Fatalf("error=%v, want \"break outside of loop\"", err)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -347,13 +347,13 @@ func (p *Parser) parseDeferStatement() ast.Statement {
 }
 
 func (p *Parser) parseBreakStatement() *ast.BreakStmt {
-	stmt := &ast.BreakStmt{Token: p.curToken}
-	p.nextToken() // eat 'break'
-	// Optional newline
-	if p.peekToken.Type == token.NEWLINE {
-		p.nextToken()
-	}
-	return stmt
+	// Nao avanca token nenhum: o contrato de ParseProgram/parseBlockStatement/
+	// parseCaseBody e que parseStatement retorne com curToken no ULTIMO token
+	// do statement — para o break, o proprio 'break' — e o laco chamador faz o
+	// nextToken. Comer o token seguinte aqui engolia o 'end' na forma inline
+	// (`if cond then break end`), fazendo o bloco terminar no 'end' do laco
+	// externo.
+	return &ast.BreakStmt{Token: p.curToken}
 }
 
 func (p *Parser) parseUseStatement() *ast.UseStmt {

--- a/internal/vm/loop_break_test.go
+++ b/internal/vm/loop_break_test.go
@@ -1,0 +1,151 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// traceVMSource roda o programa coletando os inteiros passados a test_trace(),
+// na ordem em que o VM os observa. Serve para auditar QUAIS iteracoes de um
+// laco rodaram e se o codigo depois do laco chegou a executar.
+func traceVMSource(t *testing.T, source string) []int64 {
+	t.Helper()
+	machine := New()
+	trace := []int64{}
+	machine.DefineNative("test_trace", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			trace = append(trace, args[0].AsInt)
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	return trace
+}
+
+func requireTrace(t *testing.T, got []int64, want ...int64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("trace esperado %v, veio %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("trace esperado %v, veio %v", want, got)
+		}
+	}
+}
+
+// break dentro de for...in deve sair do laco e continuar no statement
+// seguinte — nao encerrar o programa silenciosamente.
+func TestBreakInsideForEachExitsLoopAndResumesAfterIt(t *testing.T) {
+	trace := traceVMSource(t, `
+for item in [1, 2, 3] do
+    test_trace(item)
+    if item == 2 then break end
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 1, 2, 99)
+}
+
+// break sobre map (o for compila um slot oculto $map extra) segue a mesma
+// regra: sai do laco e o programa continua.
+func TestBreakInsideForEachOverMapResumesAfterLoop(t *testing.T) {
+	trace := traceVMSource(t, `
+let m: map[string, int] = {"a": 1}
+for key in m do
+    test_trace(m[key])
+    break
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 1, 99)
+}
+
+// break no for interno encerra apenas o laco interno; o externo prossegue.
+func TestBreakInsideNestedForEachExitsOnlyInnerLoop(t *testing.T) {
+	trace := traceVMSource(t, `
+for outer in [1, 2] do
+    for inner in [10, 20] do
+        test_trace(inner)
+        break
+    end
+    test_trace(outer)
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 10, 1, 10, 2, 99)
+}
+
+// break dentro de um for aninhado em while nao pode escapar o while: o laco
+// externo deve continuar iterando.
+func TestBreakInsideForNestedInWhileExitsOnlyTheFor(t *testing.T) {
+	trace := traceVMSource(t, `
+let i: int = 0
+while i < 2 do
+    for item in [10, 20] do
+        test_trace(item)
+        break
+    end
+    test_trace(i)
+    i = i + 1
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 10, 0, 10, 1, 99)
+}
+
+// Depois do for, o break do while que o envolve tem de voltar a mirar o
+// while — nao o for ja encerrado.
+func TestBreakAfterForEachTargetsEnclosingWhile(t *testing.T) {
+	trace := traceVMSource(t, `
+let i: int = 0
+while i < 3 do
+    for item in [10] do
+        test_trace(item)
+    end
+    if i == 1 then break end
+    test_trace(i)
+    i = i + 1
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 10, 0, 10, 99)
+}
+
+// A forma inline `if cond then break end` (a que a doc de concorrencia usa)
+// tem de fechar o if no seu proprio 'end' — o while que a envolve continua
+// sendo fechado pelo 'end' dele.
+func TestBreakInlineInsideWhileClosesOnlyTheIf(t *testing.T) {
+	trace := traceVMSource(t, `
+let i: int = 0
+while i < 5 do
+    test_trace(i)
+    if i == 1 then break end
+    i = i + 1
+end
+test_trace(99)`)
+
+	requireTrace(t, trace, 0, 1, 99)
+}
+
+// O for deixa a pilha de valores equilibrada apos um break: expressoes
+// avaliadas depois do laco veem os mesmos slots locais de antes.
+func TestBreakInsideForEachLeavesLocalsIntact(t *testing.T) {
+	trace := traceVMSource(t, `
+func run() -> int
+    let total: int = 0
+    for item in [1, 2, 3] do
+        total = total + item
+        if item == 2 then break end
+    end
+    return total
+end
+
+test_trace(run())
+test_trace(99)`)
+
+	requireTrace(t, trace, 3, 99)
+}


### PR DESCRIPTION
## Summary

- Fecha o bug pré-existente relatado na verificação final do #33: `break` dentro de `for ... in` não saía do laço. A investigação achou **duas** causas-raiz independentes — o snippet do report esbarra nas duas.

- **Compilador** (`internal/compiler/compiler.go`, branch do `ForStatement`): o laço era empilhado em `c.loops`, mas o branch nunca fazia o pareamento que o `while` já faz — não patchava `loop.BreakJumps` nem desempilhava o laço no fim. O jump do `break` ficava com o operando de placeholder (`0xffff`), o `ip` saltava para fora do chunk e a guarda `ip >= len(c.Code)` do executor (`internal/vm/executor.go:61`) fazia `return nil`, isto é, **sucesso** — daí o sintoma exato: exit 0, saída truncada, nenhum erro. Sem o desempilhamento havia ainda dois efeitos secundários: um `break` posterior mirava o `for` já encerrado (mesmo jump nunca patchado) e `break` fora de qualquer laço deixava de ser erro de compilação.

- **Parser** (`internal/parser/parser.go`, `parseBreakStatement`): a forma inline do próprio report — `if item == 2 then break end` — nem compilava. A função avançava um token depois do `break`, violando o contrato dos laços de statement (`ParseProgram`/`parseBlockStatement`/`parseCaseBody` esperam `curToken` no último token do statement e fazem o `nextToken` eles mesmos). Na forma multilinha o `NEWLINE` absorvia o excesso e o bug não aparecia; na inline o `end` do `if` era engolido e o bloco só fechava no `end` do laço externo (`SyntaxError: expected 'end' after for loop, found EOF`). Atingia `while` também — os exemplos de `docs/concurrency.md` (`if v == -1 then break end`) não rodavam.

- Ambos pré-existentes, reproduzem em v0.4.0 e v0.5.0. Nenhum foi introduzido pelo #33.

### Antes / depois

```noxy
for item in [1, 2, 3] do
    print(item)
    if item == 2 then break end
end
print("depois do laco")
```

| | antes | depois |
|---|---|---|
| inline (acima) | `[6:1] SyntaxError: expected 'end' after for loop, found EOF`, exit 1 | `1 / 2 / depois do laco`, exit 0 |
| `break` em linha própria | `1 / 2`, exit 0 — para em silêncio | `1 / 2 / depois do laco`, exit 0 |

## Components

- `internal/compiler/compiler.go` — no fim do `ForStatement`: patch dos `loop.BreakJumps` e pop de `c.loops`. O alvo do patch fica **depois** do pop da condição e **antes** do `endScope`, que é onde a pilha do `break` (`[$collection, $index, $len]`, já que o `BreakStmt` só estoura os locais além de `EnclosingLocals`) coincide com a da saída normal — assim o `break` paga os pops do escopo wrapper junto com ela.
- `internal/parser/parser.go` — `parseBreakStatement` deixou de avançar token: retorna com `curToken` no próprio `break`, como o contrato pede.
- `internal/vm/loop_break_test.go` (novo) — 7 testes de execução ponta a ponta, via helper de trace (`test_trace`) que registra quais iterações rodaram e se o código depois do laço executou: array, map (o `for` sobre map tem o slot oculto `$map` a mais), `for` aninhado, `for` dentro de `while`, `break` do `while` depois de um `for`, inline em `while`, e locais intactos após o break.
- `internal/compiler/loop_break_test.go` (novo) — `break` solto depois de um `for` volta a ser rejeitado com `break outside of loop`.
- `CHANGELOG.md` — seção `[Unreleased] / Fixed` com as duas entradas.

## Test Plan

- [x] Implementação das duas correções
- [x] 8 testes novos, todos verificados em **RED antes** do fix (os dois últimos com os fixes revertidos via `git stash` para confirmar a falha), depois GREEN
- [x] Repro do #33 nas duas formas (inline e multilinha) rodando pelo CLI com saída completa e exit 0
- [x] Exemplo produtor/consumidor de `docs/concurrency.md` volta a rodar — antes era `[26:1] SyntaxError: expected 'end', found EOF` (confirmado com os fixes revertidos)
- [x] `go test ./...` completo verde
- [x] `go build ./...` e `go vet` limpos em `internal/parser`, `internal/compiler` e `internal/vm`
- [x] Suíte revalidada em worktree isolado a partir de `develop` (parser, compiler, vm)
- [ ] Review

## Related Issues

- Follow-up do item 2 da verificação final do #33 (bug pré-existente, issue própria sugerida no review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
