### PR TITLE
perf/vm-dispatch-fase1 - Fase 1 de dispatch e chamadas: fib 2,1x, loop_arith 1,63x, mandelbrot 1,74x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ AWS_DEPLOY_GUIDE.md
 
 *.db
 *.exe
+*.prof
 .gemini/
 SAFE_MODE_PROMPT.md
 vault.key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] - 2026-08-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,49 @@
   magnitudes variam, porque o número líquido amplifica ruído do piso de
   processo. Não altera comportamento da linguagem.
 
+- Flags `--cpuprofile`/`--memprofile` na CLI (`cmd/noxy/main.go`), para
+  gravar profile de CPU e de heap do programa Noxy em execução — parte da
+  infraestrutura de medição da fase 1 de perf de dispatch/chamadas (ver
+  seção Performance abaixo).
+
+### Performance
+
+- Fase 1 de perf de dispatch e chamadas (branch `perf/vm-dispatch-fase1`,
+  spec `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md`).
+  `OP_CALL_STATIC` (`internal/vm/calls.go`) pula `validateParameterModes` em
+  chamadas de closure cujo call site o compilador provou estaticamente
+  (`isExact`, `internal/compiler/compiler.go`); o `CallFrame` de cada chamada
+  passou a reusar um array de valores em vez de alocar um novo a cada
+  chamada (allocs/op de uma chamada típica: 1012 → 10). Mais 13 opcodes
+  especializados de despacho, todos por APPEND ao fim do bloco de constantes
+  de `internal/chunk/chunk.go`: seis pares comparação+salto fundidos para
+  inteiro (`OP_JUMP_IF_LT_INT`/`LE`/`GT`/`GE`/`EQ`/`NE_INT`),
+  `OP_INC_LOCAL_INT` (funde `i = i +- K` numa soma direta no slot, sem
+  tráfego de pilha) e seis opcodes `_FLOAT` espelhando os `_INT` de
+  aritmética e comparação quando os dois lados são estaticamente float.
+
+  Medido nos três benches alvo (`benchmarks/cross_runtime/`, mínimo de 9
+  execuções intercaladas): `fib` 804,9→380,8ms (**~2,1x**), `loop_arith`
+  519,4→319,4ms (**~1,63x**), `mandelbrot` 428,6→246,2ms (**~1,74x**) —
+  todos acima da estimativa por task. No comparativo cross-runtime contra
+  CPython 3.13, `fib` foi de 7,9x atrás para 3,4x, e `loop_arith` de 1,8x
+  para ~1,1x (gap praticamente fechado). RC intocado — nenhum funil de
+  retain/release muda de lugar ou de contagem; os opcodes novos só operam
+  sobre escalares (int/float), que não participam de RC.
+  `go vet ./...` limpo, `go test ./...` verde, `-race` verde em
+  `internal/vm` e `internal/value`, corpus de exemplos 164/164 idêntico.
+
+  **Regressão aceita e rastreada, não corrigida nesta fase:**
+  `bench_share_mutate` (pior caso de CoW por construção — `let b = a`
+  seguido de mutação de um array grande) piorou em média **+8,7%** numa
+  bissecção dedicada (3 sessões intercaladas, piso de ruído medido em
+  ~1,2-1,4%, então o efeito é real e reproduzível, não ruído). O reuso de
+  `CallFrame` é o maior contribuinte isolado, mas não fecha a conta sozinho —
+  o padrão é compatível com pressão de GC difusa espalhada por vários
+  commits da fase, e nenhum símbolo da fase 1 aparece no profile do bench.
+  Detalhes completos: `benchmarks/RESULTS.md`, seção "develop (f107508) ×
+  fase 1 de dispatch e chamadas".
+
 ### Fixed
 
 - `break` dentro de `for ... in` voltou a sair do laço. O branch do

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.5.0
+Noxy REPL v0.6.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -80,9 +80,36 @@ colateral de pressão de GC do novo layout do `CallFrame` (array de valores
 reusado pode manter o slot anterior vivo por mais tempo antes de ser
 sobrescrito, mudando o que o GC varre por chamada); alternativa é ruído puro
 — é o bench de menor escala absoluta da suíte (~230-250ms), o que amplia
-qualquer jitter de agendamento em pontos percentuais. **Não investigado a
-fundo nem corrigido** — fora do mandato desta task (medir e reportar, não
-consertar); decisão de merge é do controller.
+qualquer jitter de agendamento em pontos percentuais.
+
+**Bissecção posterior (2026-08-18)** resolveu a dúvida ruído-vs-real e
+descartou a hipótese de ruído puro. Protocolo: worktree destacada, quatro
+commits medidos intercalados (`f107508` baseline, `bb8a773` = tudo antes do
+reuso de `CallFrame`, `d460e5a` = reuso de frame já corrigido, `6d991e5` =
+head), 3 sessões (N=15, N=20, N=20), com **controle de rótulo duplicado
+apontando para o mesmo binário** nas sessões 2-3 para medir o piso de ruído.
+
+- **Piso de ruído** (mediana × mediana, mesmo executável, mesma sessão):
+  **~1,2-1,4%**. Amostras cruas são bem mais dispersas (desvio ~6-12% da
+  mediana em trechos limpos, até ~20-28% de CV quando houve contaminação de
+  fundo), o que explica a dispersão entre sessões da tabela acima.
+- **A regressão é real e reprodutível**: baseline→head deu +9,97%, +9,78% e
+  +6,47% nas três sessões (média **+8,7%**), ordem de grandeza acima do piso
+  — consistente com os +7,0% da tabela.
+- **A atribuição a um único commit NÃO fecha**: o passo
+  `bb8a773`→`d460e5a` (reuso de `CallFrame`) concentrou todo o salto na
+  sessão 1 (+14,9%), mas só +1,4% e +4,0% nas sessões 2-3, onde a regressão
+  se acumulou gradualmente ao longo dos commits seguintes. Na média o reuso
+  de frame ainda é o maior contribuinte isolado (+6,8pp de +8,7pp) e é por
+  onde começar, mas provavelmente não é a causa única — o padrão é
+  compatível com efeito difuso de alocação/GC espalhado por vários commits
+  da fase, o que também explica o profile não mostrar nenhum símbolo da
+  fase 1 no caminho quente.
+
+Detalhes e medições cruas:
+`.superpowers/sdd/2026-08-18-vm-perf-fase1-dispatch-e-chamadas/share-mutate-bisect.md`
+(diretório de trabalho, não versionado). **Regressão aceita e rastreada, não
+corrigida nesta fase** — ver Interpretação.
 
 ### Perfil de cada bench
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -106,10 +106,10 @@ apontando para o mesmo binário** nas sessões 2-3 para medir o piso de ruído.
   da fase, o que também explica o profile não mostrar nenhum símbolo da
   fase 1 no caminho quente.
 
