### PR TITLE
bench/cross-runtime - Suite cross-runtime situa o VM contra CPython, Lua e Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Added
+
+- Suíte de benchmark cross-runtime em `benchmarks/cross_runtime/`, comparando o
+  VM com CPython 3.13, Lua 5.4 e Go nativo na mesma carga. Sete benches
+  (`startup`, `loop_arith`, `map_churn`, `mandelbrot`, `string_ops`,
+  `bubblesort`, `fib`) escritos em Noxy e Python; `startup`, `loop_arith` e
+  `fib` também em Lua e Go, como calibração — o Lua é o comparável direto
+  (bytecode puro, sem JIT, sem inline cache) e o Go é o teto do hospedeiro.
+  Cada implementação imprime a mesma linha `CHECKSUM:` e o harness
+  (`run_cross_runtime.ps1`) aborta se divergirem, então a comparação é sempre
+  da mesma carga. Medição intercalada entre runtimes, mínimo de N execuções em
+  vez de mediana (sob carga a distribuição só tem cauda à direita) e cópia dos
+  fontes para disco local — medir de dentro do repo, que fica em OneDrive,
+  inflava os tempos em ~2x por filtro de sync e antivírus no read. Resultado em
+  `benchmarks/cross_runtime/results/`: descontado o piso de processo, o Noxy
+  está 1,8x a 9,6x atrás do CPython e ~14x a ~15x atrás do Lua, com o custo
+  concentrado em chamada de função, acesso indexado a array e operação de
+  string; o despacho de bytecode puro fica a 1,8x do CPython e o startup ganha
+  dele (63ms contra 94ms). O ranking se repetiu em cinco rodadas; as
+  magnitudes variam, porque o número líquido amplifica ruído do piso de
+  processo. Não altera comportamento da linguagem.
+
 ### Fixed
 
 - `break` dentro de `for ... in` voltou a sair do laço. O branch do

--- a/benchmarks/cross_runtime/README.md
+++ b/benchmarks/cross_runtime/README.md
@@ -1,0 +1,181 @@
+# Cross-runtime: Noxy × CPython × Lua × Go
+
+Comparação pontual de performance entre o VM do Noxy e outros runtimes, para
+ter uma referência externa de onde o interpretador está hoje. Não é uma suíte
+extensa: são seis cargas CPU-bound curtas, escolhidas para isolar subsistemas
+diferentes do VM, mais um piso de processo.
+
+## Como rodar
+
+```powershell
+./run_cross_runtime.ps1 -Noxy C:\caminho\local\noxy.exe
+```
+
+Saída em `results/cross_runtime.md`. `lua` e `go` são opcionais — se não
+estiverem no `PATH`, viram `-` na tabela em vez de erro.
+
+## Cobertura
+
+| bench | subsistema exercitado | noxy | python | lua | go |
+|---|---|---|---|---|---|
+| `startup` | subir processo, compilar, imprimir uma linha | ✅ | ✅ | ✅ | ✅ |
+| `loop_arith` | despacho de bytecode e aritmética inteira | ✅ | ✅ | ✅ | ✅ |
+| `fib` | chamada de função (~2,7M chamadas) | ✅ | ✅ | ✅ | ✅ |
+| `bubblesort` | leitura/escrita indexada em array, O(n²) | ✅ | ✅ | – | – |
+| `map_churn` | hashmap com chave string | ✅ | ✅ | – | – |
+| `string_ops` | construção, concatenação e fatiamento | ✅ | ✅ | – | – |
+| `mandelbrot` | aritmética de ponto flutuante | ✅ | ✅ | – | – |
+
+Noxy e CPython são a comparação principal. **Lua 5.4 e Go entraram como
+calibração** em três benches, para responder "longe do quê?":
+
+- **Lua** é o comparável mais direto que existe para o Noxy — interpretador de
+  bytecode puro, sem JIT, sem inline cache. A diferença é que ele é
+  *dinamicamente* tipado, então não tem a informação que o Noxy tem em tempo
+  de compilação.
+- **Go** é o teto do hospedeiro: quanto do tempo é o trabalho em si e quanto é
+  a camada de interpretação.
+
+Cada implementação de um bench roda **o mesmo algoritmo**, escrito da mesma
+forma: mesmos laços, mesmas operações, sem substituir o corpo por builtin
+nativo de um lado só. Todas imprimem uma linha `CHECKSUM:` e o runner aborta se
+divergirem — isso garante que a comparação é da mesma carga, não de programas
+parecidos.
+
+Os quatro rodam dentro de uma função, e não em escopo de módulo: no CPython,
+variável local é acesso por índice em array e global é lookup em dict, o que
+sozinho já valeria ~2x de vantagem indevida ao Python.
+
+## Metodologia
+
+Três decisões, cada uma por um efeito medido neste repo:
+
+1. **Intercalado.** Os runtimes alternam dentro da mesma janela de tempo, como
+   em `interleaved_compare.ps1`. Rodar todas as amostras de um runtime e depois
+   do outro deixa a comparação exposta a drift térmico e carga de background.
+2. **Mínimo, não mediana.** Sob carga a distribuição é assimétrica à direita:
+   interferência só adiciona tempo, nunca remove; o mínimo é a amostra menos
+   contaminada. Em dois lotes idênticos aqui, a mediana variou ~12% enquanto o
+   mínimo manteve o ratio estável.
+3. **Disco local.** O runner copia os fontes para `%TEMP%` antes de medir.
+   Medir com os fontes no diretório do repo (que fica em OneDrive) inflou os
+   tempos em ~2x, por filtro de sync e antivírus no read. Aponte `-Noxy` para
+   um binário em disco local também.
+
+## Resultados
+
+Noxy v0.5.0 (sobre develop @ 21e7b96) · CPython 3.13.1 · Lua 5.4.7 · Go 1.24.11
+· i7-1165G7 (4C/8T) · Windows 11 · mínimo de 9 execuções intercaladas. Números
+completos em [`results/cross_runtime.md`](results/cross_runtime.md).
+
+### Tempo total (ms)
+
+| bench | noxy | python | lua | go |
+|---|---|---|---|---|
+| `startup` | 63,0 | 94,3 | 45,5 | 47,6 |
+| `loop_arith` | 519,4 | 350,0 | 77,7 | 48,9 |
+| `map_churn` | 324,4 | 182,7 | – | – |
+| `mandelbrot` | 428,6 | 166,7 | – | – |
+| `string_ops` | 314,4 | 135,3 | – | – |
+| `bubblesort` | 666,9 | 157,1 | – | – |
+| `fib` | 804,9 | 187,7 | 93,8 | 47,8 |
+
+### Tempo de execução, descontado o piso de `startup` (ms)
+
+| bench | noxy | python | lua | go | noxy ÷ python | noxy ÷ lua |
+|---|---|---|---|---|---|---|
+| `loop_arith` | 456,4 | 255,7 | 32,2 | ~0 | **1,8x** | **14,2x** |
+| `map_churn` | 261,4 | 88,4 | – | – | **3,0x** | – |
+| `mandelbrot` | 365,6 | 72,4 | – | – | **5,1x** | – |
+| `string_ops` | 251,4 | 41,0 | – | – | **6,1x** | – |
+| `fib` | 741,9 | 93,4 | 48,3 | ~0 | **7,9x** | **15,4x** |
+| `bubblesort` | 603,9 | 62,8 | – | – | **9,6x** | – |
+
+`~0` = o trabalho cabe dentro do ruído do piso de processo do runtime.
+
+### Estabilidade entre rodadas
+
+Cinco suítes completas em condições de carga diferentes. **O ranking é idêntico
+nas cinco**; as magnitudes variam:
+
+| bench | noxy ÷ python (faixa nas 5 rodadas) |
+|---|---|
+| `loop_arith` | 1,6x – 1,9x |
+| `map_churn` | 2,4x – 3,2x |
+| `mandelbrot` | 4,6x – 5,1x |
+| `string_ops` | 4,4x – 7,1x |
+| `fib` | 6,5x – 7,9x |
+| `bubblesort` | 7,4x – 9,6x |
+
+Contra o Lua (duas rodadas): `loop_arith` 10,7x – 14,2x, `fib` 14,0x – 15,4x.
+No `startup`, o Noxy fica 1,3x – 1,5x à frente do CPython.
+
+**Limitação conhecida, e é a primeira coisa a corrigir nesta suíte:** o número
+líquido é razão entre *diferenças*, então ele amplifica qualquer variação no
+piso de processo. Onde o trabalho do runtime é pequeno perto do próprio piso, a
+barra de erro fica grande — em `string_ops` o CPython faz ~41 ms de trabalho com
+um piso de ~75–94 ms, e por isso o ratio oscila de 4,4x a 7,1x. `loop_arith` e
+`mandelbrot`, cujo trabalho domina o piso, ficam dentro de ±10%. O conserto é
+aumentar as contagens de iteração até o trabalho de cada runtime ser pelo menos
+~5x o piso dele; ainda não foi feito.
+
+Trate o resultado como **ordem de grandeza com ranking confiável**, não como
+número de três dígitos significativos.
+
+## Leitura
+
+**O CPython é uma régua enganosa.** Ele não é o piso da comparação — é o meio
+da tabela. O Lua 5.4, com um VM mais simples e sem tipos estáticos, é ~2x mais
+rápido que o CPython no `fib` e ~8x no loop apertado. Contra o Lua, o Noxy fica
+**14x a 15x mais lento**; contra o CPython, 1,8x a 9,6x.
+
+**O custo não está distribuído por igual — ele se concentra:**
+
+- `loop_arith` é o piso: laço `while` com aritmética inteira e atribuição de
+  local, sem chamada, sem índice, sem alocação. A 1,8x do CPython, o despacho
+  de bytecode puro do Noxy é competitivo com o dele. Mas o mesmo bench está a
+  14,2x do Lua — ou seja, "competitivo com o CPython" aqui é fraqueza do
+  CPython em loop numérico, não força do Noxy.
+- A partir daí o gap abre com o *tipo* de operação, não com o volume:
+  hashmap 3,0x, ponto flutuante 5,1x, string 6,1x, e o pior ponto em
+  **chamada de função (7,9x)** e **acesso indexado a array (9,6x)**.
+
+**A pista mais acionável:** `fib` não toca em nenhum tipo composto — são só
+ints. O custo ali é do protocolo de chamada em si (setup de frame), não da
+validação de tipos O(n)/chamada já mapeada para maps/structs/refs.
+
+**A inversão estrutural.** O Noxy é estaticamente tipado e compila para
+bytecode: os tipos são conhecidos em tempo de compilação, que é exatamente a
+informação que CPython e Lua pagam para descobrir em runtime. Hoje isso não
+está sendo convertido em velocidade. Some-se que o CPython 3.11+ tem um
+interpretador especializador adaptativo com inline caches nas mesmas operações
+onde o Noxy mais perde, e o formato do resultado fica consistente com **"falta
+camada de especialização"**, não com "o loop principal é ruim".
+
+**Ressalva:** essa atribuição de causa é hipótese lida a partir do formato dos
+números, **não de profiling**. Confirmar exige um `pprof` em `fib` e
+`bubblesort` antes de otimizar qualquer coisa.
+
+## Onde o Noxy ganha
+
+- **Startup contra o CPython:** 63 ms contra 94 ms, ~1,5x mais rápido — real
+  para script curto e para o caso Lambda, onde o piso de processo é boa parte
+  do custo. A vantagem, porém, é sobre o
+  CPython, não sobre todo mundo (Lua e Go sobem em ~46 ms).
+- **Carga I/O-bound:** nos casos que o Noxy realmente atende hoje (servidor
+  HTTP, SQLite, NoxyDB), o gargalo é I/O e a velocidade do interpretador quase
+  não aparece.
+- **Ordem de grandeza:** estar 2x a 10x atrás do CPython em v0.5.0 é resultado
+  respeitável em termos absolutos. A maioria das implementações jovens fica
+  50x a 100x atrás.
+
+Sendo justo com o Lua: são 30 anos de tuning em C, VM baseada em registradores,
+sem GC concorrente e sem bounds check do Go. Não é meta de curto prazo — é a
+referência de onde dá para chegar.
+
+## Próximos passos sugeridos
+
+1. Escalar as cargas até o trabalho dominar o piso de processo (ver limitação
+   acima) e re-medir.
+2. `pprof` em `fib` e `bubblesort` para confirmar onde o tempo vai.
+3. Portar os quatro benches restantes para Lua, fechando a calibração.