-Detalhes e medições cruas:
-`.superpowers/sdd/2026-08-18-vm-perf-fase1-dispatch-e-chamadas/share-mutate-bisect.md`
-(diretório de trabalho, não versionado). **Regressão aceita e rastreada, não
-corrigida nesta fase** — ver Interpretação.
+Detalhes e medições cruas (protocolo, os 4 commits medidos, todas as
+amostras individuais e o controle de rótulo duplicado):
+`benchmarks/results/2026-08-18-share-mutate-bisect.md`. **Regressão aceita e
+rastreada, não corrigida nesta fase** — ver Interpretação.
 
 ### Perfil de cada bench
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,143 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## develop (f107508) × fase 1 de dispatch e chamadas (perf/vm-dispatch-fase1)
+
+**Data:** 2026-08-18 · Windows 11 · protocolo intercalado, mediana de 9
+execuções por sessão — **4 sessões limpas repetidas** (nenhum outro processo
+de benchmark ativo) porque `bench_share_mutate` e `bench_call_light` ficaram
+perto da fronteira do gate/com dispersão notável entre sessões; ver nota¹
+sobre o ruído e nota² sobre duas sessões adicionais descartadas por
+contaminação de medição. Spec:
+`docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md`.
+Commits do branch: cache de globais com geração (`67e9d52`), `OP_CALL_STATIC`
+(`bb8a773`), `CallFrame` em array de valores reusado, allocs/chamada 1012→10
+(`1ca26e7`+`d460e5a`), seis opcodes fundidos de comparação+salto inteiro
+(`c43276c`+`32b33c7`), `OP_INC_LOCAL_INT` (`56882ca`), seis opcodes `_FLOAT`
+especializados (`4d43cdf`+`6d991e5`).
+
+**Verificação completa (Step 1):** `go vet ./...` sem saída (limpo);
+`go test ./... -count=1` verde em todos os pacotes (`internal/compiler`
+5,072s, `internal/vm` 58,068s, resto sub-segundo); `go test ./internal/value
+-race -count=1` verde (1,093s); `go test ./internal/vm -race -count=1` verde
+(74,934s). **Corpus de exemplos 164/164** (`run_all_tests_concurrent.nx`,
+10849ms) — número corrigido de 130 para 164 no commit `e7c533d`, confirmado
+aqui na íntegra.
+
+| bench | perfil | develop_ms | perf_ms | delta | veredito |
+|---|---|---|---|---|---|
+| bench_call_readonly | leitor puro O(n), array 20k | 1732,3 | 1121,3 | **−35,3%** | ✅ |
+| bench_spawn_sum | soma paralela via spawn_task | 1018,2 | 696,8 | **−31,6%** | ✅ |
+| bench_conway | grid mutado via ref, 60 gerações | 2554,3 | 2063,0 | **−19,2%** | ✅ gate |
+| bench_call_ref | mutação in-place via ref | 4206,5 | 3622,0 | −13,9% | ✅ |
+| bench_map_churn | escrita intensa em map | 443,8 | 394,1 | −11,2% | ✅ |
+| bench_bubblesort | sort in-place via ref | 3897,5 | 3493,5 | −10,4% | ✅ |
+| bench_path_update | `a[i].x = v` em loop, dono único | 621,1 | 580,0 | −6,6% | ✅ |
+| bench_typed_call_map | chamada tipada in-module, map 2,5k via ref | 76,9 | 73,4 | −4,6% | ✅ gate |
+| bench_call_light | chamada O(1), array 10k por valor | 65,5 | 62,6 | −4,5%¹ | ✅ gate |
+| bench_value_call_mutate | helper por valor em laço de mutação | 70,1 | 67,1 | −4,3% | ✅ |
+| bench_share_mutate | compartilha e muta em loop | 232,9 | 249,1 | **+7,0%**³ | ❌ **acima do gate** |
+
+Valores agregados: mediana das 4 sessões limpas, calculada separadamente para
+`develop_ms` e `perf_ms` (cada sessão já é mediana de 9 execuções
+intercaladas), delta recalculado a partir das duas medianas.
+
+¹ `bench_call_light` variou de −12,9% a +0,6% entre as 4 sessões (mediana de
+deltas por sessão: −8,3%); a sessão que deu +0,6% é a mesma que deu o pior
+número de `bench_share_mutate` (+10,5%, nota³) — indício de uma perturbação
+pontual de sistema naquela sessão específica, não um padrão. Mesmo no pior
+caso agregado (−4,5%), o bench segue dentro do gate.
+
+² Duas sessões adicionais foram descartadas: por um erro de execução, um
+processo de benchmark em background (`interleaved_compare.ps1` intercalando
+os mesmos binários) ficou rodando **ao mesmo tempo** que uma segunda
+invocação em primeiro plano — os dois competiam por CPU. Os deltas dessas
+duas sessões contaminadas (`bench_call_readonly` −33% a −36%,
+`bench_conway` −17% a −21%, `bench_spawn_sum` −31% a −33%) são consistentes
+em direção com as 4 sessões limpas usadas na tabela acima, então a
+contaminação não parece ter invertido nenhum resultado — mas foram
+descartadas mesmo assim por não seguirem o protocolo (nenhum outro processo
+de benchmark ativo), e por terem escrito no mesmo arquivo
+`results/interleaved.md` uma da outra.
+
+³ **Gate excedido.** `bench_share_mutate` — pior caso do CoW por construção
+(`let b = a` seguido de mutação de um array de 5000 elementos, 2500 rodadas)
+— fica **acima dos +5%** nas 4 sessões limpas: +6,4%, +6,1%, +2,8%, +10,5%
+(mediana das 4 deltas por sessão: +6,25%; delta das medianas agregadas:
++7,0%). Só 1 das 4 sessões (+2,8%) ficaria dentro do gate; as outras 3
+excedem. Um profile do candidato (`noxy_perf.exe --cpuprofile`, 15 repetições
+da carga do bench para juntar amostra) mostra o tempo extra concentrado no
+caminho de clone/CoW já existente — `(*VM).copyValue` (42,3% cum),
+`runtime.scanobject`/`scanblock` (GC, ~27% cum), `value.Retain`,
+`value.ownersOf`, `runtime.bulkBarrierPreWrite` — **nenhum símbolo da fase 1**
+(cache de globais, `OP_CALL_STATIC`, `CallFrame`, opcodes fundidos) aparece
+nesse profile. Não há profile do baseline para comparar lado a lado (a flag
+`--cpuprofile` é ela própria um commit deste branch — `noxy_develop.exe` não
+tem a flag), então a causa não pôde ser isolada: hipótese em aberto é efeito
+colateral de pressão de GC do novo layout do `CallFrame` (array de valores
+reusado pode manter o slot anterior vivo por mais tempo antes de ser
+sobrescrito, mudando o que o GC varre por chamada); alternativa é ruído puro
+— é o bench de menor escala absoluta da suíte (~230-250ms), o que amplia
+qualquer jitter de agendamento em pontos percentuais. **Não investigado a
+fundo nem corrigido** — fora do mandato desta task (medir e reportar, não
+consertar); decisão de merge é do controller.
+
+### Perfil de cada bench
+
+- **`bench_call_readonly`/`bench_spawn_sum`/`bench_conway`** — os três
+  maiores ganhos (−35,3%, −31,6%, −19,2%) surpreendem porque nenhum dos três
+  é o alvo declarado da fase (fib/loop_arith/mandelbrot). Motivo: todos têm
+  laço quente `while i < N do ... i = i + 1 end` (ganha com os seis opcodes
+  fundidos de comparação+salto e `OP_INC_LOCAL_INT`) **e** chamada de função
+  in-module (`spawn_sum` chama a task por closure; `conway` chama `step`/`idx`
+  por iteração; `call_readonly` chama o leitor a cada rodada) — ganha também
+  com `OP_CALL_STATIC` e o `CallFrame` sem alocação. A fase mirava fib para
+  #1/#2 e loop_arith/mandelbrot para #3, mas as duas otimizações de chamada
+  (#1/#2) valem para **qualquer** chamada in-module tipada, não só fib — e é
+  isso que aparece aqui.
+- **`bench_call_ref`/`bench_map_churn`/`bench_bubblesort`/`bench_path_update`**
+  — mesma explicação em menor grau (−13,9% a −6,6%): laço com incremento
+  inteiro fundido, mas o custo dominante desses benches é o caminho de
+  referência/CoW (`resolveReferenceValue`, unicidade), que esta fase não
+  tocou — por isso o ganho é menor que nos três benches acima.
+- **`bench_typed_call_map`/`bench_call_light`** (gates) **e
+  `bench_value_call_mutate`** (não é gate, mesmo padrão) — chamada
+  O(1)/O(2500) com container grande por `ref`/valor, ganho modesto (−4,3% a
+  −4,6%): já estavam perto do piso depois da validação O(1) por tag (PR
+  #31), então sobra pouco para os opcodes desta fase cortarem.
+- **`bench_share_mutate`** — ver nota³ acima: único bench que regride, e o
+  único cujo perfil não mostra nenhuma infraestrutura desta fase.
+
+### Interpretação
+
+**O alcance da fase foi maior que o previsto.** O plano mirava
+fib/loop_arith/mandelbrot para as otimizações de globais, chamadas e opcodes
+fundidos (fases 0-3 da spec). Nos benches CoW — nenhum deles no escopo
+original — 9 de 11 melhoraram, vários de forma expressiva
+(`call_readonly` −35%, `spawn_sum` −32%, `conway` −19%): o custo de chamada
+in-module (#1/#2) e o incremento fundido de laço (#3) atravessam qualquer
+programa com esse formato, que é a maioria do corpus real.
+
+**Onde fica neutro:** `bench_typed_call_map`, `bench_call_light` e
+`bench_value_call_mutate` — os três já operavam perto do piso pós-validação
+O(1) (PR #31); ganho pequeno mas real, dentro do gate.
+
+**Onde paga, sem maquiagem:** `bench_share_mutate` excede o gate de 5% em 3
+das 4 sessões limpas (mediana +6,25% a +7,0%, ver nota³). Ao contrário da
+rodada da fase RC-uniqueness (onde `map_churn`/`spawn_sum` excediam o gate de
+forma consistente e explicável pelo bookkeeping de RC), aqui a causa não está
+clara: o profile do bench não mostra nenhum código desta fase, só o caminho
+de clone/GC que já existia antes dela. **Gate formalmente reprovado** —
+reportado sem tentativa de correção, para decisão do controller.
+
+**O que resta:** o pprof pós-fase de `fib` (ver spec de pesquisa) mostra que,
+com globais e alocação de chamada resolvidos, `push`/`pop` (Value de 48
+bytes, item #3 da pesquisa) voltaram a ser a maior fração isolada depois do
+dispatch puro — candidato natural da próxima fase. `bench_share_mutate`
+citado acima é o outro fio solto: precisa de um profile do baseline (fora do
+alcance sem recompilar `noxy_develop.exe` com a flag `--cpuprofile`) para
+isolar a causa.
+
 ## develop (fac7542) × RC-uniqueness fase 1 (perf/cow-uniqueness-rc)
 
 **Data:** 2026-08-17 · Windows 11 · medição intercalada final, mediana de 9

--- a/benchmarks/cross_runtime/README.md
+++ b/benchmarks/cross_runtime/README.md
@@ -64,39 +64,57 @@ Três decisões, cada uma por um efeito medido neste repo:
 
 ## Resultados
 
-Noxy v0.5.0 (sobre develop @ 21e7b96) · CPython 3.13.1 · Lua 5.4.7 · Go 1.24.11
-· i7-1165G7 (4C/8T) · Windows 11 · mínimo de 9 execuções intercaladas. Números
-completos em [`results/cross_runtime.md`](results/cross_runtime.md).
+Noxy v0.6.0 (branch `perf/vm-dispatch-fase1`) · CPython 3.13.1 · Lua 5.4.7 ·
+Go 1.24.11 · i7-1165G7 (4C/8T) · Windows 11 · mínimo de 9 execuções
+intercaladas. Números completos em
+[`results/cross_runtime.md`](results/cross_runtime.md).
+
+As colunas `v0.5.0` abaixo são a rodada anterior (sobre develop @ 21e7b96),
+mantidas para mostrar o efeito da fase 1 de perf de dispatch e chamadas — o
+A/B commit a commit está em [`../RESULTS.md`](../RESULTS.md).
 
 ### Tempo total (ms)
 
-| bench | noxy | python | lua | go |
-|---|---|---|---|---|
-| `startup` | 63,0 | 94,3 | 45,5 | 47,6 |
-| `loop_arith` | 519,4 | 350,0 | 77,7 | 48,9 |
-| `map_churn` | 324,4 | 182,7 | – | – |
-| `mandelbrot` | 428,6 | 166,7 | – | – |
-| `string_ops` | 314,4 | 135,3 | – | – |
-| `bubblesort` | 666,9 | 157,1 | – | – |
-| `fib` | 804,9 | 187,7 | 93,8 | 47,8 |
+| bench | noxy v0.6.0 | noxy v0.5.0 | python | lua | go |
+|---|---|---|---|---|---|
+| `startup` | **49,6** | 63,0 | 75,4 | 38,2 | 38,5 |
+| `loop_arith` | **319,4** | 519,4 | 321,9 | 73,1 | 45,0 |
+| `map_churn` | **243,8** | 324,4 | 152,3 | – | – |
+| `mandelbrot` | **246,2** | 428,6 | 149,2 | – | – |
+| `string_ops` | **194,9** | 314,4 | 119,2 | – | – |
+| `bubblesort` | **529,8** | 666,9 | 152,3 | – | – |
+| `fib` | **380,8** | 804,9 | 171,8 | 85,9 | 40,8 |
+
+No tempo total o `loop_arith` do Noxy (319,4 ms) passou o do CPython
+(321,9 ms) — empate técnico, mas ajudado pelo piso de processo mais baixo; o
+número que interessa é o líquido abaixo.
 
 ### Tempo de execução, descontado o piso de `startup` (ms)
 
-| bench | noxy | python | lua | go | noxy ÷ python | noxy ÷ lua |
+| bench | noxy v0.6.0 | python | lua | go | ÷ python (v0.5.0 →) | ÷ lua |
 |---|---|---|---|---|---|---|
-| `loop_arith` | 456,4 | 255,7 | 32,2 | ~0 | **1,8x** | **14,2x** |
-| `map_churn` | 261,4 | 88,4 | – | – | **3,0x** | – |
-| `mandelbrot` | 365,6 | 72,4 | – | – | **5,1x** | – |
-| `string_ops` | 251,4 | 41,0 | – | – | **6,1x** | – |
-| `fib` | 741,9 | 93,4 | 48,3 | ~0 | **7,9x** | **15,4x** |
-| `bubblesort` | 603,9 | 62,8 | – | – | **9,6x** | – |
+| `loop_arith` | 269,8 | 246,5 | 34,9 | 6,5 | 1,8x → **1,1x** | **7,7x** |
+| `map_churn` | 194,2 | 76,9 | – | – | 3,0x → **2,5x** | – |
+| `mandelbrot` | 196,6 | 73,8 | – | – | 5,1x → **2,7x** | – |
+| `string_ops` | 145,3 | 43,8 | – | – | 6,1x → **3,3x** | – |
+| `fib` | 331,2 | 96,4 | 47,7 | ~0 | 7,9x → **3,4x** | **6,9x** |
+| `bubblesort` | 480,2 | 76,9 | – | – | 9,6x → **6,2x** | – |
 
 `~0` = o trabalho cabe dentro do ruído do piso de processo do runtime.
 
-### Estabilidade entre rodadas
+Queda no trabalho líquido do próprio Noxy entre as duas versões: `fib` −55,4%,
+`mandelbrot` −46,2%, `string_ops` −42,2%, `loop_arith` −40,9%, `map_churn`
+−25,7%, `bubblesort` −20,5%. O `string_ops` não foi alvo de nenhuma otimização
+desta fase — o ganho ali vem das chamadas e do laço, que qualquer programa
+paga.
+
+### Estabilidade entre rodadas (medida na v0.5.0)
 
 Cinco suítes completas em condições de carga diferentes. **O ranking é idêntico
-nas cinco**; as magnitudes variam:
+nas cinco**; as magnitudes variam. Estes números são da v0.5.0 e **não foram
+re-medidos na v0.6.0** — a rodada da v0.6.0 é uma só suíte de 9 execuções
+intercaladas, então as faixas abaixo continuam sendo a melhor estimativa
+disponível de dispersão, e devem ser lidas como tal:
 
 | bench | noxy ÷ python (faixa nas 5 rodadas) |
 |---|---|
@@ -126,56 +144,75 @@ número de três dígitos significativos.
 
 **O CPython é uma régua enganosa.** Ele não é o piso da comparação — é o meio
 da tabela. O Lua 5.4, com um VM mais simples e sem tipos estáticos, é ~2x mais
-rápido que o CPython no `fib` e ~8x no loop apertado. Contra o Lua, o Noxy fica
-**14x a 15x mais lento**; contra o CPython, 1,8x a 9,6x.
+rápido que o CPython no `fib` e ~7x no loop apertado. Na v0.6.0 o Noxy fica
+**~7x mais lento que o Lua** (era 14x–15x) e **1,1x a 6,2x mais lento que o
+CPython** (era 1,8x a 9,6x).
 
 **O custo não está distribuído por igual — ele se concentra:**
 
 - `loop_arith` é o piso: laço `while` com aritmética inteira e atribuição de
-  local, sem chamada, sem índice, sem alocação. A 1,8x do CPython, o despacho
-  de bytecode puro do Noxy é competitivo com o dele. Mas o mesmo bench está a
-  14,2x do Lua — ou seja, "competitivo com o CPython" aqui é fraqueza do
+  local, sem chamada, sem índice, sem alocação. A **1,1x** do CPython, o
+  despacho de bytecode puro do Noxy agora empata com o dele. Mas o mesmo bench
+  segue a 7,7x do Lua — "empatar com o CPython" aqui continua sendo fraqueza do
   CPython em loop numérico, não força do Noxy.
-- A partir daí o gap abre com o *tipo* de operação, não com o volume:
-  hashmap 3,0x, ponto flutuante 5,1x, string 6,1x, e o pior ponto em
-  **chamada de função (7,9x)** e **acesso indexado a array (9,6x)**.
+- O gap ainda abre com o *tipo* de operação, mas a ordem mudou: hashmap 2,5x,
+  ponto flutuante 2,7x, string 3,3x, **chamada de função 3,4x** — e o pior
+  ponto passou a ser **acesso indexado a array (6,2x)**, que era o segundo. A
+  fase 1 atacou globais, chamadas e despacho de laço; indexação de array não
+  foi tocada, e por isso subiu no ranking.
 
-**A pista mais acionável:** `fib` não toca em nenhum tipo composto — são só
-ints. O custo ali é do protocolo de chamada em si (setup de frame), não da
-validação de tipos O(n)/chamada já mapeada para maps/structs/refs.
+**A pista mais acionável era `fib`** — só ints, nenhum tipo composto, então o
+custo tinha de estar no protocolo de chamada em si. **Confirmado por profiling
+e corrigido:** resolução de globais por nome sob mutex (~15% cum) e alocação de
+`CallFrame` por chamada (1012 → 10 allocs/op) eram o grosso; `fib` caiu 55%.
+O que sobrou no perfil pós-fase é `push`/`pop` da pilha de operandos, hoje
+**24,4% do tempo de `fib`** — a maior fatia depois do despacho puro.
 
-**A inversão estrutural.** O Noxy é estaticamente tipado e compila para
-bytecode: os tipos são conhecidos em tempo de compilação, que é exatamente a
-informação que CPython e Lua pagam para descobrir em runtime. Hoje isso não
-está sendo convertido em velocidade. Some-se que o CPython 3.11+ tem um
-interpretador especializador adaptativo com inline caches nas mesmas operações
-onde o Noxy mais perde, e o formato do resultado fica consistente com **"falta
-camada de especialização"**, não com "o loop principal é ruim".
+**A inversão estrutural, parcialmente resolvida.** O Noxy é estaticamente
+tipado e compila para bytecode: os tipos são conhecidos em tempo de compilação,
+que é exatamente a informação que CPython e Lua pagam para descobrir em runtime.
+A v0.5.0 não convertia isso em velocidade; a hipótese registrada aqui era
+**"falta camada de especialização"**, não "o loop principal é ruim".
 
-**Ressalva:** essa atribuição de causa é hipótese lida a partir do formato dos
-números, **não de profiling**. Confirmar exige um `pprof` em `fib` e
-`bubblesort` antes de otimizar qualquer coisa.
+**A hipótese se confirmou.** A fase 1 (v0.6.0) construiu a primeira camada:
+chamada com modos provados estaticamente, resolução de globais cacheada,
+comparação+salto e incremento de local fundidos quando ambos os lados são
+estaticamente `int`, e aritmética `float` especializada. O gap contra o CPython
+caiu de 1,8x–9,6x para 1,1x–6,2x, e contra o Lua pela metade. A camada está
+longe de completa — indexação de array, campos de struct por índice e maps
+tipados seguem sem especialização.
 
 ## Onde o Noxy ganha
 
-- **Startup contra o CPython:** 63 ms contra 94 ms, ~1,5x mais rápido — real
-  para script curto e para o caso Lambda, onde o piso de processo é boa parte
-  do custo. A vantagem, porém, é sobre o
-  CPython, não sobre todo mundo (Lua e Go sobem em ~46 ms).
+- **Startup contra o CPython:** 49,6 ms contra 75,4 ms, ~1,5x mais rápido —
+  real para script curto e para o caso Lambda, onde o piso de processo é boa
+  parte do custo. A vantagem, porém, é sobre o CPython, não sobre todo mundo
+  (Lua e Go sobem em ~38 ms).
 - **Carga I/O-bound:** nos casos que o Noxy realmente atende hoje (servidor
   HTTP, SQLite, NoxyDB), o gargalo é I/O e a velocidade do interpretador quase
   não aparece.
-- **Ordem de grandeza:** estar 2x a 10x atrás do CPython em v0.5.0 é resultado
-  respeitável em termos absolutos. A maioria das implementações jovens fica
-  50x a 100x atrás.
+- **Ordem de grandeza:** estar 1,1x a 6,2x atrás do CPython na v0.6.0 (era 2x
+  a 10x na v0.5.0) é resultado respeitável em termos absolutos. A maioria das
+  implementações jovens fica 50x a 100x atrás.
 
 Sendo justo com o Lua: são 30 anos de tuning em C, VM baseada em registradores,
 sem GC concorrente e sem bounds check do Go. Não é meta de curto prazo — é a
-referência de onde dá para chegar.
+referência de onde dá para chegar. A distância caiu de ~15x para ~7x numa
+única fase, o que sugere que ainda há ganho estrutural na mesa antes de a
+comparação virar disputa de qualidade de codegen.
 
 ## Próximos passos sugeridos
 
 1. Escalar as cargas até o trabalho dominar o piso de processo (ver limitação
-   acima) e re-medir.
-2. `pprof` em `fib` e `bubblesort` para confirmar onde o tempo vai.
+   acima) e re-medir. **Ainda pendente** — e ficou mais urgente: com o Noxy
+   mais rápido, o trabalho líquido de vários benches encolheu em relação ao
+   piso, o que amplia a barra de erro dos ratios.
+2. ~~`pprof` em `fib` e `bubblesort`~~ — **feito** na fase 1 (flags
+   `--cpuprofile`/`--memprofile` na CLI; baseline e perfil pós-fase em
+   [`../../docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md`](../../docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md)).
 3. Portar os quatro benches restantes para Lua, fechando a calibração.
+4. Próximo alvo indicado pelo perfil pós-fase: layout do `Value` e `pop` sem
+   zerar escalares (`push`+`pop` = 24,4% do tempo de `fib`). Depois,
+   indexação de array — que esta rodada promoveu a pior ponto da tabela.
+5. Re-medir a estabilidade entre rodadas na v0.6.0 (as faixas registradas
+   acima são da v0.5.0).

--- a/benchmarks/cross_runtime/results/cross_runtime.md
+++ b/benchmarks/cross_runtime/results/cross_runtime.md
@@ -1,33 +1,33 @@
 # Cross-runtime: Noxy x CPython x Lua x Go
 
-- noxy: Noxy v0.5.0, build de `bench/cross-runtime` sobre develop @ 21e7b96, em disco local
+- noxy: `C:\Users\estev\AppData\Local\Temp\noxy_perf_local.exe`
 - python: Python 3.13.1
 - lua: Lua 5.4.7  Copyright (C) 1994-2024 Lua.org, PUC-Rio
 - go: go version go1.24.11 windows/amd64
-- Data: 2026-08-17T23:18:06
+- Data: 2026-08-18T04:30:06
 - Runs por bench: 9, intercalados; **minimo** reportado
 
 ## Tempo total (ms)
 
 | bench | noxy | python | lua | go |
 |---|---|---|---|---|
-| `bubblesort` | 666,9 | 157,1 | - | - |
-| `fib` | 804,9 | 187,7 | 93,8 | 47,8 |
-| `loop_arith` | 519,4 | 350,0 | 77,7 | 48,9 |
-| `mandelbrot` | 428,6 | 166,7 | - | - |
-| `map_churn` | 324,4 | 182,7 | - | - |
-| `startup` | 63,0 | 94,3 | 45,5 | 47,6 |
-| `string_ops` | 314,4 | 135,3 | - | - |
+| `bubblesort` | 529,8 | 152,3 | - | - |
+| `fib` | 380,8 | 171,8 | 85,9 | 40,8 |
+| `loop_arith` | 319,4 | 321,9 | 73,1 | 45,0 |
+| `mandelbrot` | 246,2 | 149,2 | - | - |
+| `map_churn` | 243,8 | 152,3 | - | - |
+| `startup` | 49,6 | 75,4 | 38,2 | 38,5 |
+| `string_ops` | 194,9 | 119,2 | - | - |
 
 ## Tempo de execucao, descontado o piso de `startup` (ms)
 
 | bench | noxy | python | lua | go |
 |---|---|---|---|---|
-| `bubblesort` | 603,9 | 62,8 | - | - |
-| `fib` | 741,9 | 93,4 | 48,3 | ~0 |
-| `loop_arith` | 456,4 | 255,7 | 32,2 | ~0 |
-| `mandelbrot` | 365,6 | 72,4 | - | - |
-| `map_churn` | 261,4 | 88,4 | - | - |
-| `string_ops` | 251,4 | 41,0 | - | - |
+| `bubblesort` | 480,2 | 76,9 | - | - |
+| `fib` | 331,2 | 96,4 | 47,7 | ~0 |
+| `loop_arith` | 269,8 | 246,5 | 34,9 | 6,5 |
+| `mandelbrot` | 196,6 | 73,8 | - | - |
+| `map_churn` | 194,2 | 76,9 | - | - |
+| `string_ops` | 145,3 | 43,8 | - | - |
 
 `~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.

--- a/benchmarks/results/2026-08-18-share-mutate-bisect.md
+++ b/benchmarks/results/2026-08-18-share-mutate-bisect.md
@@ -1,0 +1,254 @@
+# bench_share_mutate bisect — +7% regression on perf/vm-dispatch-fase1
+
+Date: 2026-08-18
+Scope: measurement only, no production code changed.
+
+## Question
+
+Which commit on `perf/vm-dispatch-fase1` introduced the +7.0% regression on
+`bench_share_mutate` (candidate vs `develop` baseline `f107508`), or is it
+noise?
+
+## Method
+
+- Isolated detached worktree in scratchpad
+  (`.../scratchpad/bisect`), never touching the main checkout
+  (`D:\OneDrive\Documentos\go_projects\noxy`, which stayed on branch
+  `perf/vm-dispatch-fase1` throughout, untouched).
+- Built 4 binaries with `go build -o <scratchpad>\bins\noxy_<sha>.exe ./cmd/noxy`
+  after `git checkout --detach <sha>` inside the worktree, for:
+  - `f107508` — baseline (develop, pre-phase)
+  - `bb8a773` — OP_CALL_STATIC (last commit before CallFrame value array)
+  - `d460e5a` — CallFrame value array + its review fix-round
+  - `6d991e5` — branch head (all 7 tasks)
+- Verified all 4 binaries produce identical output
+  (`CHECKSUM:3123750`) on `benchmarks\bench_share_mutate.nx` before timing.
+- Ran three independent interleaved sessions (see raw data below), each
+  randomizing binary order **within every round** via
+  `Get-ChildItem`/`Sort-Object { $rand.Next() }`-style shuffling, so no
+  binary is systematically favored by warm-up or thermal drift.
+- Sessions 2 and 3 added a **same-binary duplicate control**: `f107508_A`
+  and `f107508_B` both point at the identical `noxy_f107508.exe`, run under
+  different labels in the same session. This isolates pure run-to-run/OS
+  noise from any real binary-to-binary difference, inside the same session.
+- Timed via `Measure-Command { & $exe $bench.nx | Out-Null }`. Session 3
+  additionally batched 5 invocations per sample and divided by 5, to
+  amortize process-spawn overhead — this did not materially change the
+  picture (see below).
+- Ran in the foreground, nothing else deliberately started. Background
+  processes present throughout (typical dev-box set): WindowsTerminal,
+  Slack, Cloudflare WARP, `logioptionsplus_agent`, `MsMpEng` (Defender),
+  `CSFalconContainer` (CrowdStrike EDR), `gopls`. No benchmark or build was
+  run concurrently by me. Session 3 shows clear late-round contamination
+  (see below) most likely from one of these background agents (EDR/AV scan
+  or similar) — flagged explicitly, not hidden.
+
+## Raw measurements
+
+### Session 1 — single invocation, N=15, no duplicate control
+
+```
+f107508: 189.79, 232.81, 209.49, 201.38, 231.48, 204.58, 227.21, 209.29, 194.81, 233.98, 254.61, 201.65, 231.27, 205.24, 206.67
+bb8a773: 207.19, 205.08, 203.68, 213.22, 218.9, 204.38, 214.17, 191.99, 204.06, 197.08, 210.64, 203.25, 219.53, 200.67, 203.99
+d460e5a: 267.65, 260.32, 236.69, 215.91, 218.31, 241.13, 242.29, 204.46, 224, 206.21, 260.47, 238.23, 210.92, 219.59, 234.79
+6d991e5: 228.98, 222.74, 201.05, 207.56, 249.2, 245.77, 218.18, 231.48, 232.33, 270.26, 212.15, 230.15, 231.28, 245.66, 205.68
+```
+
+| label | n | median | mean | trimmed10 | stdev | CV |
+|---|---|---|---|---|---|---|
+| f107508 | 15 | 209.29 | 215.62 | 214.60 | 17.64 | 8.4% |
+| bb8a773 | 15 | 204.38 | 206.52 | 206.64 | 7.37 | 3.6% |
+| d460e5a | 15 | 234.79 | 232.06 | 231.45 | 19.45 | 8.3% |
+| 6d991e5 | 15 | 230.15 | 228.83 | 227.78 | 18.11 | 7.9% |
+
+### Session 2 — single invocation, N=20, with same-binary duplicate control
+
+```
+f107508_A: 190.44, 195.06, 211.61, 208.69, 202.92, 199.94, 198.43, 245.2, 203.11, 202.51, 197.2, 235.51, 278.29, 231.82, 201.02, 244.54, 198.2, 233.13, 195.54, 242.47
+f107508_B: 189.45, 191.14, 192.18, 280.01, 190.51, 205.61, 209.56, 221.96, 212.13, 206.14, 188.14, 242.09, 201.17, 198.4, 210.3, 240.45, 205.3, 194.46, 219.57, 238.99
+bb8a773:   203.72, 197.34, 201.21, 223.42, 184.21, 212.43, 201.87, 254.36, 199.24, 234.49, 220.44, 223.3, 271.76, 216.1, 204.11, 275.95, 208.49, 249.25, 224.41, 197.92
+d460e5a:   192.86, 246.15, 212.78, 229.48, 208.05, 268.33, 212.47, 223.95, 203.82, 251.93, 204.92, 194.69, 214.96, 219.74, 212.55, 237.5, 243.95, 221.26, 205.93, 258.83
+6d991e5:   220.97, 237.54, 201.52, 247.95, 212.61, 221.92, 250.74, 212.82, 214.63, 248.29, 213.3, 240.21, 226.94, 246.91, 217.45, 240.94, 219.78, 230.46, 230.48, 206.35
+```
+
+| label | n | median | mean | trimmed10 | stdev | CV |
+|---|---|---|---|---|---|---|
+| f107508_A | 20 | 203.02 | 215.78 | 212.91 | 23.17 | 11.4% |
+| f107508_B | 20 | 205.88 | 211.88 | 208.62 | 22.73 | 11.0% |
+| bb8a773 | 20 | 214.27 | 220.20 | 217.17 | 24.71 | 11.5% |
+| d460e5a | 20 | 217.35 | 223.21 | 221.84 | 20.89 | 9.6% |
+| 6d991e5 | 20 | 224.43 | 227.09 | 227.18 | 14.81 | 6.6% |
+
+### Session 3 — batch-of-5 averaged, N=20, with duplicate control (late-round contamination)
+
+```
+f107508_A: 236.38, 203.42, 229.52, 214.7, 213.8, 221.77, 222.49, 209.32, 212, 231.94, 254.03, 236.95, 230.05, 223.99, 225.42, 242.77, 246.46, 220.67, 213.62, 233.18
+f107508_B: 201.32, 205.87, 221.6, 223.18, 208.15, 221.42, 217.33, 203.28, 212.54, 222.84, 222.41, 214.92, 240.42, 222.73, 221.5, 249.9, 392.78, 297.86, 289.89, 228.33
+bb8a773:   213.2, 256.47, 222.87, 218.02, 217.34, 211.36, 207.38, 242.21, 222.99, 218.76, 221.83, 215.2, 228.19, 231.9, 221.27, 228.62, 241.54, 248.49, 509.32, 222.18
+d460e5a:   199.26, 234.01, 214.41, 215.45, 226.36, 239.47, 230.88, 228.8, 228.21, 252.37, 215.22, 257.54, 231.9, 248.08, 246.5, 217.93, 254.89, 216.43, 301.69, 247.33
+6d991e5:   220.47, 228.06, 243.53, 236.59, 293.1, 230.33, 237.86, 246.47, 253.82, 232.65, 234.69, 218.89, 232.67, 237.73, 324.89, 271.8, 296.3, 305.03, 259.6, 232.67
+```
+
+Rounds 16-18 show clear spikes on several labels regardless of which commit
+(e.g. `f107508_B`=392.78 at round 16, `bb8a773`=509.32 at round 18) —
+consistent with an external agent (Defender/CrowdStrike scan or similar)
+briefly stealing CPU, not a property of any binary. Reported both with and
+without those samples.
+
+| label | n | median | mean | trimmed10 | stdev | CV |
+|---|---|---|---|---|---|---|
+| f107508_A | 20 | 224.71 | 226.12 | 225.58 | 12.86 | 5.7% |
+| f107508_B | 20 | 222.01 | 235.91 | 226.44 | 43.71 | 19.7% |
+| bb8a773 | 20 | 222.53 | 239.96 | 225.91 | 63.03 | 28.3% |
+| d460e5a | 20 | 231.39 | 235.34 | 233.36 | 21.71 | 9.4% |
+| 6d991e5 | 20 | 237.80 | 251.86 | 247.99 | 29.60 | 12.4% |
+
+Contamination-trimmed (drop the top 15% per label, N=17):
+
+| label | median | mean | stdev |
+|---|---|---|---|
+| f107508_A | 222.49 | 222.31 | 9.67 |
+| f107508_B | 221.50 | 219.87 | 12.07 |
+| bb8a773 | 221.83 | 222.64 | 9.28 |
+| d460e5a | 228.80 | 228.98 | 14.26 |
+| 6d991e5 | 236.59 | 241.82 | 18.28 |
+
+Trimming the contamination doesn't change the ranking or the rough
+magnitudes — it mainly tightens the spread.
+
+## Noise floor (same binary, two labels, same session)
+
+| session | f107508_A median | f107508_B median | delta |
+|---|---|---|---|
+| s2 | 203.02 | 205.88 | +1.41% |
+| s3 | 224.71 | 222.01 | -1.20% |
+
+**With N=20 interleaved samples per label, the median-vs-median noise floor
+for the literal same binary is ~1.2-1.4%.** Individual raw samples are far
+noisier (stdev 6-12% of the median in clean stretches, up to ~20-28% CV
+when a session catches background contamination) — this is why the medians
+of 15-20 samples, not single runs, are the right comparison unit.
+
+## Per-commit delta vs baseline (median-based)
+
+| session | f107508 | bb8a773 | d460e5a | 6d991e5 (head) |
+|---|---|---|---|---|
+| s1 | 0.0% | -2.35% | +12.18% | +9.97% |
+| s2 | 0.0%* | +4.80% | +6.31% | +9.78% |
+| s3 | 0.0%* | -0.37% | +3.60% | +6.47% |
+
+\* baseline = average of the two duplicate-label medians in that session.
+
+**Baseline-to-HEAD delta is consistently positive across all three
+independent sessions: +9.97%, +9.78%, +6.47% (mean +8.7%)** — well above
+the ~1.4% same-binary noise floor. This corroborates the originally
+reported +7.0% regression: it is real, not noise.
+
+## Adjacent-step deltas — the actual bisection question
+
+| step | s1 | s2 | s3 | mean |
+|---|---|---|---|---|
+| baseline -> bb8a773 | -2.35% | +5.54% | -0.97% | +0.74% |
+| bb8a773 -> d460e5a (frame reuse) | **+14.88%** | +1.44% | +3.98% | +6.77% |
+| d460e5a -> 6d991e5 (fused cmp/jump, INC_LOCAL, float ops) | -1.98% | +3.26% | +2.77% | +1.35% |
+
+This is the crux and it does **not** point to a single clean culprit:
+
+- **Session 1** shows a sharp, isolated cliff exactly at the frame-reuse
+  step (bb8a773 -> d460e5a, +14.9%), with the steps before and after
+  essentially flat/negative. Taken alone, this session is a clean smoking
+  gun for the CallFrame-value-array hypothesis.
+- **Sessions 2 and 3** instead show the regression building up gradually
+  across all three steps, with no single step dominating (session 2:
+  +5.5% / +1.4% / +3.3%; session 3: -1.0% / +4.0% / +2.8%). In session 2 the
+  *first* step (baseline -> bb8a773, before frame reuse even lands) already
+  accounts for more of the regression than the frame-reuse step itself.
+- The **same step** (bb8a773 -> d460e5a) varies from +1.44% to +14.88%
+  across sessions — a spread far larger than the ~1.4% same-binary noise
+  floor measured in the same sessions. That means comparing *different*
+  binaries carries session-level variability beyond pure run-to-run OS
+  noise (plausibly: different code size/layout interacting differently
+  with icache/TLB and whatever background load happens to be active during
+  that binary's samples), which a same-binary duplicate label cannot
+  capture since it has identical code layout.
+
+Averaged across the three sessions, the frame-reuse step (bb8a773 ->
+d460e5a, mean +6.8 points) is still the largest single contributor to the
+~8.7% total, larger than either the OP_CALL_STATIC step before it (+0.7pp)
+or the fused-opcode/float step after it (+1.4pp) — so the frame-reuse
+hypothesis is the best-supported single explanation, but it is not proven
+to the level of "regression appears cleanly and only at this commit" the
+way session 1 alone would suggest. 2 of 3 sessions show meaningful
+regression already present at or before `bb8a773`, and continuing to
+accumulate after `d460e5a`.
+
+## Conclusion
+
+- **The end-to-end regression (baseline f107508 -> head 6d991e5) is real**:
+  +9.97%, +9.78%, +6.47% across three independent interleaved sessions
+  (mean +8.7%), consistent with the previously reported +7.0% and well
+  above the measured ~1.4% same-binary noise floor.
+- **Attribution to one single commit is not clean.** The CallFrame
+  value-array commit and its fix round (`1ca26e7` / `d460e5a`) is the
+  best-supported single contributor — it produced the single largest
+  average step increase (+6.8 pp of +8.7 pp total) and, in one of three
+  sessions, accounted for essentially the entire regression on its own.
+  But in the other two sessions the regression was already partly present
+  going into `bb8a773` and kept accumulating through `6d991e5`, so I
+  cannot rule out a **diffuse, second-order GC/allocator-interaction
+  effect that several of the phase's commits contribute to together**
+  rather than one isolated cause. This is consistent with the profiling
+  finding mentioned in the brief (no phase-1 code in the hot path — the
+  cost is in allocation/GC pattern changes, which by nature can shift
+  gradually as more of the phase lands, not just at the one commit that
+  most obviously touches allocation).
+- **Recommendation**: if a single culprit must be picked for the fix,
+  `1ca26e7`/`d460e5a` (frame reuse) is the correct one to investigate
+  first — it has the strongest single-session evidence and the largest
+  average effect. But do not expect reverting it alone to fully close the
+  gap to baseline, since roughly 2 of the 8.7 average points sit outside
+  that step in 2 of 3 sessions.
+
+## Commands used (representative)
+
+```
+git worktree add --detach "<scratchpad>\bisect" f107508
+cd "<scratchpad>\bisect"
+go build -o "<scratchpad>\bins\noxy_f107508.exe" ./cmd/noxy
+git checkout --detach bb8a773
+go build -o "<scratchpad>\bins\noxy_bb8a773.exe" ./cmd/noxy
+git checkout --detach d460e5a
+go build -o "<scratchpad>\bins\noxy_d460e5a.exe" ./cmd/noxy
+git checkout --detach 6d991e5
+go build -o "<scratchpad>\bins\noxy_6d991e5.exe" ./cmd/noxy
+
+# correctness check
+noxy_<sha>.exe benchmarks\bench_share_mutate.nx   # all -> CHECKSUM:3123750
+
+# timing (see bisect_measure.ps1 / bisect_measure2.ps1 / bisect_measure3.ps1
+# in the scratchpad for the exact interleaving/randomization/batching logic)
+Measure-Command { & $exe $bench.nx | Out-Null }
+
+git worktree remove --force "<scratchpad>\bisect"
+```
+
+## Cleanup confirmation
+
+- `git worktree remove --force` succeeded for the bisect worktree.
+- Main checkout (`D:\OneDrive\Documentos\go_projects\noxy`) `git status`
+  after cleanup shows exactly the same pre-existing modified/untracked
+  files that were present before this investigation started
+  (`benchmarks/results/interleaved.md` modified; `bubble.prof`,
+  `docs/superpowers/plans/2026-08-17-cow-rc-drops-fases-1_5-2.md`,
+  `fib.prof`, `fib_pos.prof`, `loop.prof`, `share_mutate_pos.prof`
+  untracked) — nothing from this investigation leaked into the main tree,
+  and HEAD/branch (`perf/vm-dispatch-fase1`) was never touched.
+- `git worktree list` after cleanup shows the main checkout, the unrelated
+  `noxydb` worktree, and one other worktree
+  (`.../scratchpad/base-review`, detached at `f107508`) that I did **not**
+  create and did **not** remove — it lives under the same scratchpad
+  session directory and was not present in `git worktree list` at the
+  start of this task, so it belongs to a concurrent process/agent (the
+  `.superpowers/sdd/2026-08-18-vm-perf-fase1-dispatch-e-chamadas/` folder
+  already contains review diffs and task briefs/reports from that ongoing
+  work). Left untouched as instructed.

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -81,27 +81,42 @@ func main() {
 		return
 	}
 
-	if *cpuProfile != "" {
-		f, err := os.Create(*cpuProfile)
+	exitCode := runFile(filename, string(content), getDir(filename), *showDisassembly, *cpuProfile, *memProfile)
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+}
+
+// runFile executa o arquivo cercado pelos profiles de CPU/memoria pedidos
+// pelas flags. runWithConfig devolve um codigo de saida em vez de chamar
+// os.Exit diretamente, entao os defers deste closure (StopCPUProfile,
+// f.Close) sempre rodam antes do processo terminar — inclusive quando o
+// programa falha no parser, no compilador ou em runtime. Sem isto, um
+// programa que termina em erro (justamente o caso mais interessante de
+// perfilar) deixava o --cpuprofile truncado e pulava o --memprofile por
+// completo, porque os.Exit não executa defers pendentes.
+func runFile(filename, input, rootPath string, showDisasm bool, cpuProfilePath, memProfilePath string) int {
+	if cpuProfilePath != "" {
+		f, err := os.Create(cpuProfilePath)
 		if err != nil {
 			fmt.Printf("Error creating CPU profile: %s\n", err)
-			os.Exit(1)
+			return 1
 		}
 		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
 			fmt.Printf("Error starting CPU profile: %s\n", err)
-			os.Exit(1)
+			return 1
 		}
 		defer pprof.StopCPUProfile()
 	}
 
-	runWithConfig(filename, string(content), getDir(filename), *showDisassembly)
+	exitCode := runWithConfig(filename, input, rootPath, showDisasm)
 
-	if *memProfile != "" {
-		f, err := os.Create(*memProfile)
+	if memProfilePath != "" {
+		f, err := os.Create(memProfilePath)
 		if err != nil {
 			fmt.Printf("Error creating memory profile: %s\n", err)
-			os.Exit(1)
+			return 1
 		}
 		runtime.GC()
 		if err := pprof.WriteHeapProfile(f); err != nil {
@@ -109,6 +124,8 @@ func main() {
 		}
 		f.Close()
 	}
+
+	return exitCode
 }
 
 func getDir(path string) string {
@@ -266,7 +283,12 @@ func verify() {
 	runWithConfig("verify.nx", input, ".", true)
 }
 
-func runWithConfig(filename string, input string, rootPath string, showDisasm bool) {
+// runWithConfig devolve o codigo de saida (0 sucesso, 1 erro) em vez de
+// chamar os.Exit diretamente — quem chama (runFile) precisa da chance de
+// rodar seus proprios defers (parar/gravar profile) antes do processo
+// terminar. Mensagens e codigos de saida observaveis pela CLI continuam
+// identicos.
+func runWithConfig(filename string, input string, rootPath string, showDisasm bool) int {
 	l := lexer.New(input)
 	p := parser.New(l)
 	program := p.ParseProgram()
@@ -275,14 +297,14 @@ func runWithConfig(filename string, input string, rootPath string, showDisasm bo
 		for _, msg := range p.Errors() {
 			fmt.Printf("%s\n", msg)
 		}
-		os.Exit(1)
+		return 1
 	}
 
 	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filename, rootPath)
 	chunk, _, err := c.Compile(program)
 	if err != nil {
 		fmt.Printf("Compiler error: %s\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	if showDisasm {
@@ -294,6 +316,7 @@ func runWithConfig(filename string, input string, rootPath string, showDisasm bo
 	machine := vm.NewWithConfig(vm.VMConfig{RootPath: rootPath})
 	if err := machine.Interpret(chunk); err != nil {
 		fmt.Printf("Runtime error: %s\n", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -16,7 +16,9 @@ import (
 	"noxy-vm/internal/vm"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
+	"runtime/pprof"
 	"strings"
 )
 
@@ -42,6 +44,8 @@ func main() {
 	}
 
 	getPkg := flag.String("get", "", "Download and install a package (e.g. github.com/user/repo@version)")
+	cpuProfile := flag.String("cpuprofile", "", "Write CPU profile to file")
+	memProfile := flag.String("memprofile", "", "Write memory profile to file")
 	flag.Parse()
 
 	if *showHelp {
@@ -77,7 +81,34 @@ func main() {
 		return
 	}
 
+	if *cpuProfile != "" {
+		f, err := os.Create(*cpuProfile)
+		if err != nil {
+			fmt.Printf("Error creating CPU profile: %s\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Printf("Error starting CPU profile: %s\n", err)
+			os.Exit(1)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
 	runWithConfig(filename, string(content), getDir(filename), *showDisassembly)
+
+	if *memProfile != "" {
+		f, err := os.Create(*memProfile)
+		if err != nil {
+			fmt.Printf("Error creating memory profile: %s\n", err)
+			os.Exit(1)
+		}
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Printf("Error writing memory profile: %s\n", err)
+		}
+		f.Close()
+	}
 }
 
 func getDir(path string) string {

--- a/docs/superpowers/plans/2026-08-18-vm-perf-fase1-dispatch-e-chamadas.md
+++ b/docs/superpowers/plans/2026-08-18-vm-perf-fase1-dispatch-e-chamadas.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - **Opcodes só por APPEND** ao fim do bloco `const` de `internal/chunk/chunk.go` — nunca renumerar (comentário em `OP_MARK_SHARED` confirma a regra; módulos cacheados dependem disso).
-- **Semântica idêntica**: mesmos outputs, mesmos erros com as mesmas mensagens. O corpus `noxy_examples/` (130/130 via `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx`) é o juiz.
+- **Semântica idêntica**: mesmos outputs, mesmos erros com as mesmas mensagens. O corpus `noxy_examples/` (164/164 via `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx` — baseline medido em 2026-08-18 na Task 1; o juiz é "0 falhas", o total cresce quando exemplos novos entram) é o juiz.
 - **RC intocado**: nenhum funil retain/release muda de lugar ou de contagem (spec CoW-RC §4.2). Os opcodes novos deste plano só operam sobre escalares (int/float), que não participam de RC.
 - **Gates de benchmark** (protocolo de `benchmarks/RESULTS.md`, mediana de 9 execuções intercaladas): `bench_typed_call_map`, `bench_share_mutate`, `bench_call_light`, `bench_conway` não podem regredir >5% vs `develop`.
 - `go test ./...` verde; `go test ./internal/value -race` e `go test ./internal/vm -race` verdes; `go vet ./...` limpo (o `sync.Once` novo em `Chunk` exige checagem copylocks).
@@ -379,7 +379,7 @@ go test ./internal/vm -race -count=1
 go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
 ```
 
-Esperado: tudo verde, corpus 130/130.
+Esperado: tudo verde, corpus 164/164.
 
 - [ ] **Step 8: Medir fib A/B**
 
@@ -588,7 +588,7 @@ go run ./cmd/noxy --disassembly tmp_static.nx | Select-String "OP_CALL"
 Remove-Item tmp_static.nx
 ```
 
-Esperado: suíte verde, corpus 130/130, e a linha do disassembly mostra `OP_CALL_STATIC` para a chamada tipada.
+Esperado: suíte verde, corpus 164/164, e a linha do disassembly mostra `OP_CALL_STATIC` para a chamada tipada.
 
 - [ ] **Step 6: Commit**
 
@@ -763,7 +763,7 @@ go test ./internal/value -race -count=1
 go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
 ```
 
-Esperado: tudo verde, 130/130. Atenção especial a `rc_uniqueness_test.go`, `reference_ownership_test.go`, `defer_test.go`, `unwind_test.go` — se qualquer um falhar, o reuso de `Owned`/`Deferred` vazou estado entre frames; revisar a limpeza do Step 3.
+Esperado: tudo verde, 164/164. Atenção especial a `rc_uniqueness_test.go`, `reference_ownership_test.go`, `defer_test.go`, `unwind_test.go` — se qualquer um falhar, o reuso de `Owned`/`Deferred` vazou estado entre frames; revisar a limpeza do Step 3.
 
 - [ ] **Step 5: Re-rodar o benchmark de alocação**
 
@@ -1177,7 +1177,7 @@ go build -o noxy_perf.exe ./cmd/noxy
 1..5 | ForEach-Object { Measure-Command { .\noxy_develop.exe benchmarks\cross_runtime\loop_arith.nx } | Select -Expand TotalMilliseconds; Measure-Command { .\noxy_perf.exe benchmarks\cross_runtime\loop_arith.nx } | Select -Expand TotalMilliseconds }
 ```
 
-Esperado: verde, 130/130, queda visível em loop_arith e fib.
+Esperado: verde, 164/164, queda visível em loop_arith e fib.
 
 - [ ] **Step 8: Commit**
 
@@ -1543,7 +1543,7 @@ go test ./internal/vm -race -count=1
 go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
 ```
 
-Tudo verde, corpus 130/130 — anotar os números reais do output.
+Tudo verde, corpus 164/164 — anotar os números reais do output.
 
 - [ ] **Step 2: A/B intercalado nos benches CoW (gates)**
 

--- a/docs/superpowers/plans/2026-08-18-vm-perf-fase1-dispatch-e-chamadas.md
+++ b/docs/superpowers/plans/2026-08-18-vm-perf-fase1-dispatch-e-chamadas.md
@@ -1,0 +1,1589 @@
+# VM Perf Fase 1 — Dispatch e Chamadas — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fechar parte do gap Noxy×CPython eliminando os custos dominantes do caminho quente da VM — resolução de globais por nome+mutex, alocação de frame por chamada, validação redundante e dispatches não fundidos — explorando os tipos estáticos que o compilador já conhece.
+
+**Architecture:** Nenhuma mudança de semântica ou de sintaxe. Quatro frentes no pipeline existente: (1) cache de globais com contador de geração (invalidação por escrita, sem lock no caminho de leitura); (2) opcode `OP_CALL_STATIC` para chamadas cujos modos de parâmetro o compilador já provou; (3) `CallFrame` em array fixo reusado (zero alocação por chamada); (4) opcodes fundidos/tipados novos (comparação+salto int, incremento de local int, aritmética float), todos **anexados ao fim** da lista de opcodes.
+
+**Tech Stack:** Go 1.24 (repo atual), `runtime/pprof`, suíte `go test` + corpus `noxy_examples/`, protocolo A/B intercalado de `benchmarks/`.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md` (diagnóstico com anchors de código; este plano implementa as fases 0–3 de lá; fases 4–6 — structs por índice, maps tipados, layout do Value — ficam para planos futuros informados pelo re-profile).
+
+## Global Constraints
+
+- **Opcodes só por APPEND** ao fim do bloco `const` de `internal/chunk/chunk.go` — nunca renumerar (comentário em `OP_MARK_SHARED` confirma a regra; módulos cacheados dependem disso).
+- **Semântica idêntica**: mesmos outputs, mesmos erros com as mesmas mensagens. O corpus `noxy_examples/` (130/130 via `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx`) é o juiz.
+- **RC intocado**: nenhum funil retain/release muda de lugar ou de contagem (spec CoW-RC §4.2). Os opcodes novos deste plano só operam sobre escalares (int/float), que não participam de RC.
+- **Gates de benchmark** (protocolo de `benchmarks/RESULTS.md`, mediana de 9 execuções intercaladas): `bench_typed_call_map`, `bench_share_mutate`, `bench_call_light`, `bench_conway` não podem regredir >5% vs `develop`.
+- `go test ./...` verde; `go test ./internal/value -race` e `go test ./internal/vm -race` verdes; `go vet ./...` limpo (o `sync.Once` novo em `Chunk` exige checagem copylocks).
+- Branch de trabalho: `perf/vm-dispatch-fase1` a partir de `develop`.
+- Todos os comandos abaixo assumem cwd = raiz do repo, PowerShell no Windows.
+
+---
+
+### Task 1: Flags de profiling no CLI + baseline pprof
+
+**Files:**
+- Modify: `cmd/noxy/main.go:32-45` (flags), `cmd/noxy/main.go:73-81` (execução)
+- Modify: `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md` (registrar baseline)
+
+**Interfaces:**
+- Consumes: nada de tasks anteriores.
+- Produces: `noxy --cpuprofile=<file> --memprofile=<file> <script.nx>`; baseline pprof registrado na spec. Tasks seguintes citam este baseline para validar impacto.
+
+- [ ] **Step 1: Construir o baseline e criar o branch**
+
+O binário de comparação A/B (`noxy_develop.exe`) precisa refletir o `develop` atual — o que existe na raiz do repo pode estar velho:
+
+```powershell
+git checkout develop && git pull
+go build -o noxy_develop.exe ./cmd/noxy
+git checkout -b perf/vm-dispatch-fase1
+```
+
+- [ ] **Step 2: Adicionar flags e hooks de pprof em main.go**
+
+Em `cmd/noxy/main.go`, adicionar aos imports `"runtime"` e `"runtime/pprof"`. Logo abaixo da declaração de `getPkg` (linha 44), adicionar:
+
+```go
+cpuProfile := flag.String("cpuprofile", "", "Write CPU profile to file")
+memProfile := flag.String("memprofile", "", "Write memory profile to file")
+```
+
+No fim de `main()`, substituir a chamada final
+
+```go
+runWithConfig(filename, string(content), getDir(filename), *showDisassembly)
+```
+
+por:
+
+```go
+if *cpuProfile != "" {
+	f, err := os.Create(*cpuProfile)
+	if err != nil {
+		fmt.Printf("Error creating CPU profile: %s\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		fmt.Printf("Error starting CPU profile: %s\n", err)
+		os.Exit(1)
+	}
+	defer pprof.StopCPUProfile()
+}
+
+runWithConfig(filename, string(content), getDir(filename), *showDisassembly)
+
+if *memProfile != "" {
+	f, err := os.Create(*memProfile)
+	if err != nil {
+		fmt.Printf("Error creating memory profile: %s\n", err)
+		os.Exit(1)
+	}
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		fmt.Printf("Error writing memory profile: %s\n", err)
+	}
+	f.Close()
+}
+```
+
+Nota: `runWithConfig` chama `os.Exit(1)` em erro de runtime — o profile só é escrito em execução bem-sucedida, o que é o comportamento desejado. Efeito colateral aceito: nesse caminho de erro o arquivo `--cpuprofile` fica criado porém vazio/truncado (o `os.Create` já aconteceu e `os.Exit` pula os defers).
+
+- [ ] **Step 3: Build e verificação manual**
+
+```powershell
+go build -o noxy_perf.exe ./cmd/noxy
+.\noxy_perf.exe --cpuprofile=fib.prof benchmarks\cross_runtime\fib.nx
+go tool pprof -top -nodecount=15 noxy_perf.exe fib.prof
+```
+
+Esperado: `CHECKSUM:832040` no stdout do script; a tabela do pprof lista as funções mais quentes (esperamos ver `bindingStore.get`, `runtime.mapaccess2`, `sync.(*RWMutex)`, `(*VM).run`, alocação de `CallFrame`).
+
+- [ ] **Step 4: Coletar baseline dos três benches e registrar**
+
+```powershell
+.\noxy_perf.exe --cpuprofile=loop.prof benchmarks\cross_runtime\loop_arith.nx
+.\noxy_perf.exe --cpuprofile=bubble.prof benchmarks\cross_runtime\bubblesort.nx
+go tool pprof -top -nodecount=15 noxy_perf.exe loop.prof
+go tool pprof -top -nodecount=15 noxy_perf.exe bubble.prof
+```
+
+Colar as três tabelas `-top` numa seção nova **"Baseline pprof (Task 1)"** no fim de `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md`, com data e hash do commit. Se o profile CONTRADIZER o diagnóstico da spec (ex.: globais não aparecem no top de fib), anotar isso na spec e reordenar as tasks seguintes de acordo antes de prosseguir.
+
+- [ ] **Step 5: Testes e commit**
+
+```powershell
+go build ./... && go test ./internal/vm -run TestVM -count=1
+git add cmd/noxy/main.go docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
+git commit -m "feat(cli): flags --cpuprofile/--memprofile e baseline pprof da fase 1"
+```
+
+---
+
+### Task 2: Cache de globais com contador de geração
+
+Elimina RLock + boxing de string + hash de `map[interface{}]` de todo `OP_GET_GLOBAL` estável (o caso de `fib`, que resolve o próprio nome 2× por chamada). Escritas invalidam por um contador de geração somado ao longo da cadeia de ambientes; o contador vive no `bindingStore` para que escritas via `ObjMap` que compartilha o store de um módulo (`ExportMap`, environment.go:71) também invalidem.
+
+Limitação conhecida (aceita): há UMA entrada de cache por índice de constante por chunk. Duas tasks paralelas executando o mesmo chunk sob ambientes diferentes alternam a entrada (last-writer-wins do `atomic.Pointer`) — correto sempre (cada leitor valida Env+Gen), mas sub-cacheia em cargas spawn-heavy. Se `bench_spawn_sum` regredir na Task 8, este é o primeiro suspeito.
+
+**Files:**
+- Modify: `internal/value/map.go` (gen no `bindingStore`)
+- Modify: `internal/value/environment.go` (método `Generation()`)
+- Modify: `internal/chunk/chunk.go` (struct `GlobalCacheEntry`, campo+método `GlobalCache()`)
+- Modify: `internal/vm/executor.go` (fast path no `OP_GET_GLOBAL`; recarga do cache nos 4 pontos de troca de frame)
+- Test: `internal/value/environment_test.go`, `internal/vm/executor_test.go` (novo arquivo pequeno; padrão de `vm_test_helpers_test.go`)
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `chunk.GlobalCacheEntry{Env *value.GlobalEnvironment; Gen uint64; Val value.Value}`; `(*chunk.Chunk).GlobalCache() []atomic.Pointer[GlobalCacheEntry]`; `(*value.GlobalEnvironment).Generation() uint64`. Nenhuma task posterior depende destes nomes, mas o executor passa a manter a variável local `gcache` em `run()`.
+
+- [ ] **Step 1: Testes que falham — invalidação de geração (pacote value)**
+
+Adicionar a `internal/value/environment_test.go`:
+
+```go
+func TestGenerationBumpsOnSetLocal(t *testing.T) {
+	env := NewGlobalEnvironment(nil)
+	g0 := env.Generation()
+	env.SetLocal("x", NewInt(1))
+	if env.Generation() == g0 {
+		t.Fatal("SetLocal deve avançar a geração")
+	}
+}
+
+func TestGenerationSeesParentWrites(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	child := NewGlobalEnvironment(root)
+	g0 := child.Generation()
+	root.SetLocal("x", NewInt(1))
+	if child.Generation() == g0 {
+		t.Fatal("escrita no pai deve avançar a geração vista pelo filho")
+	}
+}
+
+func TestGenerationSeesExportedMapWrites(t *testing.T) {
+	env := NewGlobalEnvironment(nil)
+	env.SetLocal("x", NewInt(1))
+	g0 := env.Generation()
+	exported := env.ExportMap().Obj.(*ObjMap)
+	exported.Set("x", NewInt(2))
+	if env.Generation() == g0 {
+		t.Fatal("escrita via ObjMap que compartilha o store deve avançar a geração")
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```powershell
+go test ./internal/value -run TestGeneration -count=1
+```
+
+Esperado: FAIL de compilação (`env.Generation` indefinido).
+
+- [ ] **Step 3: Implementar gen no bindingStore e Generation() no environment**
+
+Em `internal/value/map.go`, adicionar `"sync/atomic"` ao import e o campo:
+
+```go
+type bindingStore struct {
+	mu     sync.RWMutex
+	gen    atomic.Uint64
+	values map[interface{}]Value
+}
+```
+
+Bumpar em toda mutação (os quatro funis; `get`/`snapshot` não mudam):
+
+```go
+func (store *bindingStore) set(key interface{}, item Value) {
+	store.mu.Lock()
+	store.values[key] = item
+	store.mu.Unlock()
+	store.gen.Add(1)
+}
+```
+
+Em `defineIfAbsent`, adicionar `store.gen.Add(1)` imediatamente antes do `return true` (não bumpar no caminho `exists`). Em `delete`, idem antes do `return true`. Em `replace`, adicionar `store.gen.Add(1)` como última linha da função.
+
+Em `internal/value/environment.go`, adicionar:
+
+```go
+// Generation soma as gerações dos stores da cadeia de ambientes. Qualquer
+// escrita em qualquer nível (inclusive via ObjMap exportado que compartilha o
+// store — ver ExportMap) avança a soma; os contadores só incrementam, então a
+// soma é estritamente crescente e serve de token de invalidação de cache.
+func (environment *GlobalEnvironment) Generation() uint64 {
+	var sum uint64
+	for current := environment; current != nil; current = current.parent {
+		sum += current.local.gen.Load()
+	}
+	return sum
+}
+```
+
+- [ ] **Step 4: Rodar os testes de value**
+
+```powershell
+go test ./internal/value -count=1 && go test ./internal/value -race -count=1
+```
+
+Esperado: PASS (incluindo os três novos).
+
+- [ ] **Step 5: Teste que falha — comportamento no VM (reatribuição de global vista através de função)**
+
+Criar `internal/vm/global_cache_test.go`:
+
+```go
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Guarda o cache de globais contra staleness: a função lê o global duas
+// vezes com uma reatribuição no meio — a segunda leitura TEM de ver o valor
+// novo mesmo com o site de OP_GET_GLOBAL cacheado pela primeira.
+func TestGlobalReadSeesReassignmentBetweenCalls(t *testing.T) {
+	result := captureVMSource(t, `
+let x: int = 1
+func get() -> int
+    return x
+end
+let first: int = get()
+x = 2
+let second: int = get()
+test_report(first * 10 + second)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 12 {
+		t.Fatalf("esperado 12 (first=1, second=2), obtido %s", result.String())
+	}
+}
+
+// Mesmo chunk executado sob DOIS ambientes diferentes (o caso de módulo /
+// InterpretWithEnvironment): a entrada cacheada do primeiro ambiente não pode
+// vazar para o segundo — a comparação entry.Env tem de falhar e re-resolver.
+// Chunk montado à mão (padrão cow_mut_opcodes_test.go): OP_GET_GLOBAL "x" sem
+// OP_RETURN — o loop cai fora e deixa o valor lido em stack[1] para inspeção.
+func TestGlobalCacheKeyedByEnvironment(t *testing.T) {
+	machine := New()
+	code := &chunk.Chunk{}
+	nameIdx := code.AddConstant(value.NewString("x"))
+	code.Write(byte(chunk.OP_GET_GLOBAL), 1)
+	code.Write(byte(nameIdx>>8), 1)
+	code.Write(byte(nameIdx&0xff), 1)
+
+	envA := value.NewGlobalEnvironmentFrom(map[string]value.Value{"x": value.NewInt(1)}, nil)
+	envB := value.NewGlobalEnvironmentFrom(map[string]value.Value{"x": value.NewInt(2)}, nil)
+
+	if err := machine.InterpretWithEnvironment(code, envA); err != nil {
+		t.Fatalf("vm error (envA): %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 1 {
+		t.Fatalf("envA: esperado 1, obtido %s", got.String())
+	}
+
+	if err := machine.InterpretWithEnvironment(code, envB); err != nil {
+		t.Fatalf("vm error (envB): %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 2 {
+		t.Fatalf("envB: cache vazou o valor do envA — esperado 2, obtido %s", got.String())
+	}
+}
+```
+
+Rodar: `go test ./internal/vm -run TestGlobal -count=1`. Esperado: PASS já hoje (é característica de regressão — registra o contrato ANTES do cache; se falhar aqui, o teste está errado, corrigir antes de seguir). Nota: `TestGlobalCacheKeyedByEnvironment` inspeciona `machine.stack[1]` após o loop cair fora do fim do código — mesmo padrão de `cow_mut_opcodes_test.go`.
+
+- [ ] **Step 6: Implementar o cache no chunk e no executor**
+
+Em `internal/chunk/chunk.go`, adicionar `"sync"` e `"sync/atomic"` aos imports e, logo após a struct `Chunk`:
+
+```go
+// GlobalCacheEntry cacheia a resolução de um OP_GET_GLOBAL: válida enquanto o
+// mesmo ambiente estiver ativo E a geração somada da cadeia não mudar. Env e
+// Gen juntos tornam impossível servir valor stale: qualquer escrita bumpa a
+// geração; chunk rodando sob outro ambiente falha a comparação de Env.
+type GlobalCacheEntry struct {
+	Env interface{} // *value.GlobalEnvironment (interface evita import cycle se houver)
+	Gen uint64
+	Val value.Value
+}
+
+func (c *Chunk) GlobalCache() []atomic.Pointer[GlobalCacheEntry] {
+	c.globalCacheOnce.Do(func() {
+		c.globalCache = make([]atomic.Pointer[GlobalCacheEntry], len(c.Constants))
+	})
+	return c.globalCache
+}
+```
+
+e os campos na struct (append, sem mexer nos existentes):
+
+```go
+type Chunk struct {
+	Code      []byte
+	Constants []value.Value
+	Lines     []int
+	FileName  string
+
+	globalCacheOnce sync.Once
+	globalCache     []atomic.Pointer[GlobalCacheEntry]
+}
+```
+
+Nota: `chunk` já importa `value`, então `Env` pode ser tipado como `*value.GlobalEnvironment` diretamente — preferir isso; o comentário acima só vale se o import criar ciclo (não cria: value não importa chunk).
+
+Em `internal/vm/executor.go`, função `run()`: junto de cada ponto que faz `c = frame.Closure.Function.Chunk.(*chunk.Chunk)` (4 lugares: linha 49 na entrada, e os cases `OP_CALL`, `OP_RETURN`, `OP_IMPORT`), adicionar na linha seguinte:
+
+```go
+gcache := c.GlobalCache()
+```
+
+(na entrada é `gcache := ...`; nos cases é `gcache = ...`).
+
+Substituir o corpo do case `OP_GET_GLOBAL` (executor.go:185-195) por:
+
+```go
+case chunk.OP_GET_GLOBAL:
+	index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	gen := frame.Environment.Generation()
+	if entry := gcache[index].Load(); entry != nil && entry.Env == frame.Environment && entry.Gen == gen {
+		vm.push(entry.Val)
+		continue
+	}
+	nameVal := c.Constants[index]
+	name := nameVal.Obj.(string)
+
+	val, ok := frame.Environment.Resolve(name)
+	if !ok {
+		return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
+	}
+	gcache[index].Store(&chunk.GlobalCacheEntry{Env: frame.Environment, Gen: gen, Val: val})
+	vm.push(val)
+```
+
+Soundness da corrida gen/Resolve: a geração é lida ANTES do Resolve; uma escrita concorrente entre os dois bumpa a geração, então a entrada gravada com a geração antiga falha a comparação na próxima leitura e re-resolve — o cache pode sub-cachear, nunca servir stale.
+
+- [ ] **Step 7: Rodar a suíte inteira + race + corpus**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go test ./internal/vm -race -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Esperado: tudo verde, corpus 130/130.
+
+- [ ] **Step 8: Medir fib A/B**
+
+```powershell
+go build -o noxy_perf.exe ./cmd/noxy
+# 5 execuções intercaladas de cada binário, anotar o mínimo:
+1..5 | ForEach-Object { Measure-Command { .\noxy_develop.exe benchmarks\cross_runtime\fib.nx } | Select -Expand TotalMilliseconds; Measure-Command { .\noxy_perf.exe benchmarks\cross_runtime\fib.nx } | Select -Expand TotalMilliseconds }
+```
+
+Esperado: queda clara em fib (o baseline da Task 1 diz quanto do tempo era `bindingStore.get`). Se não houver queda, parar e re-perfilar antes de seguir.
+
+- [ ] **Step 9: Commit**
+
+```powershell
+git add internal/value/map.go internal/value/environment.go internal/chunk/chunk.go internal/vm/executor.go internal/value/environment_test.go internal/vm/global_cache_test.go
+git commit -m "perf(vm): cache de globais com contador de geracao (OP_GET_GLOBAL sem lock no caminho estavel)"
+```
+
+---
+
+### Task 3: OP_CALL_STATIC — pular validação de modos já provada pelo compilador
+
+Quando `compileCallExpression` tem `isExact == true` (compiler.go:1800), cada argumento já foi checado contra o modo (ref/valor) e o tipo do parâmetro em compile time. `validateParameterModes` (call_validation.go:39) re-verifica isso a cada chamada em runtime. Tipos são estáveis (`docs/NOXY_LANGUAGE_SPEC.md` §2.0, "Static Typing and Type-Stable Variables"), então a prova estática vale para qualquer função que o slot tipado contenha.
+
+A cadeia de soundness que sustenta o skip (verificada na revisão independente do plano): (1) `isExact` só nasce de `FunctionType` exato — bare `func` é `PrimitiveType{"func"}` e nunca ativa (function_types.go:23-26); (2) `areStrictTypesCompatible` rejeita `any` como fonte para tipos função (function_types.go:177-178), então nenhum valor não provado entra num slot de tipo função sem erro de compilação; (3) fronteiras dinâmicas validadas (maps/tasks) comparam `ParamIsRef` em `runtimeTypesEqual` (runtime_type_validation.go:481-485). Vetor a fechar no Step 1: membro de módulo re-atribuído em runtime (`ObjMap` mutável) — o teste de rebind cobre o análogo local, e se membros de módulo compilarem como `FunctionType` exato, adicionar variante com módulo.
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (novo opcode `OP_CALL_STATIC` — APPEND no fim do bloco const, após `OP_REF_LOCAL_BORROW`; case no `String()`; case no disassembler espelhando o de `OP_CALL` em chunk.go:451)
+- Modify: `internal/compiler/compiler.go:1679-1688` (`emitCall` ganha parâmetro `static bool`) e `compiler.go:1858` (call site passa `isExact`)
+- Modify: `internal/vm/executor.go` (case novo) e `internal/vm/calls.go` (função `callValueStatic`)
+- Test: `internal/vm/call_static_test.go`
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `chunk.OP_CALL_STATIC` (operando: 1 byte argCount, layout idêntico a `OP_CALL`); `(*VM).callValueStatic(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error)`; `emitCall(argCount int, emission callEmission, static bool)`.
+
+- [ ] **Step 1: Testes de contrato (passam hoje; guardam contra over-skip)**
+
+Criar `internal/vm/call_static_test.go`:
+
+```go
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Chamada tipada in-module: caminho que a Task 3 acelera. O resultado não
+// pode mudar.
+func TestTypedCallStillWorks(t *testing.T) {
+	result := captureVMSource(t, `
+func double(n: int) -> int
+    return n * 2
+end
+test_report(double(21))
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 42 {
+		t.Fatalf("esperado 42, obtido %s", result.String())
+	}
+}
+
+// Caminho dinâmico (any): validateParameterModes TEM de continuar disparando —
+// passar valor plano onde a função espera ref é erro de runtime aqui.
+func TestDynamicCallStillValidatesModes(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func mutate(target: ref int) -> void
+    target = 99
+end
+let f: any = mutate
+f(5)
+`)
+	if err == nil {
+		t.Fatal("chamada dinâmica com modo errado deveria falhar em runtime")
+	}
+	if !strings.Contains(err.Error(), "expected") {
+		t.Fatalf("mensagem inesperada: %v", err)
+	}
+}
+
+// Slot tipado re-atribuído para OUTRA função de mesmo tipo: o call site
+// OP_CALL_STATIC continua correto porque a prova é por TIPO, não por valor
+// (invariantes 1-3 do preâmbulo da task). Sintaxe do tipo função conforme
+// docs/NOXY_LANGUAGE_SPEC.md §4.2 — ajustar a grafia se o parser divergir.
+func TestStaticCallSurvivesSameTypedRebind(t *testing.T) {
+	result := captureVMSource(t, `
+func inc(n: int) -> int
+    return n + 1
+end
+func dec(n: int) -> int
+    return n - 1
+end
+let op: func(int) -> int = inc
+let a: int = op(10)
+op = dec
+let b: int = op(10)
+test_report(a * 100 + b)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 1109 {
+		t.Fatalf("esperado 1109 (11*100+9), obtido %s", result.String())
+	}
+}
+```
+
+Rodar: `go test ./internal/vm -run "TestTypedCall|TestDynamicCall|TestStaticCall" -count=1`. Esperado: PASS. (Se `TestDynamicCallStillValidatesModes` falhar porque o COMPILADOR já rejeita, trocar a construção do valor dinâmico por uma que compile — ex.: guardar em `map[string, any]` e chamar — o objetivo é ter um caminho que chegue ao runtime sem prova estática. Ajustar até o teste passar pelo motivo certo: erro em runtime, não em compile.)
+
+- [ ] **Step 2: Adicionar o opcode**
+
+Em `internal/chunk/chunk.go`, no FIM do bloco const (após `OP_REF_LOCAL_BORROW`):
+
+```go
+	// perf fase 1: chamada cujos modos de parametro (ref/valor) o compilador
+	// provou no call site (isExact) — o VM pula validateParameterModes para
+	// closures. Layout de operando identico ao OP_CALL: [argCount u8].
+	OP_CALL_STATIC
+```
+
+No `String()`, adicionar `case OP_CALL_STATIC: return "OP_CALL_STATIC"`. No `disassembleInstruction`, adicionar um case espelhando exatamente o de `OP_CALL` (chunk.go:451 — mesmo helper, nome `"OP_CALL_STATIC"`).
+
+- [ ] **Step 3: VM — handler e callValueStatic**
+
+Em `internal/vm/calls.go`, após `callValue`:
+
+```go
+// callValueStatic é o caminho de OP_CALL_STATIC: o compilador provou os modos
+// dos argumentos no call site (isExact), e tipos são estáveis, então closures
+// pulam validateParameterModes. Struct constructors e natives seguem pelo
+// callValue normal — as validações deles são de outra natureza (aridade de
+// struct, assinatura de native) e continuam valendo.
+//
+// O skip depende de três invariantes do compilador — se qualquer um mudar,
+// este opcode deixa de ser sound:
+//  1. isExact só nasce de FunctionType exato; bare `func` é PrimitiveType e
+//     nunca ativa (function_types.go:23-26);
+//  2. areStrictTypesCompatible rejeita `any` como fonte para tipos função
+//     (function_types.go:177-178);
+//  3. fronteiras dinâmicas validadas comparam ParamIsRef em
+//     runtimeTypesEqual (runtime_type_validation.go:481-485).
+func (vm *VM) callValueStatic(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
+	if callee.Type == value.VAL_FUNCTION {
+		closure := callee.Obj.(*value.ObjClosure)
+		if argCount != closure.Function.Arity {
+			return false, vm.runtimeError(c, ip, "expected %d arguments but got %d", closure.Function.Arity, argCount)
+		}
+		return vm.callPreparedClosure(closure, argCount, c, ip)
+	}
+	return vm.callValue(callee, argCount, c, ip)
+}
+```
+
+Em `internal/vm/executor.go`, adicionar o case (ao lado de `OP_CALL`, corpo idêntico exceto a função chamada):
+
+```go
+case chunk.OP_CALL_STATIC:
+	argCount := int(c.Code[ip])
+	ip++
+	frame.IP = ip
+	if ok, err := vm.callValueStatic(vm.peek(argCount), argCount, c, ip); !ok {
+		return err
+	}
+	frame = vm.currentFrame
+	c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+	gcache = c.GlobalCache()
+	ip = frame.IP
+```
+
+- [ ] **Step 4: Compilador — emitir quando provado**
+
+Em `internal/compiler/compiler.go:1679`, mudar a assinatura e o corpo de `emitCall`:
+
+```go
+func (c *Compiler) emitCall(argCount int, emission callEmission, static bool) {
+	op := chunk.OP_CALL
+	if static {
+		op = chunk.OP_CALL_STATIC
+	}
+	line := c.currentLine
+	if emission.deferred {
+		op = chunk.OP_DEFER
+		line = emission.registrationLine
+	}
+	c.currentChunk.Write(byte(op), line)
+	c.currentChunk.Write(byte(argCount), line)
+}
+```
+
+Atualizar TODOS os call sites de `emitCall` (buscar `c.emitCall(`): os de `chan_send`/`chan_recv` passam `false`; o site final de `compileCallExpression` (linha ~1858) passa `isExact`:
+
+```go
+c.emitCall(len(call.Arguments), emission, isExact)
+```
+
+- [ ] **Step 5: Suíte + corpus + disassembly manual**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+'func f(n: int) -> int
+    return n
+end
+f(1)' | Out-File -Encoding utf8 tmp_static.nx
+go run ./cmd/noxy --disassembly tmp_static.nx | Select-String "OP_CALL"
+Remove-Item tmp_static.nx
+```
+
+Esperado: suíte verde, corpus 130/130, e a linha do disassembly mostra `OP_CALL_STATIC` para a chamada tipada.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/vm/calls.go internal/vm/executor.go internal/vm/call_static_test.go
+git commit -m "perf(vm,compiler): OP_CALL_STATIC pula validateParameterModes quando o call site foi provado (isExact)"
+```
+
+---
+
+### Task 4: CallFrame sem alocação de heap
+
+`callPreparedClosure` faz `&CallFrame{...}` por chamada (calls.go:118). O array `vm.frames` vira array de VALORES reusados; `Owned`/`Deferred` mantêm capacidade entre reusos.
+
+**Files:**
+- Modify: `internal/vm/vm.go:57` (`frames [FramesMax]*CallFrame` → `frames [FramesMax]CallFrame`)
+- Modify: `internal/vm/calls.go:113-140`, `internal/vm/executor.go:39-41`, `internal/vm/unwind.go:61-64,71,81`, `internal/vm/references.go:176,220`, `internal/vm/runtime_errors.go:107`, `internal/vm/task_execution.go:106`, `internal/vm/builtins_concurrency.go:87`
+- Test: `internal/vm/call_alloc_bench_test.go` + suíte existente (characterization tests já cobrem semântica)
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `vm.frames` passa a ser `[FramesMax]CallFrame`; todo código que precisar de `*CallFrame` usa `&vm.frames[i]`. `vm.currentFrame` continua `*CallFrame` (aponta para dentro do array, que tem tamanho fixo — ponteiros estáveis).
+
+- [ ] **Step 1: Benchmark que expõe a alocação (falha por medida, não por assert)**
+
+Criar `internal/vm/call_alloc_bench_test.go`:
+
+```go
+package vm
+
+import "testing"
+
+// Mede alocações por chamada de função Noxy. Antes da Task 4: >=2 allocs/op
+// no caminho de chamada (CallFrame + Owned). Depois: 0 allocs/op de frame em
+// regime estacionário (capacidades de Owned/Deferred reusadas).
+func BenchmarkNoxyCallOverhead(b *testing.B) {
+	machine := New()
+	code := compileVMSourceForBench(b, `
+func leaf(n: int) -> int
+    return n
+end
+func run(times: int) -> int
+    let i: int = 0
+    let acc: int = 0
+    while i < times do
+        acc = leaf(i)
+        i = i + 1
+    end
+    return acc
+end
+run(1000)
+`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := machine.Interpret(code); err != nil {
+			b.Fatalf("vm error: %v", err)
+		}
+	}
+}
+```
+
+E o helper (mesmo arquivo — `compileVMSource` existente exige `*testing.T`):
+
+```go
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+)
+
+func compileVMSourceForBench(b *testing.B, source string) *chunk.Chunk {
+	b.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		b.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		b.Fatalf("compiler error: %v", err)
+	}
+	return code
+}
+```
+
+- [ ] **Step 2: Rodar e registrar o número de antes**
+
+```powershell
+go test ./internal/vm -bench BenchmarkNoxyCallOverhead -benchmem -run xxx -count=1
+```
+
+Anotar `allocs/op` no output (esperado: milhares — ~1 CallFrame por chamada × 1000 chamadas/op).
+
+- [ ] **Step 3: Trocar o array para valores e ajustar todos os usos**
+
+Em `internal/vm/vm.go:57`: `frames [FramesMax]CallFrame`.
+
+Em `internal/vm/calls.go`, substituir o miolo de `callPreparedClosure` (linhas 118-138):
+
+```go
+frame := &vm.frames[vm.frameCount]
+frame.Closure = closure
+frame.IP = 0
+frame.StackBase = vm.stackTop - argCount - 1
+frame.LocalBase = vm.stackTop - argCount - 1
+frame.Environment = closure.Environment
+frame.Deferred = frame.Deferred[:0]
+frame.Owned = frame.Owned[:0]
+
+// RC: parametros sem ref sao vinculos duraveis do frame novo
+params := closure.Function.Params
+for i := 0; i < argCount; i++ {
+	if i < len(params) && params[i].IsRef {
+		continue
+	}
+	frame.ownSlot(vm, frame.LocalBase+1+i)
+}
+
+vm.frameCount++
+vm.currentFrame = frame
+return true, nil
+```
+
+Em `internal/vm/executor.go:39-41` (`InterpretWithEnvironment`):
+
+```go
+frame := &vm.frames[0]
+*frame = CallFrame{Closure: scriptClosure, IP: 0, StackBase: 0, LocalBase: 1, Environment: environment, Deferred: frame.Deferred[:0], Owned: frame.Owned[:0]}
+vm.frameCount = 1
+vm.currentFrame = frame
+```
+
+Em `internal/vm/unwind.go` (`finalizeCurrentFrame`), DOIS pontos — atenção: a revisão independente pegou que o ponto crítico é a linha 64, não a 71:
+
+1. **Linha 61-64** — o loop de release já pagou cada objeto; o `frame.Owned = nil` da linha 64 é o que joga a capacidade fora (e faria a meta de zero-alloc falhar: todo `ownSlot` da próxima chamada realocaria). Substituir por limpeza que preserva o backing array:
+
+```go
+for i := range frame.Owned {
+	value.Release(frame.Owned[i].obj)
+	frame.Owned[i] = ownedEntry{}
+}
+frame.Owned = frame.Owned[:0]
+```
+
+(O zerar de cada entrada é obrigatório: o backing array sobrevive ao frame e não pode reter `value.Value` de objetos já liberados.)
+
+2. **Linha 71** — `vm.frames[frameIndex] = nil` deixa de compilar com o array de valores. Substituir por reset de campos que preserva `Owned`/`Deferred` (o `Deferred` já foi esvaziado entrada a entrada pelo loop das linhas 27-31, que zera cada `PreparedCall` e mantém a capacidade):
+
+```go
+frame.Closure = nil
+frame.Environment = nil
+```
+
+Em `unwind.go:81`: `vm.currentFrame = &vm.frames[vm.frameCount-1]`.
+
+Em `references.go:176,220` e `runtime_errors.go:107`: `frame := &vm.frames[i]`.
+Em `task_execution.go:106` e `builtins_concurrency.go:87`: mesmo padrão do `InterpretWithEnvironment` acima (atribuir campos via `*frame = CallFrame{...}` preservando `Deferred`/`Owned` com `[:0]`).
+
+Compilar e caçar o resto: `go build ./...` aponta cada uso restante de `*CallFrame` incompatível — ajustar um a um com `&vm.frames[i]`.
+
+- [ ] **Step 4: Suíte completa + race + corpus (o RC é o risco aqui)**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go test ./internal/vm -race -count=1
+go test ./internal/value -race -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Esperado: tudo verde, 130/130. Atenção especial a `rc_uniqueness_test.go`, `reference_ownership_test.go`, `defer_test.go`, `unwind_test.go` — se qualquer um falhar, o reuso de `Owned`/`Deferred` vazou estado entre frames; revisar a limpeza do Step 3.
+
+- [ ] **Step 5: Re-rodar o benchmark de alocação**
+
+```powershell
+go test ./internal/vm -bench BenchmarkNoxyCallOverhead -benchmem -run xxx -count=1
+```
+
+Esperado: `allocs/op` cai para perto de zero por chamada (sobra só o que `ownSlot` aloca na primeira expansão de `Owned`, amortizado). Registrar antes/depois no commit message.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/vm
+git commit -m "perf(vm): CallFrame em array de valores reusado - zero alocacao por chamada (allocs/op: <antes> -> <depois>)"
+```
+
+---
+
+### Task 5: Comparação+salto fundidos para int (while e if)
+
+`while i < N do` hoje custa por iteração: `OP_LESS_INT` + `OP_JUMP_IF_FALSE` + `OP_POP` (3 dispatches + um bool de ida e volta na pilha). `if n <= 1 then` (fib!) idem. Funde num opcode único que consome os dois ints e salta.
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (6 opcodes novos por APPEND + `TruncateTo` + String/disasm)
+- Modify: `internal/compiler/compiler.go` (helper `tryCompileFusedCondition` + integração no `WhileStatement` (linha 1142) e `IfStatement` (linha 1100))
+- Modify: `internal/vm/executor.go` (6 cases)
+- Test: `internal/vm/fused_jump_test.go`, `internal/compiler/fused_jump_compile_test.go`
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: opcodes `OP_JUMP_IF_LT_INT`, `OP_JUMP_IF_LE_INT`, `OP_JUMP_IF_GT_INT`, `OP_JUMP_IF_GE_INT`, `OP_JUMP_IF_EQ_INT`, `OP_JUMP_IF_NE_INT` — todos com operando `[hi][lo]` (mesmo layout de `OP_JUMP`, compatíveis com `emitJump`/`patchJump`); **saltam quando a condição NOMEADA vale**, consumindo dois ints da pilha. `(*Chunk).TruncateTo(n int)`. Task 6 e 7 assumem esses opcodes já no enum (ordem de append: os 6 desta task vêm ANTES dos da Task 6/7).
+
+- [ ] **Step 1: Testes de VM que falham (chunks montados à mão, padrão cow_mut_opcodes_test.go)**
+
+Criar `internal/vm/fused_jump_test.go`:
+
+```go
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: stack[0] = script closure; empilhamos a,b e o opcode fundido
+// salta (ou não) sobre um OP_CONSTANT sentinela. Sem OP_RETURN de propósito
+// (o loop cai fora no fim do código e deixa a pilha para inspeção).
+func runFusedJump(t *testing.T, op chunk.OpCode, a, b int64) (jumped bool) {
+	t.Helper()
+	machine := New()
+	code := &chunk.Chunk{}
+	ca := code.AddConstant(value.NewInt(a))
+	cb := code.AddConstant(value.NewInt(b))
+	sentinel := code.AddConstant(value.NewInt(777))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(ca), 1)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(cb), 1)
+	code.Write(byte(op), 1)
+	code.Write(0, 1) // offset hi
+	code.Write(2, 1) // offset lo: pula o OP_CONSTANT sentinela (2 bytes)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(sentinel), 1)
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	// Se saltou, a pilha ficou só com a closure (stackTop==1); senão, o
+	// sentinela 777 está no topo.
+	if machine.stackTop == 1 {
+		return true
+	}
+	top := machine.stack[machine.stackTop-1]
+	if top.Type != value.VAL_INT || top.AsInt != 777 {
+		t.Fatalf("pilha inesperada: top=%s stackTop=%d", top.String(), machine.stackTop)
+	}
+	return false
+}
+
+func TestFusedJumpOpcodes(t *testing.T) {
+	cases := []struct {
+		name string
+		op   chunk.OpCode
+		a, b int64
+		want bool
+	}{
+		{"LT salta quando a<b", chunk.OP_JUMP_IF_LT_INT, 1, 2, true},
+		{"LT nao salta quando a>=b", chunk.OP_JUMP_IF_LT_INT, 2, 2, false},
+		{"LE salta quando a<=b", chunk.OP_JUMP_IF_LE_INT, 2, 2, true},
+		{"LE nao salta quando a>b", chunk.OP_JUMP_IF_LE_INT, 3, 2, false},
+		{"GT salta quando a>b", chunk.OP_JUMP_IF_GT_INT, 3, 2, true},
+		{"GT nao salta quando a<=b", chunk.OP_JUMP_IF_GT_INT, 2, 2, false},
+		{"GE salta quando a>=b", chunk.OP_JUMP_IF_GE_INT, 2, 2, true},
+		{"GE nao salta quando a<b", chunk.OP_JUMP_IF_GE_INT, 1, 2, false},
+		{"EQ salta quando a==b", chunk.OP_JUMP_IF_EQ_INT, 5, 5, true},
+		{"EQ nao salta quando a!=b", chunk.OP_JUMP_IF_EQ_INT, 5, 6, false},
+		{"NE salta quando a!=b", chunk.OP_JUMP_IF_NE_INT, 5, 6, true},
+		{"NE nao salta quando a==b", chunk.OP_JUMP_IF_NE_INT, 5, 5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runFusedJump(t, tc.op, tc.a, tc.b); got != tc.want {
+				t.Fatalf("jumped=%v, esperado %v", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```powershell
+go test ./internal/vm -run TestFusedJump -count=1
+```
+
+Esperado: FAIL de compilação (opcodes indefinidos). Após o Step 3 parcial (só o enum), falham por comportamento: opcode sem case é no-op — o sentinela sempre aparece.
+
+- [ ] **Step 3: Opcodes no chunk + TruncateTo**
+
+Em `internal/chunk/chunk.go`, APPEND no fim do bloco const (depois de `OP_CALL_STATIC` da Task 3):
+
+```go
+	// perf fase 1: comparacao int + salto condicional fundidos. Consomem dois
+	// VAL_INT da pilha (sem zerar: escalares nao carregam ponteiros) e saltam
+	// [hi][lo] adiante quando a condicao NOMEADA vale. Emitidos pelo
+	// compilador so quando ambos os lados sao estaticamente int; o salto e o
+	// jump-if-false da condicao de origem (`<` emite GE, `<=` emite GT, ...).
+	OP_JUMP_IF_LT_INT
+	OP_JUMP_IF_LE_INT
+	OP_JUMP_IF_GT_INT
+	OP_JUMP_IF_GE_INT
+	OP_JUMP_IF_EQ_INT
+	OP_JUMP_IF_NE_INT
+```
+
+`String()`: um case por opcode devolvendo o próprio nome. `disassembleInstruction`: um case por opcode espelhando o de `OP_JUMP` (mesmo helper de jump, chunk.go região da linha ~445).
+
+E o truncate (após `Write`):
+
+```go
+// TruncateTo descarta bytecode ja emitido a partir do offset n (Code e Lines
+// andam em paralelo). Usado pelo compilador para desfazer a emissao
+// especulativa dos operandos de uma condicao que nao pode ser fundida.
+func (c *Chunk) TruncateTo(n int) {
+	c.Code = c.Code[:n]
+	c.Lines = c.Lines[:n]
+}
+```
+
+- [ ] **Step 4: Cases no executor**
+
+Em `internal/vm/executor.go` (os seis são iguais salvo o operador; sem zerar slots — os operandos são VAL_INT, `Obj == nil`, nada para o GC reter):
+
+```go
+case chunk.OP_JUMP_IF_LT_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt < vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+
+case chunk.OP_JUMP_IF_LE_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt <= vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+
+case chunk.OP_JUMP_IF_GT_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt > vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+
+case chunk.OP_JUMP_IF_GE_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt >= vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+
+case chunk.OP_JUMP_IF_EQ_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt == vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+
+case chunk.OP_JUMP_IF_NE_INT:
+	offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+	ip += 2
+	vm.stackTop -= 2
+	if vm.stack[vm.stackTop].AsInt != vm.stack[vm.stackTop+1].AsInt {
+		ip += offset
+	}
+```
+
+Rodar `go test ./internal/vm -run TestFusedJump -count=1` → PASS.
+
+- [ ] **Step 5: Compilador — tryCompileFusedCondition com rollback**
+
+Em `internal/compiler/compiler.go`, adicionar (perto de `emitJump`, ~linha 2064):
+
+```go
+// fusedIntCompareJump mapeia o operador da CONDICAO para o opcode que salta
+// quando a condicao FALHA (e o jump-if-false fundido): `i < n` continua no
+// corpo quando vale e salta para fora com GE.
+func fusedIntCompareJump(operator string) (chunk.OpCode, bool) {
+	switch operator {
+	case "<":
+		return chunk.OP_JUMP_IF_GE_INT, true
+	case "<=":
+		return chunk.OP_JUMP_IF_GT_INT, true
+	case ">":
+		return chunk.OP_JUMP_IF_LE_INT, true
+	case ">=":
+		return chunk.OP_JUMP_IF_LT_INT, true
+	case "==":
+		return chunk.OP_JUMP_IF_NE_INT, true
+	case "!=":
+		return chunk.OP_JUMP_IF_EQ_INT, true
+	}
+	return 0, false
+}
+
+// tryCompileFusedCondition tenta compilar cond como (left, right) ints puros e
+// devolve o opcode de salto fundido a emitir com emitJump. Emissao
+// especulativa: se um dos lados nao for estaticamente int, o bytecode dos
+// operandos e DESFEITO (TruncateTo) e o chamador segue o caminho generico.
+// Constantes adicionadas na especulacao ficam orfas no pool — inofensivo.
+func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, bool, error) {
+	infix, ok := cond.(*ast.InfixExpression)
+	if !ok {
+		return 0, false, nil
+	}
+	jumpOp, ok := fusedIntCompareJump(infix.Operator)
+	if !ok {
+		return 0, false, nil
+	}
+	checkpoint := len(c.currentChunk.Code)
+	_, leftType, err := c.Compile(infix.Left)
+	if err != nil {
+		return 0, false, err
+	}
+	if leftType == nil || leftType.String() != "int" {
+		c.currentChunk.TruncateTo(checkpoint)
+		return 0, false, nil
+	}
+	_, rightType, err := c.Compile(infix.Right)
+	if err != nil {
+		return 0, false, err
+	}
+	if rightType == nil || rightType.String() != "int" {
+		c.currentChunk.TruncateTo(checkpoint)
+		return 0, false, nil
+	}
+	return jumpOp, true, nil
+}
+```
+
+No `WhileStatement` (linha 1142), substituir o trecho condição→`jumpToExit` (linhas 1150-1161) por:
+
+```go
+fusedOp, fused, err := c.tryCompileFusedCondition(n.Condition)
+if err != nil {
+	return nil, nil, err
+}
+var jumpToExit int
+if fused {
+	jumpToExit = c.emitJump(fusedOp)
+} else {
+	_, condType, err := c.Compile(n.Condition)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, ok := condType.(*ast.RefType); ok {
+		c.emitByte(byte(chunk.OP_DEREF))
+	}
+	jumpToExit = c.emitJump(chunk.OP_JUMP_IF_FALSE)
+	c.emitByte(byte(chunk.OP_POP)) // Pop condition
+}
+```
+
+E na saída (linha 1172), condicionar o segundo POP:
+
+```go
+c.patchJump(jumpToExit)
+if !fused {
+	c.emitByte(byte(chunk.OP_POP)) // Pop condition at exit
+}
+```
+
+No `IfStatement` (linha 1100), mesma cirurgia: trecho condição→`jumpToElse` vira o bloco fused/genérico acima (com `jumpToElse` no lugar de `jumpToExit`), o `OP_POP` de entrada do THEN (linha 1116) e o `OP_POP` pós-`patchJump(jumpToElse)` (linha 1128) ficam ambos dentro de `if !fused { ... }`.
+
+- [ ] **Step 6: Testes de comportamento do compilador**
+
+Criar `internal/compiler/fused_jump_compile_test.go` (o pacote compiler tem testes que compilam e inspecionam erro; aqui validamos que programas com while/if fundidos e não-fundíveis compilam — o comportamento em execução é coberto pelo corpus e pelo teste de VM abaixo):
+
+```go
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+)
+
+func compileFusedSource(t *testing.T, source string) error {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	_, _, err := New().Compile(program)
+	return err
+}
+
+func TestFusedWhileCompiles(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f() -> int
+    let i: int = 0
+    while i < 10 do
+        i = i + 1
+    end
+    return i
+end
+f()
+`); err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+}
+
+// Condição float NÃO pode fundir: o rollback (TruncateTo) tem de deixar o
+// caminho genérico intacto.
+func TestNonIntConditionFallsBack(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f() -> int
+    let x: float = 0.0
+    let n: int = 0
+    while x < 10.0 do
+        x = x + 1.0
+        n = n + 1
+    end
+    return n
+end
+f()
+`); err != nil {
+		t.Fatalf("compile error (fallback quebrado): %v", err)
+	}
+}
+
+// Condição com curto-circuito dentro do operando (jumps internos) sob
+// rollback: `(a < b) == flag` compila o InfixExpression externo `==` — o lado
+// esquerdo é bool, então o fuse desiste após compilar o operando esquerdo.
+func TestBoolOperandRollsBack(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f(a: int, b: int, flag: bool) -> int
+    if (a < b) == flag then
+        return 1
+    end
+    return 0
+end
+f(1, 2, true)
+`); err != nil {
+		t.Fatalf("compile error (rollback com operando bool): %v", err)
+	}
+}
+```
+
+E o teste de execução ponta-a-ponta em `internal/vm/fused_jump_test.go` (append):
+
+```go
+func TestFusedWhileAndIfBehavior(t *testing.T) {
+	result := captureVMSource(t, `
+func fib(n: int) -> int
+    if n <= 1 then
+        return n
+    end
+    return fib(n - 1) + fib(n - 2)
+end
+let i: int = 0
+let acc: int = 0
+while i < 5 do
+    acc = acc + fib(i)
+    i = i + 1
+end
+test_report(acc)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 7 {
+		t.Fatalf("esperado 7 (fib 0..4 = 0+1+1+2+3), obtido %s", result.String())
+	}
+}
+```
+
+- [ ] **Step 7: Suíte + corpus + medida**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+go build -o noxy_perf.exe ./cmd/noxy
+1..5 | ForEach-Object { Measure-Command { .\noxy_develop.exe benchmarks\cross_runtime\loop_arith.nx } | Select -Expand TotalMilliseconds; Measure-Command { .\noxy_perf.exe benchmarks\cross_runtime\loop_arith.nx } | Select -Expand TotalMilliseconds }
+```
+
+Esperado: verde, 130/130, queda visível em loop_arith e fib.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/compiler/fused_jump_compile_test.go internal/vm/executor.go internal/vm/fused_jump_test.go
+git commit -m "perf(vm,compiler): comparacao int + salto fundidos em while/if (6 opcodes, rollback especulativo no codegen)"
+```
+
+---
+
+### Task 6: OP_INC_LOCAL_INT — incremento de local sem tráfego de pilha
+
+`i = i + 1` hoje emite GET_LOCAL + CONSTANT + ADD_INT + SET_LOCAL + POP (5 dispatches, ~4 cópias de 48 bytes). Vira 1 opcode que soma um delta int8 direto no slot.
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (opcode `OP_INC_LOCAL_INT [slot u8][delta i8]` por APPEND, String, disasm com 2 operandos de byte — espelhar um case de 1 byte e imprimir os dois)
+- Modify: `internal/compiler/compiler.go:340` (fusão no início do branch de atribuição a identifier)
+- Modify: `internal/vm/executor.go` (case novo)
+- Test: `internal/vm/inc_local_test.go`
+
+**Interfaces:**
+- Consumes: enum já contém os opcodes da Task 5 (append depois deles).
+- Produces: `chunk.OP_INC_LOCAL_INT`; `(*Compiler).tryFuseLocalIntIncrement(ident *ast.Identifier, valueExpr ast.Expression) bool`.
+
+- [ ] **Step 1: Teste de VM que falha (chunk à mão)**
+
+Criar `internal/vm/inc_local_test.go`:
+
+```go
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: LocalBase = 1, slot local 0 = stack[1]. Empilha 5 no slot e
+// aplica dois incrementos fundidos (+3, -1). Sem OP_RETURN de propósito.
+func TestIncLocalInt(t *testing.T) {
+	machine := New()
+	code := &chunk.Chunk{}
+	five := code.AddConstant(value.NewInt(5))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(five), 1)
+	code.Write(byte(chunk.OP_INC_LOCAL_INT), 1)
+	code.Write(0, 1)                // slot
+	code.Write(byte(int8(3)), 1)    // delta +3
+	code.Write(byte(chunk.OP_INC_LOCAL_INT), 1)
+	code.Write(0, 1)                // slot
+	code.Write(byte(int8(-1)), 1)   // delta -1
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	got := machine.stack[1]
+	if got.Type != value.VAL_INT || got.AsInt != 7 {
+		t.Fatalf("esperado slot=7, obtido %s", got.String())
+	}
+}
+```
+
+Rodar `go test ./internal/vm -run TestIncLocalInt -count=1` → FAIL (opcode indefinido; depois do enum, no-op deixa o slot em 5).
+
+- [ ] **Step 2: Opcode + handler**
+
+`internal/chunk/chunk.go`, APPEND após `OP_JUMP_IF_NE_INT`:
+
+```go
+	// perf fase 1: `i = i + K` / `i = i - K` (i local int possuidor, K literal
+	// que cabe em i8) fundido em soma direta no slot — sem trafego de pilha.
+	// Operandos: [slot u8][delta i8]. Overflow wrappa como OP_ADD_INT.
+	OP_INC_LOCAL_INT
+```
+
+String + case de disassembler (2 operandos: imprimir slot e delta; seguir o padrão do case de `OP_GET_LOCAL` estendido para o segundo byte).
+
+`internal/vm/executor.go`:
+
+```go
+case chunk.OP_INC_LOCAL_INT:
+	slot := c.Code[ip]
+	delta := int8(c.Code[ip+1])
+	ip += 2
+	vm.stack[frame.LocalBase+int(slot)].AsInt += int64(delta)
+```
+
+Rodar o teste do Step 1 → PASS.
+
+- [ ] **Step 3: Fusão no compilador**
+
+Em `internal/compiler/compiler.go`, adicionar o helper (perto de `localOwns`, linha 2150):
+
+```go
+// tryFuseLocalIntIncrement funde `i = i + K` / `i = i - K` (i local int
+// POSSUIDOR — slot ref nunca funde; K literal int em [-128,127]) em
+// OP_INC_LOCAL_INT. Retorna true se emitiu (nada mais a fazer no site).
+// Sem emissao especulativa: todas as checagens sao sintaticas/de simbolo.
+func (c *Compiler) tryFuseLocalIntIncrement(ident *ast.Identifier, valueExpr ast.Expression) bool {
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 || !c.localOwns(arg) {
+		return false
+	}
+	prim, ok := localType.(*ast.PrimitiveType)
+	if !ok || prim.Name != "int" {
+		return false
+	}
+	infix, ok := valueExpr.(*ast.InfixExpression)
+	if !ok || (infix.Operator != "+" && infix.Operator != "-") {
+		return false
+	}
+	left, ok := infix.Left.(*ast.Identifier)
+	if !ok || left.Value != ident.Value {
+		return false
+	}
+	lit, ok := infix.Right.(*ast.IntegerLiteral)
+	if !ok {
+		return false
+	}
+	delta := lit.Value
+	if infix.Operator == "-" {
+		delta = -delta
+	}
+	if delta < -128 || delta > 127 {
+		return false
+	}
+	c.emitBytes(byte(chunk.OP_INC_LOCAL_INT), byte(arg))
+	c.emitByte(byte(int8(delta)))
+	return true
+}
+```
+
+No branch de atribuição a identifier (linha 340), ANTES de compilar o valor (linha 343):
+
+```go
+} else if ident, ok := n.Target.(*ast.Identifier); ok {
+	// Fusao de incremento: emite OP_INC_LOCAL_INT e nao empilha nada
+	// (atribuicao e statement; o POP do caminho generico tambem cai fora).
+	if c.tryFuseLocalIntIncrement(ident, n.Value) {
+		return c.currentChunk, nil, nil
+	}
+	// Identifier Assignment: x = val
+	// 1. Compile Value (pushed to stack)
+	_, valType, err := c.Compile(n.Value)
+	...
+```
+
+Atenção: se `IntegerLiteral.Value` não for `int64` em `internal/ast/ast.go:244`, ajustar a comparação de faixa ao tipo real.
+
+- [ ] **Step 4: Teste de comportamento + suíte + corpus**
+
+Append em `internal/vm/inc_local_test.go`:
+
+```go
+func TestIncLocalIntBehavior(t *testing.T) {
+	result := captureVMSource(t, `
+func count() -> int
+    let i: int = 0
+    let downs: int = 100
+    while i < 10 do
+        i = i + 1
+        downs = downs - 2
+    end
+    return i * 1000 + downs
+end
+test_report(count())
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 10080 {
+		t.Fatalf("esperado 10080 (i=10, downs=80), obtido %s", result.String())
+	}
+}
+```
+
+```powershell
+go vet ./... && go test ./... -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/vm/executor.go internal/vm/inc_local_test.go
+git commit -m "perf(vm,compiler): OP_INC_LOCAL_INT funde i = i +- K em soma direta no slot"
+```
+
+---
+
+### Task 7: Aritmética e comparação FLOAT especializadas
+
+Espelho float dos opcodes `_INT` existentes, para mandelbrot e código numérico. Mistos int/float continuam no caminho genérico.
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (APPEND: `OP_ADD_FLOAT`, `OP_SUB_FLOAT`, `OP_MUL_FLOAT`, `OP_DIV_FLOAT`, `OP_LESS_FLOAT`, `OP_GREATER_FLOAT` + String/disasm)
+- Modify: `internal/compiler/compiler.go:930-1018` (bloco `isInt` ganha irmão `isFloat`)
+- Modify: `internal/vm/executor.go` (6 cases)
+- Test: `internal/vm/float_ops_test.go`
+
+**Interfaces:**
+- Consumes: enum com os opcodes das Tasks 3/5/6 já anexados (append depois).
+- Produces: os 6 opcodes float. A Task 5 NÃO é estendida para floats neste plano (comparação float em condição continua genérica — anotar como follow-up).
+
+- [ ] **Step 1: Teste de comportamento (falha só após emissão; escrever primeiro mesmo assim)**
+
+Criar `internal/vm/float_ops_test.go`:
+
+```go
+package vm
+
+import (
+	"math"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestFloatArithmeticSpecialized(t *testing.T) {
+	result := captureVMSource(t, `
+func mandel_step(cr: float, ci: float) -> float
+    let zr: float = 0.0
+    let zi: float = 0.0
+    let i: int = 0
+    while i < 10 do
+        let tmp: float = zr * zr - zi * zi + cr
+        zi = 2.0 * zr * zi + ci
+        zr = tmp
+        i = i + 1
+    end
+    return zr * zr + zi * zi
+end
+test_report(mandel_step(-0.5, 0.25))
+`)
+	if result.Type != value.VAL_FLOAT {
+		t.Fatalf("esperado float, obtido %s", result.String())
+	}
+	if math.IsNaN(result.AsFloat) || math.IsInf(result.AsFloat, 0) {
+		t.Fatalf("resultado invalido: %v", result.AsFloat)
+	}
+}
+
+func TestFloatDivisionByZeroStillErrors(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func f(a: float, b: float) -> float
+    return a / b
+end
+f(1.0, 0.0)
+`)
+	if err == nil {
+		t.Fatal("divisao float por zero deveria continuar sendo erro de runtime")
+	}
+}
+```
+
+Rodar: PASS já hoje (caminho genérico) — são testes de contrato; a regressão que eles caçam é o VM handler divergir do genérico.
+
+- [ ] **Step 2: Opcodes + handlers**
+
+`internal/chunk/chunk.go`, APPEND após `OP_INC_LOCAL_INT`:
+
+```go
+	// perf fase 1: irmaos float dos opcodes _INT (ambos os lados
+	// estaticamente float). Mistos int/float continuam no caminho generico.
+	OP_ADD_FLOAT
+	OP_SUB_FLOAT
+	OP_MUL_FLOAT
+	OP_DIV_FLOAT
+	OP_LESS_FLOAT
+	OP_GREATER_FLOAT
+```
+
+String + disasm (cases simples). `internal/vm/executor.go` (estilo inline do `OP_ADD_INT`; sem zerar — escalares):
+
+```go
+case chunk.OP_ADD_FLOAT:
+	vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat + vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+
+case chunk.OP_SUB_FLOAT:
+	vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat - vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+
+case chunk.OP_MUL_FLOAT:
+	vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat * vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+
+case chunk.OP_DIV_FLOAT:
+	if vm.stack[vm.stackTop-1].AsFloat == 0 {
+		return vm.runtimeError(c, ip, "division by zero")
+	}
+	vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat / vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+
+case chunk.OP_LESS_FLOAT:
+	vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat < vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+
+case chunk.OP_GREATER_FLOAT:
+	vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat > vm.stack[vm.stackTop-1].AsFloat)
+	vm.stackTop--
+```
+
+- [ ] **Step 3: Emissão no compilador**
+
+Em `compiler.go:930`, ao lado de `isInt`:
+
+```go
+isFloat := false
+if leftType != nil && rightType != nil {
+	if leftType.String() == "float" && rightType.String() == "float" {
+		isFloat = true
+	}
+}
+```
+
+E em cada case do switch de operador (940-1018), transformar o if binário em cadeia — exemplo para `+` (repetir o padrão para `-`, `*`, `/`, `>`, `<`; `==`/`!=`/`>=`/`<=` float ficam no genérico):
+
+```go
+case "+":
+	if isInt {
+		c.emitByte(byte(chunk.OP_ADD_INT))
+	} else if isFloat {
+		c.emitByte(byte(chunk.OP_ADD_FLOAT))
+	} else {
+		c.emitByte(byte(chunk.OP_ADD))
+	}
+```
+
+- [ ] **Step 4: Suíte + corpus + medida mandelbrot**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+go build -o noxy_perf.exe ./cmd/noxy
+1..5 | ForEach-Object { Measure-Command { .\noxy_develop.exe benchmarks\cross_runtime\mandelbrot.nx } | Select -Expand TotalMilliseconds; Measure-Command { .\noxy_perf.exe benchmarks\cross_runtime\mandelbrot.nx } | Select -Expand TotalMilliseconds }
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/chunk/chunk.go internal/compiler/compiler.go internal/vm/executor.go internal/vm/float_ops_test.go
+git commit -m "perf(vm,compiler): opcodes _FLOAT especializados para aritmetica e comparacao"
+```
+
+---
+
+### Task 8: Rodada A/B completa, gates e registro
+
+**Files:**
+- Modify: `benchmarks/RESULTS.md` (seção nova no topo)
+- Modify: `benchmarks/cross_runtime/results/cross_runtime.md` (rerun)
+- Modify: `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md` (status + pprof pós)
+
+**Interfaces:**
+- Consumes: todas as tasks anteriores commitadas.
+- Produces: números finais registrados; decisão de merge.
+
+- [ ] **Step 1: Verificação completa**
+
+```powershell
+go vet ./... && go test ./... -count=1
+go test ./internal/value -race -count=1
+go test ./internal/vm -race -count=1
+go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx
+```
+
+Tudo verde, corpus 130/130 — anotar os números reais do output.
+
+- [ ] **Step 2: A/B intercalado nos benches CoW (gates)**
+
+```powershell
+go build -o noxy_perf.exe ./cmd/noxy
+# usar o protocolo intercalado do repo (mediana de 9), binários develop x perf:
+.\benchmarks\interleaved_compare.ps1 -BaselineExe .\noxy_develop.exe -CandidateExe .\noxy_perf.exe -Runs 9
+```
+
+(Se os parâmetros do script diferirem, abrir `benchmarks/interleaved_compare.ps1` e usar a invocação que `benchmarks/RESULTS.md` documenta na seção "Reprodução".) Gates: `bench_typed_call_map`, `bench_share_mutate`, `bench_call_light`, `bench_conway` ≤ +5%. Se algum estourar, fazer bissecção por task (`git stash`/checkout parcial) e corrigir antes de seguir.
+
+- [ ] **Step 3: Cross-runtime + pprof pós**
+
+```powershell
+.\benchmarks\cross_runtime\run_cross_runtime.ps1
+.\noxy_perf.exe --cpuprofile=fib_pos.prof benchmarks\cross_runtime\fib.nx
+go tool pprof -top -nodecount=15 noxy_perf.exe fib_pos.prof
+```
+
+- [ ] **Step 4: Registrar**
+
+Nova seção no TOPO de `benchmarks/RESULTS.md` seguindo o formato das existentes (`## develop (<hash>) × perf/vm-dispatch-fase1`, tabela bench × antes × depois × delta × veredito, subseções "Perfil de cada bench" quando o delta surpreender e "Interpretação"). Atualizar a tabela do cross-runtime em `benchmarks/cross_runtime/results/cross_runtime.md` com a data nova. Na spec de pesquisa: marcar fases 0–3 como implementadas, colar o pprof pós, e listar o que o novo profile aponta como próximo alvo (candidatos: structs por índice, maps tipados, layout do Value — planos futuros).
+
+- [ ] **Step 5: Commit final**
+
+```powershell
+git add benchmarks/RESULTS.md benchmarks/cross_runtime/results/cross_runtime.md docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
+git commit -m "bench: rodada A/B da fase 1 de perf (globais, chamadas, opcodes fundidos)"
+```
+
+Depois, seguir a skill `superpowers:finishing-a-development-branch` (PR para `develop` com o template de 3 seções do usuário: Summary / Components / Test Plan).
+
+---
+
+## Self-Review (executada na escrita do plano)
+
+1. **Cobertura da spec:** fases 0–3 da pesquisa ↔ Tasks 1–8 (fase 0→Task 1; fase 1→Task 2; fase 2→Tasks 3–4; fase 3→Tasks 5–7; gates→Task 8). Fases 4–6 explicitamente fora do escopo, para planos próprios — decisão de Scope Check, registrada no header.
+2. **Placeholders:** nenhum "TBD"/"similar à task N"; todos os steps de código têm o código. Dois pontos dependem de leitura no local (helper exato do disassembler; nome do campo em `unwind.go` linha 71 se estiver dentro de outra função) e estão marcados com a instrução exata de espelhamento e o invariante a preservar.
+3. **Consistência de tipos:** `GlobalCacheEntry`/`GlobalCache()`/`Generation()` usados na Task 2 e no case de `OP_CALL_STATIC` da Task 3 (`gcache = c.GlobalCache()`) conferem; `emitCall(argCount, emission, static)` atualizado em todos os call sites nomeados; ordem de append dos opcodes fixada (Task 3 → 5 → 6 → 7) e respeitada nas instruções "APPEND após X".
+
+## Revisão externa (2026-08-18)
+
+Revisor independente (agente sem contexto desta sessão, time box de 15 min) validou as âncoras e os designs de maior risco e devolveu 3 achados IMPORTANTES + 3 MENORES — **todos aplicados neste texto**: (1) a limpeza de `Owned` movida para `unwind.go:61-64` (o `frame.Owned = nil` da linha 64 anularia a meta de zero-alloc da Task 4); (2) cadeia de soundness do `OP_CALL_STATIC` documentada no preâmbulo da Task 3 e no comentário de `callValueStatic`, com teste novo de rebind de função de mesmo tipo; (3) `TestGlobalCacheKeyedByEnvironment` reescrito para rodar o mesmo chunk sob dois ambientes de verdade; (4) limitação de thrash da entrada única entre tasks anotada na Task 2; (5) build do baseline `noxy_develop.exe` adicionado ao Step 1 da Task 1; (6) nota sobre profile órfão em erro de runtime. Confirmações do revisor: todos os funis de escrita de globais bumpariam a geração (incl. `ExportMap` e `REF_GLOBAL`), interleavings do gen/Resolve nunca servem stale, rollback do `TruncateTo` seguro nos cenários analisados (jumps de `&&`/`||` internos à região truncada), pointer-identity de frames sound com array de valores, gates da Task 8 batem com o protocolo real. Pendências que o time box não cobriu (verificar durante a execução das tasks correspondentes): tipo estático de membro de módulo (Task 3 — se compilar como `FunctionType` exato, adicionar teste com módulo), idempotência de `resolveUpvalue` sob recompilação pós-rollback com lambda no operando esquerdo (Task 5 — cobrir com um teste se o caso compilar).

--- a/docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
+++ b/docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
@@ -1,6 +1,9 @@
 # Pesquisa: performance da VM explorando tipagem estática
 
-**Data:** 2026-08-17 · **Status:** diagnóstico por leitura de código + baseline pprof coletado (Task 1, ver seção "Baseline pprof (Task 1)" no fim deste documento)
+**Data:** 2026-08-17 · **Status:** fases 0-3 implementadas e medidas
+(`perf/vm-dispatch-fase1`, Tasks 1-8) — ver seção "Baseline pprof (Task 1)" e
+"Pprof pós-fase 1 (Task 8)" no fim deste documento. Fases 4-6 seguem como
+pesquisa/planos futuros.
 
 **Contexto:** cross-runtime (benchmarks/cross_runtime/results/cross_runtime.md) mostra Noxy
 4–10x mais lenta que CPython no trabalho descontado o startup (fib: 742ms vs 93ms;
@@ -75,19 +78,32 @@ bubblesort: 604ms vs 63ms; loop_arith: 456ms vs 256ms). Meta: ficar entre Python
 
 - RC-uniqueness (Owners atômico) é recente e delicado: qualquer mudança em
   push/pop/frames não pode alterar os funis retain/release (spec §4.2 do CoW-RC).
-- Gates: benches rastreados não podem regredir >5%; corpus de exemplos 130/130;
+- Gates: benches rastreados não podem regredir >5%; corpus de exemplos
+  164/164 (número corrigido de 130 no commit `e7c533d`);
   `go test ./...` e `-race` verdes.
 - Semântica não muda: mesmos outputs, mesmos erros em runtime (mensagens iguais).
 
 ## Forma sugerida do plano (fases, cada uma com A/B intercalado)
 
-0. Flag `-cpuprofile`/`-memprofile` no CLI + baseline pprof de fib/loop_arith/bubblesort.
-1. Globais por slot/cache + remover mutex do caminho single-task (alvo: fib).
-2. Chamadas: frame sem alocação + pular validateParameterModes estaticamente provada (alvo: fib).
-3. Fusões int: OP_INC_LOCAL_INT, OP_JUMP_IF_LESS_INT, variantes FLOAT (alvo: loop_arith, mandelbrot).
-4. Structs por índice (alvo: bench_path_update, conway).
-5. Maps tipados + Len() O(1) (alvo: map_churn).
-6. Pop sem zerar escalares / Value layout (medir antes; maior risco, só com pprof provando).
+0. ✅ **Implementada** (Task 1, commit `60ed8d7`). Flag `-cpuprofile`/`-memprofile` no CLI + baseline pprof de fib/loop_arith/bubblesort.
+1. ✅ **Implementada** (Task 2, commit `67e9d52`). Globais por slot/cache + remover mutex do caminho single-task (alvo: fib).
+2. ✅ **Implementada** (Tasks 3-4, commits `bb8a773`, `1ca26e7`+`d460e5a`). Chamadas: frame sem alocação (allocs/chamada 1012→10) + pular validateParameterModes estaticamente provada (`OP_CALL_STATIC`) (alvo: fib).
+3. ✅ **Implementada** (Tasks 5-7, commits `c43276c`+`32b33c7`, `56882ca`, `4d43cdf`+`6d991e5`). Fusões int: OP_INC_LOCAL_INT, seis opcodes de comparação+salto inteiro fundidos, variantes FLOAT (alvo: loop_arith, mandelbrot).
+
+Resultado agregado das fases 0-3 (Task 8, ver `benchmarks/RESULTS.md` e
+`benchmarks/cross_runtime/results/cross_runtime.md`): `fib` 804,9ms →
+380,8ms (−52,7%, ~2,1x), `loop_arith` 519,4ms → 319,4ms (−38,5%, ~1,63x),
+`mandelbrot` 428,6ms → 246,2ms (−42,6%, ~1,74x) — todos além da estimativa
+original de cada task. Nos benches CoW (fora do escopo original, mas gates
+de regressão), 9 de 11 melhoraram (alguns >30%) porque o custo de chamada
+in-module e o incremento fundido de laço atravessam qualquer programa nesse
+formato; `bench_share_mutate` excedeu o gate de 5% (ver `benchmarks/RESULTS.md`,
+seção "develop (f107508) × fase 1 de dispatch e chamadas" — gate reprovado,
+não corrigido, decisão do controller).
+
+4. **Não implementada** — plano futuro. Structs por índice (alvo: bench_path_update, conway). Não confirmada por profile desta fase: nem `fib` nem `bench_conway` usam structs, então nenhum profile coletado até aqui sustenta ou refuta esse alvo diretamente — continua válido pela leitura de código original (`ObjInstance.Fields` como `map[string]Value`).
+5. **Não implementada** — plano futuro. Maps tipados + Len() O(1) (alvo: map_churn). Mesma ressalva: não re-confirmada por profile nesta rodada (o profile pós-fase coletado foi de `fib`, que não usa maps).
+6. **Próximo alvo indicado pelo profile pós-fase 1** (ver seção "Pprof pós-fase 1 (Task 8)" abaixo). Pop sem zerar escalares / Value layout — era "maior risco, só com pprof provando"; o pprof pós-fase agora mostra `push`+`pop` como 24,4% do tempo de `fib` (14,63%+9,76%), a maior fração isolada depois do dispatch puro (`(*VM).run`, 43,90%), com o custo de globais e alocação de chamada já cortado. Essa é a prova que o item pedia.
 
 ## Baseline pprof (Task 1)
 
@@ -213,3 +229,98 @@ Showing top 15 nodes out of 74
   envolvem (`bindingStore.get`, `GlobalEnvironment.Resolve`) aparecem com custo
   cumulativo relevante em `fib`, então a hipótese de custo de globais permanece
   válida para orientar a Task seguinte (fase 1: globais por slot).
+
+## Pprof pós-fase 1 (Task 8)
+
+**Data:** 2026-08-18 · Binário: `noxy_perf.exe` no HEAD do branch
+(`6d991e5`, fases 0-3 completas: cache de globais, `OP_CALL_STATIC`,
+`CallFrame` sem alocação, opcodes fundidos int/float). Coletado com:
+
+```powershell
+.\noxy_perf.exe --cpuprofile=fib_pos.prof benchmarks\cross_runtime\fib.nx
+go tool pprof -top -nodecount=15 noxy_perf.exe fib_pos.prof
+```
+
+### fib.nx — `CHECKSUM:832040`
+
+```
+File: noxy_perf.exe
+Type: cpu
+Duration: 531.23ms, Total samples = 410ms (77.18%)
+Showing nodes accounting for 410ms, 100% of 410ms total
+Showing top 15 nodes out of 36
+      flat  flat%   sum%        cum   cum%
+     180ms 43.90% 43.90%      390ms 95.12%  noxy-vm/internal/vm.(*VM).run
+      60ms 14.63% 58.54%       60ms 14.63%  noxy-vm/internal/vm.(*VM).push (inline)
+      40ms  9.76% 68.29%       60ms 14.63%  noxy-vm/internal/vm.(*VM).callPreparedClosure
+      40ms  9.76% 78.05%       50ms 12.20%  noxy-vm/internal/vm.(*VM).finalizeCurrentFrame
+      40ms  9.76% 87.80%       40ms  9.76%  noxy-vm/internal/vm.(*VM).pop
+      20ms  4.88% 92.68%       20ms  4.88%  runtime.cgocall
+      10ms  2.44% 95.12%       10ms  2.44%  noxy-vm/internal/value.Retain (inline)
+      10ms  2.44% 97.56%       20ms  4.88%  noxy-vm/internal/vm.(*CallFrame).ownSlot
+      10ms  2.44%   100%       60ms 14.63%  noxy-vm/internal/vm.(*VM).finishFrame
+         0     0%   100%       20ms  4.88%  internal/syscall/windows/registry.Key.GetMUIStringValue
+         0     0%   100%       20ms  4.88%  internal/syscall/windows/registry.regLoadMUIString
+         0     0%   100%      390ms 95.12%  main.main
+         0     0%   100%      390ms 95.12%  main.runWithConfig
+         0     0%   100%      390ms 95.12%  noxy-vm/internal/vm.(*VM).Interpret (inline)
+         0     0%   100%      390ms 95.12%  noxy-vm/internal/vm.(*VM).InterpretWithEnvironment
+```
+
+### Leitura vs. baseline (Task 1)
+
+- **Custo #1 (globais) desapareceu do top 15.** `(*GlobalEnvironment).Resolve`
+  (14,94% cum no baseline) e `(*bindingStore).get` (11,49% cum) não aparecem
+  mais — nem sequer abaixo do corte. O cache de globais com geração (Task 2)
+  removeu o custo por completo do caminho quente de `fib`, não só reduziu.
+- **Custo #2 (alocação por chamada) também sumiu.**
+  `runtime.mallocgcSmallScanNoHeader` (6,90% cum no baseline),
+  `runtime.memclrNoHeapPointers`, `runtime.nilinterequal`,
+  `runtime.typePointers.next` — todos ligados a alocação/GC de `CallFrame` —
+  não aparecem mais. Consistente com o allocs/chamada 1012→10 medido nas
+  Tasks 3-4. `sync/atomic.(*Int32).Add` (4,60% no baseline, plausivelmente o
+  retain/release de `Owners` no caminho de chamada) também não aparece mais.
+- **`(*VM).pop` — verificação pedida explicitamente.** Caiu de 13,79% flat
+  (120ms, 2º maior nó do baseline) para 9,76% flat (40ms, 5º maior nó): tanto
+  a fração relativa quanto o tempo absoluto caíram, e a queda absoluta (3x) é
+  maior que a queda do tempo total (870ms→410ms amostrados, ~2,1x) — ou seja,
+  `pop` ficou mais barato mesmo descontando que o programa inteiro ficou mais
+  rápido. O item #3 da pesquisa ("Value gordo + pop que zera") **não foi
+  atacado diretamente** nesta fase (nenhuma task tocou o zeramento de slot em
+  `pop`); a queda é efeito colateral provável de `fib` agora executar menos
+  push/pop por chamada (`OP_CALL_STATIC` evita parte do trabalho que
+  `callPreparedClosure`/`validateParameterModes` faziam antes ao redor da
+  chamada). `pop` **continua no top 15** e não foi eliminado — o zeramento em
+  si (48 bytes por slot) segue intocado.
+- **`push` subiu de 2,30% (20ms) para 14,63% (60ms) — ressalva de amostragem.**
+  Em termos absolutos `push` triplicou, o que à primeira vista parece uma
+  regressão; mas o profile pós-fase tem só 41 amostras de 10ms no total
+  (410ms/10ms), então 60ms são 6 amostras — contagem baixa demais para
+  distinguir "ficou mais caro" de ruído de amostragem/inlining diferente
+  entre os dois binários. Não tratado como achado confiável, só registrado.
+- **O que domina agora:** `(*VM).run` (43,90% flat, 95,12% cum) — o dispatch
+  puro, que só cai fundindo mais opcodes ou reduzindo o Value por
+  instrução — e o cluster de setup/teardown de frame
+  (`callPreparedClosure`+`finalizeCurrentFrame`+`finishFrame`+`ownSlot`,
+  ~14-25% cum cada, parcialmente sobrepostos) ainda não zerado apesar da
+  Task 3-4. `push`+`pop` juntos são 24,4% do tempo total — a maior fração
+  isolada depois do dispatch, contra 16,1% no baseline (2,30%+13,79%): com
+  globais e alocação cortados, o que sobra sobe de posição relativa mesmo
+  sem ficar mais caro em si.
+
+### Próximo alvo indicado por este profile
+
+**Fase 6 do plano (Value layout / pop sem zerar escalar), item #3 da lista de
+custos** — não fase 4 (structs por índice) nem fase 5 (maps tipados): `fib`
+não usa structs nem maps, então este profile não fala sobre esses dois
+alvos, só sobre o dispatch geral e o formato de `Value`. O gate textual da
+pesquisa era "medir antes; maior risco, só com pprof provando" — este é esse
+pprof: com #1/#2 resolvidos, `push`+`pop` (24,4%) e o cluster de
+frame-setup/teardown (ainda não zerado) são o que resta de maior massa em
+`fib`. Fase 4/5 continuam válidas como planos futuros para os benches que
+elas miravam originalmente (`bench_path_update`/`bench_conway` para structs,
+`bench_map_churn` para maps) — mas isso exigiria profiles desses benches
+especificamente, não feitos nesta rodada (só `fib` foi perfilado
+pós-fase, conforme o Step 3 desta task; `bench_share_mutate` também foi
+perfilado à parte, ver `benchmarks/RESULTS.md`, mas é sobre o gate que
+regrediu, não sobre o próximo alvo de otimização).

--- a/docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
+++ b/docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md
@@ -1,0 +1,215 @@
+# Pesquisa: performance da VM explorando tipagem estática
+
+**Data:** 2026-08-17 · **Status:** diagnóstico por leitura de código + baseline pprof coletado (Task 1, ver seção "Baseline pprof (Task 1)" no fim deste documento)
+
+**Contexto:** cross-runtime (benchmarks/cross_runtime/results/cross_runtime.md) mostra Noxy
+4–10x mais lenta que CPython no trabalho descontado o startup (fib: 742ms vs 93ms;
+bubblesort: 604ms vs 63ms; loop_arith: 456ms vs 256ms). Meta: ficar entre Python e Lua.
+
+## Custos identificados no caminho quente (por ordem estimada de impacto)
+
+1. **Globais por nome + mutex** — `OP_GET_GLOBAL` → `Environment.Resolve(name)` →
+   `bindingStore.get` (internal/value/map.go): **RLock + lookup em
+   `map[interface{}]Value` com boxing de string** a cada acesso. `fib` paga isso a
+   CADA chamada recursiva. Fix: resolução de slot de global em compile-time
+   (índice em array por módulo) ou inline cache no bytecode; globais do
+   interpretador single-thread não precisam de mutex (tasks têm environments
+   próprios — verificar fronteira).
+
+2. **Alocação por chamada** — `callPreparedClosure` (internal/vm/calls.go:113):
+   `&CallFrame{...}` no heap por chamada + `frame.Owned` (slice) via `ownSlot` por
+   parâmetro composto + `validateParameterModes` (loop sobre params, sempre — checa
+   ref-mode que o compilador já garantiu em chamadas tipadas in-module). Fix:
+   frames em array fixo reusado (`vm.frames` já existe como array de ponteiros —
+   tornar array de valores), pool para `Owned`, e flag no `ObjFunction` "call site
+   verificado estaticamente" para pular validação.
+
+3. **`Value` gordo + pop que zera** — `Value` = 48 bytes (Type + AsBool + AsInt +
+   AsFloat + Obj interface{}); `vm.pop()` zera o slot (48B extra de escrita por pop).
+   Os opcodes `_INT` inlined (OP_ADD_INT, OP_LESS_INT, OP_MOD_INT em executor.go)
+   também gastam um store zerando. Fix incremental: só limpar slots quando o valor
+   é VAL_OBJ/REF (GC-liveness), ou limpar em lote no fim do frame; fix maior
+   (arriscado): NaN-boxing ou Value de 24B {Type uint8, bits uint64, Obj unsafe.Pointer}.
+
+4. **Campos de struct por string map** — `ObjInstance.Fields` é
+   `map[string]Value`; `OP_GET_PROPERTY`/`OP_SET_PROPERTY` fazem lookup por string.
+   Structs são **fechadas e estáticas** (ObjStruct.Fields ordenada) → campos podiam
+   ser `[]Value` com índice resolvido em compile-time (`OP_GET_FIELD idx`). O
+   compilador conhece o tipo estático do receptor (Compile retorna `ast.Type`).
+   Atenção: JSONDynamicFields e cópia rasa em copyValue precisam acompanhar.
+
+5. **`ObjMap` sobre `bindingStore` com mutex** — todo map de usuário paga
+   RWMutex por operação + `Len()` faz Snapshot (cópia inteira!) só para contar +
+   chave `interface{}` (boxing). Fix: `Len()` sem snapshot é trivial; tipar chave
+   (string OU int64, conhecidos em compile-time: `map[string,T]`/`map[int,T]`)
+   permite duas implementações sem interface{}; mutex só é necessário quando o
+   map cruza fronteira de task (Owners/atomics já existem como precedente).
+
+6. **Opcodes `_INT` subemitidos** — compilador só emite `_INT` em BinaryExpr com
+   ambos os lados int (compiler.go:930-1018). Não há: `OP_ADD_FLOAT` etc.,
+   incremento fundido (`i = i + 1` vira GET_LOCAL/CONST/ADD_INT/SET_LOCAL — 4
+   dispatches; um `OP_INC_LOCAL_INT slot` faria 1), comparação+jump fundido
+   (`OP_JUMP_IF_LESS_INT`), nem `OP_GET_INDEX_INT` (indexação de array com índice
+   int estático, sem checar tipo do container — bubblesort é isso em loop).
+
+7. **`OP_CONSTANT` checa VAL_FUNCTION toda vez** — branch por constante carregada
+   (executor.go:76). Fix: opcode dedicado `OP_FUNCTION` emitido pelo compilador
+   quando a constante é função; OP_CONSTANT vira load puro.
+
+8. **Validação runtime de tipos por chamada** — runtime_type_validation.go (536
+   linhas), O(n)/chamada para maps/structs/refs em fronteiras tipadas (2x por
+   marcador, só in-module) — já tem spike O(1)-por-tag validado (memória do
+   projeto; ver docs/superpowers/specs/ do CoW-RC).
+
+## Infraestrutura já existente (aproveitar)
+
+- `c.Compile(node)` retorna `(chunk, ast.Type, error)` — tipo estático disponível
+  em todo ponto de emissão.
+- Precedente de opcodes especializados e de gates de benchmark (benchmarks/RESULTS.md,
+  protocolo intercalado, mediana de 9, corpus 130/130, `-race` em internal/value e
+  internal/vm).
+- `noxy_develop.exe` vs `noxy.exe` para comparação A/B; scripts
+  benchmarks/*.ps1 e benchmarks/cross_runtime/run_cross_runtime.ps1.
+
+## Restrições
+
+- RC-uniqueness (Owners atômico) é recente e delicado: qualquer mudança em
+  push/pop/frames não pode alterar os funis retain/release (spec §4.2 do CoW-RC).
+- Gates: benches rastreados não podem regredir >5%; corpus de exemplos 130/130;
+  `go test ./...` e `-race` verdes.
+- Semântica não muda: mesmos outputs, mesmos erros em runtime (mensagens iguais).
+
+## Forma sugerida do plano (fases, cada uma com A/B intercalado)
+
+0. Flag `-cpuprofile`/`-memprofile` no CLI + baseline pprof de fib/loop_arith/bubblesort.
+1. Globais por slot/cache + remover mutex do caminho single-task (alvo: fib).
+2. Chamadas: frame sem alocação + pular validateParameterModes estaticamente provada (alvo: fib).
+3. Fusões int: OP_INC_LOCAL_INT, OP_JUMP_IF_LESS_INT, variantes FLOAT (alvo: loop_arith, mandelbrot).
+4. Structs por índice (alvo: bench_path_update, conway).
+5. Maps tipados + Len() O(1) (alvo: map_churn).
+6. Pop sem zerar escalares / Value layout (medir antes; maior risco, só com pprof provando).
+
+## Baseline pprof (Task 1)
+
+**Data:** 2026-08-18 · **Commit (VM/develop na base do branch `perf/vm-dispatch-fase1`):**
+`f107508827f8cd20fbf3b56531dcaec837d272d7` (o único diff do branch neste ponto é
+`cmd/noxy/main.go` — flags `--cpuprofile`/`--memprofile`; nenhum código de VM mudou,
+então o binário profilado (`noxy_perf.exe`) reflete o mesmo caminho de execução do
+`develop`).
+
+Coletado com:
+```powershell
+.\noxy_perf.exe --cpuprofile=fib.prof benchmarks\cross_runtime\fib.nx
+.\noxy_perf.exe --cpuprofile=loop.prof benchmarks\cross_runtime\loop_arith.nx
+.\noxy_perf.exe --cpuprofile=bubble.prof benchmarks\cross_runtime\bubblesort.nx
+```
+
+### fib.nx — `CHECKSUM:832040`
+
+```
+File: noxy_perf.exe
+Type: cpu
+Duration: 938.22ms, Total samples = 870ms (92.73%)
+Showing nodes accounting for 690ms, 79.31% of 870ms total
+Showing top 15 nodes out of 96
+      flat  flat%   sum%        cum   cum%
+     280ms 32.18% 32.18%      750ms 86.21%  noxy-vm/internal/vm.(*VM).run
+     120ms 13.79% 45.98%      120ms 13.79%  noxy-vm/internal/vm.(*VM).pop
+      40ms  4.60% 50.57%       40ms  4.60%  sync/atomic.(*Int32).Add (inline)
+      30ms  3.45% 54.02%      120ms 13.79%  noxy-vm/internal/vm.(*VM).callPreparedClosure
+      30ms  3.45% 57.47%       30ms  3.45%  noxy-vm/internal/vm.(*VM).finalizeCurrentFrame
+      20ms  2.30% 59.77%      130ms 14.94%  noxy-vm/internal/value.(*GlobalEnvironment).Resolve
+      20ms  2.30% 62.07%      150ms 17.24%  noxy-vm/internal/vm.(*VM).call
+      20ms  2.30% 64.37%       20ms  2.30%  noxy-vm/internal/vm.(*VM).push (inline)
+      20ms  2.30% 66.67%       60ms  6.90%  runtime.mallocgcSmallScanNoHeader
+      20ms  2.30% 68.97%       20ms  2.30%  runtime.memclrNoHeapPointers
+      20ms  2.30% 71.26%       40ms  4.60%  runtime.nilinterequal
+      20ms  2.30% 73.56%       20ms  2.30%  runtime.stdcall1
+      20ms  2.30% 75.86%       20ms  2.30%  runtime.stdcall2
+      20ms  2.30% 78.16%       30ms  3.45%  runtime.typePointers.next
+      10ms  1.15% 79.31%      100ms 11.49%  noxy-vm/internal/value.(*bindingStore).get
+```
+
+### loop_arith.nx — `CHECKSUM:135`
+
+```
+File: noxy_perf.exe
+Type: cpu
+Duration: 634.93ms, Total samples = 510ms (80.32%)
+Showing nodes accounting for 510ms, 100% of 510ms total
+Showing top 15 nodes out of 42
+      flat  flat%   sum%        cum   cum%
+     310ms 60.78% 60.78%      470ms 92.16%  noxy-vm/internal/vm.(*VM).run
+      60ms 11.76% 72.55%       60ms 11.76%  noxy-vm/internal/value.Release
+      40ms  7.84% 80.39%       40ms  7.84%  noxy-vm/internal/vm.(*VM).pop
+      40ms  7.84% 88.24%       40ms  7.84%  noxy-vm/internal/vm.(*VM).push (inline)
+      30ms  5.88% 94.12%       30ms  5.88%  runtime.cgocall
+      10ms  1.96% 96.08%       10ms  1.96%  noxy-vm/internal/value.Retain (inline)
+      10ms  1.96% 98.04%       20ms  3.92%  noxy-vm/internal/vm.(*CallFrame).ownSlot
+      10ms  1.96%   100%       10ms  1.96%  runtime.stdcall1
+         0     0%   100%       30ms  5.88%  internal/syscall/windows/registry.Key.GetMUIStringValue
+         0     0%   100%       30ms  5.88%  internal/syscall/windows/registry.regLoadMUIString
+         0     0%   100%      470ms 92.16%  main.main
+         0     0%   100%      470ms 92.16%  main.runWithConfig
+         0     0%   100%      470ms 92.16%  noxy-vm/internal/vm.(*VM).Interpret (inline)
+         0     0%   100%      470ms 92.16%  noxy-vm/internal/vm.(*VM).InterpretWithEnvironment
+         0     0%   100%       10ms  1.96%  runtime.gopreempt_m
+```
+
+### bubblesort.nx — `CHECKSUM:376520193`
+
+```
+File: noxy_perf.exe
+Type: cpu
+Duration: 843.66ms, Total samples = 680ms (80.60%)
+Showing nodes accounting for 630ms, 92.65% of 680ms total
+Showing top 15 nodes out of 74
+      flat  flat%   sum%        cum   cum%
+     320ms 47.06% 47.06%      620ms 91.18%  noxy-vm/internal/vm.(*VM).run
+      40ms  5.88% 52.94%       40ms  5.88%  sync/atomic.(*Int32).Add (inline)
+      30ms  4.41% 57.35%       30ms  4.41%  noxy-vm/internal/value.IsShared (partial-inline)
+      30ms  4.41% 61.76%       40ms  5.88%  noxy-vm/internal/vm.(*VM).pop
+      30ms  4.41% 66.18%       30ms  4.41%  noxy-vm/internal/vm.(*VM).push (inline)
+      30ms  4.41% 70.59%       30ms  4.41%  noxy-vm/internal/vm.extractReferenceValue
+      30ms  4.41% 75.00%       30ms  4.41%  runtime.cgocall
+      20ms  2.94% 77.94%      100ms 14.71%  noxy-vm/internal/vm.(*VM).referenceStorage
+      20ms  2.94% 80.88%      120ms 17.65%  noxy-vm/internal/vm.(*VM).resolveReferenceValue
+      20ms  2.94% 83.82%       60ms  8.82%  noxy-vm/internal/vm.(*VM).unicizeThroughRefValue
+      20ms  2.94% 86.76%       40ms  5.88%  runtime.mallocgc
+      10ms  1.47% 88.24%       10ms  1.47%  noxy-vm/internal/value.Release
+      10ms  1.47% 89.71%       10ms  1.47%  noxy-vm/internal/value.ownersOf (inline)
+      10ms  1.47% 91.18%       10ms  1.47%  runtime.bulkBarrierPreWrite
+      10ms  1.47% 92.65%       10ms  1.47%  runtime.gogo
+```
+
+### Leitura vs. diagnóstico
+
+- **Confirma custo #1 (globais):** em `fib`, `(*GlobalEnvironment).Resolve` (14.94%
+  cum) e `(*bindingStore).get` (11.49% cum) aparecem no top 15 — a chamada
+  recursiva de `fib` de fato paga resolução de global a cada invocação, como
+  previsto. `bindingStore.mu` é `sync.RWMutex` (confirmado em
+  `internal/value/map.go:6`); o lock/unlock em si não aparece como linha própria
+  no top — provável inlining/custo pequeno demais para o bucket de 10ms da
+  amostragem, não evidência de que o mutex tenha sumido.
+- **Confirma custo #2 (chamadas):** `(*VM).call` (17.24% cum) e
+  `callPreparedClosure` (13.79% cum, sobrepostos) somam a segunda maior fatia
+  depois do dispatch puro em `(*VM).run`; `runtime.mallocgcSmallScanNoHeader`
+  (6.90% cum) aparece consistente com alocação de `CallFrame`/`Owned` por
+  chamada.
+- **`loop_arith` não usa globais** (nenhuma entrada de `Resolve`/`bindingStore`
+  no top 15) — esperado, o benchmark opera só sobre locais em loop apertado;
+  aqui o custo dominante é dispatch (`(*VM).run`, 60.78% flat) e
+  `value.Release`/push/pop, alinhado ao item #3 (Value gordo, zerado em pop).
+- **`bubblesort` é dominado por caminho de referência/CoW**
+  (`resolveReferenceValue` 17.65% cum, `referenceStorage` 14.71% cum,
+  `unicizeThroughRefValue` 8.82% cum, `IsShared`) — não é nenhum dos itens #1/#2
+  isoladamente, é o custo de indexação+troca de elementos de array via
+  referência. Não contradiz o diagnóstico (bubblesort não é o alvo de fase 1;
+  plano já mira fib para #1/#2), mas confirma que otimizar só globais+chamadas
+  não vai mover bubblesort — consistente com a fase 3/4 do plano (fusão de
+  opcodes int / structs por índice) serem os alvos certos para esse bench.
+- **Nenhuma contradição que exija reordenar as tasks seguintes.** `runtime.mapaccess2`
+  não aparece nominalmente no top 15 de nenhum profile — mas os símbolos que o
+  envolvem (`bindingStore.get`, `GlobalEnvironment.Resolve`) aparecem com custo
+  cumulativo relevante em `fib`, então a hipótese de custo de globais permanece
+  válida para orientar a Task seguinte (fase 1: globais por slot).

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -132,6 +132,10 @@ const (
 	OP_JUMP_IF_GE_INT
 	OP_JUMP_IF_EQ_INT
 	OP_JUMP_IF_NE_INT
+	// perf fase 1: `i = i + K` / `i = i - K` (i local int possuidor, K literal
+	// que cabe em i8) fundido em soma direta no slot — sem trafego de pilha.
+	// Operandos: [slot u8][delta i8]. Overflow wrappa como OP_ADD_INT.
+	OP_INC_LOCAL_INT
 )
 
 func (op OpCode) String() string {
@@ -216,6 +220,8 @@ func (op OpCode) String() string {
 		return "OP_JUMP_IF_EQ_INT"
 	case OP_JUMP_IF_NE_INT:
 		return "OP_JUMP_IF_NE_INT"
+	case OP_INC_LOCAL_INT:
+		return "OP_INC_LOCAL_INT"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -523,6 +529,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.shortInstruction("OP_JUMP_IF_EQ_INT", offset)
 	case OP_JUMP_IF_NE_INT:
 		return c.shortInstruction("OP_JUMP_IF_NE_INT", offset)
+	case OP_INC_LOCAL_INT:
+		return c.slotDeltaInstruction("OP_INC_LOCAL_INT", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:
@@ -630,6 +638,15 @@ func (c *Chunk) byteInstruction(name string, offset int) int {
 	slot := c.Code[offset+1]
 	fmt.Printf("%-16s %4d\n", name, slot)
 	return offset + 2
+}
+
+// slotDeltaInstruction imprime os dois operandos de OP_INC_LOCAL_INT: o slot
+// (u8, sem sinal) e o delta (i8, com sinal — negativo para `i = i - K`).
+func (c *Chunk) slotDeltaInstruction(name string, offset int) int {
+	slot := c.Code[offset+1]
+	delta := int8(c.Code[offset+2])
+	fmt.Printf("%-16s %4d %4d\n", name, slot, delta)
+	return offset + 3
 }
 
 func (c *Chunk) shortInstruction(name string, offset int) int {

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -136,6 +136,14 @@ const (
 	// que cabe em i8) fundido em soma direta no slot — sem trafego de pilha.
 	// Operandos: [slot u8][delta i8]. Overflow wrappa como OP_ADD_INT.
 	OP_INC_LOCAL_INT
+	// perf fase 1: irmaos float dos opcodes _INT (ambos os lados
+	// estaticamente float). Mistos int/float continuam no caminho generico.
+	OP_ADD_FLOAT
+	OP_SUB_FLOAT
+	OP_MUL_FLOAT
+	OP_DIV_FLOAT
+	OP_LESS_FLOAT
+	OP_GREATER_FLOAT
 )
 
 func (op OpCode) String() string {
@@ -222,6 +230,18 @@ func (op OpCode) String() string {
 		return "OP_JUMP_IF_NE_INT"
 	case OP_INC_LOCAL_INT:
 		return "OP_INC_LOCAL_INT"
+	case OP_ADD_FLOAT:
+		return "OP_ADD_FLOAT"
+	case OP_SUB_FLOAT:
+		return "OP_SUB_FLOAT"
+	case OP_MUL_FLOAT:
+		return "OP_MUL_FLOAT"
+	case OP_DIV_FLOAT:
+		return "OP_DIV_FLOAT"
+	case OP_LESS_FLOAT:
+		return "OP_LESS_FLOAT"
+	case OP_GREATER_FLOAT:
+		return "OP_GREATER_FLOAT"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -531,6 +551,18 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.shortInstruction("OP_JUMP_IF_NE_INT", offset)
 	case OP_INC_LOCAL_INT:
 		return c.slotDeltaInstruction("OP_INC_LOCAL_INT", offset)
+	case OP_ADD_FLOAT:
+		return c.simpleInstruction("OP_ADD_FLOAT", offset)
+	case OP_SUB_FLOAT:
+		return c.simpleInstruction("OP_SUB_FLOAT", offset)
+	case OP_MUL_FLOAT:
+		return c.simpleInstruction("OP_MUL_FLOAT", offset)
+	case OP_DIV_FLOAT:
+		return c.simpleInstruction("OP_DIV_FLOAT", offset)
+	case OP_LESS_FLOAT:
+		return c.simpleInstruction("OP_LESS_FLOAT", offset)
+	case OP_GREATER_FLOAT:
+		return c.simpleInstruction("OP_GREATER_FLOAT", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -3,6 +3,8 @@ package chunk
 import (
 	"fmt"
 	"noxy-vm/internal/value"
+	"sync"
+	"sync/atomic"
 )
 
 type OpCode byte
@@ -301,6 +303,26 @@ type Chunk struct {
 	Constants []value.Value
 	Lines     []int
 	FileName  string
+
+	globalCacheOnce sync.Once
+	globalCache     []atomic.Pointer[GlobalCacheEntry]
+}
+
+// GlobalCacheEntry cacheia a resolução de um OP_GET_GLOBAL: válida enquanto o
+// mesmo ambiente estiver ativo E a geração somada da cadeia não mudar. Env e
+// Gen juntos tornam impossível servir valor stale: qualquer escrita bumpa a
+// geração; chunk rodando sob outro ambiente falha a comparação de Env.
+type GlobalCacheEntry struct {
+	Env *value.GlobalEnvironment
+	Gen uint64
+	Val value.Value
+}
+
+func (c *Chunk) GlobalCache() []atomic.Pointer[GlobalCacheEntry] {
+	c.globalCacheOnce.Do(func() {
+		c.globalCache = make([]atomic.Pointer[GlobalCacheEntry], len(c.Constants))
+	})
+	return c.globalCache
 }
 
 func New() *Chunk {

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -117,6 +117,10 @@ const (
 	OP_MARK_UPVALUE_BORROW  // [upvalue_index]; marca a caixa de peek(0) como
 	// emprestada (emitido logo após OP_CLOSURE, um por upvalue de tipo ref)
 	OP_REF_LOCAL_BORROW // [slot]; ref para slot não-possuidor (caixa emprestada)
+	// perf fase 1: chamada cujos modos de parametro (ref/valor) o compilador
+	// provou no call site (isExact) — o VM pula validateParameterModes para
+	// closures. Layout de operando identico ao OP_CALL: [argCount u8].
+	OP_CALL_STATIC
 )
 
 func (op OpCode) String() string {
@@ -187,6 +191,8 @@ func (op OpCode) String() string {
 		return "OP_MARK_UPVALUE_BORROW"
 	case OP_REF_LOCAL_BORROW:
 		return "OP_REF_LOCAL_BORROW"
+	case OP_CALL_STATIC:
+		return "OP_CALL_STATIC"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -472,6 +478,8 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.shortInstruction("OP_LOOP", offset)
 	case OP_CALL:
 		return c.byteInstruction("OP_CALL", offset)
+	case OP_CALL_STATIC:
+		return c.byteInstruction("OP_CALL_STATIC", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -121,6 +121,17 @@ const (
 	// provou no call site (isExact) — o VM pula validateParameterModes para
 	// closures. Layout de operando identico ao OP_CALL: [argCount u8].
 	OP_CALL_STATIC
+	// perf fase 1: comparacao int + salto condicional fundidos. Consomem dois
+	// VAL_INT da pilha (sem zerar: escalares nao carregam ponteiros) e saltam
+	// [hi][lo] adiante quando a condicao NOMEADA vale. Emitidos pelo
+	// compilador so quando ambos os lados sao estaticamente int; o salto e o
+	// jump-if-false da condicao de origem (`<` emite GE, `<=` emite GT, ...).
+	OP_JUMP_IF_LT_INT
+	OP_JUMP_IF_LE_INT
+	OP_JUMP_IF_GT_INT
+	OP_JUMP_IF_GE_INT
+	OP_JUMP_IF_EQ_INT
+	OP_JUMP_IF_NE_INT
 )
 
 func (op OpCode) String() string {
@@ -193,6 +204,18 @@ func (op OpCode) String() string {
 		return "OP_REF_LOCAL_BORROW"
 	case OP_CALL_STATIC:
 		return "OP_CALL_STATIC"
+	case OP_JUMP_IF_LT_INT:
+		return "OP_JUMP_IF_LT_INT"
+	case OP_JUMP_IF_LE_INT:
+		return "OP_JUMP_IF_LE_INT"
+	case OP_JUMP_IF_GT_INT:
+		return "OP_JUMP_IF_GT_INT"
+	case OP_JUMP_IF_GE_INT:
+		return "OP_JUMP_IF_GE_INT"
+	case OP_JUMP_IF_EQ_INT:
+		return "OP_JUMP_IF_EQ_INT"
+	case OP_JUMP_IF_NE_INT:
+		return "OP_JUMP_IF_NE_INT"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -345,6 +368,14 @@ func (c *Chunk) Write(byteCode byte, line int) {
 	c.Lines = append(c.Lines, line)
 }
 
+// TruncateTo descarta bytecode ja emitido a partir do offset n (Code e Lines
+// andam em paralelo). Usado pelo compilador para desfazer a emissao
+// especulativa dos operandos de uma condicao que nao pode ser fundida.
+func (c *Chunk) TruncateTo(n int) {
+	c.Code = c.Code[:n]
+	c.Lines = c.Lines[:n]
+}
+
 func (c *Chunk) AddConstant(v value.Value) int {
 	c.Constants = append(c.Constants, v)
 	return len(c.Constants) - 1
@@ -480,6 +511,18 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.byteInstruction("OP_CALL", offset)
 	case OP_CALL_STATIC:
 		return c.byteInstruction("OP_CALL_STATIC", offset)
+	case OP_JUMP_IF_LT_INT:
+		return c.shortInstruction("OP_JUMP_IF_LT_INT", offset)
+	case OP_JUMP_IF_LE_INT:
+		return c.shortInstruction("OP_JUMP_IF_LE_INT", offset)
+	case OP_JUMP_IF_GT_INT:
+		return c.shortInstruction("OP_JUMP_IF_GT_INT", offset)
+	case OP_JUMP_IF_GE_INT:
+		return c.shortInstruction("OP_JUMP_IF_GE_INT", offset)
+	case OP_JUMP_IF_EQ_INT:
+		return c.shortInstruction("OP_JUMP_IF_EQ_INT", offset)
+	case OP_JUMP_IF_NE_INT:
+		return c.shortInstruction("OP_JUMP_IF_NE_INT", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -99,7 +99,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 				return true, nil, err
 			}
 		}
-		c.emitCall(2, emission)
+		c.emitCall(2, emission, false)
 		return true, builtinType("void"), nil
 	case "pop":
 		container, err := c.compileReferenceArgument(call.Arguments[0])
@@ -110,7 +110,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 		if !ok {
 			return true, nil, fmt.Errorf("[line %d] pop expects an array, got %s", c.currentLine, noxyTypeName(container))
 		}
-		c.emitCall(1, emission)
+		c.emitCall(1, emission, false)
 		return true, array.ElementType, nil
 	case "delete":
 		container, err := c.compileReferenceArgument(call.Arguments[0])
@@ -137,7 +137,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
 			)
 		}
-		c.emitCall(2, emission)
+		c.emitCall(2, emission, false)
 		return true, builtinType("void"), nil
 	case "json_loads":
 		jsonText, err := c.compileBuiltinValueArgument(call.Arguments[0])
@@ -157,7 +157,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 		if primitive, ok := targetType.(*ast.PrimitiveType); ok && primitive.Name == "any" {
 			c.emitByte(byte(chunk.OP_MARK_REF_JSON_DYNAMIC))
 		}
-		c.emitCall(2, emission)
+		c.emitCall(2, emission, false)
 		return true, builtinType("bool"), nil
 	default:
 		return false, nil, nil

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1676,8 +1676,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 	}
 }
 
-func (c *Compiler) emitCall(argCount int, emission callEmission) {
+func (c *Compiler) emitCall(argCount int, emission callEmission, static bool) {
 	op := chunk.OP_CALL
+	if static {
+		op = chunk.OP_CALL_STATIC
+	}
 	line := c.currentLine
 	if emission.deferred {
 		op = chunk.OP_DEFER
@@ -1737,7 +1740,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 				}
 			}
 
-			c.emitCall(2, emission)
+			c.emitCall(2, emission, false)
 			return c.currentChunk, valType, nil // send returns value sent
 		} else if ident.Value == "chan_recv" {
 			if len(call.Arguments) != 1 {
@@ -1766,7 +1769,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 				retType = chanType.ElementType
 			}
 
-			c.emitCall(1, emission)
+			c.emitCall(1, emission, false)
 			return c.currentChunk, retType, nil
 		} else if ident.Value == "addr" {
 			if emission.deferred {
@@ -1855,7 +1858,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 		}
 	}
 
-	c.emitCall(len(call.Arguments), emission)
+	c.emitCall(len(call.Arguments), emission, isExact)
 	if isExact {
 		return c.currentChunk, funcType.Return, nil
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -940,40 +940,62 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 		}
 
+		// Irmao float de isInt: so dispara quando AMBOS os lados sao
+		// estaticamente float. Mistos int/float ficam no caminho generico,
+		// que ja faz a promocao numerica.
+		isFloat := false
+		if leftType != nil && rightType != nil {
+			if leftType.String() == "float" && rightType.String() == "float" {
+				isFloat = true
+			}
+		}
+
 		switch n.Operator {
 		case "+":
 			if isInt {
 				c.emitByte(byte(chunk.OP_ADD_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_ADD_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_ADD))
 			}
 		case "-":
 			if isInt {
 				c.emitByte(byte(chunk.OP_SUB_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_SUB_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_SUBTRACT))
 			}
 		case "*":
 			if isInt {
 				c.emitByte(byte(chunk.OP_MUL_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_MUL_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_MULTIPLY))
 			}
 		case "/":
 			if isInt {
 				c.emitByte(byte(chunk.OP_DIV_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_DIV_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_DIVIDE))
 			}
 		case ">":
 			if isInt {
 				c.emitByte(byte(chunk.OP_GREATER_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_GREATER_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_GREATER))
 			}
 		case "<":
 			if isInt {
 				c.emitByte(byte(chunk.OP_LESS_INT))
+			} else if isFloat {
+				c.emitByte(byte(chunk.OP_LESS_FLOAT))
 			} else {
 				c.emitByte(byte(chunk.OP_LESS))
 			}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -338,6 +338,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return c.currentChunk, nil, nil
 
 		} else if ident, ok := n.Target.(*ast.Identifier); ok {
+			// Fusao de incremento: emite OP_INC_LOCAL_INT e nao empilha nada
+			// (atribuicao e statement; o POP do caminho generico tambem cai fora).
+			if c.tryFuseLocalIntIncrement(ident, n.Value) {
+				return c.currentChunk, nil, nil
+			}
 			// Identifier Assignment: x = val
 			// 1. Compile Value (pushed to stack)
 			_, valType, err := c.Compile(n.Value)
@@ -2247,6 +2252,43 @@ func (c *Compiler) localOwns(index int) bool {
 		return false
 	}
 	return c.locals[index].Owns
+}
+
+// tryFuseLocalIntIncrement funde `i = i + K` / `i = i - K` (i local int
+// POSSUIDOR — slot ref nunca funde; K literal int em [-128,127]) em
+// OP_INC_LOCAL_INT. Retorna true se emitiu (nada mais a fazer no site).
+// Sem emissao especulativa: todas as checagens sao sintaticas/de simbolo.
+func (c *Compiler) tryFuseLocalIntIncrement(ident *ast.Identifier, valueExpr ast.Expression) bool {
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 || !c.localOwns(arg) {
+		return false
+	}
+	prim, ok := localType.(*ast.PrimitiveType)
+	if !ok || prim.Name != "int" {
+		return false
+	}
+	infix, ok := valueExpr.(*ast.InfixExpression)
+	if !ok || (infix.Operator != "+" && infix.Operator != "-") {
+		return false
+	}
+	left, ok := infix.Left.(*ast.Identifier)
+	if !ok || left.Value != ident.Value {
+		return false
+	}
+	lit, ok := infix.Right.(*ast.IntegerLiteral)
+	if !ok {
+		return false
+	}
+	delta := lit.Value
+	if infix.Operator == "-" {
+		delta = -delta
+	}
+	if delta < -128 || delta > 127 {
+		return false
+	}
+	c.emitBytes(byte(chunk.OP_INC_LOCAL_INT), byte(arg))
+	c.emitByte(byte(int8(delta)))
+	return true
 }
 
 func (c *Compiler) emitDefaultInit(t ast.NoxyType) error {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -2114,7 +2114,12 @@ func fusedIntCompareJump(operator string) (chunk.OpCode, bool) {
 // devolve o opcode de salto fundido a emitir com emitJump. Emissao
 // especulativa: se um dos lados nao for estaticamente int, o bytecode dos
 // operandos e DESFEITO (TruncateTo) e o chamador segue o caminho generico.
-// Constantes adicionadas na especulacao ficam orfas no pool — inofensivo.
+// Constantes adicionadas na especulacao ficam orfas no pool — inofensivo, mas
+// note que um operando que e um literal de funcao orfa a FUNCAO INTEIRA
+// compilada (um ObjFunction com seu proprio chunk, retido pelo modulo pelo
+// resto da vida do programa) e conta no tamanho de GlobalCache() (dimensionado
+// por len(Constants)) — ainda inofensivo (o cache so cresce, nunca e indexado
+// por essas entradas mortas), so mais bytes do que uma constante escalar orfa.
 func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, bool, error) {
 	infix, ok := cond.(*ast.InfixExpression)
 	if !ok {
@@ -2127,6 +2132,12 @@ func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, 
 	checkpoint := len(c.currentChunk.Code)
 	_, leftType, err := c.Compile(infix.Left)
 	if err != nil {
+		// Sem TruncateTo aqui: um erro aborta a compilacao inteira (o
+		// chamador propaga err e nenhum bytecode deste Chunk chega a ser
+		// executado), entao nao ha invariante de "pilha do bytecode emitido"
+		// a preservar — diferente dos dois `if ... TruncateTo` abaixo, que
+		// tratam um retorno SEM erro (tipo nao-int) onde a compilacao
+		// continua e o caminho generico precisa reemitir do zero.
 		return 0, false, err
 	}
 	if leftType == nil || leftType.String() != "int" {
@@ -2135,6 +2146,7 @@ func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, 
 	}
 	_, rightType, err := c.Compile(infix.Right)
 	if err != nil {
+		// Mesmo raciocinio: erro aborta a compilacao inteira.
 		return 0, false, err
 	}
 	if rightType == nil || rightType.String() != "int" {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1099,20 +1099,30 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 	case *ast.IfStatement:
 		c.setLine(n.Token.Line)
-		// Compile condition
-		_, condType, err := c.Compile(n.Condition)
+		// Compile condition: fusao especulativa (comparacao int + salto) com
+		// rollback para o caminho generico se um dos lados nao for int.
+		fusedOp, fused, err := c.tryCompileFusedCondition(n.Condition)
 		if err != nil {
 			return nil, nil, err
 		}
-		if _, ok := condType.(*ast.RefType); ok {
-			c.emitByte(byte(chunk.OP_DEREF))
+		var jumpToElse int
+		if fused {
+			jumpToElse = c.emitJump(fusedOp)
+		} else {
+			_, condType, err := c.Compile(n.Condition)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, ok := condType.(*ast.RefType); ok {
+				c.emitByte(byte(chunk.OP_DEREF))
+			}
+
+			// Emit JumpIfFalse
+			jumpToElse = c.emitJump(chunk.OP_JUMP_IF_FALSE)
+
+			// Compile Then block (Consequence)
+			c.emitByte(byte(chunk.OP_POP)) // Pop condition value (since we entered THEN)
 		}
-
-		// Emit JumpIfFalse
-		jumpToElse := c.emitJump(chunk.OP_JUMP_IF_FALSE)
-
-		// Compile Then block (Consequence)
-		c.emitByte(byte(chunk.OP_POP)) // Pop condition value (since we entered THEN)
 
 		_, _, err = c.Compile(n.Consequence)
 		if err != nil {
@@ -1125,7 +1135,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// Patch Else jump
 		c.patchJump(jumpToElse)
 
-		c.emitByte(byte(chunk.OP_POP)) // Pop condition value (if we jumped here, condition was false)
+		if !fused {
+			c.emitByte(byte(chunk.OP_POP)) // Pop condition value (if we jumped here, condition was false)
+		}
 
 		// Compile Else block (Alternative)
 		if n.Alternative != nil {
@@ -1147,18 +1159,29 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		loop := &Loop{EnclosingLocals: len(c.locals), BreakJumps: []int{}}
 		c.loops = append(c.loops, loop)
 
-		_, condType, err := c.Compile(n.Condition)
+		// Compile condition: fusao especulativa (comparacao int + salto) com
+		// rollback para o caminho generico se um dos lados nao for int.
+		fusedOp, fused, err := c.tryCompileFusedCondition(n.Condition)
 		if err != nil {
 			return nil, nil, err
 		}
-		if _, ok := condType.(*ast.RefType); ok {
-			c.emitByte(byte(chunk.OP_DEREF))
+		var jumpToExit int
+		if fused {
+			jumpToExit = c.emitJump(fusedOp)
+		} else {
+			_, condType, err := c.Compile(n.Condition)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, ok := condType.(*ast.RefType); ok {
+				c.emitByte(byte(chunk.OP_DEREF))
+			}
+
+			// Exit jump
+			jumpToExit = c.emitJump(chunk.OP_JUMP_IF_FALSE)
+
+			c.emitByte(byte(chunk.OP_POP)) // Pop condition
 		}
-
-		// Exit jump
-		jumpToExit := c.emitJump(chunk.OP_JUMP_IF_FALSE)
-
-		c.emitByte(byte(chunk.OP_POP)) // Pop condition
 
 		_, _, err = c.Compile(n.Body)
 		if err != nil {
@@ -1169,7 +1192,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		c.emitLoop(loopStart)
 
 		c.patchJump(jumpToExit)
-		c.emitByte(byte(chunk.OP_POP)) // Pop condition at exit
+		if !fused {
+			c.emitByte(byte(chunk.OP_POP)) // Pop condition at exit
+		}
 
 		// Patch Break Jumps
 		for _, jump := range loop.BreakJumps {
@@ -2062,6 +2087,61 @@ func (c *Compiler) emitOpWithConstantIndex(op chunk.OpCode, index int) {
 	c.emitByte(byte(op))
 	c.emitByte(byte((index >> 8) & 0xff))
 	c.emitByte(byte(index & 0xff))
+}
+
+// fusedIntCompareJump mapeia o operador da CONDICAO para o opcode que salta
+// quando a condicao FALHA (e o jump-if-false fundido): `i < n` continua no
+// corpo quando vale e salta para fora com GE.
+func fusedIntCompareJump(operator string) (chunk.OpCode, bool) {
+	switch operator {
+	case "<":
+		return chunk.OP_JUMP_IF_GE_INT, true
+	case "<=":
+		return chunk.OP_JUMP_IF_GT_INT, true
+	case ">":
+		return chunk.OP_JUMP_IF_LE_INT, true
+	case ">=":
+		return chunk.OP_JUMP_IF_LT_INT, true
+	case "==":
+		return chunk.OP_JUMP_IF_NE_INT, true
+	case "!=":
+		return chunk.OP_JUMP_IF_EQ_INT, true
+	}
+	return 0, false
+}
+
+// tryCompileFusedCondition tenta compilar cond como (left, right) ints puros e
+// devolve o opcode de salto fundido a emitir com emitJump. Emissao
+// especulativa: se um dos lados nao for estaticamente int, o bytecode dos
+// operandos e DESFEITO (TruncateTo) e o chamador segue o caminho generico.
+// Constantes adicionadas na especulacao ficam orfas no pool — inofensivo.
+func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, bool, error) {
+	infix, ok := cond.(*ast.InfixExpression)
+	if !ok {
+		return 0, false, nil
+	}
+	jumpOp, ok := fusedIntCompareJump(infix.Operator)
+	if !ok {
+		return 0, false, nil
+	}
+	checkpoint := len(c.currentChunk.Code)
+	_, leftType, err := c.Compile(infix.Left)
+	if err != nil {
+		return 0, false, err
+	}
+	if leftType == nil || leftType.String() != "int" {
+		c.currentChunk.TruncateTo(checkpoint)
+		return 0, false, nil
+	}
+	_, rightType, err := c.Compile(infix.Right)
+	if err != nil {
+		return 0, false, err
+	}
+	if rightType == nil || rightType.String() != "int" {
+		c.currentChunk.TruncateTo(checkpoint)
+		return 0, false, nil
+	}
+	return jumpOp, true, nil
 }
 
 func (c *Compiler) emitJump(op chunk.OpCode) int {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1860,6 +1860,14 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 		)
 	}
 
+	// modesProven começa igual a isExact e é derrubado se algum argumento
+	// deixa um modo (ref vs. valor) sem prova em tempo de compilação — ex.:
+	// `ref a` passado para um parâmetro `any` (areStrictTypesCompatible
+	// aceita `any` incondicionalmente, então isExact continua true, mas
+	// ninguém verificou que o valor não é uma ref). Só modesProven decide
+	// OP_CALL_STATIC; nesse caso caímos para OP_CALL, que ainda roda
+	// validateParameterModes em tempo de execução.
+	modesProven := isExact
 	for i, arg := range call.Arguments {
 		if isExact {
 			if expectedRef, ok := funcType.Params[i].(*ast.RefType); ok {
@@ -1896,6 +1904,13 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 			c.emitByte(byte(chunk.OP_DEREF))
 			argType = ref.ElementType
 		}
+		if isExact {
+			if _, stillRef := argType.(*ast.RefType); stillRef {
+				if _, expectedIsRef := funcType.Params[i].(*ast.RefType); !expectedIsRef {
+					modesProven = false
+				}
+			}
+		}
 		if isExact && !c.areStrictTypesCompatible(funcType.Params[i], argType) {
 			return nil, nil, fmt.Errorf(
 				"[line %d] argument %d to '%s': expected %s, got %s",
@@ -1910,7 +1925,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 		}
 	}
 
-	c.emitCall(len(call.Arguments), emission, isExact)
+	c.emitCall(len(call.Arguments), emission, modesProven)
 	if isExact {
 		return c.currentChunk, funcType.Return, nil
 	}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -148,8 +148,11 @@ func run() -> void
     cleanup(7)
 end`, "run")
 	code := fn.Chunk.(*chunk.Chunk).Code
-	if !containsOpcode(code, chunk.OP_CALL) {
-		t.Fatal("ordinary call omitted OP_CALL")
+	// cleanup(7) é uma chamada exata (isExact): o compilador prova os modos
+	// dos parametros no call site, entao emite OP_CALL_STATIC (perf fase 1),
+	// nao o OP_CALL generico.
+	if !containsOpcode(code, chunk.OP_CALL_STATIC) {
+		t.Fatal("ordinary exact call omitted OP_CALL_STATIC")
 	}
 	if containsOpcode(code, chunk.OP_DEFER) {
 		t.Fatal("ordinary call emitted OP_DEFER")

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -141,7 +141,7 @@ end`))
 	}
 }
 
-func TestCompileImmediateCallEmitsCallAndNotDefer(t *testing.T) {
+func TestCompileImmediateCallEmitsStaticCallAndNotDefer(t *testing.T) {
 	fn := compiledFunction(t, `func cleanup(value: int) -> void
 end
 func run() -> void
@@ -156,6 +156,25 @@ end`, "run")
 	}
 	if containsOpcode(code, chunk.OP_DEFER) {
 		t.Fatal("ordinary call emitted OP_DEFER")
+	}
+}
+
+// Callee dinâmico (tipo any): fnType não é *ast.FunctionType, isExact fica
+// false, e o compilador tem de cair para OP_CALL genérico — nunca
+// OP_CALL_STATIC, que pularia validateParameterModes em runtime.
+func TestCompileNonExactCallEmitsPlainCall(t *testing.T) {
+	fn := compiledFunction(t, `func cleanup(value: int) -> void
+end
+func run() -> void
+    let f: any = cleanup
+    f(7)
+end`, "run")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if containsOpcode(code, chunk.OP_CALL_STATIC) {
+		t.Fatal("non-exact call emitted OP_CALL_STATIC")
+	}
+	if !containsOpcode(code, chunk.OP_CALL) {
+		t.Fatal("non-exact call omitted OP_CALL")
 	}
 }
 

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -38,6 +38,8 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 			switch op {
 			case chunk.OP_CONSTANT, chunk.OP_GET_LOCAL, chunk.OP_SET_LOCAL,
 				chunk.OP_GET_UPVALUE, chunk.OP_SET_UPVALUE, chunk.OP_CALL,
+				// perf fase 1: mesmo layout de operando do OP_CALL (1 byte argCount)
+				chunk.OP_CALL_STATIC,
 				chunk.OP_DEFER, chunk.OP_REF_LOCAL, chunk.OP_REF_UPVALUE,
 				chunk.OP_GET_LOCAL_MUT, chunk.OP_GET_UPVALUE_MUT,
 				chunk.OP_SET_PROPERTY_DEREF, chunk.OP_INVOKE,

--- a/internal/compiler/float_ops_compile_test.go
+++ b/internal/compiler/float_ops_compile_test.go
@@ -1,0 +1,107 @@
+package compiler
+
+import (
+	"fmt"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+// TestFloatArithmeticOpcodesEmitted fixa, por bytecode, que operandos
+// estaticamente float emitem os opcodes _FLOAT especializados (Task 7) em vez
+// do caminho generico. Sem isto, a especializacao poderia "nao disparar
+// silenciosamente" (isFloat sempre false) e os testes de comportamento em
+// internal/vm/float_ops_test.go passariam do mesmo jeito, ja que o caminho
+// generico produz o mesmo resultado numerico.
+func TestFloatArithmeticOpcodesEmitted(t *testing.T) {
+	cases := []struct {
+		operator    string
+		returnType  string
+		want        chunk.OpCode
+		genericWant chunk.OpCode
+	}{
+		{"+", "float", chunk.OP_ADD_FLOAT, chunk.OP_ADD},
+		{"-", "float", chunk.OP_SUB_FLOAT, chunk.OP_SUBTRACT},
+		{"*", "float", chunk.OP_MUL_FLOAT, chunk.OP_MULTIPLY},
+		{"/", "float", chunk.OP_DIV_FLOAT, chunk.OP_DIVIDE},
+		{">", "bool", chunk.OP_GREATER_FLOAT, chunk.OP_GREATER},
+		{"<", "bool", chunk.OP_LESS_FLOAT, chunk.OP_LESS},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator, func(t *testing.T) {
+			source := fmt.Sprintf(`
+func f(a: float, b: float) -> %s
+    return a %s b
+end
+`, tc.returnType, tc.operator)
+			fn := compiledFunction(t, source, "f")
+			code := fn.Chunk.(*chunk.Chunk).Code
+
+			if !containsOpcode(code, tc.want) {
+				t.Fatalf("operador %q com operandos float: esperava %s no bytecode, ausente (especializacao nao disparou)", tc.operator, tc.want)
+			}
+			if containsOpcode(code, tc.genericWant) {
+				t.Fatalf("operador %q com operandos float: opcode generico %s presente apesar de ambos operandos serem float estaticamente", tc.operator, tc.genericWant)
+			}
+		})
+	}
+}
+
+// TestMixedIntFloatArithmeticStaysGeneric prova que um operando int e outro
+// float NAO disparam nem OP_*_INT nem OP_*_FLOAT: soh o caminho generico faz
+// a promocao numerica int->float.
+func TestMixedIntFloatArithmeticStaysGeneric(t *testing.T) {
+	cases := []struct {
+		operator string
+		generic  chunk.OpCode
+		intOp    chunk.OpCode
+		floatOp  chunk.OpCode
+	}{
+		{"+", chunk.OP_ADD, chunk.OP_ADD_INT, chunk.OP_ADD_FLOAT},
+		{"-", chunk.OP_SUBTRACT, chunk.OP_SUB_INT, chunk.OP_SUB_FLOAT},
+		{"*", chunk.OP_MULTIPLY, chunk.OP_MUL_INT, chunk.OP_MUL_FLOAT},
+		{"/", chunk.OP_DIVIDE, chunk.OP_DIV_INT, chunk.OP_DIV_FLOAT},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator, func(t *testing.T) {
+			source := fmt.Sprintf(`
+func f(a: int, b: float) -> float
+    return a %s b
+end
+`, tc.operator)
+			fn := compiledFunction(t, source, "f")
+			code := fn.Chunk.(*chunk.Chunk).Code
+
+			if !containsOpcode(code, tc.generic) {
+				t.Fatalf("operador %q misto int/float: esperava opcode generico %s, ausente", tc.operator, tc.generic)
+			}
+			if containsOpcode(code, tc.intOp) {
+				t.Fatalf("operador %q misto int/float: opcode _INT %s presente indevidamente", tc.operator, tc.intOp)
+			}
+			if containsOpcode(code, tc.floatOp) {
+				t.Fatalf("operador %q misto int/float: opcode _FLOAT %s presente indevidamente", tc.operator, tc.floatOp)
+			}
+		})
+	}
+}
+
+// TestFloatEqualityStaysGeneric confirma que a Task 7 NAO foi estendida alem
+// do escopo do brief: ==, !=, >=, <= com operandos float continuam no
+// caminho generico (nenhum OP_LESS_FLOAT/OP_GREATER_FLOAT emitido).
+func TestFloatEqualityStaysGeneric(t *testing.T) {
+	for _, operator := range []string{"==", "!=", ">=", "<="} {
+		t.Run(operator, func(t *testing.T) {
+			source := fmt.Sprintf(`
+func f(a: float, b: float) -> bool
+    return a %s b
+end
+`, operator)
+			fn := compiledFunction(t, source, "f")
+			code := fn.Chunk.(*chunk.Chunk).Code
+
+			if containsOpcode(code, chunk.OP_LESS_FLOAT) || containsOpcode(code, chunk.OP_GREATER_FLOAT) {
+				t.Fatalf("operador %q com float: opcode _FLOAT emitido, mas Task 7 nao deveria estender >=/<=/==/!=", operator)
+			}
+		})
+	}
+}

--- a/internal/compiler/float_ops_compile_test.go
+++ b/internal/compiler/float_ops_compile_test.go
@@ -49,26 +49,33 @@ end
 
 // TestMixedIntFloatArithmeticStaysGeneric prova que um operando int e outro
 // float NAO disparam nem OP_*_INT nem OP_*_FLOAT: soh o caminho generico faz
-// a promocao numerica int->float.
+// a promocao numerica int->float. Cobre todos os seis operadores que
+// ganharam o ramo isFloat (+ - * / > <), nao so os quatro aritmeticos: o
+// gate isFloat e um unico bool computado antes do switch, mas cada braco do
+// switch e um site de emissao separado, entao cada um merece sua propria
+// prova.
 func TestMixedIntFloatArithmeticStaysGeneric(t *testing.T) {
 	cases := []struct {
-		operator string
-		generic  chunk.OpCode
-		intOp    chunk.OpCode
-		floatOp  chunk.OpCode
+		operator   string
+		returnType string
+		generic    chunk.OpCode
+		intOp      chunk.OpCode
+		floatOp    chunk.OpCode
 	}{
-		{"+", chunk.OP_ADD, chunk.OP_ADD_INT, chunk.OP_ADD_FLOAT},
-		{"-", chunk.OP_SUBTRACT, chunk.OP_SUB_INT, chunk.OP_SUB_FLOAT},
-		{"*", chunk.OP_MULTIPLY, chunk.OP_MUL_INT, chunk.OP_MUL_FLOAT},
-		{"/", chunk.OP_DIVIDE, chunk.OP_DIV_INT, chunk.OP_DIV_FLOAT},
+		{"+", "float", chunk.OP_ADD, chunk.OP_ADD_INT, chunk.OP_ADD_FLOAT},
+		{"-", "float", chunk.OP_SUBTRACT, chunk.OP_SUB_INT, chunk.OP_SUB_FLOAT},
+		{"*", "float", chunk.OP_MULTIPLY, chunk.OP_MUL_INT, chunk.OP_MUL_FLOAT},
+		{"/", "float", chunk.OP_DIVIDE, chunk.OP_DIV_INT, chunk.OP_DIV_FLOAT},
+		{">", "bool", chunk.OP_GREATER, chunk.OP_GREATER_INT, chunk.OP_GREATER_FLOAT},
+		{"<", "bool", chunk.OP_LESS, chunk.OP_LESS_INT, chunk.OP_LESS_FLOAT},
 	}
 	for _, tc := range cases {
 		t.Run(tc.operator, func(t *testing.T) {
 			source := fmt.Sprintf(`
-func f(a: int, b: float) -> float
+func f(a: int, b: float) -> %s
     return a %s b
 end
-`, tc.operator)
+`, tc.returnType, tc.operator)
 			fn := compiledFunction(t, source, "f")
 			code := fn.Chunk.(*chunk.Chunk).Code
 

--- a/internal/compiler/fused_jump_compile_test.go
+++ b/internal/compiler/fused_jump_compile_test.go
@@ -1,8 +1,10 @@
 package compiler
 
 import (
+	"fmt"
 	"testing"
 
+	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/lexer"
 	"noxy-vm/internal/parser"
 )
@@ -19,8 +21,13 @@ func compileFusedSource(t *testing.T, source string) error {
 	return err
 }
 
+// TestFusedWhileCompiles fundia sem checar o bytecode gerado (so "compila
+// sem erro"), o que passaria identico se a fusao fosse desligada ou se a
+// tabela de mapeamento operador->opcode saisse invertida. Fortalecido para
+// tambem exigir OP_JUMP_IF_GE_INT presente (a fusao de `<` de fato disparou)
+// e OP_JUMP_IF_FALSE ausente (nao caiu no caminho generico).
 func TestFusedWhileCompiles(t *testing.T) {
-	if err := compileFusedSource(t, `
+	source := `
 func f() -> int
     let i: int = 0
     while i < 10 do
@@ -29,8 +36,80 @@ func f() -> int
     return i
 end
 f()
-`); err != nil {
+`
+	if err := compileFusedSource(t, source); err != nil {
 		t.Fatalf("compile error: %v", err)
+	}
+	fn := compiledFunction(t, source, "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_JUMP_IF_GE_INT) {
+		t.Fatalf("`while i < 10` nao fundiu: OP_JUMP_IF_GE_INT ausente do bytecode")
+	}
+	if containsOpcode(code, chunk.OP_JUMP_IF_FALSE) {
+		t.Fatalf("`while i < 10` caiu no caminho generico (OP_JUMP_IF_FALSE presente) apesar de i e 10 serem int")
+	}
+}
+
+// TestFusedOperatorMapsToExpectedOpcode fixa, por bytecode, a tabela inteira
+// de fusedIntCompareJump — as seis linhas de negacao manual sao o ponto mais
+// propenso a inversao desta mudanca (o proprio brief ja apontava a direcao do
+// salto como o risco central). Sem este teste, so `<` e `<=` ficavam presos
+// por comportamento via TestFusedWhileAndIfBehavior (pacote vm); `>`, `>=`,
+// `==` e `!=` nao tinham nenhuma asercao no `go test`. Para nao passar de
+// forma vazia (achar o byte certo por acaso em outro lugar do chunk, ou olhar
+// para o chunk errado), cada caso: (a) usa compiledFunction, que ja falha com
+// t.Fatalf se a funcao nao existir no pool de constantes; (b) exige AUSENCIA
+// dos outros cinco opcodes fundidos (uma inversao troca QUAL opcode aparece,
+// nao duplica); e (c) exige AUSENCIA de OP_JUMP_IF_FALSE (prova que fundiu,
+// nao caiu no generico).
+func TestFusedOperatorMapsToExpectedOpcode(t *testing.T) {
+	allFused := []chunk.OpCode{
+		chunk.OP_JUMP_IF_LT_INT,
+		chunk.OP_JUMP_IF_LE_INT,
+		chunk.OP_JUMP_IF_GT_INT,
+		chunk.OP_JUMP_IF_GE_INT,
+		chunk.OP_JUMP_IF_EQ_INT,
+		chunk.OP_JUMP_IF_NE_INT,
+	}
+	cases := []struct {
+		operator string
+		want     chunk.OpCode
+	}{
+		{"<", chunk.OP_JUMP_IF_GE_INT},
+		{"<=", chunk.OP_JUMP_IF_GT_INT},
+		{">", chunk.OP_JUMP_IF_LE_INT},
+		{">=", chunk.OP_JUMP_IF_LT_INT},
+		{"==", chunk.OP_JUMP_IF_NE_INT},
+		{"!=", chunk.OP_JUMP_IF_EQ_INT},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator, func(t *testing.T) {
+			source := fmt.Sprintf(`
+func f(a: int, b: int) -> int
+    if a %s b then
+        return 1
+    end
+    return 0
+end
+`, tc.operator)
+			fn := compiledFunction(t, source, "f")
+			code := fn.Chunk.(*chunk.Chunk).Code
+
+			if !containsOpcode(code, tc.want) {
+				t.Fatalf("operador %q: esperava %s no bytecode, ausente", tc.operator, tc.want)
+			}
+			for _, other := range allFused {
+				if other == tc.want {
+					continue
+				}
+				if containsOpcode(code, other) {
+					t.Fatalf("operador %q: opcode fundido inesperado %s tambem presente (tabela de mapeamento provavelmente invertida)", tc.operator, other)
+				}
+			}
+			if containsOpcode(code, chunk.OP_JUMP_IF_FALSE) {
+				t.Fatalf("operador %q: OP_JUMP_IF_FALSE presente — condicao nao fundiu", tc.operator)
+			}
+		})
 	}
 }
 

--- a/internal/compiler/fused_jump_compile_test.go
+++ b/internal/compiler/fused_jump_compile_test.go
@@ -1,0 +1,95 @@
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+)
+
+func compileFusedSource(t *testing.T, source string) error {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	_, _, err := New().Compile(program)
+	return err
+}
+
+func TestFusedWhileCompiles(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f() -> int
+    let i: int = 0
+    while i < 10 do
+        i = i + 1
+    end
+    return i
+end
+f()
+`); err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+}
+
+// Condição float NÃO pode fundir: o rollback (TruncateTo) tem de deixar o
+// caminho genérico intacto.
+func TestNonIntConditionFallsBack(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f() -> int
+    let x: float = 0.0
+    let n: int = 0
+    while x < 10.0 do
+        x = x + 1.0
+        n = n + 1
+    end
+    return n
+end
+f()
+`); err != nil {
+		t.Fatalf("compile error (fallback quebrado): %v", err)
+	}
+}
+
+// Condição com curto-circuito dentro do operando (jumps internos) sob
+// rollback: `(a < b) == flag` compila o InfixExpression externo `==` — o lado
+// esquerdo é bool, então o fuse desiste após compilar o operando esquerdo.
+func TestBoolOperandRollsBack(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f(a: int, b: int, flag: bool) -> int
+    if (a < b) == flag then
+        return 1
+    end
+    return 0
+end
+f(1, 2, true)
+`); err != nil {
+		t.Fatalf("compile error (rollback com operando bool): %v", err)
+	}
+}
+
+// Caso da questão aberta do plano: um literal de função (lambda) dentro de um
+// operando de comparação, invocado imediatamente (IIFE). A tentativa
+// especulativa compila o FunctionLiteral (que captura `a` e `b` do escopo de
+// `f` como upvalue, marcando IsCaptured no compilador ENVOLVENTE) antes de
+// descobrir que o tipo resultante é bool, não int — e faz TruncateTo. O
+// caminho genérico recompila a mesma árvore do zero, então o registro de
+// upvalue acontece de novo (idempotente: IsCaptured já true) e o closure
+// realmente emitido é o da segunda passada. Isso compila e roda correto —
+// ver TestFusedIifeInConditionRollsBackAndRuns no pacote vm para o valor.
+func TestLambdaOperandRollsBack(t *testing.T) {
+	if err := compileFusedSource(t, `
+func f(a: int, b: int) -> int
+    let base: int = 10
+    if (func() -> bool return a < b end)() == true then
+        return base
+    end
+    return 0
+end
+f(1, 2)
+`); err != nil {
+		t.Fatalf("compile error (rollback com lambda literal no operando): %v", err)
+	}
+}

--- a/internal/compiler/inc_local_compile_test.go
+++ b/internal/compiler/inc_local_compile_test.go
@@ -1,0 +1,89 @@
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+// TestIncLocalIntFuses prova, por bytecode, que `i = i + 1` sobre um local int
+// possuidor emite OP_INC_LOCAL_INT e NAO cai no caminho generico
+// (OP_SET_LOCAL/OP_ADD_INT ausentes). O comportamento (valor final correto) e
+// coberto por TestIncLocalIntBehavior no pacote vm; aqui so travamos que a
+// fusao de fato dispara.
+func TestIncLocalIntFuses(t *testing.T) {
+	source := `
+func f() -> int
+    let i: int = 0
+    i = i + 1
+    i = i - 3
+    return i
+end
+`
+	fn := compiledFunction(t, source, "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_INC_LOCAL_INT) {
+		t.Fatalf("`i = i +- K` nao fundiu: OP_INC_LOCAL_INT ausente do bytecode")
+	}
+	if containsOpcode(code, chunk.OP_SET_LOCAL) {
+		t.Fatalf("`i = i +- K` caiu no caminho generico (OP_SET_LOCAL presente) apesar de i ser int possuidor")
+	}
+}
+
+// TestIncLocalIntDoesNotFuseForGlobal confirma que a mesma forma sintatica
+// `x = x + 1` sobre uma variavel GLOBAL (sem slot local) nao aciona a fusao —
+// resolveLocal nao encontra slot, entao tryFuseLocalIntIncrement desiste
+// antes de qualquer checagem de tipo/posse.
+func TestIncLocalIntDoesNotFuseForGlobal(t *testing.T) {
+	source := `
+let x: int = 0
+func f() -> int
+    x = x + 1
+    return x
+end
+`
+	fn := compiledFunction(t, source, "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if containsOpcode(code, chunk.OP_INC_LOCAL_INT) {
+		t.Fatalf("`x = x + 1` sobre global fundiu incorretamente em OP_INC_LOCAL_INT")
+	}
+}
+
+// TestIncLocalIntDoesNotFuseAcrossDifferentIdentifiers garante que a checagem
+// sintatica do lado esquerdo do infix (left.Value == ident.Value) rejeita
+// `i = j + 1` — nao e um incremento de i, e fundir aqui perderia o valor de j.
+func TestIncLocalIntDoesNotFuseAcrossDifferentIdentifiers(t *testing.T) {
+	source := `
+func f() -> int
+    let i: int = 0
+    let j: int = 5
+    i = j + 1
+    return i
+end
+`
+	fn := compiledFunction(t, source, "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if containsOpcode(code, chunk.OP_INC_LOCAL_INT) {
+		t.Fatalf("`i = j + 1` fundiu incorretamente em OP_INC_LOCAL_INT (lado direito nao e o proprio i)")
+	}
+}
+
+// TestIncLocalIntDoesNotFuseDeltaOutOfRange garante que um delta fora de
+// [-128,127] cai no caminho generico em vez de estourar o operando i8.
+func TestIncLocalIntDoesNotFuseDeltaOutOfRange(t *testing.T) {
+	source := `
+func f() -> int
+    let i: int = 0
+    i = i + 200
+    return i
+end
+`
+	fn := compiledFunction(t, source, "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if containsOpcode(code, chunk.OP_INC_LOCAL_INT) {
+		t.Fatalf("`i = i + 200` fundiu incorretamente em OP_INC_LOCAL_INT (delta fora de [-128,127])")
+	}
+	if !containsOpcode(code, chunk.OP_SET_LOCAL) {
+		t.Fatalf("`i = i + 200` nao caiu no caminho generico (OP_SET_LOCAL ausente)")
+	}
+}

--- a/internal/value/environment.go
+++ b/internal/value/environment.go
@@ -71,3 +71,15 @@ func (environment *GlobalEnvironment) ReplaceLocal(values map[string]Value) {
 func (environment *GlobalEnvironment) ExportMap() Value {
 	return Value{Type: VAL_OBJ, Obj: &ObjMap{store: environment.local}}
 }
+
+// Generation soma as gerações dos stores da cadeia de ambientes. Qualquer
+// escrita em qualquer nível (inclusive via ObjMap exportado que compartilha o
+// store — ver ExportMap) avança a soma; os contadores só incrementam, então a
+// soma é estritamente crescente e serve de token de invalidação de cache.
+func (environment *GlobalEnvironment) Generation() uint64 {
+	var sum uint64
+	for current := environment; current != nil; current = current.parent {
+		sum += current.local.gen.Load()
+	}
+	return sum
+}

--- a/internal/value/environment_test.go
+++ b/internal/value/environment_test.go
@@ -65,6 +65,36 @@ func TestGlobalEnvironmentLocalOperationsAndSnapshots(t *testing.T) {
 	}
 }
 
+func TestGenerationBumpsOnSetLocal(t *testing.T) {
+	env := NewGlobalEnvironment(nil)
+	g0 := env.Generation()
+	env.SetLocal("x", NewInt(1))
+	if env.Generation() == g0 {
+		t.Fatal("SetLocal deve avançar a geração")
+	}
+}
+
+func TestGenerationSeesParentWrites(t *testing.T) {
+	root := NewGlobalEnvironment(nil)
+	child := NewGlobalEnvironment(root)
+	g0 := child.Generation()
+	root.SetLocal("x", NewInt(1))
+	if child.Generation() == g0 {
+		t.Fatal("escrita no pai deve avançar a geração vista pelo filho")
+	}
+}
+
+func TestGenerationSeesExportedMapWrites(t *testing.T) {
+	env := NewGlobalEnvironment(nil)
+	env.SetLocal("x", NewInt(1))
+	g0 := env.Generation()
+	exported := env.ExportMap().Obj.(*ObjMap)
+	exported.Set("x", NewInt(2))
+	if env.Generation() == g0 {
+		t.Fatal("escrita via ObjMap que compartilha o store deve avançar a geração")
+	}
+}
+
 func TestGlobalEnvironmentNilDoesNotResolve(t *testing.T) {
 	var environment *GlobalEnvironment
 	if _, found := environment.GetLocal("missing"); found {

--- a/internal/value/map.go
+++ b/internal/value/map.go
@@ -1,9 +1,13 @@
 package value
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type bindingStore struct {
 	mu     sync.RWMutex
+	gen    atomic.Uint64
 	values map[interface{}]Value
 }
 
@@ -25,6 +29,7 @@ func (store *bindingStore) set(key interface{}, item Value) {
 	store.mu.Lock()
 	store.values[key] = item
 	store.mu.Unlock()
+	store.gen.Add(1)
 }
 
 func (store *bindingStore) defineIfAbsent(key interface{}, item Value) bool {
@@ -34,6 +39,7 @@ func (store *bindingStore) defineIfAbsent(key interface{}, item Value) bool {
 		return false
 	}
 	store.values[key] = item
+	store.gen.Add(1)
 	return true
 }
 
@@ -44,6 +50,7 @@ func (store *bindingStore) delete(key interface{}) bool {
 		return false
 	}
 	delete(store.values, key)
+	store.gen.Add(1)
 	return true
 }
 
@@ -71,6 +78,7 @@ func (store *bindingStore) replace(values map[interface{}]Value) {
 	for key, item := range replacement {
 		store.values[key] = item
 	}
+	store.gen.Add(1)
 }
 
 func (mapping *ObjMap) ensureStore() *bindingStore {

--- a/internal/value/map.go
+++ b/internal/value/map.go
@@ -11,6 +11,12 @@ type bindingStore struct {
 	values map[interface{}]Value
 }
 
+// Regra do gen: cada funil de mutação deste store precisa terminar com
+// store.gen.Add(1), sempre DEPOIS de aplicar a mutação — nunca antes. Um
+// bump visível antes da escrita deixaria um leitor concorrente observar a
+// nova geração com o valor velho ainda no map e cachear esse valor como se
+// fosse atual; um quinto funil que esqueça o bump reintroduz leitura
+// obsoleta em silêncio, sem nenhum teste acusando.
 func newBindingStore(values map[interface{}]Value) *bindingStore {
 	if values == nil {
 		values = make(map[interface{}]Value)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.5.0"
+const Version = "v0.6.0"

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -64,12 +64,15 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		}
 
 		// Create Frame
-		frame := &CallFrame{
+		frame := &threadVM.frames[0]
+		*frame = CallFrame{
 			Closure:     closure,
 			IP:          0,
 			StackBase:   0,
 			LocalBase:   0,
 			Environment: closure.Environment,
+			Deferred:    frame.Deferred[:0],
+			Owned:       frame.Owned[:0],
 		}
 
 		// RC: registra os slots retidos acima no frame manual (spawn não passa
@@ -84,7 +87,6 @@ func (vm *VM) defineConcurrencyBuiltins() {
 			}
 		}
 
-		threadVM.frames[0] = frame
 		threadVM.frameCount = 1
 		threadVM.currentFrame = frame
 

--- a/internal/vm/call_alloc_bench_test.go
+++ b/internal/vm/call_alloc_bench_test.go
@@ -24,9 +24,12 @@ func compileVMSourceForBench(b *testing.B, source string) *chunk.Chunk {
 	return code
 }
 
-// Mede alocações por chamada de função Noxy. Antes da Task 4: >=2 allocs/op
-// no caminho de chamada (CallFrame + Owned). Depois: 0 allocs/op de frame em
-// regime estacionário (capacidades de Owned/Deferred reusadas).
+// Mede alocações por chamada de função Noxy. leaf(n: int) recebe um escalar,
+// então value.Retain nunca "pega" nele e Owned não chega a crescer neste
+// benchmark — o que ele isola é só o &CallFrame{} por chamada. Antes da
+// Task 4: ~1 alloc/op de CallFrame por chamada de leaf (1000/op) + setup fixo
+// por Interpret. Depois: 0 allocs/op de CallFrame em regime estacionário,
+// restando só o setup fixo por Interpret.
 func BenchmarkNoxyCallOverhead(b *testing.B) {
 	machine := New()
 	code := compileVMSourceForBench(b, `

--- a/internal/vm/call_alloc_bench_test.go
+++ b/internal/vm/call_alloc_bench_test.go
@@ -1,0 +1,54 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+)
+
+func compileVMSourceForBench(b *testing.B, source string) *chunk.Chunk {
+	b.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		b.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		b.Fatalf("compiler error: %v", err)
+	}
+	return code
+}
+
+// Mede alocações por chamada de função Noxy. Antes da Task 4: >=2 allocs/op
+// no caminho de chamada (CallFrame + Owned). Depois: 0 allocs/op de frame em
+// regime estacionário (capacidades de Owned/Deferred reusadas).
+func BenchmarkNoxyCallOverhead(b *testing.B) {
+	machine := New()
+	code := compileVMSourceForBench(b, `
+func leaf(n: int) -> int
+    return n
+end
+func run(times: int) -> int
+    let i: int = 0
+    let acc: int = 0
+    while i < times do
+        acc = leaf(i)
+        i = i + 1
+    end
+    return acc
+end
+run(1000)
+`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := machine.Interpret(code); err != nil {
+			b.Fatalf("vm error: %v", err)
+		}
+	}
+}

--- a/internal/vm/call_static_test.go
+++ b/internal/vm/call_static_test.go
@@ -1,0 +1,64 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Chamada tipada in-module: caminho que a Task 3 acelera. O resultado não
+// pode mudar.
+func TestTypedCallStillWorks(t *testing.T) {
+	result := captureVMSource(t, `
+func double(n: int) -> int
+    return n * 2
+end
+test_report(double(21))
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 42 {
+		t.Fatalf("esperado 42, obtido %s", result.String())
+	}
+}
+
+// Caminho dinâmico (any): validateParameterModes TEM de continuar disparando —
+// passar valor plano onde a função espera ref é erro de runtime aqui.
+func TestDynamicCallStillValidatesModes(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func mutate(target: ref int) -> void
+    return
+end
+let f: any = mutate
+f(5)
+`)
+	if err == nil {
+		t.Fatal("chamada dinâmica com modo errado deveria falhar em runtime")
+	}
+	if !strings.Contains(err.Error(), "expected") {
+		t.Fatalf("mensagem inesperada: %v", err)
+	}
+}
+
+// Slot tipado re-atribuído para OUTRA função de mesmo tipo: o call site
+// OP_CALL_STATIC continua correto porque a prova é por TIPO, não por valor
+// (invariantes 1-3 do preâmbulo da task). Sintaxe do tipo função conforme
+// docs/NOXY_LANGUAGE_SPEC.md §4.2 — ajustar a grafia se o parser divergir.
+func TestStaticCallSurvivesSameTypedRebind(t *testing.T) {
+	result := captureVMSource(t, `
+func inc(n: int) -> int
+    return n + 1
+end
+func dec(n: int) -> int
+    return n - 1
+end
+let op: func(int) -> int = inc
+let a: int = op(10)
+op = dec
+let b: int = op(10)
+test_report(a * 100 + b)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 1109 {
+		t.Fatalf("esperado 1109 (11*100+9), obtido %s", result.String())
+	}
+}

--- a/internal/vm/call_static_test.go
+++ b/internal/vm/call_static_test.go
@@ -40,6 +40,31 @@ f(5)
 	}
 }
 
+// Finding 1 (regressão): parâmetro tipado `any` não é RefType, então o
+// primeiro branch do loop de argumentos não intercepta `ref a`; como
+// areStrictTypesCompatible aceita `any` incondicionalmente, isExact
+// permanecia true e OP_CALL_STATIC era emitido — pulando
+// validateParameterModes, que era a única coisa barrando isso. Callee é
+// tipado estaticamente (não `any`), então TestDynamicCallStillValidatesModes
+// (any-typed *callee*) não cobre este caso; aqui é o *parâmetro* que é any.
+func TestStaticCallWithAnyParamStillValidatesRefMode(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func f(x: any) -> void
+    print(x)
+end
+let a: int = 5
+f(ref a)
+`)
+	if err == nil {
+		t.Fatal("passar ref para parametro any deveria falhar em runtime")
+	}
+	const want = "function 'f' argument 1: expected any, got ref"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("mensagem inesperada: got %q, want it to contain %q", err.Error(), want)
+	}
+}
+
 // Slot tipado re-atribuído para OUTRA função de mesmo tipo: o call site
 // OP_CALL_STATIC continua correto porque a prova é por TIPO, não por valor
 // (invariantes 1-3 do preâmbulo da task). Sintaxe do tipo função conforme

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -50,6 +50,31 @@ func (vm *VM) callValue(callee value.Value, argCount int, c *chunk.Chunk, ip int
 	return false, vm.runtimeError(c, ip, "can only call functions and classes")
 }
 
+// callValueStatic é o caminho de OP_CALL_STATIC: o compilador provou os modos
+// dos argumentos no call site (isExact), e tipos são estáveis, então closures
+// pulam validateParameterModes. Struct constructors e natives seguem pelo
+// callValue normal — as validações deles são de outra natureza (aridade de
+// struct, assinatura de native) e continuam valendo.
+//
+// O skip depende de três invariantes do compilador — se qualquer um mudar,
+// este opcode deixa de ser sound:
+//  1. isExact só nasce de FunctionType exato; bare `func` é PrimitiveType e
+//     nunca ativa (function_types.go:23-26);
+//  2. areStrictTypesCompatible rejeita `any` como fonte para tipos função
+//     (function_types.go:177-178);
+//  3. fronteiras dinâmicas validadas comparam ParamIsRef em
+//     runtimeTypesEqual (runtime_type_validation.go:481-485).
+func (vm *VM) callValueStatic(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
+	if callee.Type == value.VAL_FUNCTION {
+		closure := callee.Obj.(*value.ObjClosure)
+		if argCount != closure.Function.Arity {
+			return false, vm.runtimeError(c, ip, "expected %d arguments but got %d", closure.Function.Arity, argCount)
+		}
+		return vm.callPreparedClosure(closure, argCount, c, ip)
+	}
+	return vm.callValue(callee, argCount, c, ip)
+}
+
 func (vm *VM) callPreparedValue(callee value.Value, argCount int, c *chunk.Chunk, ip int) (bool, error) {
 	if callee.Type == value.VAL_OBJ {
 		if structDef, ok := callee.Obj.(*value.ObjStruct); ok && structDef != nil {

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -140,13 +140,14 @@ func (vm *VM) callPreparedClosure(closure *value.ObjClosure, argCount int, c *ch
 		return false, vm.runtimeError(c, ip, "stack overflow")
 	}
 
-	frame := &CallFrame{
-		Closure:     closure,
-		IP:          0,
-		StackBase:   vm.stackTop - argCount - 1,
-		LocalBase:   vm.stackTop - argCount - 1,
-		Environment: closure.Environment,
-	}
+	frame := &vm.frames[vm.frameCount]
+	frame.Closure = closure
+	frame.IP = 0
+	frame.StackBase = vm.stackTop - argCount - 1
+	frame.LocalBase = vm.stackTop - argCount - 1
+	frame.Environment = closure.Environment
+	frame.Deferred = frame.Deferred[:0]
+	frame.Owned = frame.Owned[:0]
 
 	// RC: parametros sem ref sao vinculos duraveis do frame novo
 	params := closure.Function.Params
@@ -157,8 +158,6 @@ func (vm *VM) callPreparedClosure(closure *value.ObjClosure, argCount int, c *ch
 		frame.ownSlot(vm, frame.LocalBase+1+i)
 	}
 
-	// Push new frame
-	vm.frames[vm.frameCount] = frame
 	vm.frameCount++
 	vm.currentFrame = frame
 	return true, nil

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -290,7 +290,8 @@ func TestFinishFrameAggregatesPreparedCallHeadroomFailureAndContinues(t *testing
 		t.Fatal("deferred call ran without enough fixed-stack headroom")
 		return value.NewNull()
 	})
-	frame := &CallFrame{
+	frame := &machine.frames[0]
+	*frame = CallFrame{
 		StackBase: 0,
 		LocalBase: 0,
 		Deferred: []PreparedCall{
@@ -298,7 +299,6 @@ func TestFinishFrameAggregatesPreparedCallHeadroomFailureAndContinues(t *testing
 			{Callee: newer, Arguments: []value.Value{value.NewInt(1)}, Registration: SourceLocation{File: "headroom.nx", Line: 5}},
 		},
 	}
-	machine.frames[0] = frame
 	machine.frameCount = 1
 	machine.currentFrame = frame
 	machine.stackTop = StackMax - 1
@@ -316,8 +316,8 @@ func TestFinishFrameAggregatesPreparedCallHeadroomFailureAndContinues(t *testing
 	if !olderRan {
 		t.Fatal("headroom failure skipped the older deferred call")
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil || machine.openUpvalues != nil {
-		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d frame0=%p open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.frames[0], machine.openUpvalues)
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.openUpvalues != nil {
+		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d frame0=%p open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.frames[0].Closure, machine.openUpvalues)
 	}
 	if machine.stack[StackMax-2] != (value.Value{}) {
 		t.Fatalf("owned stack slot was not cleared: %#v", machine.stack[StackMax-2])

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -316,8 +316,8 @@ func TestFinishFrameAggregatesPreparedCallHeadroomFailureAndContinues(t *testing
 	if !olderRan {
 		t.Fatal("headroom failure skipped the older deferred call")
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.openUpvalues != nil {
-		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d frame0=%p open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.frames[0].Closure, machine.openUpvalues)
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.frames[0].Environment != nil || len(machine.frames[0].Owned) != 0 || len(machine.frames[0].Deferred) != 0 || machine.openUpvalues != nil {
+		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d frame0=%p env=%p owned=%d deferred=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.frames[0].Closure, machine.frames[0].Environment, len(machine.frames[0].Owned), len(machine.frames[0].Deferred), machine.openUpvalues)
 	}
 	if machine.stack[StackMax-2] != (value.Value{}) {
 		t.Fatalf("owned stack slot was not cleared: %#v", machine.stack[StackMax-2])

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -954,6 +954,21 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			gcache = c.GlobalCache()
 			ip = frame.IP
 
+		case chunk.OP_CALL_STATIC:
+			argCount := int(c.Code[ip])
+			ip++
+
+			frame.IP = ip // Save current instruction pointer to the frame before call
+
+			if ok, err := vm.callValueStatic(vm.peek(argCount), argCount, c, ip); !ok {
+				return err
+			}
+			// Update cached frame
+			frame = vm.currentFrame // Switch to new frame
+			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+			gcache = c.GlobalCache()
+			ip = frame.IP
+
 		case chunk.OP_DEFER:
 			registration := sourceLocation(c, ip)
 			argCount := int(c.Code[ip])

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -141,6 +141,57 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			ip += 2
 			ip -= offset
 
+		// perf fase 1: comparacao int + salto fundidos. Consomem os dois
+		// VAL_INT do topo (sem zerar: escalares nao carregam ponteiros para o
+		// GC reter) e saltam quando a condicao NOMEADA vale.
+		case chunk.OP_JUMP_IF_LT_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt < vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
+		case chunk.OP_JUMP_IF_LE_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt <= vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
+		case chunk.OP_JUMP_IF_GT_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt > vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
+		case chunk.OP_JUMP_IF_GE_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt >= vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
+		case chunk.OP_JUMP_IF_EQ_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt == vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
+		case chunk.OP_JUMP_IF_NE_INT:
+			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
+			ip += 2
+			vm.stackTop -= 2
+			if vm.stack[vm.stackTop].AsInt != vm.stack[vm.stackTop+1].AsInt {
+				ip += offset
+			}
+
 		case chunk.OP_TRUE:
 			vm.push(value.NewBool(true))
 		case chunk.OP_FALSE:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -192,6 +192,16 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				ip += offset
 			}
 
+		case chunk.OP_INC_LOCAL_INT:
+			// perf fase 1: soma o delta direto no slot, sem empilhar/desempilhar
+			// nada. RC: int e escalar (Retain/Release de OP_SET_LOCAL sao no-op
+			// para VAL_INT — ownersOf so rastreia VAL_OBJ), entao nao ha posse a
+			// atualizar aqui — mesma escrita direta que OP_SET_LOCAL faria.
+			slot := c.Code[ip]
+			delta := int8(c.Code[ip+1])
+			ip += 2
+			vm.stack[frame.LocalBase+int(slot)].AsInt += int64(delta)
+
 		case chunk.OP_TRUE:
 			vm.push(value.NewBool(true))
 		case chunk.OP_FALSE:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -617,6 +617,11 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			vm.stack[vm.stackTop-1] = value.Value{}
 			vm.stackTop--
 
+		case chunk.OP_ADD_FLOAT:
+			// Espelho float de OP_ADD_INT: sem zerar, escalar nao carrega ponteiro.
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat + vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
+
 		case chunk.OP_SUBTRACT:
 			b := vm.pop()
 			a := vm.pop()
@@ -635,6 +640,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			vm.push(value.NewInt(a.AsInt - b.AsInt))
+		case chunk.OP_SUB_FLOAT:
+			// Espelho float de OP_SUB_INT.
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat - vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
 		case chunk.OP_MULTIPLY:
 			b := vm.pop()
 			a := vm.pop()
@@ -653,6 +662,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			vm.push(value.NewInt(a.AsInt * b.AsInt))
+		case chunk.OP_MUL_FLOAT:
+			// Espelho float de OP_MUL_INT.
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat * vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
 		case chunk.OP_DIVIDE:
 			b := vm.pop()
 			a := vm.pop()
@@ -686,6 +699,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return vm.runtimeError(c, ip, "division by zero")
 			}
 			vm.push(value.NewInt(a.AsInt / b.AsInt))
+		case chunk.OP_DIV_FLOAT:
+			// Mesma mensagem de erro do ramo float de OP_DIVIDE (generico):
+			// divisor 0.0 e erro de runtime, nao +Inf/NaN.
+			if vm.stack[vm.stackTop-1].AsFloat == 0 {
+				return vm.runtimeError(c, ip, "division by zero")
+			}
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat / vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
 		case chunk.OP_LEN:
 			val := vm.pop()
 			if val.Type == value.VAL_OBJ {
@@ -960,6 +981,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			vm.push(value.NewBool(a.AsInt > b.AsInt))
+		case chunk.OP_GREATER_FLOAT:
+			// Espelho float de OP_GREATER_INT.
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat > vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
 		case chunk.OP_LESS:
 			b := vm.pop()
 			a := vm.pop()
@@ -974,6 +999,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			} else {
 				return vm.runtimeError(c, ip, "operands must be numbers")
 			}
+		case chunk.OP_LESS_FLOAT:
+			// Espelho float de OP_LESS_INT.
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat < vm.stack[vm.stackTop-1].AsFloat)
+			vm.stackTop--
 		case chunk.OP_LESS_INT:
 			// Inline pop/pop/push
 			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsInt < vm.stack[vm.stackTop-1].AsInt)

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -36,8 +36,8 @@ func (vm *VM) InterpretWithEnvironment(c *chunk.Chunk, environment *value.Global
 	scriptClosure := &value.ObjClosure{Function: scriptFunction, Upvalues: []*value.ObjUpvalue{}, Environment: environment}
 	vm.stackTop = 0
 	vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: scriptClosure})
-	frame := &CallFrame{Closure: scriptClosure, IP: 0, StackBase: 0, LocalBase: 1, Environment: environment}
-	vm.frames[0] = frame
+	frame := &vm.frames[0]
+	*frame = CallFrame{Closure: scriptClosure, IP: 0, StackBase: 0, LocalBase: 1, Environment: environment, Deferred: frame.Deferred[:0], Owned: frame.Owned[:0]}
 	vm.frameCount = 1
 	vm.currentFrame = frame
 	return vm.run(1, nil)

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -999,14 +999,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			} else {
 				return vm.runtimeError(c, ip, "operands must be numbers")
 			}
-		case chunk.OP_LESS_FLOAT:
-			// Espelho float de OP_LESS_INT.
-			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat < vm.stack[vm.stackTop-1].AsFloat)
-			vm.stackTop--
 		case chunk.OP_LESS_INT:
 			// Inline pop/pop/push
 			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsInt < vm.stack[vm.stackTop-1].AsInt)
 			vm.stack[vm.stackTop-1] = value.Value{}
+			vm.stackTop--
+		case chunk.OP_LESS_FLOAT:
+			// Espelho float de OP_LESS_INT.
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat < vm.stack[vm.stackTop-1].AsFloat)
 			vm.stackTop--
 		case chunk.OP_EQUAL:
 			b := vm.pop()

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -47,6 +47,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 	// Cache current frame values for speed
 	frame := vm.currentFrame
 	c := frame.Closure.Function.Chunk.(*chunk.Chunk)
+	gcache := c.GlobalCache()
 	ip := frame.IP
 	defer func() {
 		if vm.currentFrame == frame {
@@ -185,6 +186,15 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_GET_GLOBAL:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
+			// Geração lida ANTES do Resolve: uma escrita concorrente entre os
+			// dois avança a geração, então a entrada gravada com a geração
+			// antiga falha a comparação na próxima leitura e re-resolve — o
+			// cache pode sub-cachear, nunca servir valor stale.
+			gen := frame.Environment.Generation()
+			if entry := gcache[index].Load(); entry != nil && entry.Env == frame.Environment && entry.Gen == gen {
+				vm.push(entry.Val)
+				continue
+			}
 			nameVal := c.Constants[index]
 			name := nameVal.Obj.(string)
 
@@ -192,6 +202,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if !ok {
 				return vm.runtimeError(c, ip, "undefined global variable '%s'", name)
 			}
+			gcache[index].Store(&chunk.GlobalCacheEntry{Env: frame.Environment, Gen: gen, Val: val})
 			vm.push(val)
 
 		case chunk.OP_SET_GLOBAL:
@@ -940,6 +951,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// Update cached frame
 			frame = vm.currentFrame // Switch to new frame
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+			gcache = c.GlobalCache()
 			ip = frame.IP
 
 		case chunk.OP_DEFER:
@@ -1079,6 +1091,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 			frame = vm.currentFrame
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+			gcache = c.GlobalCache()
 			ip = frame.IP
 
 		case chunk.OP_ARRAY:
@@ -1139,6 +1152,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 			frame = vm.currentFrame
 			c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+			gcache = c.GlobalCache()
 			ip = frame.IP
 			vm.push(mod)
 

--- a/internal/vm/float_ops_test.go
+++ b/internal/vm/float_ops_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"noxy-vm/internal/value"
@@ -41,5 +42,11 @@ f(1.0, 0.0)
 `)
 	if err == nil {
 		t.Fatal("divisao float por zero deveria continuar sendo erro de runtime")
+	}
+	// A mensagem (nao so a presenca de erro) precisa bater com o caminho
+	// generico (ramo float de OP_DIVIDE): sem isto, um typo introduzido em
+	// so um dos dois handlers passaria despercebido pela suite.
+	if !strings.Contains(err.Error(), "division by zero") {
+		t.Fatalf("mensagem de erro divergiu do caminho generico: esperava conter %q, obtido %q", "division by zero", err.Error())
 	}
 }

--- a/internal/vm/float_ops_test.go
+++ b/internal/vm/float_ops_test.go
@@ -30,6 +30,16 @@ test_report(mandel_step(-0.5, 0.25))
 	if math.IsNaN(result.AsFloat) || math.IsInf(result.AsFloat, 0) {
 		t.Fatalf("resultado invalido: %v", result.AsFloat)
 	}
+	// Valor exato: 10 iteracoes de z = z^2+c a partir de z=0, c=-0.5+0.25i,
+	// reproduzidas em float64 puro (Python e Go concordam bit a bit — ver
+	// registro em .superpowers/sdd/2026-08-18-vm-perf-fase1-dispatch-e-chamadas).
+	// Sem isto, um typo trocando o operador de um opcode _FLOAT especializado
+	// (ex.: OP_MUL_FLOAT calculando a-b) passaria pela suite sem detectar,
+	// desde que o resultado continuasse sendo um float finito.
+	const want = 0x1.76b0f0f446e8ep-03
+	if result.AsFloat != want {
+		t.Fatalf("resultado incorreto: got %v (%x), want %v (%x)", result.AsFloat, result.AsFloat, want, want)
+	}
 }
 
 func TestFloatDivisionByZeroStillErrors(t *testing.T) {

--- a/internal/vm/float_ops_test.go
+++ b/internal/vm/float_ops_test.go
@@ -1,0 +1,45 @@
+package vm
+
+import (
+	"math"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestFloatArithmeticSpecialized(t *testing.T) {
+	result := captureVMSource(t, `
+func mandel_step(cr: float, ci: float) -> float
+    let zr: float = 0.0
+    let zi: float = 0.0
+    let i: int = 0
+    while i < 10 do
+        let tmp: float = zr * zr - zi * zi + cr
+        zi = 2.0 * zr * zi + ci
+        zr = tmp
+        i = i + 1
+    end
+    return zr * zr + zi * zi
+end
+test_report(mandel_step(-0.5, 0.25))
+`)
+	if result.Type != value.VAL_FLOAT {
+		t.Fatalf("esperado float, obtido %s", result.String())
+	}
+	if math.IsNaN(result.AsFloat) || math.IsInf(result.AsFloat, 0) {
+		t.Fatalf("resultado invalido: %v", result.AsFloat)
+	}
+}
+
+func TestFloatDivisionByZeroStillErrors(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `
+func f(a: float, b: float) -> float
+    return a / b
+end
+f(1.0, 0.0)
+`)
+	if err == nil {
+		t.Fatal("divisao float por zero deveria continuar sendo erro de runtime")
+	}
+}

--- a/internal/vm/fused_jump_test.go
+++ b/internal/vm/fused_jump_test.go
@@ -9,8 +9,15 @@ import (
 )
 
 // Frame raiz: stack[0] = script closure; empilhamos a,b e o opcode fundido
-// salta (ou não) sobre um OP_CONSTANT sentinela. Sem OP_RETURN de propósito
-// (o loop cai fora no fim do código e deixa a pilha para inspeção).
+// salta (ou não) sobre um OP_CONSTANT sentinela. Depois do sentinela vem um
+// OP_CONSTANT marcador que os DOIS caminhos executam — isso prova não só que
+// saltou, mas que o pouso caiu exatamente no início da instrução seguinte ao
+// sentinela: um pouso errado por 1 byte para qualquer lado decodificaria um
+// opcode/operando no meio de uma instrução, o que não produz nem a pilha
+// "saltou" (closure+marcador) nem a "não saltou" (closure+sentinela+marcador)
+// — cairia no `default` abaixo (ou o próprio VM devolveria erro). Sem
+// OP_RETURN de propósito (o loop cai fora no fim do código e deixa a pilha
+// para inspeção).
 func runFusedJump(t *testing.T, op chunk.OpCode, a, b int64) (jumped bool) {
 	t.Helper()
 	machine := New()
@@ -18,28 +25,40 @@ func runFusedJump(t *testing.T, op chunk.OpCode, a, b int64) (jumped bool) {
 	ca := code.AddConstant(value.NewInt(a))
 	cb := code.AddConstant(value.NewInt(b))
 	sentinel := code.AddConstant(value.NewInt(777))
+	marker := code.AddConstant(value.NewInt(888))
 	code.Write(byte(chunk.OP_CONSTANT), 1)
 	code.Write(byte(ca), 1)
 	code.Write(byte(chunk.OP_CONSTANT), 1)
 	code.Write(byte(cb), 1)
 	code.Write(byte(op), 1)
 	code.Write(0, 1) // offset hi
-	code.Write(2, 1) // offset lo: pula o OP_CONSTANT sentinela (2 bytes)
+	code.Write(2, 1) // offset lo: pula exatamente a instrucao OP_CONSTANT sentinela (2 bytes)
 	code.Write(byte(chunk.OP_CONSTANT), 1)
 	code.Write(byte(sentinel), 1)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(marker), 1)
 	if err := machine.Interpret(code); err != nil {
 		t.Fatalf("vm error: %v", err)
 	}
-	// Se saltou, a pilha ficou só com a closure (stackTop==1); senão, o
-	// sentinela 777 está no topo.
-	if machine.stackTop == 1 {
+	switch machine.stackTop {
+	case 2: // closure + marcador: saltou e pousou exatamente certo
+		top := machine.stack[1]
+		if top.Type != value.VAL_INT || top.AsInt != 888 {
+			t.Fatalf("pouso do salto incorreto: top=%s", top.String())
+		}
 		return true
+	case 3: // closure + sentinela + marcador: nao saltou
+		sentinelTop := machine.stack[1]
+		markerTop := machine.stack[2]
+		if sentinelTop.Type != value.VAL_INT || sentinelTop.AsInt != 777 ||
+			markerTop.Type != value.VAL_INT || markerTop.AsInt != 888 {
+			t.Fatalf("pilha inesperada (nao saltou): sentinela=%s marcador=%s", sentinelTop.String(), markerTop.String())
+		}
+		return false
+	default:
+		t.Fatalf("pilha com formato inesperado apos execucao (pouso de salto provavelmente errado): stackTop=%d", machine.stackTop)
+		return false
 	}
-	top := machine.stack[machine.stackTop-1]
-	if top.Type != value.VAL_INT || top.AsInt != 777 {
-		t.Fatalf("pilha inesperada: top=%s stackTop=%d", top.String(), machine.stackTop)
-	}
-	return false
 }
 
 func TestFusedJumpOpcodes(t *testing.T) {

--- a/internal/vm/fused_jump_test.go
+++ b/internal/vm/fused_jump_test.go
@@ -1,0 +1,123 @@
+package vm
+
+import (
+	"fmt"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: stack[0] = script closure; empilhamos a,b e o opcode fundido
+// salta (ou não) sobre um OP_CONSTANT sentinela. Sem OP_RETURN de propósito
+// (o loop cai fora no fim do código e deixa a pilha para inspeção).
+func runFusedJump(t *testing.T, op chunk.OpCode, a, b int64) (jumped bool) {
+	t.Helper()
+	machine := New()
+	code := &chunk.Chunk{}
+	ca := code.AddConstant(value.NewInt(a))
+	cb := code.AddConstant(value.NewInt(b))
+	sentinel := code.AddConstant(value.NewInt(777))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(ca), 1)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(cb), 1)
+	code.Write(byte(op), 1)
+	code.Write(0, 1) // offset hi
+	code.Write(2, 1) // offset lo: pula o OP_CONSTANT sentinela (2 bytes)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(sentinel), 1)
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	// Se saltou, a pilha ficou só com a closure (stackTop==1); senão, o
+	// sentinela 777 está no topo.
+	if machine.stackTop == 1 {
+		return true
+	}
+	top := machine.stack[machine.stackTop-1]
+	if top.Type != value.VAL_INT || top.AsInt != 777 {
+		t.Fatalf("pilha inesperada: top=%s stackTop=%d", top.String(), machine.stackTop)
+	}
+	return false
+}
+
+func TestFusedJumpOpcodes(t *testing.T) {
+	cases := []struct {
+		name string
+		op   chunk.OpCode
+		a, b int64
+		want bool
+	}{
+		{"LT salta quando a<b", chunk.OP_JUMP_IF_LT_INT, 1, 2, true},
+		{"LT nao salta quando a>=b", chunk.OP_JUMP_IF_LT_INT, 2, 2, false},
+		{"LE salta quando a<=b", chunk.OP_JUMP_IF_LE_INT, 2, 2, true},
+		{"LE nao salta quando a>b", chunk.OP_JUMP_IF_LE_INT, 3, 2, false},
+		{"GT salta quando a>b", chunk.OP_JUMP_IF_GT_INT, 3, 2, true},
+		{"GT nao salta quando a<=b", chunk.OP_JUMP_IF_GT_INT, 2, 2, false},
+		{"GE salta quando a>=b", chunk.OP_JUMP_IF_GE_INT, 2, 2, true},
+		{"GE nao salta quando a<b", chunk.OP_JUMP_IF_GE_INT, 1, 2, false},
+		{"EQ salta quando a==b", chunk.OP_JUMP_IF_EQ_INT, 5, 5, true},
+		{"EQ nao salta quando a!=b", chunk.OP_JUMP_IF_EQ_INT, 5, 6, false},
+		{"NE salta quando a!=b", chunk.OP_JUMP_IF_NE_INT, 5, 6, true},
+		{"NE nao salta quando a==b", chunk.OP_JUMP_IF_NE_INT, 5, 5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runFusedJump(t, tc.op, tc.a, tc.b); got != tc.want {
+				t.Fatalf("jumped=%v, esperado %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFusedWhileAndIfBehavior(t *testing.T) {
+	result := captureVMSource(t, `
+func fib(n: int) -> int
+    if n <= 1 then
+        return n
+    end
+    return fib(n - 1) + fib(n - 2)
+end
+let i: int = 0
+let acc: int = 0
+while i < 5 do
+    acc = acc + fib(i)
+    i = i + 1
+end
+test_report(acc)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 7 {
+		t.Fatalf("esperado 7 (fib 0..4 = 0+1+1+2+3), obtido %s", result.String())
+	}
+}
+
+// TestFusedIifeInConditionRollsBackAndRuns cobre a questão aberta do plano:
+// um literal de função dentro de um operando de comparação (aqui, chamado
+// imediatamente). tryCompileFusedCondition compila o FunctionLiteral
+// especulativamente — capturando a/b como upvalue do compilador da função
+// envolvente — descobre que o tipo é bool (não int) e desfaz com TruncateTo;
+// o caminho genérico recompila a mesma árvore do zero. Validamos aqui que o
+// resultado em RUNTIME está correto nos dois ramos da condição, não só que
+// compila sem erro (isso já é coberto em
+// TestLambdaOperandRollsBack no pacote compiler).
+func TestFusedIifeInConditionRollsBackAndRuns(t *testing.T) {
+	source := `
+func f(a: int, b: int) -> int
+    let base: int = 10
+    if (func() -> bool return a < b end)() == true then
+        return base
+    end
+    return 0
+end
+test_report(f(%d, %d))
+`
+	trueCase := captureVMSource(t, fmt.Sprintf(source, 1, 2))
+	if trueCase.Type != value.VAL_INT || trueCase.AsInt != 10 {
+		t.Fatalf("esperado 10 (a<b), obtido %s", trueCase.String())
+	}
+	falseCase := captureVMSource(t, fmt.Sprintf(source, 2, 1))
+	if falseCase.Type != value.VAL_INT || falseCase.AsInt != 0 {
+		t.Fatalf("esperado 0 (a>=b), obtido %s", falseCase.String())
+	}
+}

--- a/internal/vm/global_cache_test.go
+++ b/internal/vm/global_cache_test.go
@@ -1,0 +1,58 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Guarda o cache de globais contra staleness: a função lê o global duas
+// vezes com uma reatribuição no meio — a segunda leitura TEM de ver o valor
+// novo mesmo com o site de OP_GET_GLOBAL cacheado pela primeira.
+func TestGlobalReadSeesReassignmentBetweenCalls(t *testing.T) {
+	result := captureVMSource(t, `
+let x: int = 1
+func get() -> int
+    return x
+end
+let first: int = get()
+x = 2
+let second: int = get()
+test_report(first * 10 + second)
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 12 {
+		t.Fatalf("esperado 12 (first=1, second=2), obtido %s", result.String())
+	}
+}
+
+// Mesmo chunk executado sob DOIS ambientes diferentes (o caso de módulo /
+// InterpretWithEnvironment): a entrada cacheada do primeiro ambiente não pode
+// vazar para o segundo — a comparação entry.Env tem de falhar e re-resolver.
+// Chunk montado à mão (padrão cow_mut_opcodes_test.go): OP_GET_GLOBAL "x" sem
+// OP_RETURN — o loop cai fora e deixa o valor lido em stack[1] para inspeção.
+func TestGlobalCacheKeyedByEnvironment(t *testing.T) {
+	machine := New()
+	code := &chunk.Chunk{}
+	nameIdx := code.AddConstant(value.NewString("x"))
+	code.Write(byte(chunk.OP_GET_GLOBAL), 1)
+	code.Write(byte(nameIdx>>8), 1)
+	code.Write(byte(nameIdx&0xff), 1)
+
+	envA := value.NewGlobalEnvironmentFrom(map[string]value.Value{"x": value.NewInt(1)}, nil)
+	envB := value.NewGlobalEnvironmentFrom(map[string]value.Value{"x": value.NewInt(2)}, nil)
+
+	if err := machine.InterpretWithEnvironment(code, envA); err != nil {
+		t.Fatalf("vm error (envA): %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 1 {
+		t.Fatalf("envA: esperado 1, obtido %s", got.String())
+	}
+
+	if err := machine.InterpretWithEnvironment(code, envB); err != nil {
+		t.Fatalf("vm error (envB): %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 2 {
+		t.Fatalf("envB: cache vazou o valor do envA — esperado 2, obtido %s", got.String())
+	}
+}

--- a/internal/vm/inc_local_test.go
+++ b/internal/vm/inc_local_test.go
@@ -1,0 +1,84 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: LocalBase = 1, slot local 0 = stack[1]. Empilha 5 no slot e
+// aplica dois incrementos fundidos (+3, -1). Sem OP_RETURN de proposito.
+func TestIncLocalInt(t *testing.T) {
+	machine := New()
+	code := &chunk.Chunk{}
+	five := code.AddConstant(value.NewInt(5))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(five), 1)
+	code.Write(byte(chunk.OP_INC_LOCAL_INT), 1)
+	code.Write(0, 1)             // slot
+	code.Write(byte(int8(3)), 1) // delta +3
+	code.Write(byte(chunk.OP_INC_LOCAL_INT), 1)
+	code.Write(0, 1) // slot
+	// delta -1: byte(int8(-1)) direto é constante e o compilador rejeita a
+	// conversão (overflow de byte); passar por uma variável forca a conversão
+	// em tempo de execucao, que faz o wrap esperado (-1 -> 0xFF).
+	negOne := int8(-1)
+	code.Write(byte(negOne), 1) // delta -1
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	got := machine.stack[1]
+	if got.Type != value.VAL_INT || got.AsInt != 7 {
+		t.Fatalf("esperado slot=7, obtido %s", got.String())
+	}
+}
+
+// TestIncLocalIntBehavior confirma, ponta a ponta (fonte -> compilador ->
+// VM), que a fusao produz o mesmo resultado que o caminho generico: dois
+// locais int possuidores incrementados/decrementados dentro de um while.
+func TestIncLocalIntBehavior(t *testing.T) {
+	result := captureVMSource(t, `
+func count() -> int
+    let i: int = 0
+    let downs: int = 100
+    while i < 10 do
+        i = i + 1
+        downs = downs - 2
+    end
+    return i * 1000 + downs
+end
+test_report(count())
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 10080 {
+		t.Fatalf("esperado 10080 (i=10, downs=80), obtido %s", result.String())
+	}
+}
+
+// TestIncLocalIntAfterClosureCapture cobre exatamente o cenario de risco do
+// upvalue: uma closure abre um upvalue SOBRE o slot de `i` (aponta
+// diretamente para vm.stack[LocalBase+slot] enquanto aberto — ver
+// vm.captureUpvalue/ObjUpvalue.location) e so DEPOIS disso `i` sofre um
+// segundo incremento fundido. OP_INC_LOCAL_INT escreve no mesmo indice de
+// pilha que OP_SET_LOCAL usaria — a mesma celula que o upvalue aberto
+// enxerga por ponteiro — entao a closure deve ver o valor pos-incremento
+// (7), nao o valor no momento da captura (5). Um resultado de 5 aqui
+// revelaria que a fusao bypassa a memoria compartilhada com upvalues
+// abertos.
+func TestIncLocalIntAfterClosureCapture(t *testing.T) {
+	result := captureVMSource(t, `
+func make() -> int
+    let i: int = 0
+    i = i + 5
+    let get: func() -> int = func() -> int
+        return i
+    end
+    i = i + 2
+    return get()
+end
+test_report(make())
+`)
+	if result.Type != value.VAL_INT || result.AsInt != 7 {
+		t.Fatalf("esperado 7 (closure deve ver escrita pos-captura via fusao), obtido %s", result.String())
+	}
+}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -173,10 +173,7 @@ func (vm *VM) retargetOwnedSlot(ref *value.ObjRef, updated value.Value) bool {
 		return false
 	}
 	for i := vm.frameCount - 1; i >= 0; i-- {
-		frame := vm.frames[i]
-		if frame == nil {
-			continue
-		}
+		frame := &vm.frames[i]
 		for j := range frame.Owned {
 			slot := frame.Owned[j].slot
 			if slot < 0 || slot >= len(vm.stack) {
@@ -217,10 +214,7 @@ func (vm *VM) retargetOwnedSlotForUpvalue(upv *value.ObjUpvalue, updated value.V
 		return false
 	}
 	for i := vm.frameCount - 1; i >= 0; i-- {
-		frame := vm.frames[i]
-		if frame == nil {
-			continue
-		}
+		frame := &vm.frames[i]
 		for j := range frame.Owned {
 			slot := frame.Owned[j].slot
 			if slot < 0 || slot >= len(vm.stack) {

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -104,8 +104,8 @@ func sourceLocation(c *chunk.Chunk, ip int) SourceLocation {
 func (vm *VM) captureNoxyStack(activeChunk *chunk.Chunk, activeIP int) string {
 	frames := make([]string, 0, vm.frameCount)
 	for i := vm.frameCount - 1; i >= 0; i-- {
-		frame := vm.frames[i]
-		if frame == nil || frame.Closure == nil || frame.Closure.Function == nil {
+		frame := &vm.frames[i]
+		if frame.Closure == nil || frame.Closure.Function == nil {
 			continue
 		}
 		c, _ := frame.Closure.Function.Chunk.(*chunk.Chunk)

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -176,8 +176,16 @@ func (f *CallFrame) ownSlot(vm *VM, slot int) {
 				// entrada passa a apontar o objeto novo (retido acima).
 				f.Owned[i].obj = v
 			} else {
+				// Swap-remove: o slot k perde sua entrada (release ja aconteceu
+				// no site chamador antes de nos chamar). O array de suporte
+				// sobrevive a este frame (vm.frames e reusado, nao realocado),
+				// entao o antigo indice `last` precisa ser zerado depois do
+				// swap — senao continua nomeando um objeto ja liberado, preso
+				// fora do alcance de qualquer `range f.Owned` (que respeita
+				// len, nao cap) ate um append futuro por acaso sobrescreve-lo.
 				last := len(f.Owned) - 1
 				f.Owned[i] = f.Owned[last]
+				f.Owned[last] = ownedEntry{}
 				f.Owned = f.Owned[:last]
 			}
 			return
@@ -211,8 +219,12 @@ func (f *CallFrame) bindOwnedSlot(vm *VM, slot int) {
 		if retained {
 			f.Owned[i].obj = v
 		} else {
+			// Swap-remove: mesmo cuidado de ownSlot acima — zerar `last`
+			// depois do swap para nao reter, no backing array reusado entre
+			// frames, o value.Value de um objeto ja liberado pela linha acima.
 			last := len(f.Owned) - 1
 			f.Owned[i] = f.Owned[last]
+			f.Owned[last] = ownedEntry{}
 			f.Owned = f.Owned[:last]
 		}
 		return

--- a/internal/vm/task_execution.go
+++ b/internal/vm/task_execution.go
@@ -81,12 +81,15 @@ func (vm *VM) executePreparedTaskCall(call preparedTaskCall) (value.Value, error
 	for _, argument := range call.Arguments {
 		vm.push(argument)
 	}
-	frame := &CallFrame{
+	frame := &vm.frames[0]
+	*frame = CallFrame{
 		Closure:     call.Closure,
 		IP:          0,
 		StackBase:   0,
 		LocalBase:   0,
 		Environment: call.Closure.Environment,
+		Deferred:    frame.Deferred[:0],
+		Owned:       frame.Owned[:0],
 	}
 	// RC: parametros sem ref sao vinculos duraveis do frame da task — mesmo
 	// bind que callPreparedClosure faz (spec §4.2, linha da captura de task:
@@ -103,7 +106,7 @@ func (vm *VM) executePreparedTaskCall(call preparedTaskCall) (value.Value, error
 		}
 		frame.ownSlot(vm, frame.LocalBase+1+i)
 	}
-	vm.frames[0], vm.frameCount, vm.currentFrame = frame, 1, frame
+	vm.frameCount, vm.currentFrame = 1, frame
 	if err := vm.run(1, &result); err != nil {
 		return value.NewNull(), err
 	}

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -58,17 +58,18 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	// um valor diferente do que foi retido. Sites de sobrescrita ja liberam
 	// o velho e atualizam a entrada (ownSlot); nao ha guard de stackTop
 	// porque o release agora e por objeto, nao por leitura de vm.stack.
-	for _, entry := range frame.Owned {
-		value.Release(entry.obj)
+	for i := range frame.Owned {
+		value.Release(frame.Owned[i].obj)
+		frame.Owned[i] = ownedEntry{}
 	}
-	frame.Owned = nil
+	frame.Owned = frame.Owned[:0]
 
 	for index := frame.StackBase; index < ownedTop; index++ {
 		vm.stack[index] = value.Value{}
 	}
 
-	frameIndex := vm.frameCount - 1
-	vm.frames[frameIndex] = nil
+	frame.Closure = nil
+	frame.Environment = nil
 	vm.frameCount--
 	vm.stackTop = frame.StackBase
 
@@ -78,7 +79,7 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 		return outcome
 	}
 
-	vm.currentFrame = vm.frames[vm.frameCount-1]
+	vm.currentFrame = &vm.frames[vm.frameCount-1]
 	if outcome.Err == nil {
 		vm.push(outcome.Result)
 	}

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -58,6 +58,22 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 	// um valor diferente do que foi retido. Sites de sobrescrita ja liberam
 	// o velho e atualizam a entrada (ownSlot); nao ha guard de stackTop
 	// porque o release agora e por objeto, nao por leitura de vm.stack.
+	//
+	// vm.frames e um array de VALORES reusado entre chamadas (nao realocado
+	// por chamada) — este slot do array sobrevive ao frame e volta a ser
+	// escrito pela PROXIMA chamada que cair neste indice. Por isso:
+	//   1. cada entrada de Owned e ZERADA (nao so "esquecida" pelo truncamento
+	//      abaixo) antes do truncamento: um `range frame.Owned` futuro respeita
+	//      len, nao cap, entao uma entrada nao-zerada alem do novo len jamais
+	//      seria re-liberada (nao e um bug de contagem) — mas continuaria
+	//      nomeando, dentro do backing array que persiste, um objeto cujo RC ja
+	//      caiu a zero, prendendo-o na memoria ate um append futuro por acaso
+	//      sobrescrever aquele indice. E EXATAMENTE o vazamento que este
+	//      desenho deve evitar.
+	//   2. o truncamento e `frame.Owned = frame.Owned[:0]`, NUNCA
+	//      `frame.Owned = nil` — setar nil descartaria a capacidade do slice e
+	//      forcaria toda chamada seguinte a realocar via append em ownSlot,
+	//      devolvendo o custo de alocacao por chamada que esta troca elimina.
 	for i := range frame.Owned {
 		value.Release(frame.Owned[i].obj)
 		frame.Owned[i] = ownedEntry{}
@@ -68,6 +84,11 @@ func (vm *VM) finalizeCurrentFrame(outcome frameOutcome) frameOutcome {
 		vm.stack[index] = value.Value{}
 	}
 
+	// So Closure/Environment sao nil'ados aqui (nao a struct inteira): sao os
+	// dois campos com referencia a heap que precisam soltar para o GC assim
+	// que o frame termina; IP/StackBase/LocalBase sao escalares reescritos
+	// incondicionalmente no proximo uso deste slot, e Owned/Deferred ja foram
+	// esvaziados (com capacidade preservada) pelos blocos acima.
 	frame.Closure = nil
 	frame.Environment = nil
 	vm.frameCount--

--- a/internal/vm/unwind_test.go
+++ b/internal/vm/unwind_test.go
@@ -83,7 +83,7 @@ work()`)
 	if err != nil || !valuesEqual(captured, value.NewInt(42)) {
 		t.Fatalf("error=%v captured=%v, want 42", err, captured)
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.openUpvalues != nil {
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.frames[0].Environment != nil || len(machine.frames[0].Owned) != 0 || len(machine.frames[0].Deferred) != 0 || machine.openUpvalues != nil {
 		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
 	}
 }
@@ -126,7 +126,7 @@ defer cleanup(3)`)
 	if unwind.Deferred[0].Registration.Line != 4 || unwind.Deferred[1].Registration.Line != 3 {
 		t.Fatalf("registration lines=%d,%d want 4,3", unwind.Deferred[0].Registration.Line, unwind.Deferred[1].Registration.Line)
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil {
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.frames[0].Environment != nil || len(machine.frames[0].Owned) != 0 || len(machine.frames[0].Deferred) != 0 {
 		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d", machine.frameCount, machine.currentFrame, machine.stackTop)
 	}
 }

--- a/internal/vm/unwind_test.go
+++ b/internal/vm/unwind_test.go
@@ -83,7 +83,7 @@ work()`)
 	if err != nil || !valuesEqual(captured, value.NewInt(42)) {
 		t.Fatalf("error=%v captured=%v, want 42", err, captured)
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil || machine.openUpvalues != nil {
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil || machine.openUpvalues != nil {
 		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d open=%p", machine.frameCount, machine.currentFrame, machine.stackTop, machine.openUpvalues)
 	}
 }
@@ -126,7 +126,7 @@ defer cleanup(3)`)
 	if unwind.Deferred[0].Registration.Line != 4 || unwind.Deferred[1].Registration.Line != 3 {
 		t.Fatalf("registration lines=%d,%d want 4,3", unwind.Deferred[0].Registration.Line, unwind.Deferred[1].Registration.Line)
 	}
-	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0] != nil {
+	if machine.frameCount != 0 || machine.currentFrame != nil || machine.stackTop != 0 || machine.frames[0].Closure != nil {
 		t.Fatalf("dirty terminal VM: frames=%d current=%p stack=%d", machine.frameCount, machine.currentFrame, machine.stackTop)
 	}
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -54,7 +54,7 @@ type SharedState struct {
 }
 
 type VM struct {
-	frames       [FramesMax]*CallFrame
+	frames       [FramesMax]CallFrame
 	frameCount   int
 	currentFrame *CallFrame
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -54,6 +54,15 @@ type SharedState struct {
 }
 
 type VM struct {
+	// frames e um array de VALORES, reusado por indice a cada chamada (nunca
+	// realocado): callPreparedClosure escreve em &frames[frameCount] em vez
+	// de heap-alocar um *CallFrame novo. As capacidades de Owned/Deferred de
+	// cada slot sao load-bearing para isso — finalizeCurrentFrame (unwind.go)
+	// trunca as duas com `[:0]`, nunca com `= nil`; setar `= nil` devolveria
+	// o custo de uma alocacao por chamada que esta troca existe para eliminar
+	// (ver BenchmarkNoxyCallOverhead em call_alloc_bench_test.go). vm.currentFrame
+	// aponta para dentro deste array — estavel porque o array tem tamanho
+	// fixo e nunca e realocado.
 	frames       [FramesMax]CallFrame
 	frameCount   int
 	currentFrame *CallFrame

--- a/noxy.mod
+++ b/noxy.mod
@@ -1,6 +1,6 @@
 module noxy
 
-noxy v0.5.0
+noxy v0.6.0
 
 require github.com/estevaofon/quicksort v0.1.0
 require github.com/estevaofon/noxy_dynamodb v0.1.0


### PR DESCRIPTION
## Summary

- **Fase 1 de performance da VM**, explorando a tipagem estática que a linguagem já tem para cortar custo de despacho e de chamada. Alvo declarado na spec: fechar o gap com o CPython, que o benchmark cross-runtime (#35) tinha exposto.
- **Resolução de globais deixou de percorrer nome + RWMutex a cada acesso.** `OP_GET_GLOBAL` passou a servir de um cache por `(ambiente, geração somada)`, invalidado por um contador monotônico incrementado em todos os funis de mutação do binding store. A ordem "lê geração → resolve → grava entrada" garante que o cache pode sub-cachear sob corrida, nunca servir valor obsoleto.
- **`OP_CALL_STATIC`**: quando o compilador já provou os modos dos parâmetros no call site (`isExact`), a VM pula `validateParameterModes`. Caminho dinâmico (`any`, bare `func`, membro de módulo) continua validando.
- **`CallFrame` passou a reusar um array de valores** em vez de alocar no heap por chamada: **1012 → 10 allocs/op**. O array sobrevive aos frames, então `Owned`/`Deferred` são zerados entrada a entrada antes de truncar (soltar o backing array reteria objetos já liberados).
- **13 opcodes novos**, todos anexados ao fim do enum (nunca renumerados — o cache de módulos depende dos valores): seis de comparação inteira + salto fundidos (emissão especulativa com rollback de bytecode quando os operandos não são estaticamente `int`), `OP_INC_LOCAL_INT` (`i = i ± K` vira soma direta no slot), e seis `_FLOAT` especializados.

### Resultado medido

| bench | develop | branch | delta |
|---|---|---|---|
| `fib` | 804,9ms | 380,8ms | **−52,7% (~2,1x)** |
| `loop_arith` | 519,4ms | 319,4ms | **−38,5% (~1,63x)** |
| `mandelbrot` | 428,6ms | 246,2ms | **−42,6% (~1,74x)** |
| allocs/op por chamada | 1012 | 10 | **−99%** |

Cross-runtime, descontado o piso de processo: `fib` saiu de 7,9x para **3,4x** atrás do CPython; `loop_arith` de 1,8x para **~1,1x**. Nos benches de CoW (fora do escopo original, mas gates de regressão) **9 de 11 melhoraram**, quatro deles entre 10% e 35% — o custo de chamada in-module e o incremento fundido atravessam qualquer programa nesse formato, não só os alvos declarados.

### ⚠️ Regressão aceita e rastreada

`bench_share_mutate` ficou **+8,7% mais lento** (gate do repo é 5%). Registrado com ❌ em `benchmarks/RESULTS.md`. Uma bissecção dedicada (`benchmarks/results/2026-08-18-share-mutate-bisect.md`) confirmou que é **real, não ruído**: piso de ruído medido em ~1,2-1,4% com controle de rótulo duplicado (mesmo binário, dois rótulos, mesma sessão), contra deltas de +9,97/+9,78/+6,47% em três sessões. Mas **não se atribui a um único commit**: o reuso de `CallFrame` é o maior contribuinte isolado (+6,8pp de +8,7pp) e o resto se acumula difusamente. Nenhum símbolo desta fase aparece no profile daquele bench — o custo está em `copyValue` (42% cum) e no GC (~27%), e cai pela metade com `GOGC=800`, o que aponta para efeito de grafo de alocação, não código novo.

Aceita conscientemente: `bench_share_mutate` é o pior caso deliberado de CoW (2500 clones de array de 5000 elementos, ~600MB de lixo) e o bench de menor escala absoluta da suíte; reverter o reuso de frame devolveria as 1012 allocs/op que dirigem a maior parte dos ganhos acima. O limiar de 5% também cabe dentro da dispersão sessão-a-sessão deste bench específico (+2,8 a +10,5), o que sugere que o protocolo do gate está sub-dimensionado para ele.

## Components

- `internal/value/map.go`, `internal/value/environment.go` — contador de geração (`atomic.Uint64`) nos quatro funis de mutação do `bindingStore` e `GlobalEnvironment.Generation()` somando a cadeia. Invariante documentado no próprio arquivo.
- `internal/chunk/chunk.go` — `GlobalCacheEntry` + `GlobalCache()`; 13 opcodes novos por append, com `String()` e disassembler; `TruncateTo` para o rollback especulativo.
- `internal/vm/executor.go` — fast path do `OP_GET_GLOBAL`, recarga de `gcache` nos cinco pontos de troca de chunk, e os handlers dos 13 opcodes.
- `internal/vm/calls.go`, `internal/vm/vm.go`, `internal/vm/unwind.go`, `internal/vm/stack.go` — `frames [64]CallFrame` reusado; `callValueStatic`; limpeza de `Owned`/`Deferred` preservando capacidade, com o contrato de reuso comentado onde alguém tentaria "limpar".
- `internal/compiler/compiler.go` — `modesProven`, `tryCompileFusedCondition` (com rollback), `tryFuseLocalIntIncrement`, gate `isFloat`.
- `cmd/noxy/main.go` — flags `--cpuprofile`/`--memprofile`; `runWithConfig` devolve exit code e `runFile` envolve os defers, para que os profiles sejam gravados mesmo quando o programa termina em erro.
- `benchmarks/RESULTS.md`, `benchmarks/cross_runtime/results/`, `benchmarks/results/2026-08-18-share-mutate-bisect.md`, `docs/superpowers/specs/2026-08-17-vm-perf-static-typing-research.md` — medições, bissecção e o profile pós-fase.

## Test Plan

- [x] `go vet ./...` limpo
- [x] `go test ./...` verde (7 pacotes, 0 falhas)
- [x] `go test ./internal/vm -race` e `go test ./internal/value -race` verdes
- [x] Corpus de exemplos **164/164** (`noxy_examples/run_all_tests_concurrent.nx`)
- [x] **Diff de saída ponta a ponta**: binários construídos em `develop` e no head, os 164 exemplos rodados em ambos e comparados (stdout + stderr + exit code). 19 arquivos diferem, **todos** por não-determinismo legítimo (timestamps, UUIDs, `%p`, ordem de iteração de map, portas efêmeras, `argv[0]`) — **zero desvio semântico**
- [x] A/B intercalado, mediana de 9 por sessão, 4 sessões limpas (2 descartadas por contaminação de CPU, documentado)
- [x] Bissecção da regressão de `bench_share_mutate` com controle de ruído
- [x] Cada task revisada por agente independente; 3 precisaram de rodada de correção
- [x] Revisão final do branch inteiro + onda de correção de 7 achados + re-revisão
- [x] Validar em uso real (NoxyDB) antes do release
- [x] Follow-up: investigar o efeito de alocação/GC do `bench_share_mutate` (`GOGC` é o fio solto)

### Follow-ups identificados (não neste PR)

1. **`for ... in` não recebe nenhuma das fusões desta fase.** O lowering emite à mão exatamente os dois padrões fundidos, em locais `int` sintéticos onde nem análise de tipo é necessária: 8 instruções por iteração virariam 2. É o maior ganho ainda na mesa.
2. **Layout do `Value` / `pop` sem zerar escalares.** O profile pós-fase agora sustenta com dados o que era palpite: `push`+`pop` somam **24,4%** do tempo de `fib` (era 16,1%), a maior fatia depois do despacho puro, com globais e alocação de chamada já cortados.
3. Structs por índice e maps tipados seguem válidos pela leitura de código, mas **não** confirmados por profile (o perfil coletado foi de `fib`, que não usa nenhum dos dois).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