--- a/benchmarks/cross_runtime/bubblesort.nx
+++ b/benchmarks/cross_runtime/bubblesort.nx
@@ -1,0 +1,37 @@
+// O(n^2) de leitura/escrita indexada em array, ordenado in-place via ref
+// (equivalente a lista Python, que ja e passada por referencia).
+func bubble(data: ref int[]) -> void
+    let n: int = length(data)
+    let i: int = 0
+    while i < n do
+        let j: int = 0
+        while j < n - i - 1 do
+            if data[j] > data[j + 1] then
+                let tmp: int = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            end
+            j = j + 1
+        end
+        i = i + 1
+    end
+end
+
+func main()
+    let data: int[]
+    let i: int = 0
+    while i < 1200 do
+        append(data, (i * 7919) % 104729)
+        i = i + 1
+    end
+    bubble(data)
+    let s: int = 0
+    i = 0
+    while i < 1200 do
+        s = s + data[i] * (i % 13)
+        i = i + 1
+    end
+    print(f"CHECKSUM:{s}")
+end
+
+main()

--- a/benchmarks/cross_runtime/bubblesort.py
+++ b/benchmarks/cross_runtime/bubblesort.py
@@ -1,0 +1,31 @@
+# O(n^2) de leitura/escrita indexada em array, ordenado in-place.
+def bubble(data):
+    n = len(data)
+    i = 0
+    while i < n:
+        j = 0
+        while j < n - i - 1:
+            if data[j] > data[j + 1]:
+                tmp = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            j = j + 1
+        i = i + 1
+
+
+def main():
+    data = []
+    i = 0
+    while i < 1200:
+        data.append((i * 7919) % 104729)
+        i = i + 1
+    bubble(data)
+    s = 0
+    i = 0
+    while i < 1200:
+        s = s + data[i] * (i % 13)
+        i = i + 1
+    print(f"CHECKSUM:{s}")
+
+
+main()

--- a/benchmarks/cross_runtime/fib.lua
+++ b/benchmarks/cross_runtime/fib.lua
@@ -1,0 +1,11 @@
+-- Recursao pura: custo de chamada de funcao + aritmetica de inteiros.
+local function fib(n)
+  if n <= 1 then return n end
+  return fib(n - 1) + fib(n - 2)
+end
+
+local function main()
+  print("CHECKSUM:" .. fib(30))
+end
+
+main()

--- a/benchmarks/cross_runtime/fib.nx
+++ b/benchmarks/cross_runtime/fib.nx
@@ -1,0 +1,13 @@
+// Recursao pura: custo de chamada de funcao + aritmetica de inteiros.
+func fib(n: int) -> int
+    if n <= 1 then
+        return n
+    end
+    return fib(n - 1) + fib(n - 2)
+end
+
+func main()
+    print(f"CHECKSUM:{fib(30)}")
+end
+
+main()

--- a/benchmarks/cross_runtime/fib.py
+++ b/benchmarks/cross_runtime/fib.py
@@ -1,0 +1,12 @@
+# Recursao pura: custo de chamada de funcao + aritmetica de inteiros.
+def fib(n: int) -> int:
+    if n <= 1:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+
+def main():
+    print(f"CHECKSUM:{fib(30)}")
+
+
+main()

--- a/benchmarks/cross_runtime/go/fib/main.go
+++ b/benchmarks/cross_runtime/go/fib/main.go
@@ -1,0 +1,18 @@
+// Recursao pura: custo de chamada de funcao + aritmetica de inteiros.
+//
+// Um .go por diretorio: varios "package main" com func main() no mesmo
+// diretorio quebram `go build ./...` no modulo do repo.
+package main
+
+import "fmt"
+
+func fib(n int) int {
+	if n <= 1 {
+		return n
+	}
+	return fib(n-1) + fib(n-2)
+}
+
+func main() {
+	fmt.Printf("CHECKSUM:%d\n", fib(30))
+}

--- a/benchmarks/cross_runtime/go/loop_arith/main.go
+++ b/benchmarks/cross_runtime/go/loop_arith/main.go
@@ -1,0 +1,13 @@
+// Loop apertado: despacho e aritmetica inteira, sem alocacao.
+package main
+
+import "fmt"
+
+func main() {
+	i, s := 0, 0
+	for i < 3000000 {
+		s = (s + i*3) % 1000003
+		i = i + 1
+	}
+	fmt.Printf("CHECKSUM:%d\n", s)
+}

--- a/benchmarks/cross_runtime/go/startup/main.go
+++ b/benchmarks/cross_runtime/go/startup/main.go
@@ -1,0 +1,8 @@
+// Piso de custo: subir o processo e imprimir uma linha.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("CHECKSUM:0")
+}

--- a/benchmarks/cross_runtime/loop_arith.lua
+++ b/benchmarks/cross_runtime/loop_arith.lua
@@ -1,0 +1,11 @@
+-- Loop apertado: despacho de bytecode e aritmetica inteira, sem alocacao.
+local function main()
+  local i, s = 0, 0
+  while i < 3000000 do
+    s = (s + i * 3) % 1000003
+    i = i + 1
+  end
+  print("CHECKSUM:" .. s)
+end
+
+main()

--- a/benchmarks/cross_runtime/loop_arith.nx
+++ b/benchmarks/cross_runtime/loop_arith.nx
@@ -1,0 +1,12 @@
+// Loop apertado: despacho de bytecode e aritmetica inteira, sem alocacao.
+func main()
+    let i: int = 0
+    let s: int = 0
+    while i < 3000000 do
+        s = (s + i * 3) % 1000003
+        i = i + 1
+    end
+    print(f"CHECKSUM:{s}")
+end
+
+main()

--- a/benchmarks/cross_runtime/loop_arith.py
+++ b/benchmarks/cross_runtime/loop_arith.py
@@ -1,0 +1,11 @@
+# Loop apertado: despacho de bytecode e aritmetica inteira, sem alocacao.
+def main():
+    i = 0
+    s = 0
+    while i < 3000000:
+        s = (s + i * 3) % 1000003
+        i = i + 1
+    print(f"CHECKSUM:{s}")
+
+
+main()

--- a/benchmarks/cross_runtime/mandelbrot.nx
+++ b/benchmarks/cross_runtime/mandelbrot.nx
@@ -1,0 +1,31 @@
+// Aritmetica de ponto flutuante em loop fechado.
+func mandel(w: int, h: int, max_iter: int) -> int
+    let total: int = 0
+    let py: int = 0
+    while py < h do
+        let y0: float = to_float(py) / to_float(h) * 2.0 - 1.0
+        let px: int = 0
+        while px < w do
+            let x0: float = to_float(px) / to_float(w) * 3.0 - 2.0
+            let x: float = 0.0
+            let y: float = 0.0
+            let it: int = 0
+            while it < max_iter && x * x + y * y <= 4.0 do
+                let xt: float = x * x - y * y + x0
+                y = 2.0 * x * y + y0
+                x = xt
+                it = it + 1
+            end
+            total = total + it
+            px = px + 1
+        end
+        py = py + 1
+    end
+    return total
+end
+
+func main()
+    print(f"CHECKSUM:{mandel(200, 200, 50)}")
+end
+
+main()

--- a/benchmarks/cross_runtime/mandelbrot.py
+++ b/benchmarks/cross_runtime/mandelbrot.py
@@ -1,0 +1,28 @@
+# Aritmetica de ponto flutuante em loop fechado.
+def mandel(w: int, h: int, max_iter: int) -> int:
+    total = 0
+    py = 0
+    while py < h:
+        y0 = float(py) / float(h) * 2.0 - 1.0
+        px = 0
+        while px < w:
+            x0 = float(px) / float(w) * 3.0 - 2.0
+            x = 0.0
+            y = 0.0
+            it = 0
+            while it < max_iter and x * x + y * y <= 4.0:
+                xt = x * x - y * y + x0
+                y = 2.0 * x * y + y0
+                x = xt
+                it = it + 1
+            total = total + it
+            px = px + 1
+        py = py + 1
+    return total
+
+
+def main():
+    print(f"CHECKSUM:{mandel(200, 200, 50)}")
+
+
+main()

--- a/benchmarks/cross_runtime/map_churn.nx
+++ b/benchmarks/cross_runtime/map_churn.nx
@@ -1,0 +1,19 @@
+// Escrita e leitura intensa em hashmap de chave string.
+func main()
+    let m: map[string, int] = {"seed": 0}
+    let round: int = 0
+    let s: int = 0
+    while round < 100 do
+        let i: int = 0
+        while i < 3000 do
+            let k: string = f"k{i % 500}"
+            m[k] = round * i
+            s = s + m[k] % 7
+            i = i + 1
+        end
+        round = round + 1
+    end
+    print(f"CHECKSUM:{s}")
+end
+
+main()

--- a/benchmarks/cross_runtime/map_churn.py
+++ b/benchmarks/cross_runtime/map_churn.py
@@ -1,0 +1,17 @@
+# Escrita e leitura intensa em hashmap de chave string.
+def main():
+    m = {"seed": 0}
+    rnd = 0
+    s = 0
+    while rnd < 100:
+        i = 0
+        while i < 3000:
+            k = f"k{i % 500}"
+            m[k] = rnd * i
+            s = s + m[k] % 7
+            i = i + 1
+        rnd = rnd + 1
+    print(f"CHECKSUM:{s}")
+
+
+main()

--- a/benchmarks/cross_runtime/results/cross_runtime.md
+++ b/benchmarks/cross_runtime/results/cross_runtime.md
@@ -1,0 +1,33 @@
+# Cross-runtime: Noxy x CPython x Lua x Go
+
+- noxy: Noxy v0.5.0, build de `bench/cross-runtime` sobre develop @ 21e7b96, em disco local
+- python: Python 3.13.1
+- lua: Lua 5.4.7  Copyright (C) 1994-2024 Lua.org, PUC-Rio
+- go: go version go1.24.11 windows/amd64
+- Data: 2026-08-17T23:18:06
+- Runs por bench: 9, intercalados; **minimo** reportado
+
+## Tempo total (ms)
+
+| bench | noxy | python | lua | go |
+|---|---|---|---|---|
+| `bubblesort` | 666,9 | 157,1 | - | - |
+| `fib` | 804,9 | 187,7 | 93,8 | 47,8 |
+| `loop_arith` | 519,4 | 350,0 | 77,7 | 48,9 |
+| `mandelbrot` | 428,6 | 166,7 | - | - |
+| `map_churn` | 324,4 | 182,7 | - | - |
+| `startup` | 63,0 | 94,3 | 45,5 | 47,6 |
+| `string_ops` | 314,4 | 135,3 | - | - |
+
+## Tempo de execucao, descontado o piso de `startup` (ms)
+
+| bench | noxy | python | lua | go |
+|---|---|---|---|---|
+| `bubblesort` | 603,9 | 62,8 | - | - |
+| `fib` | 741,9 | 93,4 | 48,3 | ~0 |
+| `loop_arith` | 456,4 | 255,7 | 32,2 | ~0 |
+| `mandelbrot` | 365,6 | 72,4 | - | - |
+| `map_churn` | 261,4 | 88,4 | - | - |
+| `string_ops` | 251,4 | 41,0 | - | - |
+
+`~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.

--- a/benchmarks/cross_runtime/run_cross_runtime.ps1
+++ b/benchmarks/cross_runtime/run_cross_runtime.ps1
@@ -1,0 +1,163 @@
+param(
+    [string]$Noxy = (Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) "noxy.exe"),
+    [string]$Python = "python",
+    [string]$Lua = "lua",
+    [int]$Runs = 9
+)
+# Compara o VM do Noxy com outros runtimes na mesma carga.
+#
+# Noxy e CPython cobrem os sete benches. Lua 5.4 e Go nativo cobrem so tres
+# (startup, loop_arith, fib): entraram como calibracao, para responder "longe
+# do que?" — o Lua e o comparavel direto (bytecode puro, sem JIT, sem inline
+# cache, dinamicamente tipado) e o Go e o teto do hospedeiro. Um runtime
+# ausente vira "-" na tabela, nao um erro.
+#
+# Tres decisoes de metodologia, cada uma por um efeito medido neste repo:
+#
+# 1. Intercalado (mesma tecnica de interleaved_compare.ps1): os runtimes
+#    alternam dentro da mesma janela de tempo, imunizando a comparacao contra
+#    drift termico/carga de background que contamina rodadas sequenciais por
+#    rotulo.
+#
+# 2. Reporta o MINIMO, nao a mediana. Sob carga a distribuicao e assimetrica a
+#    direita: interferencia so adiciona tempo, nunca remove. Medido aqui: a
+#    mediana variou ~12% entre dois lotes identicos, o minimo manteve o ratio.
+#
+# 3. Copia os fontes para disco local. Este repo vive em OneDrive, e medir de
+#    la inflou os tempos em ~2x (filtro de sync + antivirus no read). Aponte
+#    -Noxy para um binario em disco local tambem.
+#
+# Cada implementacao de um bench imprime a mesma linha CHECKSUM: o script
+# aborta se divergirem, porque ai nao seria a mesma carga.
+$ErrorActionPreference = "Stop"
+
+function Have([string]$exe) {
+    return [bool](Get-Command $exe -ErrorAction SilentlyContinue)
+}
+
+$work = Join-Path $env:TEMP ("noxy_cross_" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Force $work | Out-Null
+
+try {
+    Copy-Item (Join-Path $PSScriptRoot "*.nx")  $work -Force
+    Copy-Item (Join-Path $PSScriptRoot "*.py")  $work -Force
+    Copy-Item (Join-Path $PSScriptRoot "*.lua") $work -Force -ErrorAction SilentlyContinue
+
+    $hasLua = Have $Lua
+    $hasGo  = Have "go"
+
+    # Go compila antes de medir: o benchmark e do binario, nao do compilador.
+    $goExe = @{}
+    if ($hasGo) {
+        Get-ChildItem (Join-Path $PSScriptRoot "go") -Directory | ForEach-Object {
+            $out = Join-Path $work ("go_" + $_.Name + ".exe")
+            & go build -o $out (Join-Path $_.FullName "main.go")
+            if ($LASTEXITCODE -ne 0) { throw "go build falhou para $($_.Name)" }
+            $goExe[$_.Name] = $out
+        }
+    }
+
+    # Ordem fixa: define a ordem das colunas e a ordem do intercalamento.
+    $order = @("noxy", "python", "lua", "go")
+
+    $rows = @()
+    foreach ($p in (Get-ChildItem $work -Filter "*.nx" | Sort-Object Name)) {
+        $b = $p.BaseName
+
+        # Monta so os runtimes que existem para este bench.
+        $cmds = [ordered]@{}
+        $cmds["noxy"]   = { & $Noxy   $p.FullName }.GetNewClosure()
+        $py = [IO.Path]::ChangeExtension($p.FullName, ".py")
+        if (Test-Path $py) { $cmds["python"] = { & $Python $py }.GetNewClosure() }
+        $lu = [IO.Path]::ChangeExtension($p.FullName, ".lua")
+        if ($hasLua -and (Test-Path $lu)) { $cmds["lua"] = { & $Lua $lu }.GetNewClosure() }
+        if ($goExe.ContainsKey($b)) { $g = $goExe[$b]; $cmds["go"] = { & $g }.GetNewClosure() }
+
+        # Warmup (aquece o cache de arquivo) + equivalencia entre runtimes.
+        $chk = $null
+        foreach ($k in $cmds.Keys) {
+            $c = (& $cmds[$k] | Where-Object { $_ -match "^CHECKSUM:" })
+            if (-not $c) { throw "$b/$k : sem linha CHECKSUM" }
+            if ($null -eq $chk) { $chk = $c }
+            elseif ($c -ne $chk) { throw "$b : checksum divergente ($k=$c, esperado $chk)" }
+        }
+
+        $times = @{}
+        foreach ($k in $cmds.Keys) { $times[$k] = @() }
+        for ($i = 0; $i -lt $Runs; $i++) {
+            foreach ($k in $cmds.Keys) {
+                $times[$k] += (Measure-Command { & $cmds[$k] | Out-Null }).TotalMilliseconds
+            }
+        }
+
+        $row = [ordered]@{ bench = $b; checksum = $chk }
+        foreach ($k in $order) {
+            $row[$k] = if ($times.ContainsKey($k)) {
+                [math]::Round(($times[$k] | Measure-Object -Minimum).Minimum, 1)
+            } else { $null }
+        }
+        $rows += [pscustomobject]$row
+
+        $shown = ($order | Where-Object { $null -ne $row[$_] } |
+                  ForEach-Object { "{0}={1}ms" -f $_, $row[$_] }) -join "  "
+        Write-Host ("{0,-12} {1}" -f $b, $shown)
+    }
+} finally {
+    Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ---- relatorio ----
+$base = $rows | Where-Object { $_.bench -eq "startup" }
+$present = $order | Where-Object { $b = $_; ($rows | Where-Object { $null -ne $_.$b }).Count -gt 0 }
+
+function Cell($v) { if ($null -eq $v) { "-" } else { "{0:N1}" -f $v } }
+
+# Liquido: total menos o piso de processo do proprio runtime. Para runtimes
+# rapidos o trabalho pode caber dentro do ruido do piso, e a subtracao vai a
+# zero ou fica negativa — reportamos "~0" em vez de fingir precisao.
+function Net($v, $floor) {
+    if ($null -eq $v -or $null -eq $floor) { return "-" }
+    $n = $v - $floor
+    if ($n -le 5) { return "~0" }
+    return "{0:N1}" -f $n
+}
+
+$lines = @(
+    "# Cross-runtime: Noxy x CPython x Lua x Go",
+    "",
+    "- noxy: ``$Noxy``",
+    "- python: $((& $Python --version 2>&1) -join '')",
+    "- lua: $(if (Have $Lua) { (& $Lua -v 2>&1) -join '' } else { 'ausente' })",
+    "- go: $(if (Have 'go') { (& go version) -join '' } else { 'ausente' })",
+    "- Data: $(Get-Date -Format s)",
+    "- Runs por bench: $Runs, intercalados; **minimo** reportado",
+    "",
+    "## Tempo total (ms)",
+    "",
+    # Parenteses obrigatorios: dentro de @(...) o "+" entre strings vira
+    # concatenacao de array e a linha sai quebrada em varios elementos.
+    ("| bench | " + ($present -join " | ") + " |"),
+    ("|---" * ($present.Count + 1) + "|")
+)
+foreach ($r in $rows) {
+    $lines += "| ``$($r.bench)`` | " + (($present | ForEach-Object { Cell $r.$_ }) -join " | ") + " |"
+}
+
+$lines += @(
+    "",
+    "## Tempo de execucao, descontado o piso de ``startup`` (ms)",
+    "",
+    ("| bench | " + ($present -join " | ") + " |"),
+    ("|---" * ($present.Count + 1) + "|")
+)
+foreach ($r in $rows) {
+    if ($r.bench -eq "startup") { continue }
+    $lines += "| ``$($r.bench)`` | " + (($present | ForEach-Object { Net $r.$_ $base.$_ }) -join " | ") + " |"
+}
+$lines += ""
+$lines += "``~0`` = o trabalho cabe dentro do ruido do piso de processo do runtime."
+
+$outDir = Join-Path $PSScriptRoot "results"
+New-Item -ItemType Directory -Force $outDir | Out-Null
+$lines | Set-Content (Join-Path $outDir "cross_runtime.md")
+Write-Host "wrote results/cross_runtime.md"

--- a/benchmarks/cross_runtime/startup.lua
+++ b/benchmarks/cross_runtime/startup.lua
@@ -1,0 +1,6 @@
+-- Piso de custo: subir o processo, compilar o fonte e imprimir uma linha.
+local function main()
+  print("CHECKSUM:0")
+end
+
+main()

--- a/benchmarks/cross_runtime/startup.nx
+++ b/benchmarks/cross_runtime/startup.nx
@@ -1,0 +1,6 @@
+// Piso de custo: subir o processo, compilar e imprimir uma linha.
+func main()
+    print("CHECKSUM:0")
+end
+
+main()

--- a/benchmarks/cross_runtime/startup.py
+++ b/benchmarks/cross_runtime/startup.py
@@ -1,0 +1,6 @@
+# Piso de custo: subir o processo, compilar e imprimir uma linha.
+def main():
+    print("CHECKSUM:0")
+
+
+main()

--- a/benchmarks/cross_runtime/string_ops.nx
+++ b/benchmarks/cross_runtime/string_ops.nx
@@ -1,0 +1,18 @@
+// Construcao, concatenacao e fatiamento de strings curtas.
+use strings select *
+
+func main()
+    let i: int = 0
+    let acc: int = 0
+    while i < 200000 do
+        let s: string = "item_" + to_str(i)
+        acc = acc + length(s)
+        if substring(s, 5, 6) == "1" then
+            acc = acc + 1
+        end
+        i = i + 1
+    end
+    print(f"CHECKSUM:{acc}")
+end
+
+main()

--- a/benchmarks/cross_runtime/string_ops.py
+++ b/benchmarks/cross_runtime/string_ops.py
@@ -1,0 +1,14 @@
+# Construcao, concatenacao e fatiamento de strings curtas.
+def main():
+    i = 0
+    acc = 0
+    while i < 200000:
+        s = "item_" + str(i)
+        acc = acc + len(s)
+        if s[5:6] == "1":
+            acc = acc + 1
+        i = i + 1
+    print(f"CHECKSUM:{acc}")
+
+
+main()


### PR DESCRIPTION
## Summary

- Suíte de benchmark cross-runtime em `benchmarks/cross_runtime/`, situando o VM do Noxy contra CPython 3.13, Lua 5.4 e Go nativo na mesma carga.
- Sete benches em Noxy e Python (`startup`, `loop_arith`, `map_churn`, `mandelbrot`, `string_ops`, `bubblesort`, `fib`); `startup`, `loop_arith` e `fib` também em Lua e Go, como calibração — o Lua é o comparável direto (bytecode puro, sem JIT, sem inline cache) e o Go é o teto do hospedeiro.
- **Equivalência por construção:** cada implementação imprime a mesma linha `CHECKSUM:` e o harness aborta se divergirem, então a comparação nunca degrada para "programas parecidos". Os quatro rodam dentro de uma função, não em escopo de módulo — no CPython, local é acesso por índice e global é lookup em dict, o que sozinho valeria ~2x de vantagem indevida ao Python.
- Três decisões de medição, cada uma por um efeito medido neste repo: intercalar os runtimes na mesma janela de tempo; reportar o **mínimo** em vez da mediana (sob carga a distribuição só tem cauda à direita, e a mediana variou ~12% entre lotes idênticos); e copiar os fontes para disco local, porque medir de dentro do repo — que fica em OneDrive — inflava os tempos em ~2x por filtro de sync e antivírus no read.
- **Não altera comportamento da linguagem.** Só adiciona benchmark e documentação; o diff não toca nada em `internal/`.

### Resultado

Descontado o piso de processo, o Noxy está **1,8x a 9,6x atrás do CPython** e **~14x a ~15x atrás do Lua**. O custo não está distribuído por igual — ele se concentra:

| bench | noxy ÷ python | noxy ÷ lua |
|---|---|---|
| `loop_arith` (despacho puro) | 1,8x | 14,2x |
| `map_churn` | 3,0x | – |
| `mandelbrot` | 5,1x | – |
| `string_ops` | 6,1x | – |
| `fib` (chamada de função) | 7,9x | 15,4x |
| `bubblesort` (índice em array) | 9,6x | – |

O despacho de bytecode puro parece competitivo com o do CPython (1,8x), mas o mesmo bench está a 14,2x do Lua — ou seja, "competitivo com o CPython" ali é fraqueza do CPython em loop numérico, não força do Noxy. O pior ponto é chamada de função e acesso indexado a array. No `startup` o Noxy ganha do CPython (63ms contra 94ms), embora Lua e Go subam em ~46ms.

`fib` não toca em nenhum tipo composto — são só ints — então o custo ali é do protocolo de chamada em si (setup de frame), não da validação de tipos O(n)/chamada já mapeada para maps/structs/refs. **Isso é hipótese lida do formato dos números, não de profiling**; confirmar exige `pprof`.

## Components

- `benchmarks/cross_runtime/*.nx` — sete benches em Noxy.
- `benchmarks/cross_runtime/*.py` — os mesmos sete em Python, algoritmo idêntico laço a laço.
- `benchmarks/cross_runtime/*.lua` — `startup`, `loop_arith`, `fib` em Lua 5.4.
- `benchmarks/cross_runtime/go/<bench>/main.go` — os mesmos três em Go. Um `.go` por diretório: vários `package main` com `func main()` no mesmo diretório quebrariam `go build ./...` no módulo do repo.
- `benchmarks/cross_runtime/run_cross_runtime.ps1` — harness. Descobre benches pelos `.nx`, compila os Go antes de medir, verifica os checksums, intercala e reporta o mínimo. `lua` e `go` são opcionais: ausentes viram `-` na tabela, não erro.
- `benchmarks/cross_runtime/results/cross_runtime.md` — saída da rodada de referência, medida sobre `develop @ 21e7b96`.
- `benchmarks/cross_runtime/README.md` — cobertura, metodologia, resultados, leitura e limitações.
- `CHANGELOG.md` — entrada em `[Unreleased] / Added`, acima do `### Fixed` do #34.

## Limitação conhecida

O número líquido é razão entre *diferenças*, então amplifica variação no piso de processo. Onde o trabalho do runtime é pequeno perto do próprio piso, a barra de erro fica grande: em `string_ops` o CPython faz ~41ms de trabalho com piso de ~75–94ms, e o ratio oscilou de 4,4x a 7,1x entre rodadas. `loop_arith` e `mandelbrot`, cujo trabalho domina o piso, ficaram dentro de ±10%. O conserto é escalar as contagens de iteração até o trabalho ser ~5x o piso — está documentado no README como o primeiro próximo passo, e não foi feito neste PR.

Trate o resultado como ordem de grandeza com ranking confiável, não como três dígitos significativos.

## Test Plan

- [x] Checksums idênticos entre os quatro runtimes em todos os sete benches (o harness aborta se divergirem — não abortou)
- [x] Rebaseado sobre `develop @ 21e7b96` (pós-merge do #34) e **re-medido na base nova**; conflito no `CHANGELOG.md` resolvido mantendo o `### Fixed` do #34 verbatim e inserindo o `### Added` acima
- [x] Checksums revalidados após o rebase — o fix do `break` não alterou resultado nem performance dos benches (nenhum deles usa `break`)
- [x] Cinco suítes completas em condições de carga diferentes; ranking idêntico nas cinco
- [x] `go build ./...` passa com os novos diretórios `go/<bench>/`
- [x] `go vet ./benchmarks/...` passa
- [x] Degradação graciosa validada: com `-Lua` apontando para binário inexistente, a coluna vira `-`, o header registra `lua: ausente` e o exit code é 0
- [x] Geração do markdown corrigida (dentro de `@(...)` o `+` entre strings virava concatenação de array e quebrava as linhas da tabela)
- [ ] Rodar em outra máquina/SO para confirmar que o ranking se mantém fora deste hardware
- [ ] `pprof` em `fib` e `bubblesort` para confirmar a hipótese de custo no setup de frame
