### PR TITLE
feat/generics - Genericos por monomorfizacao (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## [0.7.0] - 2026-08-18
+
+### Added
+
+- **Genéricos por monomorfização**: funções e structs no top level podem
+  declarar parâmetros de tipo entre `<>` (`func first<T>(arr: T[]) -> T`,
+  `struct Stack<T>`), usáveis em qualquer posição de tipo (parâmetros,
+  retorno, campos, corpo). Toda instanciação é por **inferência a partir do
+  uso** — não existe sintaxe de instanciação explícita em posição de
+  expressão (`first<int>(x)` não existe), o que mantém `<`/`>` sem
+  ambiguidade com os operadores de comparação. Cada instanciação
+  (`Stack<int>`, `Stack<string>`) é um tipo/função nominal **distinto**,
+  monomorfizado em tempo de compilação: o bytecode gerado é idêntico ao de
+  código especializado escrito à mão (provado por teste de igualdade de
+  opcodes), sem overhead de runtime e **nenhuma mudança na VM**. Funções
+  genéricas também circulam como valores de primeira classe via
+  target-typing — anotação de `let`, retorno declarado, elemento de array,
+  campo de struct, argumento de chamada, com unificação bidirecional quando
+  o argumento também é genérico (`aplica(nums, identity)`). Cross-módulo,
+  templates são importáveis via `select`/`select *` (dependências do corpo
+  do template precisam estar visíveis no importador); acessar um template
+  pelo namespace (`use m` seguido de `m.f(...)`) é erro de compilação
+  dedicado. V1 não tem constraints (`T` é irrestrito; o corpo é checado por
+  instanciação), é restrita ao top level (sem genérico aninhado em função) e
+  não permite `T` bindar um tipo `ref` (idioma: declarar o parâmetro como
+  `ref T`). Documentado em `docs/NOXY_LANGUAGE_SPEC.md` §6; spec de design em
+  `docs/superpowers/specs/2026-08-18-generics-design.md`.
+
+  - **Limitação documentada (v1)**: `print`/`%T` de uma instância de struct
+    genérico mostra o nome **qualificado** (`<main::Caixa<int> instance>`),
+    não o nome de exibição (`<Caixa instance>`) — vazamento cosmético
+    aceito, `value.go` usa `Struct.Name` sem distinguir display name de
+    identidade interna. Comportamento de v1 documentado, não um bug.
+
+- Módulo `collections` (`noxy_examples/collections.nx`), escrito em Noxy
+  puro usando os genéricos novos: `map_arr<A, B>`, `filter<T>`, `reduce<T,
+  R>`, `contains_val<T>` — a mesma classe de abstração que antes só existia
+  como builtin (`append`/`length`/`contains`), agora escrevível em código de
+  usuário. (`map` é palavra reservada de tipo — `map[K, V]` — por isso a
+  função de transformação chama-se `map_arr`, não `map`.)
+
+### Changed (BREAKING) — imports tipados
+
+Nomes importados (`use m select ...`/`select *`) passam a carregar o **tipo
+declarado** dos exports em vez de entrar apagados (`nil`) no compilador —
+pré-requisito para a inferência de tipo genérico funcionar sobre dados e
+funções vindos de outro módulo (`primeiro(numeros_importado)`).
+
+- **Código cross-módulo dinâmico que hoje compila com tipo apagado pode
+  passar a falhar em compile-time.** Um argumento cujo tipo estático era
+  `nil` (permissivo por padrão) agora carrega um tipo real — inclusive `any`
+  explícito, que a checagem **estrita** de argumento de chamada (assinatura
+  exata) rejeita onde antes não havia checagem nenhuma. Migração: anotar o
+  valor num `let` intermediário com tipo concreto antes de passá-lo a um
+  parâmetro de assinatura exata (a checagem de `let` é permissiva e emite
+  guarda de tipo em runtime), ou corrigir o erro de tipo latente que a
+  checagem revelou.
+- Um exemplo do corpus foi corrigido por essa via:
+  `noxy_examples/mergesort_with_slice.nx` passava o retorno de
+  `array_utils.slice` (declarado `any`, curry dinâmico) direto como
+  argumento de `merge_sort(arr: int[])`; o fix introduz `let left_slice:
+  int[] = slice(...)` antes da chamada, em vez de mudar `array_utils.nx`
+  (stdlib empacotada com o compilador, fora do escopo de um fix de corpus).
+- Critério de aceite: o corpus `.nx` existente inteiro (167 arquivos)
+  continua compilando e passando após o fix acima —
+  `noxy_examples/run_all_tests_concurrent.nx` reporta 167/167.
+
+### Fixed
+
+- Operadores aritméticos (`+`, `-`, `*`, `/`, `%`) sobre structs agora são
+  erro de **compilação**, não mais crash de runtime. Antes, `a + b` com
+  `a`/`b` struct compilava silenciosamente e só estourava em runtime
+  (`operands must be numbers, strings or bytes`, `internal/vm/executor.go`)
+  quando a linha executava — inclusive dentro do corpo de uma instância
+  genérica monomorfizada, onde o erro escaparia por completo da cadeia de
+  instanciação (que só envolve erros de compilação). Nenhum programa válido
+  existente depende desse comportamento — a VM sempre crashava nesses casos
+  — então nenhum programa quebra; a checagem nova (`internal/compiler`)
+  só torna o erro visível mais cedo, com a linha do próprio operador.
+
 ## [0.6.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,25 @@ funções vindos de outro módulo (`primeiro(numeros_importado)`).
   continua compilando e passando após o fix acima —
   `noxy_examples/run_all_tests_concurrent.nx` reporta 167/167.
 
+### Changed
+
+- A variável de `for ... in` passa a receber o **tipo estático do elemento**
+  da coleção quando ele é conhecido (array → tipo do elemento; map → tipo da
+  chave, que é o que o laço produz). Antes ela entrava sempre sem tipo.
+  Requisito dos genéricos — sem isso, `identity(v)` dentro de um for-each
+  chega à unificação sem âncora e `T` fica sem binding —, mas o efeito é
+  geral: **pode revelar erros de tipo latentes** em código que hoje compila,
+  mesma classe (e mesma migração) da mudança de imports tipados acima.
+  Coleção de tipo desconhecido continua produzindo variável sem tipo.
+
 ### Fixed
+
+- **REPL preserva structs declarados entre linhas.** Cada linha recebia um
+  mapa de structs novo, então um `struct Point ... end` digitado numa linha
+  simplesmente não existia na linha seguinte. Bug **pré-existente** (não
+  introduzido pelos genéricos), corrigido junto porque a mesma linha de
+  código passou a persistir também o registry de templates genéricos da
+  sessão (`cmd/noxy/main.go`, spec §5).
 
 - Operadores aritméticos (`+`, `-`, `*`, `/`, `%`) sobre structs agora são
   erro de **compilação**, não mais crash de runtime. Antes, `a + b` com

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ be mutable.
 - ✅ Value semantics with copy-on-write (composites are independent values; `ref` is the only sharing mechanism)
 - ✅ First-class functions
 - ✅ Closures
+- ✅ Generics with zero runtime cost (monomorphization: `func first<T>(arr: T[]) -> T`, `struct Stack<T>`, always inferred from usage)
 - ✅ Concurrency (noxy routines) [docs/CONCURRENCY.md](docs/CONCURRENCY.md)
 - ✅ Garbage collection
 - ✅ Built-in modules (io, net, http, sqlite)
@@ -222,6 +223,32 @@ print(b[0])  // 104 (ASCII 'h')
 
 let from_str: bytes = to_bytes("text")
 let from_int: bytes = to_bytes(65)  // b"A"
+```
+
+### Generics
+
+Generic functions and structs are monomorphized at compile time — zero
+runtime cost, always instantiated by inference (no explicit `first<int>(x)`
+syntax). See [NOXY_LANGUAGE_SPEC.md §6](docs/NOXY_LANGUAGE_SPEC.md) for the
+full contract.
+
+```noxy
+struct Stack<T>
+    items: T[]
+end
+
+func push<T>(s: ref Stack<T>, item: T)
+    append(s.items, item)
+end
+
+func peek<T>(s: Stack<T>) -> T
+    return s.items[length(s.items) - 1]
+end
+
+let ints: Stack<int> = Stack([])   // T inferred from the `let` annotation
+push(ref ints, 10)
+push(ref ints, 20)
+print(peek(ints))  // 20
 ```
 
 ## Builtin Functions

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.6.0
+Noxy REPL v0.7.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,152 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## develop (bff429a) × genéricos paramétricos (feat/generics)
+
+**Data:** 2026-08-18 · Windows 11 · protocolo intercalado, mediana de 9
+execuções por sessão. Spec: `docs/superpowers/specs/2026-08-18-generics-design.md`
+§11. Task: `.superpowers/sdd/2026-08-18-generics/task-16-brief.md`. Gates
+novos desta seção: `generic_vs_hand` e regressão do corpus não-genérico são
+gates duros; `startup_generics` é informativo (spec §11: "sem regressão
+material do startup", sem limiar numérico fixado — este relatório adota
+sinalização em `> +15ms` como critério operacional, per orientação da task
+brief).
+
+**Verificação completa:** `go vet ./...` sem saída (limpo); `go test ./...
+-count=1` verde em todos os pacotes (`internal/compiler` 68,117s,
+`internal/vm` 145,820s, resto sub-segundo — a suíte de `internal/vm` inclui
+os testes novos de genéricos: unificação, cloner de AST com guard por
+reflexão, igualdade de bytecode, E2E, interações de runtime, negativos).
+**Corpus de exemplos 164/164** (`run_all_tests_concurrent.nx`, 20187ms) no
+binário `feat/generics` (`noxy_generics_bench.exe`, `c93cfb3`) — mesmo número
+já reportado na seção da fase 1 de dispatch, confirmando que o corpus
+existente continua passando por inteiro com genéricos ativos (gate de
+regressão do corpus, spec §11).
+
+### Gate 1 — `generic_vs_hand`: razão ≤ 1,05 (Ruling R4 do controller)
+
+**Divergência registrada:** a spec §11 declara gate de razão **1,0x**; o
+controller (Ruling R4, binding) definiu **≤ 1,05** como folga de ruído sobre
+esse 1,0x — a garantia dura de custo-zero continua sendo o teste de
+igualdade de bytecode (Task 8: `first<int>` monomorfizado emite a mesma
+sequência de opcodes que a versão escrita à mão), não este benchmark de
+parede. Este relatório usa 1,05 por autoridade de R4.
+
+`benchmarks/bench_generic_vs_hand.nx` só roda no binário `feat/generics` (o
+binário `develop` não faz parse de `<T>`), então não há segundo binário para
+intercalar contra. Em vez disso a medição é **interna ao processo**
+(`time_now_ms()`), em ordem **ABBA** (gen, hand, hand, gen) dentro da mesma
+execução — necessário porque uma medição AB simples (gen sempre primeiro)
+mostrou deriva sistemática de até +9% entre sessões¹, e o gate de 5% é
+apertado demais para o piso de ruído documentado no resto da suíte
+(~1-4%). ABBA dá às duas funções a mesma posição média (2,5) na sequência,
+cancelando deriva linear dentro do processo. O binário inteiro roda 9 vezes
+por sessão; mediana de `GEN_MS`/`HAND_MS` calculada separadamente, razão das
+duas medianas.
+
+| sessão | gen_ms (mediana) | hand_ms (mediana) | razão |
+|---|---|---|---|
+| 1 | 387 | 400 | 0,968 |
+| 2 | 378 | 387 | 0,977 |
+| 3 | 377 | 374 | 1,008 |
+
+**Agregado (mediana das 3 sessões, por lado):** gen_ms=378, hand_ms=387,
+**razão = 0,977** → ✅ **dentro do gate** (≤ 1,05). Checksum idêntico
+(`384128000`) em todas as 27 execuções (3 sessões × 9), confirmando que
+`soma_gen<int>` e `soma_hand` computam o mesmo resultado.
+
+### Gate 2 — regressão do corpus não-genérico (develop × genéricos)
+
+Roda 3 benchmarks existentes não-genéricos (`bench_bubblesort.nx`,
+`bench_call_light.nx`, `bench_typed_call_map.nx` — os três já rastreados
+como gate na seção da fase 1 de dispatch) via `interleaved_compare.ps1`
+apontado para um diretório temporário só com esses três arquivos (copiados;
+o script varre `bench_*.nx` do próprio diretório e os dois arquivos novos
+desta tarefa usam sintaxe `<T>` que o binário `develop` não faz parse —
+incluí-los quebraria a varredura inteira no lado `develop`). **5 sessões**
+rodadas (uma sessão inicial cujo `results/interleaved.md` falhou por
+diretório ausente, valores só no console — mantida porque a medição em si é
+válida — mais 4 sessões limpas), porque `bench_typed_call_map` deu um
+outlier de +12,6% na sessão 2, acima do limiar de ~5% usado no resto do
+projeto — ver nota².
+
+| bench | develop_ms | generics_ms | delta agregado | veredito |
+|---|---|---|---|---|
+| bench_bubblesort | 4013,8 | 4050,0 | +0,90% | ✅ |
+| bench_call_light | 78,0 | 75,9 | −2,69% | ✅ |
+| bench_typed_call_map | 87,1 | 86,6 | −0,57%² | ✅ |
+
+Valores agregados: mediana das 5 sessões, calculada separadamente para
+`develop_ms` e `generics_ms`, delta recalculado a partir das duas medianas
+(mesma convenção da seção da fase 1 de dispatch).
+
+### Info — `startup_generics` (sem gate duro; sinalizar > +15ms)
+
+`benchmarks/startup_generics.nx` (1 template `Caixa<T>` + 2 instanciações,
+`Caixa<int>` e `Caixa<string>`, + print) contra
+`benchmarks/cross_runtime/startup.nx` (piso de processo sem genéricos),
+**ambos no binário `feat/generics`** — isola o custo marginal da detecção
+"há genéricos?" e do pass 1 de monomorfização sobre o mesmo binário, sem
+confundir com qualquer outra diferença entre binários. Script ad hoc
+(`interleaved_files.ps1`, mesma técnica de `interleaved_compare.ps1` com o
+eixo trocado: binário fixo, arquivo variável), 3 sessões de 9 execuções.
+
+| sessão | startup_ms (sem genéricos) | startup_generics_ms | delta |
+|---|---|---|---|
+| 1 | 51,3 | 53,3 | +2,0ms |
+| 2 | 52,2 | 52,8 | +0,6ms |
+| 3 | 51,4 | 55,4 | +4,0ms |
+
+**Agregado:** 51,4ms → 53,3ms, **delta = +1,9ms** — bem abaixo do limiar de
+sinalização de +15ms. Custo de compilação dobrando sobre uma base de poucos
+ms (spec §11: "a compilação ~dobra, sobre uma base de poucos ms") é
+consistente com a ordem de grandeza aqui: o programa inteiro (parse + duas
+passes + compile + run + print) segue no mesmo patamar do piso de processo
+(~50-55ms), a monomorfização de 1 template com 2 instanciações não é visível
+acima do ruído de spawn de processo nesta escala.
+
+¹ Medição AB descartada (não commitada): mesmo bench, ordem fixa gen-depois-
+hand, 2 sessões de 9 execuções — sessão 1 deu razão 1,008 (dentro do gate),
+sessão 2 deu **1,094** (acima do gate de 1,05). A causa aparente é a segunda
+função chamada dentro do processo herdar cache/branch-predictor "quente" da
+primeira, não custo real de despacho genérico — a versão ABBA committada
+elimina essa fonte de viés por construção (ver corpo do gate 1 acima).
+
+² O outlier da sessão 2 (`bench_typed_call_map` +12,6%, base=79,9ms
+cand=90ms) não se repete nas outras 4 sessões (deltas: +0,9%, −0,6%, −0,1%,
+−3,2%) — é o bench de menor escala absoluta dos três (~80-90ms), mesmo
+padrão de sensibilidade a ruído de sistema já documentado para benches
+curtos na seção da fase 1 de dispatch (nota¹ daquela seção). A mediana
+agregada das 5 sessões (−0,57%) fica bem dentro do gate; sem esse outlier a
+leitura seria idêntica.
+
+### Interpretação
+
+**Gate 1 confirma o custo-zero em runtime além do teste de bytecode.** A
+razão agregada (0,977, faixa 0,968–1,008 nas 3 sessões) está centrada em
+torno de 1,0, sem viés sistemático para nenhum lado — exatamente o esperado
+quando `soma_gen<int>` e `soma_hand` emitem a mesma sequência de opcodes
+(Task 8). A divergência do gate declarado na spec (1,0x → ≤1,05x, Ruling R4)
+existe para dar folga ao ruído de medição de parede, não porque exista custo
+real: o teste de bytecode é quem carrega a prova, este benchmark é
+confirmação empírica adicional.
+
+**Gate 2 confirma que o corpus não-genérico não paga nada pela existência de
+genéricos no compilador.** As três magnitudes agregadas (+0,90%, −2,69%,
+−0,57%) ficam dentro do mesmo piso de ruído (~1-4%) documentado nas seções
+anteriores deste arquivo para essa máquina — nenhum sinal de regressão real.
+Consistente com a spec §11: "programa sem genéricos continua pulando o pass
+1 inteiro".
+
+**O startup paga um custo pequeno e não sinalizável.** +1,9ms agregados (faixa
++0,6 a +4,0ms nas 3 sessões) para compilar um programa com 1 template e 2
+instanciações, contra um piso de processo de ~51ms — ordem de grandeza
+consistente com a spec (compilação "~dobra... sobre uma base de poucos ms").
+Não há indício de que a detecção "há genéricos?" ou o pass 1 de
+monomorfização introduzam custo que se acumule com o tamanho do programa
+nesta escala; ficaria para benchmarks futuros com mais templates/instâncias
+verificar se o custo permanece sub-linear.
+
 ## develop (f107508) × fase 1 de dispatch e chamadas (perf/vm-dispatch-fase1)
 
 **Data:** 2026-08-18 · Windows 11 · protocolo intercalado, mediana de 9

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -149,6 +149,52 @@ monomorfização introduzam custo que se acumule com o tamanho do programa
 nesta escala; ficaria para benchmarks futuros com mais templates/instâncias
 verificar se o custo permanece sub-linear.
 
+### Adendo — startup de `use` (finding C1 da revisão final de branch)
+
+**Data:** 2026-08-18, sessão posterior às medições acima. Motivo: a revisão
+final de branch mediu um caso que `startup_generics` **não** cobria —
+startup de um programa que só faz `use`, **sem genérico nenhum** — e achou
+uma amplificação de ~8x. Gate 2 (corpus não-genérico) não a pegou porque os
+três benches daquele gate não importam módulo.
+
+**Causa** (`internal/compiler/module_exports.go`): `loadModuleDeclarations`
+re-parseava **e** re-compilava (validator descartável) o módulo a cada
+chamada, recursivamente, sem cache algum. O branch de genéricos somou ~4
+chamadas por `use` (`predeclareImportedTemplates` →
+`discoverModuleExports` + `moduleTopLevelBindings`; `predeclareImport`; o
+case `*ast.UseStmt`), tudo dobrado pelo two-pass. Custo pré-existente
+(base já pagava 1,4s num `select *`), amplificado pelo branch.
+
+**Correção:** memoização por `moduleDiscoveryState` (módulo → programa
+parseado + submódulos), com o estado agora criado **uma vez por compilador**
+(`discoveryState()`) e propagado por `NewChild`/`newPass1Compiler` — antes,
+cada chamador fabricava um estado descartável e nenhum memo sobreviveria.
+Só sucessos entram no cache: uma falha pode ser contextual (guard de ciclo),
+um sucesso nunca é.
+
+Sondas versionadas: `benchmarks/startup_use_selectall.nx` e
+`benchmarks/startup_use_namespace.nx`. Mediana de 9 execuções por célula,
+mesmo processo/binário por linha. `head (pré-C1)` = `314428d`, último commit
+do branch antes desta rodada de fixes.
+
+| sonda | base (`bff429a`) | head (pré-C1) | head (pós-C1) |
+|---|---|---|---|
+| `startup_use_selectall.nx` (`use http select *`) | 1445,8 ms | 11681,2 ms | **96,2 ms** |
+| `startup_use_namespace.nx` (`use http`) | 361,5 ms | 1474,4 ms | **101,2 ms** |
+| `startup_generics.nx` (controle, com genéricos) | 62,3 ms | 65,8 ms | 60,2 ms |
+
+O head pós-fix não só volta à ordem de grandeza da base como fica **~15x
+mais rápido que a base** no `select *` — a memoização paga também o custo
+pré-existente, que a base sempre teve. A sonda de controle
+(`startup_generics`) não se move: o caminho de genéricos não foi tocado.
+
+Efeito colateral na suíte de testes (mesma causa, mesmo fix):
+`go test ./internal/compiler` 48,7s → **1,3s**; `go test ./internal/vm`
+128,8s → **41,6s**.
+
+**Corpus:** 167/167 (`run_all_tests_concurrent.nx`, 11502ms) no binário
+pós-fix — sem regressão.
+
 ## develop (f107508) × fase 1 de dispatch e chamadas (perf/vm-dispatch-fase1)
 
 **Data:** 2026-08-18 · Windows 11 · protocolo intercalado, mediana de 9

--- a/benchmarks/bench_generic_vs_hand.nx
+++ b/benchmarks/bench_generic_vs_hand.nx
@@ -1,0 +1,75 @@
+// bench_generic_vs_hand: mesmo laco quente identico via funcao generica e
+// via funcao especializada a mao. Gate: razao <= 1.05 (spec S11, R4 do
+// controller da fase de genericos — folga de ruido sobre o 1.0x; a garantia
+// dura de custo-zero e o teste de igualdade de bytecode da Task 8).
+//
+// So roda no binario com suporte a genericos (o binario develop nao faz
+// parse de "<T>"). Por isso a medicao usa relogio interno (time_now_ms)
+// dentro de um unico processo, em vez do Measure-Command externo dos outros
+// benches: o gate de 5% e apertado demais para o ruido de spawn de processo
+// (que os outros benches evitam comparando o MESMO overhead de startup dos
+// dois lados). Repita o processo inteiro N vezes e tire a mediana de
+// GEN_MS/HAND_MS entre execucoes, como no resto da suite.
+//
+// Ordem ABBA (gen, hand, hand, gen), cada metade com n/2 iteracoes: uma
+// medicao AB simples (gen sempre primeiro) mostrou deriva sistematica de ate
+// +9% entre sessoes na mesma maquina, maior que o piso de ruido de ~1-4%
+// documentado no resto da suite — a segunda funcao chamada dentro do mesmo
+// processo tende a herdar cache/branch-predictor "quente" da primeira. ABBA
+// da as duas funcoes a mesma posicao media (2,5) na sequencia, cancelando
+// qualquer deriva linear dentro do processo.
+func soma_gen<T>(arr: T[], n: int) -> int
+    let acc: int = 0
+    let i: int = 0
+    while i < n do
+        acc = acc + length(arr)
+        i = i + 1
+    end
+    return acc
+end
+
+func soma_hand(arr: int[], n: int) -> int
+    let acc: int = 0
+    let i: int = 0
+    while i < n do
+        acc = acc + length(arr)
+        i = i + 1
+    end
+    return acc
+end
+
+func main()
+    let data: int[]
+    let i: int = 0
+    while i < 64 do
+        append(data, i)
+        i = i + 1
+    end
+    let half_n: int = 1500000
+
+    // Aquecimento: garante que a instanciacao/monomorfizacao ja aconteceu
+    // antes da janela medida (o teste de igualdade de bytecode da Task 8 ja
+    // prova que a instanciacao acontece em tempo de compilacao, nao em
+    // runtime — isto e so para tirar qualquer efeito de cache de disco/OS).
+    let warm_gen: int = soma_gen(data, 1000)
+    let warm_hand: int = soma_hand(data, 1000)
+
+    let t0: int = time_now_ms()
+    let g1: int = soma_gen(data, half_n)
+    let t1: int = time_now_ms()
+    let h1: int = soma_hand(data, half_n)
+    let t2: int = time_now_ms()
+    let h2: int = soma_hand(data, half_n)
+    let t3: int = time_now_ms()
+    let g2: int = soma_gen(data, half_n)
+    let t4: int = time_now_ms()
+
+    let gen_ms: int = (t1 - t0) + (t4 - t3)
+    let hand_ms: int = (t2 - t1) + (t3 - t2)
+
+    print(f"GEN_MS:{gen_ms}")
+    print(f"HAND_MS:{hand_ms}")
+    print(f"CHECKSUM:{g1 + g2 + h1 + h2 + warm_gen + warm_hand}")
+end
+
+main()

--- a/benchmarks/startup_generics.nx
+++ b/benchmarks/startup_generics.nx
@@ -1,0 +1,17 @@
+// startup_generics: variante do bench de startup (benchmarks/cross_runtime/
+// startup.nx) usando genericos — 1 template + 2 instanciacoes + print. Mede
+// o custo end-to-end (parse, deteccao "ha genericos?", pass 1 de
+// monomorfizacao, compile, run) contra o piso de startup sem genericos.
+// Gate: sem regressao material do caso Lambda (spec S11); sinalizar delta
+// > +15ms mesmo sem gate duro (ver task-16-brief).
+struct Caixa<T>
+    valor: T
+end
+
+func main()
+    let a: Caixa<int> = Caixa(1)
+    let b: Caixa<string> = Caixa("x")
+    print(f"CHECKSUM:{a.valor}")
+end
+
+main()

--- a/benchmarks/startup_use_namespace.nx
+++ b/benchmarks/startup_use_namespace.nx
@@ -1,0 +1,9 @@
+// startup_use_namespace: par de startup_use_selectall.nx na forma de
+// namespace (`use m`, sem select). Importa zero nomes, mas ainda paga a carga
+// do modulo e das suas dependencias — por isso sofria a mesma amplificacao do
+// finding C1 (mais branda: 4x em vez de 8x, por ter menos chamadores por
+// `use`). Serve para separar "custo de carregar o modulo" de "custo de ligar
+// os nomes importados".
+use http
+
+print("CHECKSUM:1")

--- a/benchmarks/startup_use_selectall.nx
+++ b/benchmarks/startup_use_selectall.nx
@@ -1,0 +1,12 @@
+// startup_use_selectall: sonda de startup com `use ... select *` — o caso que
+// mais carrega modulos (http reexporta http_parser + http_client +
+// http_server via wildcard aninhado). NENHUM generico envolvido: mede o custo
+// de carga de modulos do compilador puro (parse + Compile de validacao por
+// modulo), que o finding C1 da revisao final mostrou amplificado ~8x pelo
+// branch de genericos (cada `use` era recarregado por chamador, dobrado pelo
+// two-pass) e que a memoizacao de loadModuleDeclarations
+// (internal/compiler/module_exports.go) derrubou para uma carga por modulo.
+// Par obrigatorio: startup_use_namespace.nx (forma sem select).
+use http select *
+
+print("CHECKSUM:1")

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -140,8 +140,18 @@ func startREPL(showDisasm bool) {
 	machine := vm.NewWithConfig(vm.VMConfig{RootPath: "."})
 	scanner := bufio.NewScanner(os.Stdin)
 
-	// Persist globals across REPL lines
+	// Persist globals, struct definitions (comuns e instancias monomorfizadas
+	// de generico) e o registry de templates genericos entre linhas do REPL
+	// (spec §5) — os tres compoem o estado de sessao. replStructs conserta um
+	// bug pre-existente: antes desta task, cada linha recebia um mapa de
+	// structs NOVO, entao um `struct Point ... end` numa linha desaparecia na
+	// linha seguinte. replGenerics faz o REPL enxergar na proxima linha um
+	// template genérico (`struct Caixa<T>`/`func id<T>`) declarado numa linha
+	// anterior — sem ele, SetGenericState nunca era chamado e cada linha via
+	// um GenericRegistry vazio.
 	replGlobals := make(map[string]ast.NoxyType)
+	replStructs := make(map[string]*ast.StructStatement)
+	replGenerics := compiler.NewGenericRegistry()
 
 	var inputBuffer string
 
@@ -229,7 +239,8 @@ func startREPL(showDisasm bool) {
 		}
 
 		// 3. Compile
-		c := compiler.NewWithState(replGlobals, make(map[string]*ast.StructStatement), "REPL")
+		c := compiler.NewWithState(replGlobals, replStructs, "REPL")
+		c.SetGenericState(replGenerics)
 		chunk, _, err := c.Compile(program)
 		if err != nil {
 			fmt.Printf("Compiler error: %s\n", err)

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -23,7 +23,7 @@ The current implementation is a **Stack-based VM** written in **Go**.
 | Category | Keywords |
 |----------|----------|
 | Declarations | `let`, `func`, `struct` |
-| Control Flow | `if`, `elif`, `then`, `else`, `end`, `while`, `do`, `return`, `break`, `for`, `in`, `defer` |
+| Control Flow | `if`, `elif`, `then`, `else`, `end`, `while`, `do`, `return`, `break`, `for`, `in`, `defer`, `when`, `case`, `default` |
 | Types | `int`, `float`, `string`, `str`, `bool`, `void`, `ref`, `bytes`, `func` |
 | Literals | `true`, `false`, `null` |
 | Modules | `use`, `select`, `as` |
@@ -528,7 +528,309 @@ end
 
 ---
 
-## 6. Control Flow
+## 6. Generics
+
+Noxy supports generic functions and structs, monomorphized at compile time:
+each instantiation (`Stack<int>`, `Stack<string>`) is compiled into its own
+concrete, fully-typed code. There is no runtime type erasure and no runtime
+overhead compared to code written by hand for a single type — this is a
+compile-time feature only.
+
+### 6.1 Declaring generic functions and structs
+
+Type parameters are listed in `<>` right after the name and can be used
+anywhere a type is expected — parameters, return type, fields, and the body:
+
+```noxy
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+
+struct Stack<T>
+    items: T[]
+end
+```
+
+A generic type only appears in **type position** — annotations, fields,
+return types (`Stack<int>`, `Node<string>`, `Stack<Stack<int>>`). There is no
+explicit instantiation syntax in expression position; `first<int>(x)` does
+not exist as syntax, which keeps `<`/`>` unambiguous with the comparison
+operators.
+
+Structs can reference themselves through a type parameter, exactly like the
+non-generic self-reference in §5:
+
+```noxy
+struct Node<T>
+    value: T
+    next: ref Node<T>
+end
+
+let n2: Node<int> = Node(2, null)
+let n1: Node<int> = Node(1, ref n2)
+print(n1.next.value) // 2
+```
+
+### 6.2 Instantiation is always by inference
+
+There is no explicit instantiation syntax. Every use of a generic function or
+struct infers its type parameters from context:
+
+```noxy
+struct Stack<T>
+    items: T[]
+end
+
+func push<T>(s: ref Stack<T>, item: T)
+    append(s.items, item)
+end
+
+func peek<T>(s: Stack<T>) -> T
+    return s.items[length(s.items) - 1]
+end
+
+let ints: Stack<int> = Stack([])   // T from the `let` annotation — the
+                                    // constructor argument ([]) is empty and
+                                    // carries no type information by itself
+push(ref ints, 10)
+push(ref ints, 20)
+print(peek(ints)) // 20
+```
+
+This works because every `let` in Noxy already requires a type annotation —
+the language already forces the caller to write the information inference
+needs. `Stack<int>` and `Stack<string>` are distinct nominal struct types;
+using one where the other is expected is a compile-time type error, the same
+as any other struct mismatch.
+
+Nested instantiation resolves inside-out — `Caixa<int>` is instantiated
+before `Caixa<Caixa<int>>` needs it:
+
+```noxy
+struct Caixa<T>
+    valor: T
+end
+
+let dupla: Caixa<Caixa<int>> = Caixa(Caixa(9))
+dupla.valor.valor = dupla.valor.valor + 1
+print(dupla.valor.valor) // 10
+```
+
+Generic structs keep Noxy's ordinary copy-on-write value semantics — a copy of
+`Caixa<Caixa<int>>` never mutates the original, at any depth:
+
+```noxy
+let outra: Caixa<Caixa<int>> = dupla
+outra.valor.valor = 100
+print(dupla.valor.valor) // still 10 — the copy does not reach the original
+```
+
+### 6.3 Generic functions as values (target-typing)
+
+A generic function can be used as a plain function value — assigned,
+returned, stored in an array, passed as an argument — as long as the
+surrounding context gives it a **concrete target type**. Instantiation
+happens at the point the generic becomes a value:
+
+```noxy
+func identity<T>(x: T) -> T
+    return x
+end
+
+// `let` annotation is the target
+let f: func(int) -> int = identity
+print(f(5)) // 5
+
+// return type of the enclosing function is the target
+func escolhe() -> func(int) -> int
+    return identity
+end
+
+// array element type is the target (parentheses required — see §4.2)
+let fs: (func(int) -> int)[] = [identity]
+```
+
+When a generic function is passed as an argument to another generic function,
+Noxy unifies both signatures together: the non-generic arguments resolve
+first, and the resulting (possibly still partial) expected type is unified
+against the argument function's own signature, propagating bindings in both
+directions:
+
+```noxy
+func aplica<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+
+let nums: int[] = [1, 2, 3]
+let mesmos: int[] = aplica(nums, identity) // A=int from `nums`, then
+                                             // func(A)->B unified against
+                                             // identity's func(T)->T gives B=int
+```
+
+A generic function cannot become a value where the compiler has no concrete
+type to instantiate against — a bare `func` annotation, `any`, or a chain of
+generics with nothing anchoring the middle. These are exactly the positions
+where an ordinary function value would already lose static checking:
+
+```noxy
+let g: func = identity   // ERROR: 'identity' needs a concrete type — annotate
+                          // the full signature or call it directly
+```
+
+### 6.4 Cross-module rules
+
+A template's free identifiers — helper functions, other generics — must
+resolve inside the module that defines it. Because the instance is compiled
+in the importer's context, the importer must also have those dependencies
+visible:
+
+| Import form | Dependencies visible? | Result |
+|---|---|---|
+| `use m select *` | yes — everything enters the importer's globals | always works |
+| `use m select f` (selective) | only if imported together | actionable error: *add it to the select list or use `select *`* |
+| `use m` (namespace) | n/a | calling the template via `m.f(...)` is a compile-time error |
+
+```noxy
+// colecoes.nx
+func ajuda(x: int) -> int
+    return x + 1
+end
+func processa<T>(arr: T[]) -> int
+    return ajuda(length(arr))
+end
+```
+
+```noxy
+// main.nx — selective import missing the dependency
+use colecoes select processa
+let ns: int[] = [1]
+processa(ns)   // ERROR: 'processa<...>' needs 'ajuda' from 'colecoes' —
+               // add it to the select list or use `select *`
+
+// fixed: import the dependency alongside the template
+use colecoes select processa, ajuda
+let ns: int[] = [1, 2]
+processa(ns)   // OK
+```
+
+Templates themselves are **not accessible through the namespace form**: since
+a template never exists as a runtime value, member access cannot resolve it.
+
+```noxy
+use colecoes
+let nums: int[] = [1]
+colecoes.processa(nums) // ERROR: generic template 'processa' is not
+                         // accessible via namespace access — use `select`
+```
+
+Imported names carry their **declared type** to the importer, so a generic
+call can infer its type parameters from data or functions defined in another
+module:
+
+```noxy
+// dados.nx
+let numeros: int[] = [5, 6]
+```
+
+```noxy
+// main.nx
+use dados select numeros
+func primeiro<T>(arr: T[]) -> T
+    return arr[0]
+end
+print(primeiro(numeros)) // 5 — T inferred from the imported `numeros`
+```
+
+> Imported names now carry their real declared type to the importer instead
+> of an erased one. Existing cross-module code that relied on the erased type
+> being permissive can start failing to compile — see the 0.7.0 entry in
+> `CHANGELOG.md` for the migration note.
+
+### 6.5 v1 limitations
+
+- **No constraints.** A type parameter `T` is unconstrained; the body is
+  checked **per instantiation**. `soma<T>(a: T, b: T) -> T` with `a + b` in
+  the body compiles fine when called with `int`, and fails — pointing at the
+  call site that produced the failing instantiation — when called with a
+  struct that has no `+` operator:
+
+  ```noxy
+  struct Ponto
+      x: int
+  end
+  func soma<T>(a: T, b: T) -> T
+      return a + b
+  end
+  soma(1, 2)                    // OK — soma<int>
+  soma(Ponto(1), Ponto(2))      // ERROR: soma<Ponto> (instantiated at this
+                                 // line): operator '+' is not defined for Ponto
+  ```
+
+- **Top level only.** A `func` or `struct` declared with type parameters
+  cannot be nested inside a function body.
+
+- **`T` cannot bind a `ref` type.** Passing a `ref` value where `T` would
+  bind to `ref X` is a compile-time error; declare the parameter as `ref T`
+  instead when the generic needs to receive a reference:
+
+  ```noxy
+  func identity<T>(x: T) -> T
+      return x
+  end
+  let r: ref int = null
+  let v: ref int = identity(r)   // ERROR: T cannot be a ref type
+
+  func identity_ref<T>(x: ref T) -> ref T  // idiomatic form: `ref` is
+      return x                              // explicit, T binds to int
+  end
+  ```
+
+- **`func` and `any` are not valid instantiation targets**, as shown in §6.3
+  — Noxy never falls back to instantiating a generic implicitly as `any`.
+  Type inference that cannot resolve a type parameter is always a
+  compile-time error, never a silent `any`; this includes trying to infer a
+  type solely from a `null` argument (`identity(null)` with no other anchor
+  is a compile-time error too).
+
+A generic struct instance is an ordinary struct value everywhere else in the
+language — no special-casing needed for f-strings, `json_dumps`, or as a
+channel payload sent and received with the `when`/`case` construct described
+below:
+
+```noxy
+struct Caixa<T>
+    valor: T
+end
+let c: Caixa<int> = Caixa(7)
+let ch: any = make_chan(1)
+chan_send(ch, c)
+let recebida: Caixa<int>
+when
+    case bound = chan_recv(ch) then
+        recebida = bound
+    default
+        recebida = Caixa(-1)
+end
+print(recebida.valor * 6) // 42 — the whole Caixa<int> traveled through the
+                           // channel, not just its field
+```
+
+> **Note:** `map` is a type keyword (`map[K, V]`), so it cannot be used as the
+> name of a generic function. The standard idiom, used by the `collections`
+> module, is to call the transformation function `map_arr` instead:
+> `func map_arr<A, B>(arr: A[], fn: func(A) -> B) -> B[]`.
+
+> **Cosmetic note:** printing a generic struct instance shows its qualified
+> name, e.g. `<main::Caixa<int> instance>` instead of `<Caixa instance>`.
+> This is documented v1 behavior, not a bug.
+
+---
+
+## 7. Control Flow
 
 ### If-Then-Else
 ```noxy
@@ -622,9 +924,61 @@ Those suppressed errors cannot participate in defer aggregation; only runtime
 errors observable from the deferred call are aggregated. Likewise, the
 ordinary result from `io.close_result(...)` is discarded when deferred.
 
+### When / Channel Select
+
+`when` evaluates a set of channel operations and runs the body of the first
+`case` that is ready, exactly once:
+
+```noxy
+let ch1: any = make_chan(1)
+let ch2: any = make_chan(1)
+
+chan_send(ch1, "hello")
+when
+    case msg = chan_recv(ch1) then
+        print("Received from ch1:", msg)
+    case chan_recv(ch2) then
+        print("Received from ch2")
+    default
+        print("Default case (should not happen if ch1 ready)")
+end
+```
+
+Each `case` is one of:
+
+- `case <var> = chan_recv(<chan>) then` — receives and binds the value to a
+  new variable, scoped to that case's body.
+- `case chan_recv(<chan>) then` — receives and discards the value, useful
+  when only the channel's readiness matters.
+- `case chan_send(<chan>, <value>) then` — succeeds when the send can
+  complete immediately.
+
+An optional `default` case runs immediately when no other case is ready,
+making the `when` non-blocking. Without `default`, `when` blocks until one
+case becomes ready:
+
+```noxy
+let ch3: any = make_chan()
+let ch4: any = make_chan()
+
+spawn(sender, ch3, "delayed_msg_3", 100)
+spawn(sender, ch4, "delayed_msg_4", 50)
+
+when
+    case m1 = chan_recv(ch3) then
+        print("Got from ch3:", m1)
+    case m2 = chan_recv(ch4) then
+        print("Got from ch4:", m2)
+end
+```
+
+Any value a channel can carry — including a generic struct instance such as
+`Caixa<int>` (§6) — travels through `chan_send`/`chan_recv` and is received
+by `when`/`case` exactly like any other value.
+
 ---
 
-## 7. Expressions
+## 8. Expressions
 
 ### Mathematical
 `+`, `-`, `*`, `/`, `%`
@@ -646,7 +1000,7 @@ ordinary result from `io.close_result(...)` is discarded when deferred.
 
 ---
 
-## 8. F-Strings
+## 9. F-Strings
 
 String interpolation with `f"..."`.
 
@@ -655,7 +1009,7 @@ let name: string = "Noxy"
 print(f"Hello, {name}!")
 ```
 
-## 9. Built-in Functions
+## 10. Built-in Functions
 
 ### I/O
 - `print(expr)`: Prints to stdout.
@@ -762,7 +1116,7 @@ Supervised tasks share globals, module state, runtime resources, closure environ
 
 ---
 
-## 10. Module System
+## 11. Module System
 
 ### Basic Import
 ```noxy
@@ -784,7 +1138,7 @@ print(to_upper("hello"))
 
 ---
 
-## 11. Standard Library
+## 12. Standard Library
 
 Noxy comes with a comprehensive standard library. Available modules include:
 

--- a/docs/superpowers/plans/2026-08-18-generics.md
+++ b/docs/superpowers/plans/2026-08-18-generics.md
@@ -1,0 +1,1621 @@
+# Genéricos por Monomorfização — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Funções e structs genéricos (`func map<A,B>`, `struct Stack<T>`) com monomorfização lazy, inferência sem instanciação explícita, target-typing, e custo zero em runtime.
+
+**Architecture:** Two-pass no `Compiler.Compile(*ast.Program)`: pass 1 compila descartando bytecode, intercepta usos genéricos, infere tipos por unificação, clona+substitui ASTs de templates (memoizado, nome qualificado `módulo::nome<args>`) e reescreve o AST; pass 2 prepende as declarações monomorfizadas e compila o AST reescrito pelo caminho 100% normal. Zero mudança em `internal/vm` (exceto testes).
+
+**Tech Stack:** Go (compilador/VM existentes), testes `go test`, corpus `.nx` em `noxy_examples/`, benchmarks PowerShell em `benchmarks/`.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-generics-design.md` — o plano argumenta a partir dela; leia a spec antes de executar qualquer task. Referências §N abaixo são seções da spec.
+
+## Global Constraints
+
+- **Branch:** `feat/generics` a partir de `develop`.
+- **Proibido editar arquivos não-teste de `internal/vm/`** (§5/§10 — "zero mudança na VM"). Testes novos em `internal/vm/*_test.go` são permitidos.
+- Nome qualificado de instância: `módulo::base<arg1,arg2>` (unidade principal usa módulo `main`). Identificadores de usuário nunca contêm `<` ou `::`.
+- Mensagens de erro seguem o catálogo do §9 **verbatim no essencial** (mesmos fatos na mensagem; formatação `[linha N]` como o compilador já faz). Erros de corpo carregam cadeia: `em NOME<ARGS> (instanciado na linha N)`.
+- Toda task termina com `go test ./internal/... -count=1` verde e commit. A última task exige o corpus `noxy_examples/run_all_tests_concurrent.nx` 164/164 + novos.
+- Release 0.7.0; CHANGELOG na task final. Comentários de código em português, como o codebase.
+- Commits: mensagem em português, sufixo `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Nós de AST genéricos
+
+**Files:**
+- Modify: `internal/ast/ast.go` (structs `FunctionStatement` ~linha 377, `StructStatement` ~linha 498; novos tipos junto aos NoxyType ~linha 45)
+- Test: `internal/ast/generics_ast_test.go` (novo)
+
+**Interfaces:**
+- Produces: `ast.GenericType{Name string, Args []NoxyType}` (é NoxyType; `String()` = `Name<arg1, arg2>`); `ast.TypeParamType{Name string}` (é NoxyType; `String()` = `Name`); campo `TypeParams []string` em `FunctionStatement` e `StructStatement` (vazio = declaração comum).
+
+- [ ] **Step 1: Escrever teste que falha**
+
+```go
+package ast
+
+import "testing"
+
+func TestGenericTypeString(t *testing.T) {
+	g := &GenericType{Name: "Stack", Args: []NoxyType{&PrimitiveType{Name: "int"}}}
+	if got := g.String(); got != "Stack<int>" {
+		t.Fatalf("String() = %q, quer Stack<int>", got)
+	}
+	nested := &GenericType{Name: "Stack", Args: []NoxyType{g}}
+	if got := nested.String(); got != "Stack<Stack<int>>" {
+		t.Fatalf("String() = %q, quer Stack<Stack<int>>", got)
+	}
+	multi := &GenericType{Name: "Map", Args: []NoxyType{
+		&PrimitiveType{Name: "string"}, &PrimitiveType{Name: "int"},
+	}}
+	if got := multi.String(); got != "Map<string, int>" {
+		t.Fatalf("String() = %q, quer Map<string, int>", got)
+	}
+}
+
+func TestTypeParamTypeString(t *testing.T) {
+	p := &TypeParamType{Name: "T"}
+	if got := p.String(); got != "T" {
+		t.Fatalf("String() = %q, quer T", got)
+	}
+}
+
+func TestTypeParamsFieldsExist(t *testing.T) {
+	f := &FunctionStatement{TypeParams: []string{"T"}}
+	s := &StructStatement{TypeParams: []string{"K", "V"}}
+	if len(f.TypeParams) != 1 || len(s.TypeParams) != 2 {
+		t.Fatal("campos TypeParams ausentes")
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar** — `go test ./internal/ast -run 'Generic|TypeParam' -count=1` → FAIL (tipos não existem).
+
+- [ ] **Step 3: Implementar em `ast.go`**
+
+```go
+// GenericType é um tipo genérico em posição de anotação: Stack<int>.
+// Name é resolvido para um template em escopo durante a compilação (§6/§8 da
+// spec); a identidade nominal final é o nome qualificado da instância.
+type GenericType struct {
+	Name string
+	Args []NoxyType
+}
+
+func (gt *GenericType) String() string {
+	parts := make([]string, len(gt.Args))
+	for i, a := range gt.Args {
+		parts[i] = a.String()
+	}
+	return gt.Name + "<" + strings.Join(parts, ", ") + ">"
+}
+
+// TypeParamType é um parâmetro de tipo (T) dentro de um template. Nó distinto
+// de PrimitiveType para não colidir com um struct real chamado T.
+type TypeParamType struct {
+	Name string
+}
+
+func (tp *TypeParamType) String() string { return tp.Name }
+```
+
+E adicionar `TypeParams []string` em `FunctionStatement` e `StructStatement` (logo após `Name`).
+
+- [ ] **Step 4: Rodar e ver passar** — `go test ./internal/ast -count=1` → PASS.
+- [ ] **Step 5: Commit** — `git add internal/ast && git commit -m "feat(ast): nos GenericType/TypeParamType e campos TypeParams"`
+
+---
+
+### Task 2: Cloner profundo de AST com guard por reflexão
+
+**Files:**
+- Create: `internal/ast/clone.go`
+- Test: `internal/ast/clone_test.go`
+
+**Interfaces:**
+- Produces: `ast.CloneStatement(s Statement) Statement`, `ast.CloneExpression(e Expression) Expression`, `ast.CloneType(t NoxyType) NoxyType`, `ast.CloneBlock(b *BlockStatement) *BlockStatement`. Clones profundos: nenhum ponteiro de nó compartilhado com o original (tokens `token.Token` são valores, copiar por valor é suficiente).
+- Consumes: nós da Task 1.
+
+Cobertura obrigatória (lista fechada — o guard do Step 3 impõe): Statements — `AssignStmt, LetStmt, ReturnStmt, DeferStmt, BreakStmt, UseStmt, ExpressionStmt, BlockStatement, IfStatement, WhileStatement, FunctionStatement, ForStatement, StructStatement, WhenStatement` (+ o que mais implementar `statementNode()`); Expressions — `Identifier, IntegerLiteral, FloatLiteral, StringLiteral, BytesLiteral, NullLiteral, ZerosLiteral, PrefixExpression, InfixExpression, FunctionLiteral, CallExpression, ArrayLiteral, MapLiteral, IndexExpression, MemberAccessExpression` (+ o que mais implementar `expressionNode()`); Types — `PrimitiveType, ArrayType, MapType, RefType, ChanType, FunctionType, GenericType, TypeParamType`. Structs auxiliares clonados junto: `Parameter, StructField, CaseClause`. `StructStatement` tem **dois** espelhos de campos (`Fields map[string]NoxyType` e `FieldsList []*StructField`) — clonar ambos e mantê-los consistentes.
+
+- [ ] **Step 1: Escrever o guard por reflexão (falha enquanto o cloner não cobre tudo)**
+
+```go
+package ast
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClonerCoversEveryNode enumera os tipos concretos do pacote que
+// implementam Statement/Expression/NoxyType (via análise do fonte ast.go) e
+// falha se clone.go não tiver um case para cada um. Um nó esquecido =
+// AST compartilhado entre instâncias = contaminação silenciosa (§11 da spec).
+func TestClonerCoversEveryNode(t *testing.T) {
+	fset := token.NewFileSet()
+	nodeNames := map[string]bool{}
+	for _, file := range []string{"ast.go"} {
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				return true
+			}
+			name := fn.Name.Name
+			if name != "statementNode" && name != "expressionNode" && name != "String" {
+				return true
+			}
+			recv := fn.Recv.List[0].Type
+			if star, ok := recv.(*ast.StarExpr); ok {
+				if ident, ok := star.X.(*ast.Ident); ok {
+					nodeNames[ident.Name] = true
+				}
+			}
+			return true
+		})
+	}
+	delete(nodeNames, "Program") // Program não precisa de clone (clonamos statements)
+	delete(nodeNames, "Parameter")
+	delete(nodeNames, "StructField") // clonados por dentro dos donos; cases próprios não exigidos
+
+	cloneSrc, err := os.ReadFile(filepath.Join(".", "clone.go"))
+	if err != nil {
+		t.Fatalf("clone.go ausente: %v", err)
+	}
+	for name := range nodeNames {
+		if !strings.Contains(string(cloneSrc), "*"+name+":") {
+			t.Errorf("clone.go sem case para *%s", name)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Escrever testes de não-aliasing (representativos + mutação)**
+
+```go
+func TestCloneStatementNoAliasing(t *testing.T) {
+	original := &LetStmt{
+		Name: &Identifier{Value: "x"},
+		Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}},
+		Value: &CallExpression{
+			Function:  &Identifier{Value: "make"},
+			Arguments: []Expression{&IntegerLiteral{Value: 1}},
+		},
+	}
+	clone := CloneStatement(original).(*LetStmt)
+	// mutar o clone em profundidade
+	clone.Name.Value = "y"
+	clone.Type.(*ArrayType).ElementType = &PrimitiveType{Name: "int"}
+	clone.Value.(*CallExpression).Arguments[0] = &IntegerLiteral{Value: 99}
+	if original.Name.Value != "x" {
+		t.Fatal("Name compartilhado entre original e clone")
+	}
+	if _, ok := original.Type.(*ArrayType).ElementType.(*TypeParamType); !ok {
+		t.Fatal("Type compartilhado entre original e clone")
+	}
+	if original.Value.(*CallExpression).Arguments[0].(*IntegerLiteral).Value != 1 {
+		t.Fatal("Arguments compartilhado entre original e clone")
+	}
+}
+
+func TestCloneFunctionStatementDeep(t *testing.T) {
+	original := &FunctionStatement{
+		Name:       "first",
+		TypeParams: []string{"T"},
+		Parameters: []*Parameter{{Name: "arr", Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}}}},
+		ReturnType: &TypeParamType{Name: "T"},
+		Body: &BlockStatement{Statements: []Statement{
+			&ReturnStmt{ReturnValue: &IndexExpression{
+				Left:  &Identifier{Value: "arr"},
+				Index: &IntegerLiteral{Value: 0},
+			}},
+		}},
+	}
+	clone := CloneStatement(original).(*FunctionStatement)
+	clone.Parameters[0].Type = &PrimitiveType{Name: "int"}
+	clone.Body.Statements[0].(*ReturnStmt).ReturnValue = &NullLiteral{}
+	if _, ok := original.Parameters[0].Type.(*ArrayType); !ok {
+		t.Fatal("Parameter.Type compartilhado")
+	}
+	if _, ok := original.Body.Statements[0].(*ReturnStmt).ReturnValue.(*IndexExpression); !ok {
+		t.Fatal("Body compartilhado")
+	}
+}
+
+func TestCloneStructStatementBothFieldMirrors(t *testing.T) {
+	original := &StructStatement{
+		Name:       "Stack",
+		TypeParams: []string{"T"},
+		Fields:     map[string]NoxyType{"items": &ArrayType{ElementType: &TypeParamType{Name: "T"}}},
+		FieldsList: []*StructField{{Name: "items", Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}}}},
+	}
+	clone := CloneStatement(original).(*StructStatement)
+	clone.FieldsList[0].Type = &PrimitiveType{Name: "int"}
+	clone.Fields["items"] = &PrimitiveType{Name: "int"}
+	if _, ok := original.FieldsList[0].Type.(*ArrayType); !ok {
+		t.Fatal("FieldsList compartilhado")
+	}
+	if _, ok := original.Fields["items"].(*ArrayType); !ok {
+		t.Fatal("Fields (map) compartilhado")
+	}
+}
+```
+
+- [ ] **Step 3: Rodar e ver falhar** — `go test ./internal/ast -run Clone -count=1` → FAIL (clone.go não existe).
+
+- [ ] **Step 4: Implementar `clone.go`** — três funções com type switch exaustivo. Padrão (repetir para TODOS os nós da lista de Interfaces; o guard do Step 1 acusa faltas):
+
+```go
+package ast
+
+// Clones profundos de nós do AST, usados pela monomorfização de genéricos
+// (spec 2026-08-18-generics-design.md §4): cada instância recebe uma cópia
+// exclusiva do corpo do template. Nó compartilhado entre instâncias seria
+// contaminação silenciosa — o guard TestClonerCoversEveryNode impõe cobertura.
+
+func CloneStatement(s Statement) Statement {
+	if s == nil {
+		return nil
+	}
+	switch n := s.(type) {
+	case *LetStmt:
+		return &LetStmt{Token: n.Token, Name: cloneIdentifier(n.Name), Type: CloneType(n.Type), Value: CloneExpression(n.Value)}
+	case *ReturnStmt:
+		return &ReturnStmt{Token: n.Token, ReturnValue: CloneExpression(n.ReturnValue)}
+	case *FunctionStatement:
+		return &FunctionStatement{
+			Token: n.Token, Name: n.Name,
+			TypeParams: append([]string(nil), n.TypeParams...),
+			Parameters: cloneParameters(n.Parameters),
+			ReturnType: CloneType(n.ReturnType),
+			Body:       CloneBlock(n.Body),
+		}
+	case *StructStatement:
+		fields := make(map[string]NoxyType, len(n.Fields))
+		list := make([]*StructField, len(n.FieldsList))
+		for i, f := range n.FieldsList {
+			cloned := &StructField{Name: f.Name, Type: CloneType(f.Type)}
+			list[i] = cloned
+			fields[f.Name] = cloned.Type
+		}
+		return &StructStatement{Token: n.Token, Name: n.Name,
+			TypeParams: append([]string(nil), n.TypeParams...),
+			Fields:     fields, FieldsList: list}
+	// ... cases restantes: AssignStmt, DeferStmt, BreakStmt, UseStmt,
+	// ExpressionStmt, BlockStatement, IfStatement, WhileStatement,
+	// ForStatement, WhenStatement (clona CaseClause: Condition via
+	// CloneStatement, Body via CloneBlock)
+	default:
+		panic("CloneStatement: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+func CloneExpression(e Expression) Expression { /* mesmo padrão para todos os Expression */ }
+
+func CloneType(t NoxyType) NoxyType {
+	if t == nil {
+		return nil
+	}
+	switch n := t.(type) {
+	case *PrimitiveType:
+		return &PrimitiveType{Name: n.Name}
+	case *ArrayType:
+		return &ArrayType{ElementType: CloneType(n.ElementType), Size: n.Size}
+	case *MapType:
+		return &MapType{KeyType: CloneType(n.KeyType), ValueType: CloneType(n.ValueType)}
+	case *RefType:
+		return &RefType{ElementType: CloneType(n.ElementType)}
+	case *ChanType:
+		return &ChanType{ElementType: CloneType(n.ElementType)}
+	case *FunctionType:
+		params := make([]NoxyType, len(n.Params))
+		for i, p := range n.Params {
+			params[i] = CloneType(p)
+		}
+		return &FunctionType{Params: params, Return: CloneType(n.Return)}
+	case *GenericType:
+		args := make([]NoxyType, len(n.Args))
+		for i, a := range n.Args {
+			args[i] = CloneType(a)
+		}
+		return &GenericType{Name: n.Name, Args: args}
+	case *TypeParamType:
+		return &TypeParamType{Name: n.Name}
+	default:
+		panic("CloneType: tipo sem case")
+	}
+}
+
+func CloneBlock(b *BlockStatement) *BlockStatement { /* clona Statements um a um */ }
+func cloneIdentifier(i *Identifier) *Identifier    { /* cópia por valor + retorno de ponteiro novo */ }
+func cloneParameters(ps []*Parameter) []*Parameter { /* Parameter{Name, CloneType(Type)} */ }
+```
+
+Nota: `FunctionLiteral` (lambda dentro de template — §11) clona `Parameters`, `ReturnType`, `Body` e `Name`. `MapLiteral`: verificar em `ast.go` como os pares são armazenados e clonar chaves e valores.
+
+- [ ] **Step 5: Rodar e ver passar** — `go test ./internal/ast -count=1` → PASS (incluindo o guard).
+- [ ] **Step 6: Commit** — `git commit -m "feat(ast): cloner profundo com guard de cobertura por reflexao"`
+
+---
+
+### Task 3: Parser — parâmetros de tipo em declarações
+
+**Files:**
+- Modify: `internal/parser/parser.go` (`parseFunctionStatement` e `parseStructStatement`; struct `Parser`)
+- Test: `internal/parser/generics_parser_test.go` (novo)
+
+**Interfaces:**
+- Consumes: `ast.TypeParamType`, campos `TypeParams` (Task 1).
+- Produces: parsing de `func f<T, U>(...)` e `struct S<T> ... end`; campo `activeTypeParams map[string]bool` no `Parser` — enquanto não-vazio, `parseAtomicType` resolve `IDENT` presente no set como `&ast.TypeParamType{Name}`; método `parseTypeParameters() []string`.
+
+- [ ] **Step 1: Testes que falham**
+
+```go
+package parser
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+	"testing"
+)
+
+func parseProgramNoErrors(t *testing.T, src string) *ast.Program {
+	t.Helper()
+	p := New(lexer.New(src))
+	prog := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("erros de parse: %v", errs)
+	}
+	return prog
+}
+
+func TestParseGenericFunctionDeclaration(t *testing.T) {
+	prog := parseProgramNoErrors(t, "func first<T>(arr: T[]) -> T\n    return arr[0]\nend")
+	fn := prog.Statements[0].(*ast.FunctionStatement)
+	if len(fn.TypeParams) != 1 || fn.TypeParams[0] != "T" {
+		t.Fatalf("TypeParams = %v, quer [T]", fn.TypeParams)
+	}
+	arr := fn.Parameters[0].Type.(*ast.ArrayType)
+	if _, ok := arr.ElementType.(*ast.TypeParamType); !ok {
+		t.Fatalf("param deve ser T[] com TypeParamType, veio %T", arr.ElementType)
+	}
+	if _, ok := fn.ReturnType.(*ast.TypeParamType); !ok {
+		t.Fatalf("retorno deve ser TypeParamType, veio %T", fn.ReturnType)
+	}
+}
+
+func TestParseGenericStructDeclaration(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Pair<A, B>\n    left: A,\n    right: B\nend")
+	st := prog.Statements[0].(*ast.StructStatement)
+	if len(st.TypeParams) != 2 || st.TypeParams[0] != "A" || st.TypeParams[1] != "B" {
+		t.Fatalf("TypeParams = %v, quer [A B]", st.TypeParams)
+	}
+	if _, ok := st.FieldsList[0].Type.(*ast.TypeParamType); !ok {
+		t.Fatalf("campo left deve ser TypeParamType, veio %T", st.FieldsList[0].Type)
+	}
+}
+
+func TestTypeParamScopeEndsWithDeclaration(t *testing.T) {
+	// Depois do template, T fora de escopo volta a ser tipo comum (struct/nome)
+	prog := parseProgramNoErrors(t, "func id<T>(x: T) -> T\n    return x\nend\nlet a: int = 1")
+	if len(prog.Statements) != 2 {
+		t.Fatalf("esperava 2 statements, veio %d", len(prog.Statements))
+	}
+}
+
+func TestGenericSelfReferenceInStruct(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Node<T>\n    value: T,\n    next: ref Node<T>\nend")
+	st := prog.Statements[0].(*ast.StructStatement)
+	next := st.FieldsList[1].Type.(*ast.RefType)
+	g := next.ElementType.(*ast.GenericType)
+	if g.Name != "Node" {
+		t.Fatalf("auto-referencia Node<T>, veio %s", g.String())
+	}
+	if _, ok := g.Args[0].(*ast.TypeParamType); !ok {
+		t.Fatalf("arg de Node<T> deve ser TypeParamType, veio %T", g.Args[0])
+	}
+}
+```
+
+(Obs.: o último teste também exige `GenericType` em posição de tipo — a implementação mínima dele entra na Task 4; escreva o teste aqui, deixe-o falhando ao fim desta task com `t.Skip` removido na Task 4, OU mova-o para o arquivo da Task 4. Decisão: **mover para Task 4** se ainda falhar ao fim desta.)
+
+- [ ] **Step 2: Rodar e ver falhar** — `go test ./internal/parser -run Generic -count=1` → FAIL.
+
+- [ ] **Step 3: Implementar**
+
+Em `Parser` (struct): adicionar `activeTypeParams map[string]bool` (inicializar `nil`; setar/limpar por declaração). Em `parseFunctionStatement` (parser.go:~840) e `parseStructStatement`, logo após ler o nome:
+
+```go
+// Parametros de tipo opcionais: func nome<T, U>(...)
+if p.peekTokenIs(token.LT) {
+	stmt.TypeParams = p.parseTypeParameters()
+	if stmt.TypeParams == nil {
+		return nil
+	}
+	p.activeTypeParams = map[string]bool{}
+	for _, name := range stmt.TypeParams {
+		p.activeTypeParams[name] = true
+	}
+	defer func() { p.activeTypeParams = nil }()
+}
+```
+
+```go
+// parseTypeParameters consome <T, U> apos o nome de uma declaracao generica.
+// curToken esta no nome; ao retornar, curToken esta no GT final.
+func (p *Parser) parseTypeParameters() []string {
+	p.nextToken() // eat <
+	names := []string{}
+	for {
+		if !p.expectPeek(token.IDENTIFIER) {
+			return nil
+		}
+		names = append(names, p.curToken.Literal)
+		if p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			continue
+		}
+		break
+	}
+	if !p.expectPeek(token.GT) {
+		return nil
+	}
+	return names
+}
+```
+
+Em `parseAtomicType` (parser.go:646), no case de IDENT/tipo nomeado, **antes** da resolução atual:
+
+```go
+if p.activeTypeParams[p.curToken.Literal] {
+	return &ast.TypeParamType{Name: p.curToken.Literal}
+}
+```
+
+Atenção: genéricos aninhados são proibidos (§2.3) — se `activeTypeParams != nil` e a declaração é interna (dentro de corpo), `parseFunctionStatement` de um literal aninhado com `<` deve produzir erro `declaração genérica só é permitida no top level`. Implementar como checagem no compilador (Task 5) — o parser aceita e o compilador rejeita, para a mensagem sair com linha correta.
+
+- [ ] **Step 4: Rodar e ver passar** — `go test ./internal/parser -count=1` → PASS (mover `TestGenericSelfReferenceInStruct` para Task 4 se depender de `GenericType`).
+- [ ] **Step 5: Commit** — `git commit -m "feat(parser): parametros de tipo <T> em declaracoes de func e struct"`
+
+---
+
+### Task 4: Parser — `GenericType` em posição de tipo + split de `>>` e `>=`
+
+**Files:**
+- Modify: `internal/parser/parser.go` (`parseAtomicType`:646, `nextToken`:94, struct `Parser`)
+- Test: `internal/parser/generics_parser_test.go` (ampliar)
+
+**Interfaces:**
+- Produces: `Stack<int>` em qualquer posição de tipo → `&ast.GenericType{...}`; `Stack<Stack<int>>` e `Stack<int>=` parseiam. Mecanismo: fila `pendingTokens []token.Token` no `Parser`; `nextToken()` drena a fila antes de pedir token ao lexer; ao encontrar `SHIFT_RIGHT` onde um `GT` é esperado em lista de argumentos de tipo, substitui curToken por `GT` e enfileira outro `GT`; `GTE` → `GT` + enfileira `ASSIGN`.
+
+- [ ] **Step 1: Testes que falham**
+
+```go
+func TestParseGenericTypeAnnotation(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<int> = null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	g := let.Type.(*ast.GenericType)
+	if g.String() != "Stack<int>" {
+		t.Fatalf("tipo = %s, quer Stack<int>", g.String())
+	}
+}
+
+func TestParseNestedGenericTypeSplitsShiftRight(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<Stack<int>> = null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	if got := let.Type.String(); got != "Stack<Stack<int>>" {
+		t.Fatalf("tipo = %s", got)
+	}
+}
+
+func TestParseGenericTypeSplitsGTEBeforeAssign(t *testing.T) {
+	// sem espaco entre > e = : lexa GTE e o parser precisa dividir
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<int>= null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	if got := let.Type.String(); got != "Stack<int>" {
+		t.Fatalf("tipo = %s", got)
+	}
+	if let.Value == nil {
+		t.Fatal("valor do let perdido no split de GTE")
+	}
+}
+
+func TestGenericTypeComposesWithArrayAndRef(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet a: Stack<int>[] = []\nlet r: ref Stack<int> = null")
+	arr := prog.Statements[1].(*ast.LetStmt).Type.(*ast.ArrayType)
+	if arr.ElementType.String() != "Stack<int>" {
+		t.Fatalf("elemento = %s", arr.ElementType.String())
+	}
+	ref := prog.Statements[2].(*ast.LetStmt).Type.(*ast.RefType)
+	if ref.ElementType.String() != "Stack<int>" {
+		t.Fatalf("ref elemento = %s", ref.ElementType.String())
+	}
+}
+```
+
+(+ mover `TestGenericSelfReferenceInStruct` da Task 3 para cá, se pendente.)
+
+- [ ] **Step 2: Rodar e ver falhar** — `go test ./internal/parser -run Generic -count=1` → FAIL.
+
+- [ ] **Step 3: Implementar**
+
+Fila em `nextToken`:
+
+```go
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	if len(p.pendingTokens) > 0 {
+		p.peekToken = p.pendingTokens[0]
+		p.pendingTokens = p.pendingTokens[1:]
+		return
+	}
+	p.peekToken = p.l.NextToken()
+}
+```
+
+Em `parseAtomicType`, após resolver um IDENT que não é type-param nem tipo primitivo, checar `p.peekTokenIs(token.LT)` e parsear argumentos:
+
+```go
+// Tipo generico em posicao de anotacao: Nome<arg1, arg2>
+if p.peekTokenIs(token.LT) {
+	p.nextToken() // eat nome; curToken = <
+	args := []ast.NoxyType{}
+	for {
+		p.nextToken() // avanca para o inicio do proximo tipo
+		arg := p.parseType()
+		if arg == nil {
+			return nil
+		}
+		args = append(args, arg)
+		p.splitCompositeGT() // divide >> ou >= pendentes ANTES de checar peek
+		if p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			continue
+		}
+		break
+	}
+	if !p.expectPeek(token.GT) {
+		return nil
+	}
+	return &ast.GenericType{Name: name, Args: args}
+}
+```
+
+```go
+// splitCompositeGT divide tokens compostos que contem '>' quando estamos
+// esperando fechar uma lista de argumentos de tipo (truque C#/Java):
+//   >>  ->  > + >   (Stack<Stack<int>>)
+//   >=  ->  > + =   (let s: Stack<int>= v)
+func (p *Parser) splitCompositeGT() {
+	switch p.peekToken.Type {
+	case token.SHIFT_RIGHT:
+		gt := token.Token{Type: token.GT, Literal: ">", Line: p.peekToken.Line, Column: p.peekToken.Column}
+		p.pendingTokens = append([]token.Token{gt}, p.pendingTokens...)
+		p.peekToken = gt
+	case token.GTE:
+		assign := token.Token{Type: token.ASSIGN, Literal: "=", Line: p.peekToken.Line, Column: p.peekToken.Column + 1}
+		p.pendingTokens = append([]token.Token{assign}, p.pendingTokens...)
+		p.peekToken = token.Token{Type: token.GT, Literal: ">", Line: p.peekToken.Line, Column: p.peekToken.Column}
+	}
+}
+```
+
+Conferir os nomes de campos reais de `token.Token` (Line/Column) em `internal/token/token.go` e ajustar. `ASSIGN` é o nome do token `=` — conferir em token.go e usar o nome real.
+
+- [ ] **Step 4: Rodar e ver passar** — `go test ./internal/parser -count=1` → PASS.
+- [ ] **Step 5: Rodar suite inteira** — `go test ./internal/... -count=1` → PASS (split não pode quebrar comparações `a >> b` / `a >= b` em expressão: `splitCompositeGT` só roda dentro de lista de argumentos de tipo).
+- [ ] **Step 6: Commit** — `git commit -m "feat(parser): GenericType em posicao de tipo com split de >> e >="`
+
+---
+
+### Task 5: Compiler — registry de templates (declarações genéricas não emitem)
+
+**Files:**
+- Create: `internal/compiler/generics.go`
+- Modify: `internal/compiler/compiler.go` (cases `*ast.FunctionStatement`:1663 e `*ast.StructStatement`:643; struct `Compiler`:52; `NewWithStateAndRoot`:94)
+- Test: `internal/compiler/generics_test.go` (novo)
+
+**Interfaces:**
+- Produces:
+  - `type FuncTemplate struct { Decl *ast.FunctionStatement; Module string }`
+  - `type StructTemplate struct { Decl *ast.StructStatement; Module string }`
+  - `type GenericRegistry struct { Funcs map[string]*FuncTemplate; Structs map[string]*StructTemplate }` + `func NewGenericRegistry() *GenericRegistry`
+  - Campos novos no `Compiler`: `generics *GenericRegistry` (lazy-init), `moduleName string` (default `"main"`)
+  - `func (c *Compiler) SetGenericState(reg *GenericRegistry)` (REPL/testes)
+  - `func (c *Compiler) registryOrInit() *GenericRegistry`
+- Comportamento: declaração com `TypeParams` não-vazio → registra template e **não emite nada** (nem global, nem constante); em escopo interno (`c.scopeDepth > 0`) → erro `[linha N] declaração genérica só é permitida no top level`.
+
+- [ ] **Step 1: Testes que falham**
+
+```go
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+func TestGenericFunctionDeclarationEmitsNothing(t *testing.T) {
+	code, _, err := New().Compile(parse("func first<T>(arr: T[]) -> T\n    return arr[0]\nend"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsOpcode(code.Code, chunk.OP_CLOSURE) {
+		t.Fatal("template de funcao nao deve emitir OP_CLOSURE")
+	}
+	if containsOpcode(code.Code, chunk.OP_SET_GLOBAL) {
+		t.Fatal("template de funcao nao deve emitir OP_SET_GLOBAL")
+	}
+}
+
+func TestGenericStructDeclarationEmitsNothing(t *testing.T) {
+	code, _, err := New().Compile(parse("struct Stack<T>\n    items: T[]\nend"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsOpcode(code.Code, chunk.OP_SET_GLOBAL) {
+		t.Fatal("template de struct nao deve emitir OP_SET_GLOBAL")
+	}
+}
+
+func TestTemplateRegisteredInRegistry(t *testing.T) {
+	c := New()
+	if _, _, err := c.Compile(parse("func first<T>(arr: T[]) -> T\n    return arr[0]\nend")); err != nil {
+		t.Fatal(err)
+	}
+	tpl, ok := c.registryOrInit().Funcs["first"]
+	if !ok {
+		t.Fatal("template 'first' nao registrado")
+	}
+	if tpl.Module != "main" {
+		t.Fatalf("Module = %q, quer main", tpl.Module)
+	}
+}
+
+func TestNestedGenericDeclarationIsError(t *testing.T) {
+	_, _, err := New().Compile(parse("func outer()\n    func inner<T>(x: T) -> T\n        return x\n    end\nend"))
+	if err == nil || !strings.Contains(err.Error(), "top level") {
+		t.Fatalf("esperava erro de genericos aninhados, veio %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar** — `go test ./internal/compiler -run 'Generic|Template|Nested' -count=1` → FAIL.
+
+- [ ] **Step 3: Implementar** — `generics.go` com os tipos das Interfaces. Nos dois cases do `Compile`, **primeiro statement** do case:
+
+```go
+if len(n.TypeParams) > 0 {
+	if c.scopeDepth > 0 || c.enclosing != nil {
+		return nil, nil, fmt.Errorf("[line %d] declaração genérica só é permitida no top level", n.Token.Line)
+	}
+	c.registryOrInit().Funcs[n.Name] = &FuncTemplate{Decl: n, Module: c.moduleName}
+	return c.currentChunk, nil, nil
+}
+```
+
+(análogo para struct em `Structs`). `moduleName` default `"main"` em `NewWithStateAndRoot`; setter usado nas tasks de módulo.
+
+- [ ] **Step 4: Rodar e ver passar** — `go test ./internal/compiler -count=1` → PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat(compiler): registry de templates genericos sem emissao"`
+
+---
+
+### Task 6: Compiler — unificação
+
+**Files:**
+- Create: `internal/compiler/generics_unify.go`
+- Test: `internal/compiler/generics_unify_test.go`
+
+**Interfaces:**
+- Produces: `func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) error`. Regras (§7 da spec, verbatim): casamento estrutural por construtor; `TypeParamType` binda `actual`; conflito = erro `T inferido como X e Y`; `T` não binda `ref` (erro `T não pode ser um tipo ref`); `null` e `any` como actual **não contribuem** binding (retorna nil sem bindar); `GenericType` unifica args ponto a ponto (mesmos Name e aridade).
+- Consumes: nós de tipo das Tasks 1.
+
+- [ ] **Step 1: Testes-tabela que falham**
+
+```go
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+func tInt() ast.NoxyType    { return &ast.PrimitiveType{Name: "int"} }
+func tString() ast.NoxyType { return &ast.PrimitiveType{Name: "string"} }
+func tAny() ast.NoxyType    { return &ast.PrimitiveType{Name: "any"} }
+func tNull() ast.NoxyType   { return &ast.PrimitiveType{Name: "null"} }
+func tParam(n string) ast.NoxyType { return &ast.TypeParamType{Name: n} }
+func tArr(e ast.NoxyType) ast.NoxyType { return &ast.ArrayType{ElementType: e} }
+
+func TestUnifyTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected ast.NoxyType
+		actual   ast.NoxyType
+		want     map[string]string // binding esperado (String())
+		errPart  string            // "" = sem erro
+	}{
+		{"T contra int", tParam("T"), tInt(), map[string]string{"T": "int"}, ""},
+		{"T[] contra int[]", tArr(tParam("T")), tArr(tInt()), map[string]string{"T": "int"}, ""},
+		{"map[K,V]", &ast.MapType{KeyType: tParam("K"), ValueType: tParam("V")},
+			&ast.MapType{KeyType: tString(), ValueType: tInt()},
+			map[string]string{"K": "string", "V": "int"}, ""},
+		{"func(A)->B", &ast.FunctionType{Params: []ast.NoxyType{tParam("A")}, Return: tParam("B")},
+			&ast.FunctionType{Params: []ast.NoxyType{tInt()}, Return: tString()},
+			map[string]string{"A": "int", "B": "string"}, ""},
+		{"chan T", &ast.ChanType{ElementType: tParam("T")}, &ast.ChanType{ElementType: tInt()},
+			map[string]string{"T": "int"}, ""},
+		{"GenericType args", &ast.GenericType{Name: "Stack", Args: []ast.NoxyType{tParam("T")}},
+			&ast.GenericType{Name: "Stack", Args: []ast.NoxyType{tInt()}},
+			map[string]string{"T": "int"}, ""},
+		{"conflito", tParam("T"), tInt(), nil, ""}, // preparado abaixo com segundo unify
+		{"any nao binda", tParam("T"), tAny(), map[string]string{}, ""},
+		{"null nao binda", tParam("T"), tNull(), map[string]string{}, ""},
+		{"T nao binda ref", tParam("T"), &ast.RefType{ElementType: tInt()}, nil, "não pode ser um tipo ref"},
+		{"construtor divergente", tArr(tParam("T")), tInt(), nil, "esperava"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := map[string]ast.NoxyType{}
+			err := unify(tc.expected, tc.actual, b)
+			if tc.name == "conflito" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = unify(tc.expected, tString(), b) // T=int já bindado; string conflita
+				if err == nil || !strings.Contains(err.Error(), "inferido como") {
+					t.Fatalf("esperava conflito, veio %v", err)
+				}
+				return
+			}
+			if tc.errPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errPart) {
+					t.Fatalf("esperava erro contendo %q, veio %v", tc.errPart, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			for k, v := range tc.want {
+				got, ok := b[k]
+				if !ok || got.String() != v {
+					t.Fatalf("binding %s = %v, quer %s", k, got, v)
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**, **Step 3: Implementar** `unify` (switch no `expected`; `TypeParamType` primeiro: se actual é `ref` → erro dedicado; se actual é `any`/`null` → return nil; se binding existente diverge por `String()` → erro conflito; senão binda `CloneType(actual)`). `expected` concreto (sem type params dentro — checar com helper `containsTypeParam(t) bool`, exportado no mesmo arquivo pois Tasks 8/11 usam): delega para comparação estrutural simples e retorna erro em divergência de construtor. **Step 4: PASS.** 
+- [ ] **Step 5: Commit** — `git commit -m "feat(compiler): unificacao estrutural para inferencia de genericos"`
+
+---
+
+### Task 7: Compiler — substituição e nome qualificado de instância
+
+**Files:**
+- Create: `internal/compiler/generics_substitute.go`
+- Test: `internal/compiler/generics_substitute_test.go`
+
+**Interfaces:**
+- Produces:
+  - `func instanceName(module, base string, args []ast.NoxyType) string` → `"main::first<int>"`, `"colecoes::map<int,string>"` (args por `String()`, separados por `,` sem espaço)
+  - `func substituteType(t ast.NoxyType, b map[string]ast.NoxyType) ast.NoxyType` — clona e troca `TypeParamType` pelo binding; `GenericType` com todos os args concretos após substituição é **mantido** como `GenericType` (a resolução para nome qualificado acontece na Task 9)
+  - `func substituteFunction(tpl *FuncTemplate, b map[string]ast.NoxyType, name string) *ast.FunctionStatement` — clona `tpl.Decl`, zera `TypeParams`, renomeia para `name`, substitui em `Parameters[i].Type`, `ReturnType` e em **todas** as anotações do corpo (percorrer statements: `LetStmt.Type`, tipos dentro de `FunctionLiteral`, etc. — implementar `substituteInStatement`/`substituteInExpression` que anda no clone trocando só campos de tipo)
+  - `func substituteStruct(tpl *StructTemplate, b map[string]ast.NoxyType, name string) *ast.StructStatement` — idem para `Fields` + `FieldsList` (os dois espelhos)
+- Consumes: cloner (Task 2), templates (Task 5).
+
+- [ ] **Step 1: Testes que falham**
+
+```go
+func TestInstanceName(t *testing.T) {
+	got := instanceName("main", "first", []ast.NoxyType{tInt()})
+	if got != "main::first<int>" {
+		t.Fatalf("instanceName = %q", got)
+	}
+	got = instanceName("colecoes", "map", []ast.NoxyType{tInt(), tString()})
+	if got != "colecoes::map<int,string>" {
+		t.Fatalf("instanceName = %q", got)
+	}
+}
+
+func TestSubstituteFunctionRewritesAllTypePositions(t *testing.T) {
+	prog := parse("func first<T>(arr: T[]) -> T\n    let tmp: T = arr[0]\n    return tmp\nend")
+	tpl := &FuncTemplate{Decl: prog.Statements[0].(*ast.FunctionStatement), Module: "main"}
+	inst := substituteFunction(tpl, map[string]ast.NoxyType{"T": tInt()}, "main::first<int>")
+	if inst.Name != "main::first<int>" || len(inst.TypeParams) != 0 {
+		t.Fatalf("instancia mal formada: %s %v", inst.Name, inst.TypeParams)
+	}
+	if inst.Parameters[0].Type.String() != "int[]" {
+		t.Fatalf("param = %s", inst.Parameters[0].Type.String())
+	}
+	if inst.ReturnType.String() != "int" {
+		t.Fatalf("retorno = %s", inst.ReturnType.String())
+	}
+	let := inst.Body.Statements[0].(*ast.LetStmt)
+	if let.Type.String() != "int" {
+		t.Fatalf("let interno = %s (anotacao do corpo nao substituida)", let.Type.String())
+	}
+	// original intacto (clone, nao mutacao)
+	if tpl.Decl.Parameters[0].Type.String() != "T[]" {
+		t.Fatal("template original foi mutado")
+	}
+}
+
+func TestSubstituteStructBothMirrors(t *testing.T) {
+	prog := parse("struct Node<T>\n    value: T,\n    next: ref Node<T>\nend")
+	tpl := &StructTemplate{Decl: prog.Statements[0].(*ast.StructStatement), Module: "main"}
+	inst := substituteStruct(tpl, map[string]ast.NoxyType{"T": tInt()}, "main::Node<int>")
+	if inst.FieldsList[0].Type.String() != "int" {
+		t.Fatalf("value = %s", inst.FieldsList[0].Type.String())
+	}
+	if inst.Fields["value"].String() != "int" {
+		t.Fatalf("espelho Fields nao substituido: %s", inst.Fields["value"].String())
+	}
+	// auto-referencia: ref Node<T> vira ref Node<int> (GenericType com arg concreto)
+	if inst.FieldsList[1].Type.String() != "ref Node<int>" {
+		t.Fatalf("next = %s", inst.FieldsList[1].Type.String())
+	}
+}
+```
+
+- [ ] **Step 2: FAIL**, **Step 3: implementar**, **Step 4: PASS** — `go test ./internal/compiler -run Substitute -count=1` e depois o pacote inteiro.
+- [ ] **Step 5: Commit** — `git commit -m "feat(compiler): substituicao de templates e nome qualificado de instancia"`
+
+---
+
+### Task 8: Compiler — two-pass + interceptação de chamada direta + memo + igualdade de bytecode
+
+**Files:**
+- Modify: `internal/compiler/compiler.go` (`Compile` entrada `*ast.Program`:~147; `compileCallExpression`:1745 — interceptação ANTES de `c.Compile(call.Function)`:~1850)
+- Modify: `internal/compiler/generics.go` (fila de instâncias)
+- Test: `internal/compiler/generics_twopass_test.go` + E2E em `internal/vm/generics_e2e_test.go` (novo)
+
+**Interfaces:**
+- Produces:
+  - No `Compiler`: `instances *instanceQueue` com `type instanceQueue struct { memo map[string]bool; ordered []ast.Statement }` (compartilhado entre pass 1 e pass 2 e entre compiladores filhos)
+  - `func (c *Compiler) ensureFunctionInstance(tpl *FuncTemplate, bindings map[string]ast.NoxyType, line int) (string, *ast.FunctionType, error)` — calcula nome via `instanceName`, memo-antes-de-clonar, substitui, registra tipo em `c.globals[nome]`, **compila o clone imediatamente em modo pass-1** (recursão da cascata, §4), enfileira em `ordered`, devolve nome + tipo com params/return substituídos
+  - Fluxo do `Compile(*ast.Program)`: se `c.hasGenerics(program)` (varredura por `TypeParams`/uso de registry não-vazio) → pass 1 num compilador descartável **compartilhando** `generics`, `instances`, `globals` (cópia), `structs` (cópia) e reescrevendo o AST compartilhado; depois `program.Statements = append(instances.ordered, program.Statements...)` e pass 2 no compilador real
+  - Interceptação em `compileCallExpression` (só em pass 1; flag `c.pass1 bool`): `call.Function` é `*ast.Identifier` cujo nome está em `c.registryOrInit().Funcs` → para cada argumento não-genérico, compilar num chunk descartável para obter o tipo, `unify(param, argType, b)`; argumentos-template entram pela Task 11; erro se sobrar param sem binding: `[line N] não foi possível inferir T em 'first' — anote o tipo`; sucesso → `ensureFunctionInstance` e **reescrever** `call.Function.(*ast.Identifier).Value = nomeQualificado`
+  - Em pass 2 nada dispara: nomes reescritos não estão no registry.
+- Consumes: Tasks 5–7.
+
+- [ ] **Step 1: E2E que falha** (`internal/vm/generics_e2e_test.go`)
+
+```go
+package vm
+
+import "testing"
+
+func TestGenericFunctionEndToEnd(t *testing.T) {
+	got := captureVMSource(t, `
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+let nums: int[] = [7, 8]
+test_report(first(nums))
+`)
+	expectInt(t, got, 7, "first<int> deve devolver 7")
+}
+
+func TestGenericTwoInstantiations(t *testing.T) {
+	got := captureVMSource(t, `
+func size<T>(arr: T[]) -> int
+    return length(arr)
+end
+let nums: int[] = [1, 2, 3]
+let names: string[] = ["a"]
+test_report(size(nums) + size(names))
+`)
+	expectInt(t, got, 4, "size<int> + size<string>")
+}
+
+func TestGenericRecursion(t *testing.T) {
+	got := captureVMSource(t, `
+func soma_rec<T>(arr: T[], i: int) -> int
+    if i >= length(arr) then
+        return 0
+    end
+    return 1 + soma_rec(arr, i + 1)
+end
+let xs: string[] = ["a", "b", "c"]
+test_report(soma_rec(xs, 0))
+`)
+	expectInt(t, got, 3, "recursao generica")
+}
+
+func TestGenericCallsGeneric(t *testing.T) {
+	got := captureVMSource(t, `
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+func head_twice<T>(a: T[], b: T[]) -> T
+    let x: T = first(a)
+    return first(b)
+end
+let xs: int[] = [1]
+let ys: int[] = [2]
+test_report(head_twice(xs, ys))
+`)
+	expectInt(t, got, 2, "cascata generico->generico")
+}
+```
+
+- [ ] **Step 2: Testes de compilador que falham** (`generics_twopass_test.go`)
+
+```go
+func TestMemoizationSingleInstance(t *testing.T) {
+	c := New()
+	code, _, err := c.Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nid(1)\nid(2)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, k := range code.Constants {
+		if k.Type == value.VAL_FUNCTION && k.Obj.(*value.ObjFunction).Name == "main::id<int>" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("main::id<int> aparece %d vezes nos constants, quer 1 (memo)", count)
+	}
+}
+
+// O teste mais forte da spec (§11): bytecode da instancia == bytecode da
+// versao escrita a mao (modulo nome). Prova executavel do custo-zero.
+func TestMonomorphizedBytecodeEqualsHandwritten(t *testing.T) {
+	generic := compiledFunction(t, "func first<T>(arr: T[]) -> T\n    return arr[0]\nend\nlet xs: int[] = [1]\nfirst(xs)", "main::first<int>")
+	hand := compiledFunction(t, "func first_int(arr: int[]) -> int\n    return arr[0]\nend\nlet xs: int[] = [1]\nfirst_int(xs)", "first_int")
+	if len(generic.Chunk.Code) != len(hand.Chunk.Code) {
+		t.Fatalf("tamanhos diferem: generico %d, a mao %d", len(generic.Chunk.Code), len(hand.Chunk.Code))
+	}
+	for i := range generic.Chunk.Code {
+		if generic.Chunk.Code[i] != hand.Chunk.Code[i] {
+			t.Fatalf("bytecode diverge no offset %d: %d vs %d", i, generic.Chunk.Code[i], hand.Chunk.Code[i])
+		}
+	}
+}
+
+func TestInferenceConflictError(t *testing.T) {
+	_, _, err := New().Compile(parse("func pick<T>(a: T, b: T) -> T\n    return a\nend\npick(1, \"x\")"))
+	if err == nil || !strings.Contains(err.Error(), "inferido como") {
+		t.Fatalf("esperava conflito T=int vs T=string, veio %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: FAIL nos dois arquivos.**
+- [ ] **Step 4: Implementar** conforme Interfaces. Pontos de atenção:
+  - Pass 1 usa `NewWithState` com **cópias** de globals/structs e os mesmos ponteiros `generics`/`instances`; `c.pass1 = true`; erros do pass 1 são reportados (não engolidos) — são os erros de inferência/corpo.
+  - Erros de corpo de instância ganham a cadeia: envolver o erro de `ensureFunctionInstance` com `fmt.Errorf("[line %d] em %s (instanciado na linha %d): %w", ...)` usando nome de exibição `base<args>` (sem qualificador — §9).
+  - Argumento compilado "num chunk descartável": trocar `c.currentChunk` por `chunk.New()` temporário, compilar, restaurar (padrão já usado em `tryCompileFusedCondition`/`TruncateTo` — ver compiler.go:2158).
+  - Hint do `let` para T só no retorno: no case `*ast.LetStmt`, se `n.Value` é `*ast.CallExpression` genérico, passar `n.Type` como alvo de retorno — unificar `ReturnType` do template contra `n.Type` **depois** dos argumentos.
+- [ ] **Step 5: PASS** — `go test ./internal/compiler ./internal/vm -run Generic -count=1`, depois `go test ./internal/... -count=1` inteiro.
+- [ ] **Step 6: Commit** — `git commit -m "feat(compiler): two-pass com monomorfizacao lazy, memo e reescrita de AST"`
+
+---
+
+### Task 9: Compiler — structs genéricos por anotação de tipo (terceira família de hooks)
+
+**Files:**
+- Modify: `internal/compiler/compiler.go` (novo helper `resolveAnnotation`; chamado nos pontos que recebem `ast.NoxyType` de anotação: case `*ast.LetStmt`:~183 (`n.Type`), `compileFunction`:2527 (params e retorno de função **não**-genérica), case `*ast.StructStatement` (campos de struct não-genérico), `emitDefaultInit`:2331)
+- Modify: `internal/compiler/generics.go` (`ensureStructInstance`)
+- Test: `internal/compiler/generics_struct_test.go` + ampliar `internal/vm/generics_e2e_test.go`
+
+**Interfaces:**
+- Produces:
+  - `func (c *Compiler) resolveAnnotation(t ast.NoxyType, line int) (ast.NoxyType, error)` — percorre o tipo; cada `GenericType` encontrado: valida aridade contra o template (`[line N] 'Stack' espera 1 argumento de tipo, recebeu 2`), resolve args recursivamente, chama `ensureStructInstance`, e devolve `&ast.PrimitiveType{Name: nomeQualificado}` no lugar (composições `Stack<int>[]`, `ref Node<int>`, `map[string, Stack<int>]` preservam a estrutura externa); `TypeParamType` fora de template → erro `[line N] tipo 'T' não declarado`; `GenericType` cujo Name não é template → erro
+  - `func (c *Compiler) ensureStructInstance(tpl *StructTemplate, args []ast.NoxyType, line int) (string, error)` — memo-antes-de-clonar (auto-referência `ref Node<int>` no corpo encontra o memo e para), `substituteStruct`, **resolve as anotações dos campos da instância** (cascata `Stack<Stack<int>>`), registra em `c.structs[nome]`, enfileira em `instances.ordered` **antes** das funções pendentes que a referenciam (a fila é ordenada por criação; structs criados durante resolução entram naturalmente antes)
+- Consumes: Tasks 5, 7, 8.
+
+- [ ] **Step 1: E2E que falha**
+
+```go
+func TestGenericStructConstructorAndAccess(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let c: Caixa<int> = Caixa(41)
+c.valor = c.valor + 1
+test_report(c.valor)
+`)
+	expectInt(t, got, 42, "Caixa<int> construida e mutada")
+}
+
+func TestGenericStructAnnotationOnlyPositions(t *testing.T) {
+	// §11: instanciacao por anotacao pura — sem call site de construtor
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let vazias: Caixa<int>[] = []
+let semInit: Caixa<int>
+func conta(cs: Caixa<int>[]) -> int
+    return length(cs)
+end
+test_report(conta(vazias))
+`)
+	expectInt(t, got, 0, "anotacoes puras instanciam o struct")
+}
+
+func TestGenericStructSelfReference(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node<T>
+    value: T,
+    next: ref Node<T>
+end
+let n2: Node<int> = Node(2, null)
+let n1: Node<int> = Node(1, ref n2)
+test_report(n1.next.value)
+`)
+	expectInt(t, got, 2, "lista ligada generica")
+}
+
+func TestNestedGenericStruct(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let dupla: Caixa<Caixa<int>> = Caixa(Caixa(9))
+test_report(dupla.valor.valor)
+`)
+	expectInt(t, got, 9, "Caixa<Caixa<int>>")
+}
+```
+
+- [ ] **Step 2: Teste de compilador que falha** — aridade errada:
+
+```go
+func TestGenericStructArityError(t *testing.T) {
+	_, _, err := New().Compile(parse("struct Caixa<T>\n    valor: T\nend\nlet c: Caixa<int, string> = null"))
+	if err == nil || !strings.Contains(err.Error(), "espera 1 argumento de tipo, recebeu 2") {
+		t.Fatalf("esperava erro de aridade, veio %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: FAIL**, **Step 4: implementar** conforme Interfaces. O construtor `Caixa(41)`: em `compileCallExpression`, interceptar também identificadores em `c.registryOrInit().Structs` — inferir bindings unificando tipos dos campos contra tipos dos argumentos (posicionais), com fallback para o hint do `let` (mesmo mecanismo da Task 8); reescrever para o nome qualificado. **Step 5: PASS geral.**
+- [ ] **Step 6: Commit** — `git commit -m "feat(compiler): structs genericos com instanciacao por anotacao e construtor"`
+
+---
+
+### Task 10: Target-typing — genérica como valor em toda posição com alvo concreto
+
+**Files:**
+- Modify: `internal/compiler/compiler.go` (cases `*ast.LetStmt`, `*ast.ReturnStmt`, `*ast.ArrayLiteral`, atribuição de campo em `*ast.AssignStmt`, e argumentos em `compileCallExpression`)
+- Modify: `internal/compiler/generics.go` (`func (c *Compiler) instantiateForTarget(name string, target ast.NoxyType, line int) (string, error)`)
+- Test: `internal/compiler/generics_target_test.go` + ampliar `internal/vm/generics_e2e_test.go`
+
+**Interfaces:**
+- Produces: quando um `*ast.Identifier` em posição de **valor** nomeia um template de função e existe tipo alvo `*ast.FunctionType` concreto: `unify` da assinatura do template contra o alvo → `ensureFunctionInstance` → reescrever o identificador. Posições e fonte do alvo (§3, verbatim): `let` anotado (`n.Type`); `return` (tipo de retorno declarado da função corrente `c.funcReturnType`); elemento de array (tipo do elemento da anotação); atribuição a campo (tipo declarado do campo); argumento de chamada cujo parâmetro esperado é `FunctionType` (com **unificação bidirecional**: parâmetros de tipo do caller resolvidos pelos argumentos não-genéricos primeiro; o esperado parcialmente concreto unifica contra a assinatura do template do argumento, bindings propagando nos dois sentidos). Sem alvo concreto (`func` nu / `any`) → erro `[line N] função genérica 'map' precisa de tipo concreto — anote a assinatura completa ou chame diretamente`.
+- Consumes: Tasks 6–8.
+
+- [ ] **Step 1: E2E que falha**
+
+```go
+func TestTargetTypingLetAnnotation(t *testing.T) {
+	got := captureVMSource(t, `
+func identity<T>(x: T) -> T
+    return x
+end
+let f: func(int) -> int = identity
+test_report(f(5))
+`)
+	expectInt(t, got, 5, "identity instanciada por anotacao de let")
+}
+
+func TestTargetTypingBidirectionalArgument(t *testing.T) {
+	// §3: map(nums, identity) — A=int ancora; func(int)->B unifica contra
+	// func(T)->T do identity, propagando T=int => B=int
+	got := captureVMSource(t, `
+func identity<T>(x: T) -> T
+    return x
+end
+func aplica<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+let nums: int[] = [1, 2, 3]
+let mesmos: int[] = aplica(nums, identity)
+test_report(mesmos[2])
+`)
+	expectInt(t, got, 3, "unificacao bidirecional")
+}
+
+func TestTargetTypingArrayElementAndReturn(t *testing.T) {
+	got := captureVMSource(t, `
+func dobro(x: int) -> int
+    return x * 2
+end
+func identity<T>(x: T) -> T
+    return x
+end
+func escolhe() -> func(int) -> int
+    return identity
+end
+let fs: func(int) -> int[] = [dobro, identity]
+let g: func(int) -> int = escolhe()
+test_report(fs[1](10) + g(1))
+`)
+	expectInt(t, got, 11, "array de funcoes e return position")
+}
+```
+
+Nota sobre a sintaxe do tipo de array de função: conferir precedência real em `parseType` (`func(int) -> int[]` pode parsear como retorno `int[]`) — usar parênteses como o codebase faz (`(func(int) -> int)[]`, ver `ArrayType.String()` em ast.go:56) e ajustar o teste.
+
+- [ ] **Step 2: Negativos que falham** (`generics_target_test.go`)
+
+```go
+func TestGenericWithoutConcreteTargetIsError(t *testing.T) {
+	for _, src := range []string{
+		"func id<T>(x: T) -> T\n    return x\nend\nlet g: func = id",
+		"func id<T>(x: T) -> T\n    return x\nend\nlet h: any = id",
+	} {
+		_, _, err := New().Compile(parse(src))
+		if err == nil || !strings.Contains(err.Error(), "precisa de tipo concreto") {
+			t.Fatalf("fonte %q: esperava erro de alvo, veio %v", src, err)
+		}
+	}
+}
+
+func TestUnanchoredGenericChainIsError(t *testing.T) {
+	src := `func id<T>(x: T) -> T
+    return x
+end
+func compose<A, B, C>(f: func(A) -> B, g: func(B) -> C) -> int
+    return 0
+end
+compose(id, id)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil || !strings.Contains(err.Error(), "anote o tipo") {
+		t.Fatalf("corrente sem ancora deve pedir anotacao, veio %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: FAIL**, **Step 4: implementar**, **Step 5: PASS geral**, **Step 6: Commit** — `git commit -m "feat(compiler): target-typing de funcoes genericas em posicoes de valor"`
+
+---
+
+### Task 11: Erros com cadeia de instanciação + catálogo negativo restante
+
+**Files:**
+- Modify: `internal/compiler/generics.go` (wrap de erros de corpo)
+- Test: `internal/compiler/generics_errors_test.go`
+
+**Interfaces:**
+- Produces: todo erro vindo da compilação do corpo de uma instância é envolvido com `em <exibição> (instanciado na linha <N>)`. Cobertura test-por-linha do catálogo §9 que ainda não tem teste nas tasks anteriores.
+- Consumes: Tasks 8–10.
+
+- [ ] **Step 1: Testes que falham**
+
+```go
+func TestBodyErrorCarriesInstantiationChain(t *testing.T) {
+	src := `struct Ponto
+    x: int
+end
+func soma<T>(a: T, b: T) -> T
+    return a + b
+end
+let p1: Ponto = Ponto(1)
+let p2: Ponto = Ponto(2)
+soma(p1, p2)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("soma<Ponto> com + deve falhar")
+	}
+	for _, want := range []string{"soma<Ponto>", "instanciado na linha"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro sem %q: %v", want, err)
+		}
+	}
+}
+
+func TestNullOnlyInferenceError(t *testing.T) {
+	_, _, err := New().Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nid(null)"))
+	if err == nil || !strings.Contains(err.Error(), "não foi possível inferir T") {
+		t.Fatalf("esperava erro de inferencia com null, veio %v", err)
+	}
+}
+
+func TestTypeParamOutOfScopeError(t *testing.T) {
+	_, _, err := New().Compile(parse("let x: T = 1"))
+	if err == nil || !strings.Contains(err.Error(), "não declarado") {
+		t.Fatalf("esperava erro de tipo nao declarado, veio %v", err)
+	}
+}
+
+func TestStackAnyIsLegal(t *testing.T) {
+	// §7: any e legal como argumento de tipo explicito
+	_, _, err := New().Compile(parse("struct Caixa<T>\n    valor: T\nend\nlet c: Caixa<any> = Caixa(1)"))
+	if err != nil {
+		t.Fatalf("Caixa<any> deve compilar: %v", err)
+	}
+}
+
+func TestRefBindingError(t *testing.T) {
+	src := `func id<T>(x: T) -> T
+    return x
+end
+func pega(r: ref int) -> int
+    let v: int = id(r)
+    return v
+end
+let n: int = 1
+pega(ref n)`
+	// argumento ref auto-dereferencia em chamada por valor; forcar o caso T=ref
+	// via anotacao explicita:
+	_, _, err := New().Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nlet r: ref int = null\nlet v: ref int = id(r)"))
+	_ = src
+	if err == nil || !strings.Contains(err.Error(), "não pode ser um tipo ref") {
+		t.Fatalf("T=ref deve ser erro de unificacao, veio %v", err)
+	}
+}
+```
+
+(Se o auto-deref do compilador impedir `T=ref` de sequer chegar ao unify, o teste vira prova disso: ajustar para asserção de que o programa compila com `T=int` — decidir pelo comportamento real e deixar o comentário explicando; o requisito da spec é que `T=ref` **nunca** aconteça silenciosamente.)
+
+- [ ] **Step 2: FAIL**, **Step 3: implementar wraps/mensagens**, **Step 4: PASS**, **Step 5: Commit** — `git commit -m "feat(compiler): cadeia de instanciacao e catalogo de erros de genericos"`
+
+---
+
+### Task 12: Cross-módulo — templates importados, predeclare tipado, validações
+
+**Files:**
+- Modify: `internal/compiler/module_exports.go` (predeclare de imports: registrar tipos declarados em vez de `nil` — pontos onde hoje há `c.globals[...] = nil` (~linhas 158–171); registrar templates importados; validator pula templates — já coberto pela Task 5, adicionar teste)
+- Modify: `internal/compiler/compiler.go` (case `*ast.UseStmt`:1556 — mesmos registros no caminho de compilação; member access `m.template` → erro)
+- Modify: `internal/compiler/generics.go` (validação de escopo de definição §8: resolubilidade + identidade de tipo)
+- Test: `internal/compiler/generics_modules_test.go` + `internal/vm/generics_modules_e2e_test.go`
+
+**Interfaces:**
+- Produces:
+  - `func moduleQualifier(module string) string` — nome do módulo para `instanceName` (ex.: `colecoes`)
+  - Registro de templates importados no registry do importador com `Module` = módulo definidor
+  - Predeclare tipado: `c.globals[nome] = tipoDeclarado` extraído do AST do módulo (assinatura de função via `newFunctionType`; `LetStmt.Type`; structs via `importModuleStructs` já existente)
+  - Validação na instanciação de template importado (§8, duas partes): (a) cada identificador livre do corpo resolve no top-level do módulo definidor (usar o AST de `loadModuleDeclarations`; builtins e templates contam) — senão `'processa<Ponto>' referencia 'validar', não declarado no módulo 'colecoes'`; (b) para cada dependência, o tipo declarado visível no importador é idêntico (`String()`) ao declarado no módulo definidor — senão `'ajuda' tem tipo X no importador e Y em 'colecoes' — conflito de shadowing`; dependência ausente no importador → `'processa<Ponto>' precisa de 'ajuda' de 'colecoes' — adicione ao select ou use select *`
+  - `m.template(...)` via namespace → `[line N] template genérico 'processa' não é acessível via namespace — use select`
+- Consumes: Tasks 5–10.
+
+- [ ] **Step 1: E2E de módulos que falham** (padrão `t.TempDir()` + `os.WriteFile` de `internal/vm/module_exports_test.go:21`; conferir como aquele teste configura `RootPath` do VM e copiar o setup)
+
+```go
+func TestGenericCrossModuleSelectStar(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func primeiro<T>(arr: T[]) -> T
+    return arr[0]
+end
+`)
+	got := captureVMSourceAtRoot(t, root, `
+use colecoes select *
+let nums: int[] = [42]
+test_report(primeiro(nums))
+`)
+	expectInt(t, got, 42, "template importado por select *")
+}
+
+func TestGenericCrossModuleSelectiveWithDependency(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func ajuda(x: int) -> int
+    return x + 1
+end
+func processa<T>(arr: T[]) -> int
+    return ajuda(length(arr))
+end
+`)
+	// sem a dependencia: erro acionavel
+	err := compileErrAtRoot(t, root, "use colecoes select processa\nlet ns: int[] = [1]\nprocessa(ns)")
+	if err == nil || !strings.Contains(err.Error(), "adicione ao select") {
+		t.Fatalf("esperava erro de dependencia, veio %v", err)
+	}
+	// com a dependencia: funciona
+	got := captureVMSourceAtRoot(t, root, `
+use colecoes select processa, ajuda
+let ns: int[] = [1, 2]
+test_report(processa(ns))
+`)
+	expectInt(t, got, 3, "dependencia importada junto")
+}
+
+func TestGenericTemplateViaNamespaceIsError(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", "func primeiro<T>(arr: T[]) -> T\n    return arr[0]\nend\n")
+	err := compileErrAtRoot(t, root, "use colecoes\nlet ns: int[] = [1]\ncolecoes.primeiro(ns)")
+	if err == nil || !strings.Contains(err.Error(), "não é acessível via namespace") {
+		t.Fatalf("esperava erro de namespace, veio %v", err)
+	}
+}
+
+func TestImportedDataInference(t *testing.T) {
+	// §8: predeclare tipado — inferir T a partir de um global importado
+	root := t.TempDir()
+	write(t, root, "dados.nx", "let numeros: int[] = [5, 6]\n")
+	got := captureVMSourceAtRoot(t, root, `
+use dados select numeros
+func primeiro<T>(arr: T[]) -> T
+    return arr[0]
+end
+test_report(primeiro(numeros))
+`)
+	expectInt(t, got, 5, "inferencia sobre dado importado tipado")
+}
+
+func TestModuleUsingOwnTemplatesInternally(t *testing.T) {
+	// §5: compileAndRunModule tambem precisa do two-pass
+	root := t.TempDir()
+	write(t, root, "interno.nx", `
+func id<T>(x: T) -> T
+    return x
+end
+let resultado: int = id(11)
+`)
+	got := captureVMSourceAtRoot(t, root, "use interno select resultado\ntest_report(resultado)")
+	expectInt(t, got, 11, "modulo monomorfiza os proprios templates")
+}
+
+func TestHomonymousTemplatesDedupIsSafe(t *testing.T) {
+	// §8: dois modulos com templates homonimos + select * — nomes
+	// qualificados nunca colidem entre templates diferentes
+	root := t.TempDir()
+	write(t, root, "a.nx", "func marca<T>(x: T) -> int\n    return 1\nend\n")
+	write(t, root, "b.nx", "func marca<T>(x: T) -> int\n    return 2\nend\n")
+	err := compileErrAtRoot(t, root, "use a select *\nuse b select *\nmarca(0)")
+	// dois templates homonimos visiveis: ultima importacao vence a resolucao
+	// de NOME (comportamento atual de select *); as INSTANCIAS nao colidem.
+	// Asserção minima: compila sem colisao silenciosa OU erro claro de
+	// ambiguidade — nunca chamar o codigo errado. Verificar comportamento e
+	// fixar aqui com o resultado real + comentario.
+	_ = err
+}
+```
+
+Helpers `write`, `captureVMSourceAtRoot`, `compileErrAtRoot`: criar no arquivo E2E copiando o setup de VM com root de `module_exports_test.go` (RootPath do config + `interpretVMSource`).
+
+- [ ] **Step 2: teste do validator** (`generics_modules_test.go`): módulo contendo só um template deve continuar "loadable" — usar `discoverModuleExports` num compiler com `moduleRoot` apontando para TempDir e verificar `ok == true` e o export presente.
+- [ ] **Step 3: FAIL**, **Step 4: implementar**, **Step 5: PASS geral** — atenção especial: `go test ./internal/vm -count=1` inteiro (módulos são sensíveis).
+- [ ] **Step 6: Commit** — `git commit -m "feat(compiler): genericos cross-modulo com predeclare tipado e validacao de escopo"`
+
+---
+
+### Task 13: Gate de regressão do corpus (imports tipados)
+
+**Files:**
+- Test: rodar corpus; corrigir exemplos/`predeclare` conforme necessário
+- Modify (se o corpus acusar): exemplos `.nx` em `noxy_examples/` com erros de tipo latentes
+
+**Interfaces:** nenhum código novo — gate §8/§11.
+
+- [ ] **Step 1: Build** — `go build -o noxy_dev.exe ./cmd/noxy`
+- [ ] **Step 2: Rodar o corpus** — `./noxy_dev.exe noxy_examples/run_all_tests_concurrent.nx`; esperado 164/164 (número atual — conferir no output).
+- [ ] **Step 3: Triagem** — cada falha nova é (a) erro de tipo latente no exemplo → corrigir o exemplo, documentar no commit; ou (b) regressão do predeclare tipado → corrigir o compilador. Zero falhas restantes.
+- [ ] **Step 4: Rodar suite Go inteira** — `go test ./... -count=1` verde; `go test ./internal/vm -race -count=1` verde.
+- [ ] **Step 5: Commit** — `git commit -m "test(corpus): gate de regressao com imports tipados"`
+
+---
+
+### Task 14: REPL — persistência de templates e structs entre linhas
+
+**Files:**
+- Modify: `cmd/noxy/main.go` (loop do REPL ~linha 232: `make(map[string]*ast.StructStatement)` por linha → mapa persistente; `SetGenericState` com registry persistente)
+- Test: `cmd/noxy/repl_generics_test.go` (novo; se `cmd/noxy` não tiver testes hoje, criar — testar a função de avaliação de linha se existir, senão extrair o miolo compile-line para função testável `compileREPLLine(globals, structs, reg, src)`)
+
+**Interfaces:**
+- Consumes: `GenericRegistry`, `SetGenericState` (Task 5).
+- Produces: três estados persistentes por sessão: `replGlobals` (existente), `replStructs` (novo — conserta bug pré-existente de structs comuns no REPL, §5), `replGenerics` (novo).
+
+- [ ] **Step 1: Teste que falha** — sequência de 3 "linhas" compiladas com estado compartilhado:
+
+```go
+func TestREPLPersistsGenericsAcrossLines(t *testing.T) {
+	globals := make(map[string]ast.NoxyType)
+	structs := make(map[string]*ast.StructStatement)
+	reg := compiler.NewGenericRegistry()
+	lines := []string{
+		"struct Caixa<T>\n    valor: T\nend",
+		"let c: Caixa<int> = Caixa(7)",
+		"c.valor",
+	}
+	for i, line := range lines {
+		c := compiler.NewWithState(globals, structs, "REPL")
+		c.SetGenericState(reg)
+		if _, _, err := c.Compile(parse(line)); err != nil {
+			t.Fatalf("linha %d (%q): %v", i+1, line, err)
+		}
+		globals = c.GetGlobals()
+	}
+}
+```
+
+(Colocar em `internal/compiler/generics_repl_test.go` — testa o contrato do compilador que o REPL usa; a mudança em `main.go` é espelho direto.)
+
+- [ ] **Step 2: FAIL** (linha 2 não acha o template — registry novo por linha no estado atual), **Step 3: implementar** (persistência em main.go + qualquer ajuste no compilador para `c.structs` compartilhado reter instâncias), **Step 4: PASS + smoke manual**: `./noxy_dev.exe` interativo, digitar as 3 linhas, sair com `exit` (lembrar: REPL no Windows — não deixar console em raw mode).
+- [ ] **Step 5: Commit** — `git commit -m "feat(repl): templates e structs persistem entre linhas"`
+
+---
+
+### Task 15: Interações de runtime E2E (lambda, spawn, defer, when, JSON, f-string, CoW)
+
+**Files:**
+- Test: `internal/vm/generics_interactions_test.go` (novo)
+
+**Interfaces:** nenhuma API nova — prova de que instâncias são código comum (§10/§11). Se algum teste falhar, o fix pertence às tasks anteriores (voltar, corrigir, manter o teste).
+
+- [ ] **Step 1: Escrever os testes** (todos `captureVMSource`; sintaxe de spawn/defer/when/f-string: conferir exemplos reais em `noxy_examples/` e `internal/vm/builtins_tasks_test.go` / `defer_test.go` antes de escrever, e usar a sintaxe canônica de lá):
+
+```go
+func TestLambdaInsideGenericBody(t *testing.T) {
+	got := captureVMSource(t, `
+func aplica_dobro<T>(x: T, f: func(T) -> T) -> T
+    return f(x)
+end
+let quadruplo: int = aplica_dobro(2, func(n: int) -> int
+    return n * 4
+end)
+test_report(quadruplo)
+`)
+	expectInt(t, got, 8, "lambda como argumento de generica")
+}
+
+func TestDeferWithInstantiatedGeneric(t *testing.T) { /* defer chamando instancia; conferir sintaxe em defer_test.go */ }
+func TestSpawnWithInstantiatedGeneric(t *testing.T) { /* spawn/task com instancia; conferir builtins_tasks_test.go */ }
+func TestWhenOverGenericStruct(t *testing.T)       { /* when/case sobre campo de Caixa<int>; sintaxe do spec §6 */ }
+func TestJSONAndFStringWithGenericStruct(t *testing.T) { /* f"{c.valor}" e json de Caixa<int>; conferir builtins_json_test.go */ }
+
+func TestCoWValueSemanticsWithGenericStruct(t *testing.T) {
+	// §13: semantica de valor vale para structs genericos
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let a: Caixa<int> = Caixa(1)
+let b: Caixa<int> = a
+b.valor = 99
+test_report(a.valor)
+`)
+	expectInt(t, got, 1, "atribuicao de struct generico e copia (CoW)")
+}
+```
+
+- [ ] **Step 2: Rodar** — falhas aqui são bugs das tasks anteriores; corrigir lá e re-rodar até verde. **Step 3: PASS geral + `-race`** — `go test ./internal/vm -race -count=1`.
+- [ ] **Step 4: Commit** — `git commit -m "test(vm): interacoes de genericos com lambda, defer, spawn, when, json e cow"`
+
+---
+
+### Task 16: Benchmarks com gate
+
+**Files:**
+- Create: `benchmarks/bench_generic_vs_hand.nx`, `benchmarks/startup_generics.nx`
+- Modify: `benchmarks/RESULTS.md` (nova seção, protocolo padrão)
+
+**Interfaces:** gates §11: `generic_vs_hand` razão ≤ 1.05x (folga de ruído sobre o 1.0x — a prova dura é o teste de bytecode da Task 8); `startup_generics` sem regressão material do startup (comparar com o startup base no mesmo protocolo).
+
+- [ ] **Step 1: Escrever `bench_generic_vs_hand.nx`** — mesmo laço quente duas vezes (mesmo protocolo dos benches existentes; copiar o esqueleto de medição de `benchmarks/bench_bubblesort.nx`):
+
+```noxy
+// bench_generic_vs_hand: laco quente identico via funcao generica e via
+// funcao especializada a mao. Gate: razao <= 1.05 (spec §11).
+func soma_gen<T>(arr: T[], n: int) -> int
+    let acc: int = 0
+    let i: int = 0
+    while i < n do
+        acc = acc + length(arr)
+        i = i + 1
+    end
+    return acc
+end
+func soma_hand(arr: int[], n: int) -> int
+    let acc: int = 0
+    let i: int = 0
+    while i < n do
+        acc = acc + length(arr)
+        i = i + 1
+    end
+    return acc
+end
+// medicao: usar o mesmo padrao de tempo dos benches existentes
+```
+
+- [ ] **Step 2: `startup_generics.nx`** — programa pequeno com 1 template + 2 instâncias + print, para medir startup end-to-end (mesmo formato do bench de startup do cross_runtime).
+- [ ] **Step 3: Rodar pelo protocolo** — `benchmarks/run_benchmarks.ps1` / `interleaved_compare.ps1` (binário `develop` × `feat/generics`), mediana, intercalado.
+- [ ] **Step 4: Registrar em RESULTS.md** — seção nova no topo, com veredito ✅/❌ por gate como o arquivo faz. Gate estourado = investigar antes de prosseguir (não esconder ❌).
+- [ ] **Step 5: Commit** — `git commit -m "bench: gates generic_vs_hand e startup_generics"`
+
+---
+
+### Task 17: Dogfood `collections` + exemplos no corpus
+
+**Files:**
+- Create: `noxy_examples/test_generics_basics.nx`, `noxy_examples/test_generics_collections.nx`, `noxy_examples/collections.nx` (módulo)
+- Modify: incluir os novos nos moldes do runner (`run_all_tests_concurrent.nx` descobre `.nx` do diretório — conferir o mecanismo de descoberta/exclusão e seguir)
+
+**Interfaces:** prova §11 (dogfood): o módulo que era impossível escrever.
+
+- [ ] **Step 1: `collections.nx`**
+
+```noxy
+// collections: o modulo que a assimetria com builtins impedia de existir.
+func map<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+
+func filter<T>(arr: T[], keep: func(T) -> bool) -> T[]
+    let out: T[] = []
+    for item in arr do
+        if keep(item) then
+            append(out, item)
+        end
+    end
+    return out
+end
+
+func reduce<T, R>(arr: T[], init: R, fn: func(R, T) -> R) -> R
+    let acc: R = init
+    for item in arr do
+        acc = fn(acc, item)
+    end
+    return acc
+end
+
+func contains_val<T>(arr: T[], alvo: T) -> bool
+    for item in arr do
+        if item == alvo then
+            return true
+        end
+    end
+    return false
+end
+```
+
+- [ ] **Step 2: `test_generics_collections.nx`** — usa `use collections select *`, exercita os 4 com int e string, imprime resultados esperados no padrão dos exemplos existentes (olhar 2–3 `test_*.nx` para o padrão de asserção do corpus e seguir).
+- [ ] **Step 3: `test_generics_basics.nx`** — Stack<T> com push/pop via funções (`func push<T>(s: ref Stack<T>, item: T)`), Node<T> lista ligada, Caixa<Caixa<int>>.
+- [ ] **Step 4: Rodar o corpus completo** — `./noxy_dev.exe noxy_examples/run_all_tests_concurrent.nx` → N/N (164 + novos).
+- [ ] **Step 5: Commit** — `git commit -m "feat(stdlib): modulo collections generico + exemplos no corpus"`
+
+---
+
+### Task 18: Documentação e release 0.7.0
+
+**Files:**
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md` (nova seção "Generics" após §5 Structs: sintaxe, inferência, target-typing, regras cross-módulo em linguagem de usuário, limitações v1 — traduzir §2/§3/§8 da spec de design para documentação de usuário com os exemplos do plano)
+- Modify: `CHANGELOG.md` (0.7.0: feature, a nota sobre imports tipados poderem revelar erros latentes + migração, vazamento cosmético do nome qualificado em `print`)
+- Modify: `README.md` (mencionar genéricos na lista de features, 1–2 linhas + exemplo curto)
+
+- [ ] **Step 1: Escrever docs** (seguir tom/formatação das seções vizinhas; exemplos copiados dos testes E2E — código já provado).
+- [ ] **Step 2: Verificação final completa** — `go vet ./...` limpo; `go test ./... -count=1` verde; `go test ./internal/vm -race -count=1` verde; corpus N/N; benches registrados.
+- [ ] **Step 3: Commit** — `git commit -m "docs: genericos na spec de linguagem, changelog 0.7.0 e readme"`
+- [ ] **Step 4:** Abrir PR de `feat/generics` → `develop` (usar a skill `open-pr` do projeto; body no template Summary/Components/Test Plan).
+
+---
+
+## Self-review do plano (executado na escrita)
+
+- **Cobertura da spec:** §2 sintaxe → Tasks 3–4; §2.3 regras → Tasks 5 (top-level), 8 (nominal/memo), 10 (target), 11 (erros); §3 → Task 10; §4 → Tasks 7–8; §5 two-pass/todos os caminhos → Tasks 8 (principal), 12 (validator + módulo runtime), 14 (REPL); §6 → Tasks 1–4; §7 → Task 6 (+null/any/ref); §8 → Tasks 12–13; §9 → Tasks 8–12 (mensagens) + 11 (cadeia/negativo); §10 → Task 15 + constraint global "não editar internal/vm"; §11 → Tasks 8 (bytecode), 13 (corpus), 15 (interações), 16 (benches), 17 (dogfood); §12/§13 → fora de escopo respeitado.
+- **Placeholders:** nenhum "TBD"; onde o plano manda "conferir sintaxe em X antes de escrever", isso é instrução executável com fonte apontada, não lacuna.
+- **Consistência de tipos:** nomes usados entre tasks conferidos — `GenericRegistry/FuncTemplate/StructTemplate/instanceName/unify/substituteFunction/substituteStruct/ensureFunctionInstance/ensureStructInstance/resolveAnnotation/SetGenericState/registryOrInit` definidos uma vez e consumidos com a mesma grafia.

--- a/docs/superpowers/specs/2026-08-18-generics-design.md
+++ b/docs/superpowers/specs/2026-08-18-generics-design.md
@@ -1,0 +1,334 @@
+# Genéricos por Monomorfização
+
+**Data:** 2026-08-18 · **Branch:** `feat/generics` (base: `develop` @ ebf0067, v0.6.0)
+**Status:** aprovado em discussão; spec formal para implementação
+**Release alvo:** 0.7.0 (aditivo — nenhuma quebra de código existente)
+
+## 1. Objetivo
+
+Eliminar a assimetria entre builtins e código de usuário: hoje `append`, `length` e
+`contains` funcionam para qualquer array porque o compilador os conhece; código de
+usuário não consegue escrever essa abstração e cai em `any`, sem checagem estática.
+
+Entregar **funções e structs genéricos** com **custo zero em runtime**: o bytecode de
+uma instância monomorfizada é idêntico ao de código especializado escrito à mão —
+opcodes tipados (`OP_ADD_INT` etc.) continuam disparando dentro de código genérico.
+Nenhuma mudança na VM.
+
+## 2. Contrato de linguagem (visível ao usuário)
+
+### 2.1 Sintaxe
+
+Parâmetros de tipo entre `<>` após o nome da declaração, utilizáveis em qualquer
+posição de tipo (parâmetros, retorno, campos, corpo):
+
+```noxy
+func map<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+
+struct Stack<T>
+    items: T[]
+end
+
+struct Node<T>
+    value: T,
+    next: ref Node<T>      // auto-referência funciona
+end
+```
+
+Tipos genéricos aparecem **somente em posição de tipo** (anotações, campos,
+retorno): `Stack<int>`, `Node<string>`, `Stack<Stack<int>>`. Não existe
+instanciação explícita em posição de expressão (`first<int>(x)` não existe) —
+zero ambiguidade com os operadores `<` / `>`.
+
+### 2.2 Uso — sempre por inferência
+
+```noxy
+map(nums, dobra)               // A, B unificados dos argumentos
+let s: Stack<int> = Stack([])  // T dos argumentos; indeterminado (array vazio)
+                               // → resolvido pela anotação do let (target-typing)
+```
+
+Viável porque todo `let` em Noxy exige anotação de tipo — a linguagem já obriga o
+usuário a escrever a informação de que a instanciação precisa.
+
+### 2.3 Regras semânticas
+
+1. **Monomorfização nominal**: cada instanciação é um tipo/função distinto em
+   compile e runtime. `Stack<int>` e `Stack<string>` são structs nominais
+   diferentes (a validação de tipos CoW os distingue sem mudança alguma).
+2. **Genéricos só no top level** — sem `func`/`struct` genérico aninhado dentro de
+   função.
+3. **Funções genéricas como valores via target-typing** (ver §3): uma genérica
+   instancia em qualquer posição de valor cujo tipo alvo seja um tipo de função
+   concreto. Sem alvo concreto (`func` nu, `any`, corrente sem âncora) → erro de
+   compilação claro.
+4. **Sem constraints na v1**: `T` é irrestrito. Operações no corpo são checadas
+   **por instanciação** — `soma<T>` com `+` no corpo compila para `soma<int>` e
+   falha para `soma<Ponto>` com erro apontando o call site que instanciou
+   (estilo template C++, com mensagem legível — ver §9).
+5. **Inferência impossível é erro**, nunca fallback silencioso para `any`:
+   conflito (`T=int` vs `T=string`) ou indeterminação sem anotação produzem erro
+   com sugestão de anotar.
+
+## 3. Funções genéricas como valores (target-typing)
+
+Princípio: **toda função que existe em runtime é objeto de primeira classe, sem
+exceção.** O que não é valor é o *template* — entidade de compile-time que nunca
+existe em runtime (mesma linha de Go/Rust/C++). A instanciação acontece no ponto
+em que a genérica vira valor, guiada pelo tipo alvo:
+
+```noxy
+let f: func(int) -> int = identity     // let anotado → identity<int>, closure comum
+map(nums, identity)                     // param esperado func(A)->B com A,B já
+                                        // ancorados por nums → identity<int>
+let fs: func(int) -> int[] = [dobra, identity]  // elemento de array tipado
+campo.transform = identity              // campo de struct → tipo do campo é o alvo
+return identity                         // retorno declarado é o alvo
+```
+
+**Ordem de resolução no caso argumento-de-chamada-genérica**: resolve os
+parâmetros de tipo pelos argumentos não-genéricos primeiro; se o tipo esperado do
+argumento-função ficou totalmente concreto, instancia; senão, erro pedindo
+anotação.
+
+**Posições onde genérica não pode virar valor** (erro de compilação, mensagem em
+§9): anotação `func` nua, `any`, e corrente de genéricos sem âncora
+(`compose(identity, identity)` sem nada que fixe o tipo do meio). São exatamente
+as posições onde funções normais já perdem checagem estática hoje — a regra é
+uma só: onde o compilador sabe o tipo, genérica é valor comum; onde não sabe,
+ela não pode nascer.
+
+Depois de instanciada, a função circula livremente (arrays, campos, `defer`,
+tasks) — é um closure indistinguível de função escrita à mão.
+
+## 4. Estratégia: monomorfização lazy por substituição de AST
+
+Decisões (com alternativas descartadas):
+
+- **Monomorfização** (não erasure): erasure faria todo código genérico cair no
+  caminho lento da VM — na contramão do gargalo de performance já identificado
+  no cross-runtime. Monomorfização entrega bytecode idêntico ao especializado.
+- **Substituição de AST na frente do compilador** (não type-environment no core):
+  o core de 2600 linhas fica intocado; a maquinaria vive em arquivos novos.
+- **Lazy, dirigida por call sites, memoizada**: templates não geram código;
+  instâncias nascem sob demanda quando um uso as exige, uma vez por tupla de
+  tipos por unidade de compilação.
+
+Mecânica da instanciação:
+
+1. Call site (ou posição de target-typing) infere a tupla de tipos via unificação (§7).
+2. Nome decorado calculado: `first<int>`, `map<int,string>`, `Stack<int>`.
+   Identificadores de usuário não contêm `<`, então não há colisão possível.
+3. Memo consultado; se ausente, **registra o nome decorado antes** de clonar
+   (recursão e auto-referência terminam), clona o AST do template substituindo
+   `T→tipo concreto` em toda posição de tipo, e agenda a declaração
+   monomorfizada resultante — um `FunctionStatement`/`StructStatement` comum.
+4. O call site emite referência ao nome decorado (global comum).
+
+Cascata genérico→genérico é natural: o corpo clonado de `map<int,string>` contém
+chamadas com tipos já concretos, que disparam novas instanciações pelo mesmo
+caminho. Instanciar `Stack<Stack<int>>` exige resolver `Stack<int>` antes — a
+ordem de dependência das declarações sintéticas sai de graça da ordem de criação
+no memo.
+
+## 5. Arquitetura two-pass
+
+Problema: o compilador é single-pass streaming, mas uma instância descoberta
+dentro do corpo de `f` precisa estar **definida como global antes** de qualquer
+call site executar — e `OP_CLOSURE` captura `frame.Environment` em runtime, então
+uma função não pode virar constante pré-fabricada em compile-time.
+
+```
+parse → [há genéricos no programa ou nos módulos usados?]
+              │não                        │sim
+              ▼                           ▼
+      compila normal              Pass 1: compila descartando bytecode,
+      (custo exatamente zero)             coletando instanciações (memoizadas)
+                                          ▼
+                                  Pass 2: prepende as declarações monomorfizadas
+                                          como statements sintéticos no topo do
+                                          Program (structs antes de funções) e
+                                          compila normal
+```
+
+- No pass 2 tudo é código comum: instâncias viram globals via
+  `OP_CLOSURE`/`OP_SET_GLOBAL`, aproveitam o cache de globals existente.
+  **Zero mudança na VM.**
+- A detecção "há genéricos?" é uma varredura de declarações que já são
+  percorridas hoje (`discoverModuleExports`) — programa sem genéricos não paga
+  nada.
+- Custo quando há genéricos: a compilação ~dobra, sobre uma base de poucos ms
+  (startup total hoje: 63ms). Protegido por gate de benchmark (§11).
+- REPL: o two-pass aplica-se por linha de input; o registry de templates vive no
+  estado da sessão.
+
+## 6. Mudanças em lexer/parser/AST
+
+**AST** (`internal/ast`):
+
+- `TypeParams []string` em `FunctionStatement` e `StructStatement`
+  (vazio = declaração comum; caminho atual intocado).
+- `GenericType{Name string, Args []NoxyType}` para `Stack<int>` em posição de
+  tipo; `String()` produz o nome decorado.
+- `TypeParamType{Name string}` para `T` — nó distinto de `PrimitiveType` para
+  não colidir com um struct real chamado `T`.
+
+**Parser** (`internal/parser`):
+
+- `<T, U>` opcional após o nome em `parseFunctionStatement` /
+  `parseStructStatement`; os nomes entram em escopo de tipo durante o parse da
+  declaração (params, retorno, campos e corpo).
+- `parseAtomicType`: `IDENT` seguido de `<` em posição de tipo → `GenericType`
+  com lista de argumentos.
+- **Split de `>>`**: dentro de lista de argumentos de tipo, o token
+  `SHIFT_RIGHT` é dividido em dois `GT` (truque padrão C#/Java) —
+  `Stack<Stack<int>>` parseia.
+
+**Lexer**: nenhuma mudança.
+
+## 7. Unificação e inferência
+
+Uma função, dois usos: `unify(tipoEsperado, tipoConcreto, bindings)` — casamento
+estrutural que percorre os construtores de tipo:
+
+- `T` vs `int` → `T=int`; `T[]` vs `int[]` → `T=int`; `map[K,V]` vs
+  `map[string,int]` → `K=string, V=int`; idem `ref`, `chan`, `func(...)->...`,
+  `GenericType` (args ponto a ponto).
+- Binding conflitante (`T=int` e depois `T=string`) → erro de unificação.
+- Argumento de tipo desconhecido/`any` (ex.: literal `[]` vazio) não contribui
+  binding — outro argumento ou o alvo do target-typing resolve.
+
+Usos:
+
+1. **Chamada direta**: argumentos como âncora; anotação do `let` envolvente como
+   hint para `T` que só aparece no retorno (`let xs: int[] = vazio()`).
+2. **Target-typing** (§3): unifica a assinatura do template contra o tipo de
+   função alvo.
+3. **Construtor de struct genérico**: campos (posicionais) contra argumentos;
+   restante pela anotação do `let`.
+
+`T` não resolvido ao final → erro (§9), nunca `any` implícito.
+
+## 8. Cross-módulo e regra de escopo de definição
+
+A instância nasce **no contexto do importador** — inevitável: o módulo não pode
+compilar `processa<Ponto>` para um `Ponto` que só existe no importador. O
+importador já parseia as declarações do módulo em compile-time
+(`loadModuleDeclarations`); templates exportados entram no registry do
+importador e instanciam no two-pass dele, como globals sob nome decorado.
+
+**Regra de escopo de definição (v1, obrigatória):** todo identificador livre no
+corpo de um template **deve resolver no top-level do módulo que o define** (ou
+builtins, ou outros genéricos). Validado na instanciação contra o AST de
+declarações do módulo, que o compilador já possui. Isso proíbe por construção a
+captura de nomes do escopo do importador (quase dynamic scoping), que criaria
+código dependente de um vazamento e inviabilizaria a evolução abaixo.
+
+Consequência prática na v1: as dependências do template precisam estar visíveis
+**também** no importador —
+
+| Forma de import | Dependências do template visíveis? | Resultado |
+|---|---|---|
+| `use m select *` | sim — tudo entra nos globals | funciona sempre |
+| `use m select f` (seletivo) | só se importadas junto | erro acionável: "adicione X ao select ou use select *" |
+| corpo autossuficiente (params + builtins + genéricos) | irrelevante | funciona sempre |
+
+**Tabela de evolução** (cada passo só afrouxa exigências; nunca quebra código):
+
+| | v1 (esta spec) | v2 (env binding) | v3 (privates) |
+|---|---|---|---|
+| Corpo pode referenciar | só nomes do módulo definidor | idem | idem |
+| Importador precisa importar dependências | sim (`select *` resolve) | não — environment do módulo bindado na instância | não |
+| Helper privado usado por genérico | n/a (não há privates) | funciona | funciona |
+
+A v2 (bindar `ObjFunction.Environment` do módulo na instância, dando semântica
+de resolução no local de definição, como Go/Rust) é rota registrada, não
+compromisso desta entrega.
+
+## 9. Catálogo de erros
+
+Toda mensagem de erro de corpo carrega a **cadeia de instanciação**:
+
+```
+[linha 12] em soma<Ponto> (instanciado na linha 40): operador '+' não definido para Ponto
+```
+
+| Erro | Exemplo | Mensagem (essência) |
+|---|---|---|
+| Inferência impossível | `let s = vazio()` sem anotação utilizável | "não foi possível inferir T em 'vazio' — anote o tipo" |
+| Conflito de unificação | `indice_de(idades, "30")` | "T inferido como int (argumento 1) e string (argumento 2)" |
+| Valor sem alvo concreto | `let g: func = map` | "função genérica 'map' precisa de tipo concreto — anote a assinatura completa ou chame diretamente" |
+| Aridade de args de tipo | `Stack<int,string>` para `Stack<T>` | "'Stack' espera 1 argumento de tipo, recebeu 2" |
+| Param de tipo fora de escopo | `T` usado fora da declaração | "tipo 'T' não declarado" |
+| Genérico aninhado | `func` genérica dentro de função | "declaração genérica só é permitida no top level" |
+| Escopo de definição (§8) | template referencia nome fora do módulo | "'processa<Ponto>' referencia 'validar', não declarado no módulo 'colecoes'" |
+| Dependência não importada (§8) | import seletivo sem a dependência | "'processa<Ponto>' precisa de 'ajuda' de 'colecoes' — adicione ao select ou use select *" |
+| Erro de corpo por instanciação | `soma(pontos)` | cadeia de instanciação, como acima |
+
+## 10. Runtime — nada muda
+
+- Nomes decorados são identidades nominais distintas: `areTypesCompatible`
+  compara por string e a validação de tipos CoW de runtime funciona sem
+  qualquer alteração.
+- Instâncias de struct genérico são `StructStatement` comuns pós-substituição:
+  construtor posicional, `JSONDynamicFields`, member access — tudo pelo caminho
+  existente.
+- `OP_CALL_STATIC` continua elegível: assinaturas de instâncias são exatas.
+- Builtins (`append`, `length`, `contains`…) dentro de corpo genérico operam
+  sobre tipos concretos pós-substituição — caminho normal.
+
+## 11. Testes e benchmarks
+
+**Unit** — `unify` (bindings, conflitos, tipos aninhados), substituição de AST
+(todas as posições de tipo, auto-referência `ref Node<T>`), parser (`<T>`,
+`GenericType`, split de `>>`).
+
+**Compiler** —
+- Memoização: duas chamadas `first(ints)` → uma instância.
+- **Igualdade de bytecode** (o teste mais forte): `first<int>` monomorfizado
+  emite a mesma sequência de opcodes que a versão escrita à mão — prova
+  executável do custo-zero em runtime, e proteção permanente contra regressão.
+- Ordem das declarações sintéticas (structs antes de funções; dependências antes
+  de dependentes).
+
+**E2E `.nx`** (entram no corpus do runner) — map/filter/reduce; `Stack<T>` com
+push/pop via funções; `Node<T>` lista ligada; construtor com target-typing
+(`Stack([])`); todas as posições de target-typing do §3; cross-módulo
+(`select *`, seletivo com e sem dependências); genérico chamando genérico;
+`Stack<Stack<int>>`; recursão genérica. **Negativos**: um exemplo por linha do
+catálogo do §9.
+
+**Benchmarks com gate** —
+- `startup_generics`: variante do bench de startup com programa usando
+  genéricos; gate contra regressão do caso Lambda.
+- `generic_vs_hand`: laço quente com função genérica vs especializada à mão;
+  gate de razão 1.0x (protegido também pelo teste de igualdade de bytecode).
+- Protocolo padrão do projeto: intercalado, mediana, RESULTS.md.
+
+**Dogfood** — módulo `collections` escrito em Noxy (map/filter/reduce/contains
+genéricos): exatamente a abstração que era impossível, como prova de que a
+assimetria com builtins acabou.
+
+## 12. Fora de escopo (v1)
+
+- **Constraints** (`T: comparable`) — checagem por instanciação cobre a v1.
+- **Instanciação explícita em expressão** (`first<int>(x)`) — inferência +
+  target-typing cobrem; sintaxe pode ser adicionada depois sem quebra.
+- **Template como valor sem alvo concreto** — exige erasure; descartado.
+- **Env binding cross-módulo (v2) e privates (v3)** — rota registrada no §8.
+- **Genéricos aninhados em função** — top level apenas.
+
+## 13. Riscos e mitigações
+
+| Risco | Mitigação |
+|---|---|
+| Explosão de código (muitas instâncias) | memo por unidade de compilação; instâncias são pequenas; aceito na v1 — medir antes de otimizar |
+| Compile time em programas grandes | detecção pula o pass 1 sem genéricos; gate `startup_generics`; saídas conhecidas (cache de descoberta) se o número aparecer |
+| Qualidade de mensagens de erro | catálogo do §9 é requisito de aceite, com teste negativo por linha |
+| Interação com CoW/validação runtime | identidades nominais decoradas usam o caminho existente; testes E2E de semântica de valor com structs genéricos |

--- a/docs/superpowers/specs/2026-08-18-generics-design.md
+++ b/docs/superpowers/specs/2026-08-18-generics-design.md
@@ -92,10 +92,14 @@ campo.transform = identity              // campo de struct → tipo do campo é 
 return identity                         // retorno declarado é o alvo
 ```
 
-**Ordem de resolução no caso argumento-de-chamada-genérica**: resolve os
-parâmetros de tipo pelos argumentos não-genéricos primeiro; se o tipo esperado do
-argumento-função ficou totalmente concreto, instancia; senão, erro pedindo
-anotação.
+**Ordem de resolução no caso argumento-de-chamada-genérica** (unificação
+bidirecional): resolve os parâmetros de tipo pelos argumentos não-genéricos
+primeiro; em seguida, o tipo esperado do argumento-função — possivelmente ainda
+**parcialmente** concreto (`func(int) -> B`) — é unificado contra a assinatura
+do template do argumento (`identity: func(T) -> T`), com os bindings propagando
+nos dois sentidos (`T=int ⇒ B=int`). Se ao final da propagação todos os
+parâmetros de tipo de ambos os lados estiverem resolvidos, ambas as instâncias
+são geradas; senão, erro pedindo anotação.
 
 **Posições onde genérica não pode virar valor** (erro de compilação, mensagem em
 §9): anotação `func` nua, `any`, e corrente de genéricos sem âncora
@@ -115,21 +119,37 @@ Decisões (com alternativas descartadas):
   caminho lento da VM — na contramão do gargalo de performance já identificado
   no cross-runtime. Monomorfização entrega bytecode idêntico ao especializado.
 - **Substituição de AST na frente do compilador** (não type-environment no core):
-  o core de 2600 linhas fica intocado; a maquinaria vive em arquivos novos.
+  a maquinaria de unificação/clonagem/registry vive em arquivos novos; o core
+  ganha **hooks enumerados** (não difusos): interceptação de call site genérico
+  em `compileCallExpression` (antes do `c.Compile(call.Function)`, que hoje
+  emite o callee antes dos argumentos — compiler.go:1850), e threading de tipo
+  esperado nas posições de target-typing do §3 — `LetStmt`, `ReturnStmt`,
+  elemento de array literal, atribuição a campo e argumento de chamada. Fora
+  desses hooks, o caminho de compilação permanece o atual.
 - **Lazy, dirigida por call sites, memoizada**: templates não geram código;
   instâncias nascem sob demanda quando um uso as exige, uma vez por tupla de
   tipos por unidade de compilação.
 
 Mecânica da instanciação:
 
-1. Call site (ou posição de target-typing) infere a tupla de tipos via unificação (§7).
-2. Nome decorado calculado: `first<int>`, `map<int,string>`, `Stack<int>`.
-   Identificadores de usuário não contêm `<`, então não há colisão possível.
+1. Call site (ou posição de target-typing) é interceptado **antes** do caminho
+   normal de compilação; os argumentos são compilados fora de ordem (bytecode
+   descartado — estamos no pass 1, ver §5) só para obter seus tipos, e a tupla
+   de tipos é inferida via unificação (§7).
+2. Nome decorado calculado, **qualificado pelo módulo definidor do template**:
+   `main::first<int>`, `colecoes::map<int,string>`, `main::Stack<int>`.
+   Identificadores de usuário não contêm `<` nem `::`, então não colidem com
+   instâncias; e duas instâncias só compartilham nome se vêm do **mesmo**
+   template com a **mesma** tupla — caso em que são o mesmo código e qualquer
+   sobrescrita é dedup idempotente (ver §8).
 3. Memo consultado; se ausente, **registra o nome decorado antes** de clonar
    (recursão e auto-referência terminam), clona o AST do template substituindo
    `T→tipo concreto` em toda posição de tipo, e agenda a declaração
    monomorfizada resultante — um `FunctionStatement`/`StructStatement` comum.
-4. O call site emite referência ao nome decorado (global comum).
+4. O nó do AST é **reescrito** para referenciar o nome decorado (`map` →
+   identificador `colecoes::map<int,string>`; idem posições de target-typing).
+   O pass 2 compila o AST reescrito pelo caminho 100% normal — nenhuma lógica
+   genérica ativa no pass 2.
 
 Cascata genérico→genérico é natural: o corpo clonado de `map<int,string>` contém
 chamadas com tipos já concretos, que disparam novas instanciações pelo mesmo
@@ -148,25 +168,45 @@ uma função não pode virar constante pré-fabricada em compile-time.
 parse → [há genéricos no programa ou nos módulos usados?]
               │não                        │sim
               ▼                           ▼
-      compila normal              Pass 1: compila descartando bytecode,
-      (custo exatamente zero)             coletando instanciações (memoizadas)
+      compila normal              Pass 1: compila descartando bytecode;
+      (custo exatamente zero)             call sites genéricos são interceptados,
+                                          argumentos compilados fora de ordem para
+                                          inferência, instâncias coletadas
+                                          (memoizadas) e o AST reescrito para os
+                                          nomes decorados (§4)
                                           ▼
                                   Pass 2: prepende as declarações monomorfizadas
                                           como statements sintéticos no topo do
                                           Program (structs antes de funções) e
-                                          compila normal
+                                          compila o AST reescrito pelo caminho
+                                          100% normal
 ```
 
 - No pass 2 tudo é código comum: instâncias viram globals via
   `OP_CLOSURE`/`OP_SET_GLOBAL`, aproveitam o cache de globals existente.
   **Zero mudança na VM.**
-- A detecção "há genéricos?" é uma varredura de declarações que já são
-  percorridas hoje (`discoverModuleExports`) — programa sem genéricos não paga
-  nada.
+- **A regra vale para todo caminho que compila um `Program`** — não só o
+  compilador do programa principal. Três outros caminhos compilam módulos e
+  precisam do mesmo tratamento "declaração genérica ⇒ registra template, pula
+  corpo" (+ two-pass quando o módulo usa os próprios templates internamente):
+  1. o **validator** de módulos em compile-time (`module_exports.go:305` compila
+     o módulo inteiro; um template com `T` livre falharia e o módulo viraria
+     "not loadable" silenciosamente);
+  2. o **runtime** do `use` (`vm/modules.go` — `compileAndRunModule` recompila
+     cada módulo com compiler novo);
+  3. os caminhos de **predeclare** (`predeclareStructs` /
+     `predeclareGlobalBindings`), que hoje registrariam o template cru com
+     `TypeParamType` nos tipos.
+- A detecção "há genéricos?" varre as declarações do programa e dos módulos
+  usados (via `loadModuleDeclarations`, com cache). Para import seletivo isso
+  carrega declarações que o predeclare atual não carrega — custo pequeno, mas
+  **medido pelo gate `startup_generics` (§11), não afirmado**. Programa sem
+  genéricos continua pulando o pass 1 inteiro.
 - Custo quando há genéricos: a compilação ~dobra, sobre uma base de poucos ms
   (startup total hoje: 63ms). Protegido por gate de benchmark (§11).
-- REPL: o two-pass aplica-se por linha de input; o registry de templates vive no
-  estado da sessão.
+- REPL: o two-pass aplica-se por linha de input; o registry de templates entra
+  no **estado compartilhado da sessão** (mudança de assinatura em
+  `NewWithState`, que hoje compartilha só globals e structs entre linhas).
 
 ## 6. Mudanças em lexer/parser/AST
 
@@ -175,7 +215,10 @@ parse → [há genéricos no programa ou nos módulos usados?]
 - `TypeParams []string` em `FunctionStatement` e `StructStatement`
   (vazio = declaração comum; caminho atual intocado).
 - `GenericType{Name string, Args []NoxyType}` para `Stack<int>` em posição de
-  tipo; `String()` produz o nome decorado.
+  tipo; `String()` produz o nome de exibição. Na resolução, `Name` é resolvido
+  para o template visível naquele escopo e o tipo passa a carregar a identidade
+  **qualificada** (§4) — dois structs `Stack` de módulos diferentes nunca
+  unificam como o mesmo tipo nominal.
 - `TypeParamType{Name string}` para `T` — nó distinto de `PrimitiveType` para
   não colidir com um struct real chamado `T`.
 
@@ -186,9 +229,10 @@ parse → [há genéricos no programa ou nos módulos usados?]
   declaração (params, retorno, campos e corpo).
 - `parseAtomicType`: `IDENT` seguido de `<` em posição de tipo → `GenericType`
   com lista de argumentos.
-- **Split de `>>`**: dentro de lista de argumentos de tipo, o token
+- **Split de `>>` e `>=`**: dentro de lista de argumentos de tipo, o token
   `SHIFT_RIGHT` é dividido em dois `GT` (truque padrão C#/Java) —
-  `Stack<Stack<int>>` parseia.
+  `Stack<Stack<int>>` parseia — e o token `GTE` é dividido em `GT` + `=`, para
+  que `let s: Stack<int>= Stack([])` (sem espaço) não quebre o parse do tipo.
 
 **Lexer**: nenhuma mudança.
 
@@ -201,6 +245,13 @@ estrutural que percorre os construtores de tipo:
   `map[string,int]` → `K=string, V=int`; idem `ref`, `chan`, `func(...)->...`,
   `GenericType` (args ponto a ponto).
 - Binding conflitante (`T=int` e depois `T=string`) → erro de unificação.
+- **`T` não pode bindar um tipo `ref`** (erro de unificação na v1): a decisão
+  own-vs-borrow do compilador é sintática sobre o tipo declarado (let `ref` sem
+  own, `OP_SET_GLOBAL_BORROW`, auto-deref de argumentos), e `T = ref Ponto`
+  mudaria a semântica de posse do corpo do template conforme a instanciação —
+  exatamente a classe de sutileza que o trabalho de CoW/RC caça. A forma
+  idiomática continua disponível: `func f<T>(r: ref T)` declara o `ref`
+  explicitamente e `T` binda o tipo do elemento.
 - Argumento de tipo desconhecido/`any` (ex.: literal `[]` vazio) não contribui
   binding — outro argumento ou o alvo do target-typing resolve.
 
@@ -230,6 +281,29 @@ declarações do módulo, que o compilador já possui. Isso proíbe por constru�
 captura de nomes do escopo do importador (quase dynamic scoping), que criaria
 código dependente de um vazamento e inviabilizaria a evolução abaixo.
 
+**Imports carregam tipos declarados (pré-requisito da inferência).** Hoje todo
+nome importado entra no compilador com tipo apagado (`c.globals[name] = nil` —
+compiler.go, caso `UseStmt`), o que faria `map(nums_importado, f)` falhar a
+inferência mesmo em código correto. A v1 muda o predeclare de imports
+(seletivo e `select *`) para registrar os **tipos declarados** dos exports,
+extraídos do AST que `loadModuleDeclarations` já possui (`LetStmt.Type`,
+assinaturas de função, structs). Benefício colateral: melhora a checagem
+estática de todo código cross-módulo, genérico ou não.
+
+**Templates não são acessíveis via namespace.** Na forma `use m` (módulo como
+objeto), `m.processa(nums)` não tem como funcionar — o template não existe como
+valor em runtime e o member access não carrega tipo estático. Erro de
+compilação dedicado (§9): "template genérico não é acessível via namespace —
+use `select`".
+
+**Instâncias exportadas são inofensivas por construção.** Instâncias são
+globals comuns e portanto entram no `ExportMap` do módulo (e em `select *`).
+Como o nome decorado é qualificado pelo módulo definidor do template (§4),
+duas instâncias só têm o mesmo nome se vêm do mesmo template com a mesma tupla
+— mesmo código; sobrescrita no import é dedup idempotente, nunca shadowing de
+código diferente. (A alternativa — filtrar nomes com `<` do
+`OP_IMPORT_FROM_ALL` — exigiria mudança na VM e foi descartada.)
+
 Consequência prática na v1: as dependências do template precisam estar visíveis
 **também** no importador —
 
@@ -237,6 +311,7 @@ Consequência prática na v1: as dependências do template precisam estar visív
 |---|---|---|
 | `use m select *` | sim — tudo entra nos globals | funciona sempre |
 | `use m select f` (seletivo) | só se importadas junto | erro acionável: "adicione X ao select ou use select *" |
+| `use m` (namespace) | n/a | template via `m.f` é erro de compilação dedicado |
 | corpo autossuficiente (params + builtins + genéricos) | irrelevante | funciona sempre |
 
 **Tabela de evolução** (cada passo só afrouxa exigências; nunca quebra código):
@@ -253,7 +328,10 @@ compromisso desta entrega.
 
 ## 9. Catálogo de erros
 
-Toda mensagem de erro de corpo carrega a **cadeia de instanciação**:
+Mensagens usam o **nome de exibição** (`soma<Ponto>`, sem o qualificador de
+módulo do §4, que é identidade interna); o módulo definidor aparece por extenso
+quando relevante ("de 'colecoes'"). Toda mensagem de erro de corpo carrega a
+**cadeia de instanciação**:
 
 ```
 [linha 12] em soma<Ponto> (instanciado na linha 40): operador '+' não definido para Ponto
@@ -267,6 +345,8 @@ Toda mensagem de erro de corpo carrega a **cadeia de instanciação**:
 | Aridade de args de tipo | `Stack<int,string>` para `Stack<T>` | "'Stack' espera 1 argumento de tipo, recebeu 2" |
 | Param de tipo fora de escopo | `T` usado fora da declaração | "tipo 'T' não declarado" |
 | Genérico aninhado | `func` genérica dentro de função | "declaração genérica só é permitida no top level" |
+| Template via namespace | `m.processa(nums)` com `use m` | "template genérico 'processa' não é acessível via namespace — use `select`" |
+| `T` bindando ref | `identity(r)` com `r: ref Ponto` resolvendo `T=ref Ponto` | "T não pode ser um tipo ref — declare o parâmetro como `ref T`" |
 | Escopo de definição (§8) | template referencia nome fora do módulo | "'processa<Ponto>' referencia 'validar', não declarado no módulo 'colecoes'" |
 | Dependência não importada (§8) | import seletivo sem a dependência | "'processa<Ponto>' precisa de 'ajuda' de 'colecoes' — adicione ao select ou use select *" |
 | Erro de corpo por instanciação | `soma(pontos)` | cadeia de instanciação, como acima |
@@ -299,10 +379,16 @@ Toda mensagem de erro de corpo carrega a **cadeia de instanciação**:
 
 **E2E `.nx`** (entram no corpus do runner) — map/filter/reduce; `Stack<T>` com
 push/pop via funções; `Node<T>` lista ligada; construtor com target-typing
-(`Stack([])`); todas as posições de target-typing do §3; cross-módulo
-(`select *`, seletivo com e sem dependências); genérico chamando genérico;
-`Stack<Stack<int>>`; recursão genérica. **Negativos**: um exemplo por linha do
-catálogo do §9.
+(`Stack([])`); todas as posições de target-typing do §3 (incluindo unificação
+bidirecional `map(nums, identity)`); cross-módulo (`select *`, seletivo com e
+sem dependências); **dois módulos com templates homônimos instanciados na mesma
+tupla via `select *`** (prova do dedup por nome qualificado, §8); inferência
+sobre **dados importados** (prova do predeclare tipado, §8); **template dentro
+de módulo** passando pelo validator e pelo `compileAndRunModule` (módulo que
+usa os próprios genéricos internamente); genérico chamando genérico;
+`Stack<Stack<int>>`; `Stack<int>=` sem espaço (split de `GTE`); recursão
+genérica. **Negativos**: um exemplo por linha do catálogo do §9 — incluindo
+`use m` namespace e `T` bindando ref.
 
 **Benchmarks com gate** —
 - `startup_generics`: variante do bench de startup com programa usando
@@ -329,6 +415,6 @@ assimetria com builtins acabou.
 | Risco | Mitigação |
 |---|---|
 | Explosão de código (muitas instâncias) | memo por unidade de compilação; instâncias são pequenas; aceito na v1 — medir antes de otimizar |
-| Compile time em programas grandes | detecção pula o pass 1 sem genéricos; gate `startup_generics`; saídas conhecidas (cache de descoberta) se o número aparecer |
+| Compile time em programas grandes | detecção pula o pass 1 sem genéricos (mas carrega declarações de módulos em import seletivo — custo coberto pelo gate); gate `startup_generics`; saídas conhecidas (cache de descoberta) se o número aparecer |
 | Qualidade de mensagens de erro | catálogo do §9 é requisito de aceite, com teste negativo por linha |
 | Interação com CoW/validação runtime | identidades nominais decoradas usam o caminho existente; testes E2E de semântica de valor com structs genéricos |

--- a/docs/superpowers/specs/2026-08-18-generics-design.md
+++ b/docs/superpowers/specs/2026-08-18-generics-design.md
@@ -2,7 +2,10 @@
 
 **Data:** 2026-08-18 · **Branch:** `feat/generics` (base: `develop` @ ebf0067, v0.6.0)
 **Status:** aprovado em discussão; spec formal para implementação
-**Release alvo:** 0.7.0 (aditivo — nenhuma quebra de código existente)
+**Release alvo:** 0.7.0 (aditivo para código bem-tipado — sintaxe nova não
+quebra nada; a exceção controlada são os imports tipados do §8, que podem
+revelar erros de tipo latentes em código cross-módulo dinâmico; gate: o corpus
+`.nx` existente inteiro continua compilando e passando, §11)
 
 ## 1. Objetivo
 
@@ -124,8 +127,16 @@ Decisões (com alternativas descartadas):
   em `compileCallExpression` (antes do `c.Compile(call.Function)`, que hoje
   emite o callee antes dos argumentos — compiler.go:1850), e threading de tipo
   esperado nas posições de target-typing do §3 — `LetStmt`, `ReturnStmt`,
-  elemento de array literal, atribuição a campo e argumento de chamada. Fora
-  desses hooks, o caminho de compilação permanece o atual.
+  elemento de array literal, atribuição a campo e argumento de chamada — e a
+  terceira família, fácil de subestimar: **toda resolução de `GenericType` em
+  posição de anotação de tipo é um hook de instanciação de struct**. `let
+  stacks: Stack<int>[] = []`, `let n: ref Node<int> = null`, parâmetro
+  `Stack<int>` numa função não-genérica, `let s: Stack<int>` sem inicializador
+  (`emitDefaultInit`) — nenhum call site, nenhum target-typing, e mesmo assim o
+  struct precisa existir em `c.structs` sob o nome decorado (member access
+  resolve campo por `c.structs[nome]`) e ter runtime type info para a validação
+  CoW. Fora dessas três famílias de hooks, o caminho de compilação permanece o
+  atual.
 - **Lazy, dirigida por call sites, memoizada**: templates não geram código;
   instâncias nascem sob demanda quando um uso as exige, uma vez por tupla de
   tipos por unidade de compilação.
@@ -133,9 +144,11 @@ Decisões (com alternativas descartadas):
 Mecânica da instanciação:
 
 1. Call site (ou posição de target-typing) é interceptado **antes** do caminho
-   normal de compilação; os argumentos são compilados fora de ordem (bytecode
-   descartado — estamos no pass 1, ver §5) só para obter seus tipos, e a tupla
-   de tipos é inferida via unificação (§7).
+   normal de compilação; os argumentos **não-genéricos** são compilados fora de
+   ordem (bytecode descartado — estamos no pass 1, ver §5) só para obter seus
+   tipos. Argumentos que são templates nus (`map(nums, identity)`) **não**
+   compilam — entram pela unificação bidirecional do §3, na ordem definida lá.
+   A tupla de tipos é inferida via unificação (§7).
 2. Nome decorado calculado, **qualificado pelo módulo definidor do template**:
    `main::first<int>`, `colecoes::map<int,string>`, `main::Stack<int>`.
    Identificadores de usuário não contêm `<` nem `::`, então não colidem com
@@ -151,11 +164,16 @@ Mecânica da instanciação:
    O pass 2 compila o AST reescrito pelo caminho 100% normal — nenhuma lógica
    genérica ativa no pass 2.
 
-Cascata genérico→genérico é natural: o corpo clonado de `map<int,string>` contém
-chamadas com tipos já concretos, que disparam novas instanciações pelo mesmo
-caminho. Instanciar `Stack<Stack<int>>` exige resolver `Stack<int>` antes — a
-ordem de dependência das declarações sintéticas sai de graça da ordem de criação
-no memo.
+Cascata genérico→genérico tem timing definido: **instanciar = registrar no memo
+→ clonar → compilar o clone em modo pass-1 imediatamente** (recursivamente,
+ainda dentro do pass 1). O corpo clonado de `map<int,string>` contém chamadas
+com tipos já concretos, que disparam novas instanciações pelo mesmo caminho —
+antes de o pass 2 começar. É isso que sustenta a garantia "nenhuma lógica
+genérica ativa no pass 2" (§5): quando o pass 2 roda, todo AST alcançável já
+foi reescrito. Instanciar `Stack<Stack<int>>` exige resolver `Stack<int>` antes
+— a ordem de dependência das declarações sintéticas sai de graça da ordem de
+criação no memo. A terminação vem do memo-antes-de-clonar: recursão e
+referência mútua encontram a entrada já registrada e param.
 
 ## 5. Arquitetura two-pass
 
@@ -204,9 +222,15 @@ parse → [há genéricos no programa ou nos módulos usados?]
   genéricos continua pulando o pass 1 inteiro.
 - Custo quando há genéricos: a compilação ~dobra, sobre uma base de poucos ms
   (startup total hoje: 63ms). Protegido por gate de benchmark (§11).
-- REPL: o two-pass aplica-se por linha de input; o registry de templates entra
-  no **estado compartilhado da sessão** (mudança de assinatura em
-  `NewWithState`, que hoje compartilha só globals e structs entre linhas).
+- REPL: o two-pass aplica-se por linha de input. Hoje **só os globals persistem
+  entre linhas** — o map de structs é recriado vazio a cada linha
+  (`cmd/noxy/main.go:232`, `make(map[string]*ast.StructStatement)`), uma
+  fragilidade pré-existente que já afeta structs comuns declarados no REPL. A
+  v1 muda `NewWithState` para persistir **três** coisas na sessão: globals
+  (como hoje), o registry de templates, e o `c.structs` (que carrega as
+  instâncias monomorfizadas — sem isso, `let s: Stack<int> = Stack([])` na
+  linha N seguido de `s.items` na linha N+1 falha a resolução de campo). A
+  persistência de structs de carona conserta o bug pré-existente.
 
 ## 6. Mudanças em lexer/parser/AST
 
@@ -254,6 +278,11 @@ estrutural que percorre os construtores de tipo:
   explicitamente e `T` binda o tipo do elemento.
 - Argumento de tipo desconhecido/`any` (ex.: literal `[]` vazio) não contribui
   binding — outro argumento ou o alvo do target-typing resolve.
+- **`null` também não contribui binding** e `T` nunca binda o tipo `null`:
+  `identity(null)` sem outra âncora é erro de inferência (§9).
+- **`any` é legal como argumento de tipo explícito** (`Stack<any>`): a
+  substituição produz campos `any` comuns e `JSONDynamicFields` decorre
+  naturalmente pós-substituição.
 
 Usos:
 
@@ -277,9 +306,16 @@ importador e instanciam no two-pass dele, como globals sob nome decorado.
 **Regra de escopo de definição (v1, obrigatória):** todo identificador livre no
 corpo de um template **deve resolver no top-level do módulo que o define** (ou
 builtins, ou outros genéricos). Validado na instanciação contra o AST de
-declarações do módulo, que o compilador já possui. Isso proíbe por construção a
-captura de nomes do escopo do importador (quase dynamic scoping), que criaria
-código dependente de um vazamento e inviabilizaria a evolução abaixo.
+declarações do módulo, que o compilador já possui. Resolubilidade sozinha não
+basta: como o clone compila e executa no contexto do importador, um global
+**homônimo** do importador seria capturado em silêncio no lugar do binding do
+módulo definidor. Por isso a validação tem duas partes: (a) o nome resolve no
+módulo definidor; (b) o **tipo declarado** do binding visível no importador é
+idêntico ao declarado no módulo definidor — divergência é erro de compilação
+nomeando os dois lados. **Buraco residual documentado**: mesmo nome e mesmo
+tipo, mas código diferente (o importador shadowa uma função por outra de
+assinatura igual) não é detectável na v1 — aceito, e eliminado na v2 (env
+binding, que resolve nomes no módulo definidor por construção).
 
 **Imports carregam tipos declarados (pré-requisito da inferência).** Hoje todo
 nome importado entra no compilador com tipo apagado (`c.globals[name] = nil` —
@@ -287,8 +323,13 @@ compiler.go, caso `UseStmt`), o que faria `map(nums_importado, f)` falhar a
 inferência mesmo em código correto. A v1 muda o predeclare de imports
 (seletivo e `select *`) para registrar os **tipos declarados** dos exports,
 extraídos do AST que `loadModuleDeclarations` já possui (`LetStmt.Type`,
-assinaturas de função, structs). Benefício colateral: melhora a checagem
-estática de todo código cross-módulo, genérico ou não.
+assinaturas de função, structs). Efeito colateral **com potencial de quebra**,
+não "benefício grátis": código cross-módulo dinâmico que hoje compila com tipo
+apagado pode passar a falhar em compile-time. Critério de aceite desta
+sub-mudança: **o corpus `.nx` existente inteiro continua compilando e
+passando** (gate em §11); quebras reveladas são erros de tipo latentes e são
+corrigidas no corpus, alinhado à estratégia do projeto de front-load de
+breaking changes.
 
 **Templates não são acessíveis via namespace.** Na forma `use m` (módulo como
 objeto), `m.processa(nums)` não tem como funcionar — o template não existe como
@@ -301,8 +342,12 @@ globals comuns e portanto entram no `ExportMap` do módulo (e em `select *`).
 Como o nome decorado é qualificado pelo módulo definidor do template (§4),
 duas instâncias só têm o mesmo nome se vêm do mesmo template com a mesma tupla
 — mesmo código; sobrescrita no import é dedup idempotente, nunca shadowing de
-código diferente. (A alternativa — filtrar nomes com `<` do
-`OP_IMPORT_FROM_ALL` — exigiria mudança na VM e foi descartada.)
+código diferente. Nuance: a sobrescrita troca o closure e portanto o
+`Environment` de resolução — a idempotência é **condicionada à validação de
+identidade acima** (mesmo conjunto de nomes livres com mesmos tipos declarados
+nos dois contextos) e compartilha o mesmo buraco residual, eliminado na v2. (A
+alternativa — filtrar nomes com `<` do `OP_IMPORT_FROM_ALL` — exigiria mudança
+na VM e foi descartada.)
 
 Consequência prática na v1: as dependências do template precisam estar visíveis
 **também** no importador —
@@ -347,6 +392,8 @@ quando relevante ("de 'colecoes'"). Toda mensagem de erro de corpo carrega a
 | Genérico aninhado | `func` genérica dentro de função | "declaração genérica só é permitida no top level" |
 | Template via namespace | `m.processa(nums)` com `use m` | "template genérico 'processa' não é acessível via namespace — use `select`" |
 | `T` bindando ref | `identity(r)` com `r: ref Ponto` resolvendo `T=ref Ponto` | "T não pode ser um tipo ref — declare o parâmetro como `ref T`" |
+| Inferência só com `null` | `identity(null)` sem outra âncora | "não foi possível inferir T de null — anote o tipo" |
+| Divergência de binding cross-módulo (§8) | importador shadowa dependência com tipo diferente | "'ajuda' tem tipo X no importador e Y em 'colecoes' — conflito de shadowing" |
 | Escopo de definição (§8) | template referencia nome fora do módulo | "'processa<Ponto>' referencia 'validar', não declarado no módulo 'colecoes'" |
 | Dependência não importada (§8) | import seletivo sem a dependência | "'processa<Ponto>' precisa de 'ajuda' de 'colecoes' — adicione ao select ou use select *" |
 | Erro de corpo por instanciação | `soma(pontos)` | cadeia de instanciação, como acima |
@@ -362,12 +409,23 @@ quando relevante ("de 'colecoes'"). Toda mensagem de erro de corpo carrega a
 - `OP_CALL_STATIC` continua elegível: assinaturas de instâncias são exatas.
 - Builtins (`append`, `length`, `contains`…) dentro de corpo genérico operam
   sobre tipos concretos pós-substituição — caminho normal.
+- **Vazamento cosmético aceito na v1**: `print` de instância de struct mostra o
+  nome qualificado (`<main::Stack<int> instance>` — `value.go` usa
+  `Struct.Name`; idem `%T`). O §9 governa só mensagens do compilador. Corrigir
+  exigiria um campo display-name no `ObjStruct` (mudança pequena de runtime) —
+  fica registrado como follow-up fora desta entrega, para preservar "nada
+  muda".
 
 ## 11. Testes e benchmarks
 
-**Unit** — `unify` (bindings, conflitos, tipos aninhados), substituição de AST
-(todas as posições de tipo, auto-referência `ref Node<T>`), parser (`<T>`,
-`GenericType`, split de `>>`).
+**Unit** — `unify` (bindings, conflitos, tipos aninhados, `null`/`any`/ref),
+substituição de AST (todas as posições de tipo, auto-referência `ref Node<T>`),
+parser (`<T>`, `GenericType`, split de `>>` e `>=`). **Cloner de AST**: teste
+de não-aliasing por tipo de nó (clonar, mutar o clone, verificar original
+intacto — um nó esquecido significa AST compartilhado entre instâncias e
+contaminação silenciosa entre `<int>` e `<string>`), mais um **guard por
+reflexão** que enumera os tipos de nó do pacote `ast` e falha quando um nó novo
+não tiver caso no cloner.
 
 **Compiler** —
 - Memoização: duas chamadas `first(ints)` → uma instância.
@@ -387,8 +445,20 @@ sobre **dados importados** (prova do predeclare tipado, §8); **template dentro
 de módulo** passando pelo validator e pelo `compileAndRunModule` (módulo que
 usa os próprios genéricos internamente); genérico chamando genérico;
 `Stack<Stack<int>>`; `Stack<int>=` sem espaço (split de `GTE`); recursão
-genérica. **Negativos**: um exemplo por linha do catálogo do §9 — incluindo
-`use m` namespace e `T` bindando ref.
+genérica. **Instanciação por anotação pura** (sem call site): `let stacks:
+Stack<int>[] = []`, `let n: ref Node<int> = null`, parâmetro `Stack<int>` em
+função não-genérica, `let s: Stack<int>` sem inicializador. **Interações de
+runtime**: lambda dentro de corpo genérico; `spawn`/task e `defer` com genérica
+instanciada; `when` sobre struct genérico; f-string e JSON de `Stack<int>`;
+semântica de valor CoW com structs genéricos (citada no §13). **REPL
+multi-linha**: template numa linha, instanciação noutra, member access na
+seguinte. **Negativos**: um exemplo por linha do catálogo do §9 — incluindo
+`use m` namespace, `T` bindando ref, inferência só com `null` e divergência de
+shadowing.
+
+**Gate de regressão do corpus** — com os imports tipados do §8 ativos, o corpus
+`.nx` existente inteiro continua compilando e passando; qualquer quebra é
+triada como erro de tipo latente e corrigida no corpus antes do merge.
 
 **Benchmarks com gate** —
 - `startup_generics`: variante do bench de startup com programa usando

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -53,6 +53,30 @@ type PrimitiveType struct {
 
 func (t *PrimitiveType) String() string { return t.Name }
 
+// GenericType é um tipo genérico em posição de anotação: Stack<int>.
+// Name é resolvido para um template em escopo durante a compilação (§6/§8 da
+// spec); a identidade nominal final é o nome qualificado da instância.
+type GenericType struct {
+	Name string
+	Args []NoxyType
+}
+
+func (gt *GenericType) String() string {
+	parts := make([]string, len(gt.Args))
+	for i, a := range gt.Args {
+		parts[i] = a.String()
+	}
+	return gt.Name + "<" + strings.Join(parts, ", ") + ">"
+}
+
+// TypeParamType é um parâmetro de tipo (T) dentro de um template. Nó distinto
+// de PrimitiveType para não colidir com um struct real chamado T.
+type TypeParamType struct {
+	Name string
+}
+
+func (tp *TypeParamType) String() string { return tp.Name }
+
 type ArrayType struct {
 	ElementType NoxyType
 	Size        int // 0 for dynamic
@@ -377,6 +401,7 @@ func (ws *WhileStatement) String() string {
 type FunctionStatement struct {
 	Token      token.Token // The 'func' token
 	Name       string
+	TypeParams []string
 	Parameters []*Parameter
 	Body       *BlockStatement
 	ReturnType NoxyType
@@ -498,6 +523,7 @@ func (ie *IndexExpression) String() string {
 type StructStatement struct {
 	Token      token.Token // 'struct'
 	Name       string
+	TypeParams []string
 	Fields     map[string]NoxyType
 	FieldsList []*StructField
 }

--- a/internal/ast/clone.go
+++ b/internal/ast/clone.go
@@ -1,0 +1,233 @@
+package ast
+
+// Clones profundos de nós do AST, usados pela monomorfização de genéricos
+// (spec 2026-08-18-generics-design.md §4): cada instância recebe uma cópia
+// exclusiva do corpo do template. Nó compartilhado entre instâncias seria
+// contaminação silenciosa — o guard TestClonerCoversEveryNode impõe cobertura.
+
+func CloneStatement(s Statement) Statement {
+	if s == nil {
+		return nil
+	}
+	switch n := s.(type) {
+	case *AssignStmt:
+		return &AssignStmt{Token: n.Token, Target: CloneExpression(n.Target), Value: CloneExpression(n.Value)}
+	case *LetStmt:
+		return &LetStmt{Token: n.Token, Name: cloneIdentifier(n.Name), Type: CloneType(n.Type), Value: CloneExpression(n.Value)}
+	case *ReturnStmt:
+		return &ReturnStmt{Token: n.Token, ReturnValue: CloneExpression(n.ReturnValue)}
+	case *DeferStmt:
+		return &DeferStmt{Token: n.Token, Call: cloneCallExpression(n.Call)}
+	case *BreakStmt:
+		return &BreakStmt{Token: n.Token}
+	case *UseStmt:
+		return &UseStmt{
+			Token:     n.Token,
+			Module:    n.Module,
+			Alias:     n.Alias,
+			Selectors: append([]string(nil), n.Selectors...),
+			SelectAll: n.SelectAll,
+		}
+	case *ExpressionStmt:
+		return &ExpressionStmt{Token: n.Token, Expression: CloneExpression(n.Expression)}
+	case *BlockStatement:
+		return CloneBlock(n)
+	case *IfStatement:
+		return &IfStatement{
+			Token:       n.Token,
+			Condition:   CloneExpression(n.Condition),
+			Consequence: CloneBlock(n.Consequence),
+			Alternative: CloneBlock(n.Alternative),
+		}
+	case *WhileStatement:
+		return &WhileStatement{Token: n.Token, Condition: CloneExpression(n.Condition), Body: CloneBlock(n.Body)}
+	case *FunctionStatement:
+		return &FunctionStatement{
+			Token:      n.Token,
+			Name:       n.Name,
+			TypeParams: append([]string(nil), n.TypeParams...),
+			Parameters: cloneParameters(n.Parameters),
+			ReturnType: CloneType(n.ReturnType),
+			Body:       CloneBlock(n.Body),
+		}
+	case *ForStatement:
+		return &ForStatement{
+			Token:      n.Token,
+			Identifier: n.Identifier,
+			Collection: CloneExpression(n.Collection),
+			Body:       CloneBlock(n.Body),
+		}
+	case *StructStatement:
+		fields := make(map[string]NoxyType, len(n.Fields))
+		list := make([]*StructField, len(n.FieldsList))
+		for i, f := range n.FieldsList {
+			cloned := &StructField{Name: f.Name, Type: CloneType(f.Type)}
+			list[i] = cloned
+			fields[f.Name] = cloned.Type
+		}
+		return &StructStatement{
+			Token:      n.Token,
+			Name:       n.Name,
+			TypeParams: append([]string(nil), n.TypeParams...),
+			Fields:     fields,
+			FieldsList: list,
+		}
+	case *WhenStatement:
+		cases := make([]*CaseClause, len(n.Cases))
+		for i, c := range n.Cases {
+			cases[i] = cloneCaseClause(c)
+		}
+		return &WhenStatement{Token: n.Token, Cases: cases}
+	default:
+		panic("CloneStatement: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+func CloneExpression(e Expression) Expression {
+	if e == nil {
+		return nil
+	}
+	switch n := e.(type) {
+	case *Identifier:
+		return cloneIdentifier(n)
+	case *IntegerLiteral:
+		return &IntegerLiteral{Token: n.Token, Value: n.Value}
+	case *FloatLiteral:
+		return &FloatLiteral{Token: n.Token, Value: n.Value}
+	case *StringLiteral:
+		return &StringLiteral{Token: n.Token, Value: n.Value}
+	case *BytesLiteral:
+		return &BytesLiteral{Token: n.Token, Value: n.Value}
+	case *NullLiteral:
+		return &NullLiteral{Token: n.Token}
+	case *ZerosLiteral:
+		return &ZerosLiteral{Token: n.Token, Size: CloneExpression(n.Size)}
+	case *Boolean:
+		return &Boolean{Token: n.Token, Value: n.Value}
+	case *PrefixExpression:
+		return &PrefixExpression{Token: n.Token, Operator: n.Operator, Right: CloneExpression(n.Right)}
+	case *InfixExpression:
+		return &InfixExpression{Token: n.Token, Left: CloneExpression(n.Left), Operator: n.Operator, Right: CloneExpression(n.Right)}
+	case *FunctionLiteral:
+		return &FunctionLiteral{
+			Token:      n.Token,
+			Parameters: cloneParameters(n.Parameters),
+			Body:       CloneBlock(n.Body),
+			Name:       n.Name,
+			ReturnType: CloneType(n.ReturnType),
+		}
+	case *CallExpression:
+		return cloneCallExpression(n)
+	case *ArrayLiteral:
+		elements := make([]Expression, len(n.Elements))
+		for i, el := range n.Elements {
+			elements[i] = CloneExpression(el)
+		}
+		return &ArrayLiteral{Token: n.Token, Elements: elements}
+	case *MapLiteral:
+		keys := make([]Expression, len(n.Keys))
+		values := make([]Expression, len(n.Values))
+		pairs := make(map[Expression]Expression, len(n.Pairs))
+		for i := range n.Keys {
+			k := CloneExpression(n.Keys[i])
+			v := CloneExpression(n.Values[i])
+			keys[i] = k
+			values[i] = v
+			pairs[k] = v
+		}
+		return &MapLiteral{Token: n.Token, Pairs: pairs, Keys: keys, Values: values}
+	case *IndexExpression:
+		return &IndexExpression{Token: n.Token, Left: CloneExpression(n.Left), Index: CloneExpression(n.Index)}
+	case *MemberAccessExpression:
+		return &MemberAccessExpression{Token: n.Token, Left: CloneExpression(n.Left), Member: n.Member}
+	default:
+		panic("CloneExpression: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+func CloneType(t NoxyType) NoxyType {
+	if t == nil {
+		return nil
+	}
+	switch n := t.(type) {
+	case *PrimitiveType:
+		return &PrimitiveType{Name: n.Name}
+	case *ArrayType:
+		return &ArrayType{ElementType: CloneType(n.ElementType), Size: n.Size}
+	case *MapType:
+		return &MapType{KeyType: CloneType(n.KeyType), ValueType: CloneType(n.ValueType)}
+	case *RefType:
+		return &RefType{ElementType: CloneType(n.ElementType)}
+	case *ChanType:
+		return &ChanType{ElementType: CloneType(n.ElementType)}
+	case *FunctionType:
+		params := make([]NoxyType, len(n.Params))
+		for i, p := range n.Params {
+			params[i] = CloneType(p)
+		}
+		return &FunctionType{Params: params, Return: CloneType(n.Return)}
+	case *GenericType:
+		args := make([]NoxyType, len(n.Args))
+		for i, a := range n.Args {
+			args[i] = CloneType(a)
+		}
+		return &GenericType{Name: n.Name, Args: args}
+	case *TypeParamType:
+		return &TypeParamType{Name: n.Name}
+	default:
+		panic("CloneType: tipo sem case")
+	}
+}
+
+func CloneBlock(b *BlockStatement) *BlockStatement {
+	if b == nil {
+		return nil
+	}
+	statements := make([]Statement, len(b.Statements))
+	for i, s := range b.Statements {
+		statements[i] = CloneStatement(s)
+	}
+	return &BlockStatement{Token: b.Token, Statements: statements}
+}
+
+func cloneIdentifier(i *Identifier) *Identifier {
+	if i == nil {
+		return nil
+	}
+	clone := *i
+	return &clone
+}
+
+func cloneParameters(ps []*Parameter) []*Parameter {
+	if ps == nil {
+		return nil
+	}
+	clones := make([]*Parameter, len(ps))
+	for i, p := range ps {
+		clones[i] = &Parameter{Name: p.Name, Type: CloneType(p.Type)}
+	}
+	return clones
+}
+
+func cloneCallExpression(c *CallExpression) *CallExpression {
+	if c == nil {
+		return nil
+	}
+	args := make([]Expression, len(c.Arguments))
+	for i, a := range c.Arguments {
+		args[i] = CloneExpression(a)
+	}
+	return &CallExpression{Token: c.Token, Function: CloneExpression(c.Function), Arguments: args}
+}
+
+func cloneCaseClause(c *CaseClause) *CaseClause {
+	if c == nil {
+		return nil
+	}
+	return &CaseClause{
+		Token:     c.Token,
+		IsDefault: c.IsDefault,
+		Condition: CloneStatement(c.Condition),
+		Body:      CloneBlock(c.Body),
+	}
+}

--- a/internal/ast/clone_test.go
+++ b/internal/ast/clone_test.go
@@ -1,0 +1,123 @@
+package ast
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClonerCoversEveryNode enumera os tipos concretos do pacote que
+// implementam Statement/Expression/NoxyType (via análise do fonte ast.go) e
+// falha se clone.go não tiver um case para cada um. Um nó esquecido =
+// AST compartilhado entre instâncias = contaminação silenciosa (§11 da spec).
+func TestClonerCoversEveryNode(t *testing.T) {
+	fset := token.NewFileSet()
+	nodeNames := map[string]bool{}
+	for _, file := range []string{"ast.go"} {
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				return true
+			}
+			name := fn.Name.Name
+			if name != "statementNode" && name != "expressionNode" && name != "String" {
+				return true
+			}
+			recv := fn.Recv.List[0].Type
+			if star, ok := recv.(*ast.StarExpr); ok {
+				if ident, ok := star.X.(*ast.Ident); ok {
+					nodeNames[ident.Name] = true
+				}
+			}
+			return true
+		})
+	}
+	delete(nodeNames, "Program") // Program não precisa de clone (clonamos statements)
+	delete(nodeNames, "Parameter")
+	delete(nodeNames, "StructField") // clonados por dentro dos donos; cases próprios não exigidos
+
+	cloneSrc, err := os.ReadFile(filepath.Join(".", "clone.go"))
+	if err != nil {
+		t.Fatalf("clone.go ausente: %v", err)
+	}
+	for name := range nodeNames {
+		if !strings.Contains(string(cloneSrc), "*"+name+":") {
+			t.Errorf("clone.go sem case para *%s", name)
+		}
+	}
+}
+
+func TestCloneStatementNoAliasing(t *testing.T) {
+	original := &LetStmt{
+		Name: &Identifier{Value: "x"},
+		Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}},
+		Value: &CallExpression{
+			Function:  &Identifier{Value: "make"},
+			Arguments: []Expression{&IntegerLiteral{Value: 1}},
+		},
+	}
+	clone := CloneStatement(original).(*LetStmt)
+	// mutar o clone em profundidade
+	clone.Name.Value = "y"
+	clone.Type.(*ArrayType).ElementType = &PrimitiveType{Name: "int"}
+	clone.Value.(*CallExpression).Arguments[0] = &IntegerLiteral{Value: 99}
+	if original.Name.Value != "x" {
+		t.Fatal("Name compartilhado entre original e clone")
+	}
+	if _, ok := original.Type.(*ArrayType).ElementType.(*TypeParamType); !ok {
+		t.Fatal("Type compartilhado entre original e clone")
+	}
+	if original.Value.(*CallExpression).Arguments[0].(*IntegerLiteral).Value != 1 {
+		t.Fatal("Arguments compartilhado entre original e clone")
+	}
+}
+
+func TestCloneFunctionStatementDeep(t *testing.T) {
+	original := &FunctionStatement{
+		Name:       "first",
+		TypeParams: []string{"T"},
+		Parameters: []*Parameter{{Name: "arr", Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}}}},
+		ReturnType: &TypeParamType{Name: "T"},
+		Body: &BlockStatement{Statements: []Statement{
+			&ReturnStmt{ReturnValue: &IndexExpression{
+				Left:  &Identifier{Value: "arr"},
+				Index: &IntegerLiteral{Value: 0},
+			}},
+		}},
+	}
+	clone := CloneStatement(original).(*FunctionStatement)
+	clone.Parameters[0].Type = &PrimitiveType{Name: "int"}
+	clone.Body.Statements[0].(*ReturnStmt).ReturnValue = &NullLiteral{}
+	if _, ok := original.Parameters[0].Type.(*ArrayType); !ok {
+		t.Fatal("Parameter.Type compartilhado")
+	}
+	if _, ok := original.Body.Statements[0].(*ReturnStmt).ReturnValue.(*IndexExpression); !ok {
+		t.Fatal("Body compartilhado")
+	}
+}
+
+func TestCloneStructStatementBothFieldMirrors(t *testing.T) {
+	original := &StructStatement{
+		Name:       "Stack",
+		TypeParams: []string{"T"},
+		Fields:     map[string]NoxyType{"items": &ArrayType{ElementType: &TypeParamType{Name: "T"}}},
+		FieldsList: []*StructField{{Name: "items", Type: &ArrayType{ElementType: &TypeParamType{Name: "T"}}}},
+	}
+	clone := CloneStatement(original).(*StructStatement)
+	clone.FieldsList[0].Type = &PrimitiveType{Name: "int"}
+	clone.Fields["items"] = &PrimitiveType{Name: "int"}
+	if _, ok := original.FieldsList[0].Type.(*ArrayType); !ok {
+		t.Fatal("FieldsList compartilhado")
+	}
+	if _, ok := original.Fields["items"].(*ArrayType); !ok {
+		t.Fatal("Fields (map) compartilhado")
+	}
+}

--- a/internal/ast/generics_ast_test.go
+++ b/internal/ast/generics_ast_test.go
@@ -1,0 +1,35 @@
+package ast
+
+import "testing"
+
+func TestGenericTypeString(t *testing.T) {
+	g := &GenericType{Name: "Stack", Args: []NoxyType{&PrimitiveType{Name: "int"}}}
+	if got := g.String(); got != "Stack<int>" {
+		t.Fatalf("String() = %q, quer Stack<int>", got)
+	}
+	nested := &GenericType{Name: "Stack", Args: []NoxyType{g}}
+	if got := nested.String(); got != "Stack<Stack<int>>" {
+		t.Fatalf("String() = %q, quer Stack<Stack<int>>", got)
+	}
+	multi := &GenericType{Name: "Map", Args: []NoxyType{
+		&PrimitiveType{Name: "string"}, &PrimitiveType{Name: "int"},
+	}}
+	if got := multi.String(); got != "Map<string, int>" {
+		t.Fatalf("String() = %q, quer Map<string, int>", got)
+	}
+}
+
+func TestTypeParamTypeString(t *testing.T) {
+	p := &TypeParamType{Name: "T"}
+	if got := p.String(); got != "T" {
+		t.Fatalf("String() = %q, quer T", got)
+	}
+}
+
+func TestTypeParamsFieldsExist(t *testing.T) {
+	f := &FunctionStatement{TypeParams: []string{"T"}}
+	s := &StructStatement{TypeParams: []string{"K", "V"}}
+	if len(f.TypeParams) != 1 || len(s.TypeParams) != 2 {
+		t.Fatal("campos TypeParams ausentes")
+	}
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -87,6 +87,14 @@ type Compiler struct {
 	// antes de ser compilado. Armado em setArrayElementHint, consumido e limpo
 	// no proprio case de ArrayLiteral.
 	arrayElementHint ast.NoxyType
+	// namespaceImports mapeia o nome local de um `use m` (forma de namespace,
+	// sem select) para o modulo que ele nomeia — §8: "template genérico não é
+	// acessível via namespace". E uma COPIA por compilador (como globals/
+	// structs, nao um ponteiro compartilhado como generics/instances):
+	// um `use` dentro de um corpo de funcao (permitido — ver
+	// TestRuntimeFunctionBodyOnlyWildcardDoesNotInvalidateModule) so pode
+	// afetar o escopo daquele corpo, nunca vazar para o compilador pai.
+	namespaceImports map[string]string
 }
 
 type callEmission struct {
@@ -143,24 +151,29 @@ func NewChild(parent *Compiler) *Compiler {
 	for name, definition := range parent.structs {
 		childStructs[name] = definition
 	}
+	childNamespaceImports := make(map[string]string, len(parent.namespaceImports))
+	for name, module := range parent.namespaceImports {
+		childNamespaceImports[name] = module
+	}
 	c := &Compiler{
-		enclosing:       parent,
-		currentChunk:    chunk.New(),
-		locals:          []Local{},
-		globals:         childGlobals,
-		structs:         childStructs,
-		upvalues:        []Upvalue{},
-		scopeDepth:      0,
-		loops:           []*Loop{},
-		currentLine:     parent.currentLine,
-		FileName:        parent.FileName,
-		moduleRoot:      parent.moduleRoot,
-		programBindings: parent.programBindings,
-		moduleDiscovery: parent.moduleDiscovery,
-		generics:        parent.generics,
-		moduleName:      parent.moduleName,
-		instances:       parent.instances,
-		pass1:           parent.pass1,
+		enclosing:        parent,
+		currentChunk:     chunk.New(),
+		locals:           []Local{},
+		globals:          childGlobals,
+		structs:          childStructs,
+		upvalues:         []Upvalue{},
+		scopeDepth:       0,
+		loops:            []*Loop{},
+		currentLine:      parent.currentLine,
+		FileName:         parent.FileName,
+		moduleRoot:       parent.moduleRoot,
+		programBindings:  parent.programBindings,
+		moduleDiscovery:  parent.moduleDiscovery,
+		generics:         parent.generics,
+		moduleName:       parent.moduleName,
+		instances:        parent.instances,
+		pass1:            parent.pass1,
+		namespaceImports: childNamespaceImports,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -178,7 +191,16 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// validator de modulo, runtime do `use`, REPL — ganhe o tratamento
 		// sem duplicacao. Programa sem genericos nao paga nada alem da
 		// varredura das declaracoes do topo.
-		c.predeclareGenericTemplates(n.Statements)
+		if err := c.predeclareGenericTemplates(n.Statements); err != nil {
+			return nil, nil, err
+		}
+		// §8/R8: templates IMPORTADOS entram no registry aqui tambem, cedo —
+		// ver o comentario de predeclareImportedTemplates para o porque
+		// (hasGenerics(), logo abaixo, precisa ja enxergar um template que so
+		// veio de `use m select f`, nao de uma declaracao local).
+		if err := c.predeclareImportedTemplates(n.Statements); err != nil {
+			return nil, nil, err
+		}
 		if !c.pass1 && c.hasGenerics() {
 			if err := c.runGenericsPass1(n); err != nil {
 				return nil, nil, err
@@ -723,7 +745,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if c.scopeDepth > 0 || c.enclosing != nil {
 				return nil, nil, fmt.Errorf("[line %d] declaração genérica só é permitida no top level", n.Token.Line)
 			}
-			c.registryOrInit().Structs[n.Name] = &StructTemplate{Decl: n, Module: c.moduleName}
+			if err := c.registerStructTemplate(n.Name, &StructTemplate{Decl: n, Module: c.moduleName}, n.Token.Line); err != nil {
+				return nil, nil, err
+			}
 			return c.currentChunk, nil, nil
 		}
 		c.setLine(n.Token.Line)
@@ -1698,16 +1722,39 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if !loadable && c.enclosing == nil {
 				return nil, nil, fmt.Errorf("[line %d] failed to resolve wildcard module '%s'", n.Token.Line, n.Module)
 			}
+			// §8/R8: templates genericos exportados entram no registry
+			// (Module = modulo definidor) em vez de c.globals — importBindingFrom
+			// decide por declaracao. Templates nunca tem valor em runtime (a
+			// declaracao original nao emite bytecode nenhum), entao ficam
+			// ausentes do ExportMap que OP_IMPORT_FROM_ALL le abaixo — sem
+			// tratamento especial aqui: a instrucao so importa as chaves que
+			// EXISTEM no map do modulo, e simplesmente nao ha chave "processa".
+			bindings, _ := c.moduleTopLevelBindings(n.Module)
 			for name := range exports {
-				c.globals[name] = nil
+				if err := c.importBindingFrom(n.Module, bindings, name); err != nil {
+					return nil, nil, err
+				}
 			}
 			c.importModuleStructs(n.Module, nil)
 			c.emitByte(byte(chunk.OP_IMPORT_FROM_ALL))
 		} else if len(n.Selectors) > 0 {
 			// use pkg select a, b
 			c.importModuleStructs(n.Module, n.Selectors)
+			bindings, _ := c.moduleTopLevelBindings(n.Module)
 			for _, sel := range n.Selectors {
-				c.globals[sel] = nil
+				if err := c.importBindingFrom(n.Module, bindings, sel); err != nil {
+					return nil, nil, err
+				}
+				if isModuleTemplateDeclaration(bindings, sel) {
+					// §8: template generico nao existe como valor em runtime
+					// (sem bytecode proprio) — buscar "sel" como propriedade do
+					// objeto do modulo lancaria "undefined property" (o
+					// ExportMap nunca tem essa chave). O registro acima
+					// (importBindingFrom, no GenericRegistry) e tudo que este
+					// nome precisa: a instancia concreta nasce como declaracao
+					// sintetica comum no two-pass do IMPORTADOR.
+					continue
+				}
 				// DUP the module
 				c.emitByte(byte(chunk.OP_DUP))
 
@@ -1737,7 +1784,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 
 			nameConst := c.makeConstant(value.NewString(bindName))
-			c.globals[bindName] = nil
+			c.importNamespace(n.Module, bindName)
 			c.emitOpWithConstantIndex(chunk.OP_SET_GLOBAL, nameConst)
 			c.emitByte(byte(chunk.OP_POP)) // Pop module
 		}
@@ -1804,7 +1851,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if c.scopeDepth > 0 || c.enclosing != nil {
 				return nil, nil, fmt.Errorf("[line %d] declaração genérica só é permitida no top level", n.Token.Line)
 			}
-			c.registryOrInit().Funcs[n.Name] = &FuncTemplate{Decl: n, Module: c.moduleName}
+			if err := c.registerFuncTemplate(n.Name, &FuncTemplate{Decl: n, Module: c.moduleName}, n.Token.Line); err != nil {
+				return nil, nil, err
+			}
 			return c.currentChunk, nil, nil
 		}
 		c.setLine(n.Token.Line)
@@ -2001,6 +2050,31 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 
 			c.emitByte(byte(chunk.OP_ADDR))
 			return c.currentChunk, &ast.PrimitiveType{Name: "string"}, nil
+		}
+	}
+
+	// §8/§9: `use m` (namespace, sem select) seguido de `m.processa(...)`.
+	// O template nunca existe como valor em runtime (declaracao generica nao
+	// emite bytecode) e o member access nao carrega tipo estatico nenhum —
+	// sem esta interceptacao o caminho normal so falharia mais tarde, em
+	// runtime, com "undefined property" generico. Checa ANTES da
+	// interceptacao de call site generico abaixo porque o callee aqui e um
+	// *ast.MemberAccessExpression, nunca um *ast.Identifier — os dois hooks
+	// nao competem pelo mesmo formato de callee.
+	if memberCall, isMemberCall := call.Function.(*ast.MemberAccessExpression); isMemberCall {
+		if leftIdent, isIdent := memberCall.Left.(*ast.Identifier); isIdent {
+			if slot, _ := c.resolveLocal(leftIdent.Value); slot == -1 {
+				if upvalue, _ := c.resolveUpvalue(leftIdent.Value); upvalue == -1 {
+					if module, isNamespace := c.namespaceImports[leftIdent.Value]; isNamespace {
+						if c.moduleExportsGenericTemplateName(module, memberCall.Member) {
+							return nil, nil, fmt.Errorf(
+								"[line %d] template genérico '%s' não é acessível via namespace — use select",
+								c.currentLine, memberCall.Member,
+							)
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -954,6 +954,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return c.currentChunk, upvalueType, nil
 		} else {
 			// Global
+			// §9/§4: fallback para as posicoes de valor que nenhum hook de
+			// genericos intercepta (map literal, expression statement solto)
+			// — ver o comentario de rejectBareGenericTemplateIdentifier em
+			// generics_target.go. Sombreamento por local/upvalue ja foi
+			// descartado pelos dois ramos acima, entao a mesma regra vale
+			// aqui sem checagem extra.
+			if err := c.rejectBareGenericTemplateIdentifier(n); err != nil {
+				return nil, nil, err
+			}
 			nameConstant := c.makeConstant(value.NewString(n.Value))
 			c.emitOpWithConstantIndex(chunk.OP_GET_GLOBAL, nameConstant)
 
@@ -1031,6 +1040,21 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			c.emitByte(byte(chunk.OP_DEREF))
 			if ref, ok := rightType.(*ast.RefType); ok {
 				rightType = ref.ElementType
+			}
+		}
+
+		// Structs nunca definem operador aritmetico (OP_ADD e companhia, em
+		// runtime, so aceitam numeros — e OP_ADD tambem strings/bytes — nunca
+		// ObjStruct: cai no "operands must be numbers..." generico do
+		// executor). Sem esta checagem, 'a + b' com a,b struct compilava
+		// silenciosamente e so estourava no runtime; dentro do corpo de uma
+		// instancia generica monomorfizada isso escapava por completo da
+		// cadeia de instanciacao do §9 (instantiationChainError so envolve
+		// ERROS DE COMPILACAO). Pegar aqui cedo produz a mensagem exata do
+		// catalogo, com a linha do proprio operador.
+		if arithmeticOperators[n.Operator] {
+			if structName, isStruct := c.structOperandName(leftType, rightType); isStruct {
+				return nil, nil, fmt.Errorf("[line %d] operador '%s' não definido para %s", n.Token.Line, n.Operator, structName)
 			}
 		}
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -168,7 +168,7 @@ func NewChild(parent *Compiler) *Compiler {
 		FileName:         parent.FileName,
 		moduleRoot:       parent.moduleRoot,
 		programBindings:  parent.programBindings,
-		moduleDiscovery:  parent.moduleDiscovery,
+		moduleDiscovery:  parent.discoveryState(),
 		generics:         parent.generics,
 		moduleName:       parent.moduleName,
 		instances:        parent.instances,

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -77,6 +77,8 @@ type Compiler struct {
 	// genericReturnHint carrega a anotacao do `let` envolvente para o proximo
 	// call site generico (target-typing do §7). Armado em setGenericReturnHint,
 	// consumido e limpo em compileGenericCallSite.
+	// O mesmo campo serve ao construtor de struct generico (`let c: Caixa<int> =
+	// Caixa([])`), consumido e limpo em compileGenericConstructorSite.
 	genericReturnHint ast.NoxyType
 }
 
@@ -180,7 +182,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		for name, bindingType := range c.globals {
 			sequentialBindings[name] = bindingType
 		}
-		c.predeclareStructs(n.Statements)
+		if err := c.predeclareStructs(n.Statements); err != nil {
+			return nil, nil, err
+		}
 		if err := c.predeclareGlobalBindings(n.Statements); err != nil {
 			return nil, nil, err
 		}
@@ -206,6 +210,17 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 	case *ast.LetStmt:
 		c.setLine(n.Token.Line)
+		// §4, terceira familia de hooks: a anotacao pode nomear instancias de
+		// struct generico (`Caixa<int>`, `Caixa<int>[]`, `ref Node<int>`). A
+		// resolucao vem ANTES de tudo — antes do hint, do emitDefaultInit e da
+		// checagem de tipos — e reescreve n.Type in-place para o nome
+		// qualificado, que e o que o pass 2 compila.
+		resolvedAnnotation, err := c.resolveAnnotation(n.Type, n.Token.Line)
+		if err != nil {
+			return nil, nil, err
+		}
+		n.Type = resolvedAnnotation
+
 		var valType ast.NoxyType
 		// Compile initializer
 		if n.Value != nil {
@@ -683,6 +698,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return c.currentChunk, nil, nil
 		}
 		c.setLine(n.Token.Line)
+		// §4, terceira familia de hooks: um campo pode anotar um struct generico
+		// (`c: Caixa<int>`), inclusive num struct comum. Resolve in-place nos dois
+		// espelhos antes de derivar o valor do struct e o tipo do construtor.
+		if err := c.resolveStructFieldAnnotations(n, n.Token.Line); err != nil {
+			return nil, nil, err
+		}
 		if c.scopeDepth > 0 {
 			prior, existed := c.structs[n.Name]
 			c.scopedStructs = append(c.scopedStructs, scopedStructBinding{
@@ -1362,7 +1383,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// nascimento, a captura por closure produz caixa possuidora e o rebind
 		// usa o store contado — Owns volta a coincidir com "tipo nao-ref".
 		c.emitByte(byte(chunk.OP_OWN_LOCAL))
-		c.addOwnedLocal(n.Identifier, nil) // User variable (consumes Item from stack)
+		// Ruling R5: a variavel do laco recebe o tipo do elemento da colecao
+		// quando ele e estaticamente conhecido (array -> elemento, map -> chave,
+		// que e o que o laco produz depois da reescrita para `keys(m)`). Colecao
+		// de tipo desconhecido continua produzindo variavel sem tipo — nil aqui
+		// significa "nao sei", como antes. Sem isso nenhuma chamada generica
+		// ancorada na variavel do laco consegue inferir T.
+		c.addOwnedLocal(n.Identifier, forEachElementType(colType)) // User variable (consumes Item from stack)
 
 		// 9. Compile Body
 		_, _, err = c.Compile(n.Body)
@@ -1711,6 +1738,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		}
 		c.setLine(n.Token.Line)
 
+		// §4, terceira familia de hooks: parametro/retorno de funcao NAO-generica
+		// podem anotar um struct generico (`func conta(cs: Caixa<int>[]) -> int`).
+		// Resolve antes de registrar o tipo do global — o tipo publicado tem de ser
+		// o mesmo que o pass 2 vai derivar do AST reescrito.
+		if err := c.resolveSignatureAnnotations(n.Parameters, &n.ReturnType, n.Token.Line); err != nil {
+			return nil, nil, err
+		}
 		c.globals[n.Name] = newFunctionType(n.Parameters, n.ReturnType)
 
 		fnObj, fnCompiler, err := c.compileFunction(n.Name, n.Parameters, n.Body, n.ReturnType)
@@ -1734,6 +1768,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		fnName := n.Name
 		if fnName == "" {
 			fnName = "anonymous"
+		}
+		// Mesmo hook do FunctionStatement: a assinatura de um literal tambem pode
+		// anotar instancias de struct generico.
+		if err := c.resolveSignatureAnnotations(n.Parameters, &n.ReturnType, n.Token.Line); err != nil {
+			return nil, nil, err
 		}
 
 		fnObj, fnCompiler, err := c.compileFunction(fnName, n.Parameters, n.Body, n.ReturnType) // Literal return type? n.ReturnType? FunctionLiteral needs return type field if typed. Assuming inferred/any if nil.
@@ -1904,9 +1943,18 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 	// Um local/parametro que sombreia o nome do template tambem nao dispara —
 	// quem vence e o binding mais interno, como no caminho normal.
 	if callee, ok := call.Function.(*ast.Identifier); ok {
-		if template, isTemplate := c.registryOrInit().Funcs[callee.Value]; isTemplate {
+		registry := c.registryOrInit()
+		if template, isTemplate := registry.Funcs[callee.Value]; isTemplate {
 			if slot, _ := c.resolveLocal(callee.Value); slot == -1 {
 				if err := c.compileGenericCallSite(call, callee, template); err != nil {
+					return nil, nil, err
+				}
+			}
+		} else if structTemplate, isStructTemplate := registry.Structs[callee.Value]; isStructTemplate {
+			// Construtor de struct generico: `Caixa(41)`. Mesmo hook, mesma regra
+			// de sombreamento — um local com o nome do template vence.
+			if slot, _ := c.resolveLocal(callee.Value); slot == -1 {
+				if err := c.compileGenericConstructorSite(call, callee, structTemplate); err != nil {
 					return nil, nil, err
 				}
 			}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -80,6 +80,13 @@ type Compiler struct {
 	// O mesmo campo serve ao construtor de struct generico (`let c: Caixa<int> =
 	// Caixa([])`), consumido e limpo em compileGenericConstructorSite.
 	genericReturnHint ast.NoxyType
+	// arrayElementHint carrega o tipo de elemento da anotacao do `let`
+	// envolvente para o proximo array literal (target-typing do §3, posicao 3):
+	// `let fs: (func(int) -> int)[] = [dobro, identity]` precisa que cada
+	// elemento identificador nu (`identity`) saiba o alvo `func(int) -> int`
+	// antes de ser compilado. Armado em setArrayElementHint, consumido e limpo
+	// no proprio case de ArrayLiteral.
+	arrayElementHint ast.NoxyType
 }
 
 type callEmission struct {
@@ -224,12 +231,26 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		var valType ast.NoxyType
 		// Compile initializer
 		if n.Value != nil {
+			// §3 target-typing, posicao 1: o valor do `let` pode ser um
+			// identificador NU nomeando um template de funcao (`let f:
+			// func(int) -> int = identity`) — a anotacao e o alvo concreto que
+			// instancia a genérica antes de qualquer tentativa de compilar o
+			// identificador normalmente (o que hoje leria um global nunca
+			// definido).
+			if err := c.rewriteIfGenericValue(n.Value, n.Type); err != nil {
+				return nil, nil, err
+			}
 			// Target-typing do §7: a anotacao do `let` e o hint para o T que
 			// so aparece no retorno do template. Armado imediatamente antes
 			// (e limpo imediatamente depois) da compilacao do valor.
 			c.setGenericReturnHint(n.Type, n.Value)
+			// §3, posicao 3: elemento de array literal — o tipo de elemento
+			// da anotacao e o alvo para cada identificador nu dentro de `[
+			// ... ]`. Mesma disciplina de armar/limpar do hint acima.
+			c.setArrayElementHint(n.Type, n.Value)
 			_, t, err := c.Compile(n.Value)
 			c.genericReturnHint = nil
+			c.arrayElementHint = nil
 			if err != nil {
 				return nil, nil, err
 			}
@@ -629,13 +650,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				leftType = nil
 			}
 
-			// 2. Compile Value
-			_, valType, err := c.Compile(n.Value)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			// RESOLVE FIELD TYPE:
+			// RESOLVE FIELD TYPE (antes de compilar o valor: §3 target-typing,
+			// posicao 4, precisa do tipo declarado do campo como alvo para
+			// decidir se n.Value e um template de funcao nu):
 			var fieldType ast.NoxyType
 			if prim, ok := leftType.(*ast.PrimitiveType); ok {
 				if structDef, exists := c.structs[prim.Name]; exists {
@@ -646,6 +663,18 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						}
 					}
 				}
+			}
+
+			// §3 target-typing, posicao 4: `campo.transform = identity` — o
+			// tipo declarado do campo e o alvo concreto.
+			if err := c.rewriteIfGenericValue(n.Value, fieldType); err != nil {
+				return nil, nil, err
+			}
+
+			// 2. Compile Value
+			_, valType, err := c.Compile(n.Value)
+			if err != nil {
+				return nil, nil, err
 			}
 
 			// TYPE-BASED ASSIGNMENT LOGIC:
@@ -787,8 +816,19 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, nil, nil
 
 	case *ast.ArrayLiteral:
+		// §3 target-typing, posicao 3: consome o hint armado pelo `let`
+		// envolvente (setArrayElementHint) ANTES de compilar qualquer
+		// elemento — leitura unica, para nao vazar num array literal aninhado
+		// dentro de um elemento deste.
+		elementHint := c.arrayElementHint
+		c.arrayElementHint = nil
 		var elemType ast.NoxyType
 		for i, el := range n.Elements {
+			if elementHint != nil {
+				if err := c.rewriteIfGenericValue(el, elementHint); err != nil {
+					return nil, nil, err
+				}
+			}
 			_, t, err := c.Compile(el)
 			if err != nil {
 				return nil, nil, err
@@ -1695,6 +1735,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return c.currentChunk, nil, nil
 		}
 
+		// §3 target-typing, posicao 2: `return identity` dentro de uma funcao
+		// cujo retorno declarado e um tipo de funcao concreto instancia a
+		// genérica antes da compilacao normal do valor de retorno.
+		if err := c.rewriteIfGenericValue(n.ReturnValue, expected); err != nil {
+			return nil, nil, err
+		}
+
 		_, actual, err := c.Compile(n.ReturnValue)
 		if err != nil {
 			return nil, nil, err
@@ -2005,6 +2052,24 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 				}
 				continue
 			}
+		}
+
+		// §3 target-typing, posicao 5 (parte nao-generica: callee comum
+		// recebendo um template de funcao nu, `func aplicaSimples(fn:
+		// func(int)->int)` chamado com `aplicaSimples(identity)`): quando o
+		// tipo do parametro e conhecido e concreto, e o alvo; sem alvo
+		// conhecido (isExact falso), rewriteIfGenericValue erra pedindo
+		// anotacao — exatamente a regra do §9 para identificador de template
+		// em posicao de valor sem tipo concreto. Callees GENERICOS (`aplica`)
+		// ja tiveram seus argumentos-template resolvidos e reescritos em
+		// compileGenericCallSite antes de chegar aqui; o registro nao tem mais
+		// a chave crua, entao este hook e um no-op para eles.
+		var argTarget ast.NoxyType
+		if isExact {
+			argTarget = funcType.Params[i]
+		}
+		if err := c.rewriteIfGenericValue(arg, argTarget); err != nil {
+			return nil, nil, err
 		}
 
 		_, argType, err := c.Compile(arg)

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -68,6 +68,16 @@ type Compiler struct {
 	moduleDiscovery     *moduleDiscoveryState
 	generics            *GenericRegistry // lazy-init: use registryOrInit()
 	moduleName          string           // default "main"; setter usado nas tasks de modulo
+	instances           *instanceQueue   // lazy-init: use instancesOrInit()
+	// pass1 marca o compilador descartavel da primeira passada dos genericos
+	// (§5): interceptacao de call site generico so acontece com ele ligado, e
+	// ele tambem e o guard de recursao do two-pass (um Compile(*ast.Program)
+	// em pass 1 nao reentra na pass 1).
+	pass1 bool
+	// genericReturnHint carrega a anotacao do `let` envolvente para o proximo
+	// call site generico (target-typing do §7). Armado em setGenericReturnHint,
+	// consumido e limpo em compileGenericCallSite.
+	genericReturnHint ast.NoxyType
 }
 
 type callEmission struct {
@@ -140,6 +150,8 @@ func NewChild(parent *Compiler) *Compiler {
 		moduleDiscovery: parent.moduleDiscovery,
 		generics:        parent.generics,
 		moduleName:      parent.moduleName,
+		instances:       parent.instances,
+		pass1:           parent.pass1,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -152,6 +164,18 @@ func (c *Compiler) GetGlobals() map[string]ast.NoxyType {
 func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 	switch n := node.(type) {
 	case *ast.Program:
+		// Two-pass dos genericos (§5). Fica AQUI, na entrada de *ast.Program,
+		// para que todo caminho que compila um Program — programa principal,
+		// validator de modulo, runtime do `use`, REPL — ganhe o tratamento
+		// sem duplicacao. Programa sem genericos nao paga nada alem da
+		// varredura das declaracoes do topo.
+		c.predeclareGenericTemplates(n.Statements)
+		if !c.pass1 && c.hasGenerics() {
+			if err := c.runGenericsPass1(n); err != nil {
+				return nil, nil, err
+			}
+		}
+
 		sequentialBindings := make(map[string]ast.NoxyType, len(c.globals))
 		for name, bindingType := range c.globals {
 			sequentialBindings[name] = bindingType
@@ -185,7 +209,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		var valType ast.NoxyType
 		// Compile initializer
 		if n.Value != nil {
+			// Target-typing do §7: a anotacao do `let` e o hint para o T que
+			// so aparece no retorno do template. Armado imediatamente antes
+			// (e limpo imediatamente depois) da compilacao do valor.
+			c.setGenericReturnHint(n.Type, n.Value)
 			_, t, err := c.Compile(n.Value)
+			c.genericReturnHint = nil
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1862,6 +1891,25 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 
 			c.emitByte(byte(chunk.OP_ADDR))
 			return c.currentChunk, &ast.PrimitiveType{Name: "string"}, nil
+		}
+	}
+
+	// Interceptacao de call site generico (§4): tem de vir ANTES do caminho
+	// normal, que compilaria o callee e leria o tipo CRU do template (com
+	// TypeParamType) do registro de globals. Depois da interceptacao o
+	// identificador ja aponta para a instancia monomorfizada e o caminho
+	// normal resolve um global comum.
+	//
+	// No pass 2 nada dispara: os nomes reescritos nao sao chaves do registro.
+	// Um local/parametro que sombreia o nome do template tambem nao dispara —
+	// quem vence e o binding mais interno, como no caminho normal.
+	if callee, ok := call.Function.(*ast.Identifier); ok {
+		if template, isTemplate := c.registryOrInit().Funcs[callee.Value]; isTemplate {
+			if slot, _ := c.resolveLocal(callee.Value); slot == -1 {
+				if err := c.compileGenericCallSite(call, callee, template); err != nil {
+					return nil, nil, err
+				}
+			}
 		}
 	}
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1710,6 +1710,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, nil, nil
 
 	case *ast.UseStmt:
+		// §9/I1: `use` aninhado (corpo de funcao/lambda) que traga um template
+		// generico e recusado com mensagem acionavel ANTES de qualquer emissao
+		// — ver rejectNestedTemplateImport. Sem isto o template entrava no
+		// registry no meio da compilacao e a chamada batia no guard defensivo
+		// do pass 2, que acusa "bug do compilador" com a linha errada.
+		if err := c.rejectNestedTemplateImport(n); err != nil {
+			return nil, nil, err
+		}
+
 		// 1. Emit Module Name
 		nameConst := c.makeConstant(value.NewString(n.Module))
 		// 2. Emit Import (Loads module and pushes it to stack)

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -2085,20 +2085,26 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 	// normal resolve um global comum.
 	//
 	// No pass 2 nada dispara: os nomes reescritos nao sao chaves do registro.
-	// Um local/parametro que sombreia o nome do template tambem nao dispara —
-	// quem vence e o binding mais interno, como no caminho normal.
+	// Um local/parametro/UPVALUE que sombreia o nome do template tambem nao
+	// dispara — quem vence e o binding mais interno, como no caminho normal.
+	// O guard e isShadowedByLocal (locais E upvalues), o mesmo que as outras
+	// familias de hook usam (generics_target.go): checar so resolveLocal
+	// deixava passar o nome CAPTURADO por uma closure (`let id = dobro`
+	// seguido de `func() ... id(v) ... end`), e a chamada era interceptada
+	// como generica em vez de chamar o valor capturado — codigo errado em
+	// silencio, sem erro nenhum.
 	if callee, ok := call.Function.(*ast.Identifier); ok {
 		registry := c.registryOrInit()
 		if template, isTemplate := registry.Funcs[callee.Value]; isTemplate {
-			if slot, _ := c.resolveLocal(callee.Value); slot == -1 {
+			if !c.isShadowedByLocal(callee.Value) {
 				if err := c.compileGenericCallSite(call, callee, template); err != nil {
 					return nil, nil, err
 				}
 			}
 		} else if structTemplate, isStructTemplate := registry.Structs[callee.Value]; isStructTemplate {
 			// Construtor de struct generico: `Caixa(41)`. Mesmo hook, mesma regra
-			// de sombreamento — um local com o nome do template vence.
-			if slot, _ := c.resolveLocal(callee.Value); slot == -1 {
+			// de sombreamento — um local ou upvalue com o nome do template vence.
+			if !c.isShadowedByLocal(callee.Value) {
 				if err := c.compileGenericConstructorSite(call, callee, structTemplate); err != nil {
 					return nil, nil, err
 				}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -66,6 +66,8 @@ type Compiler struct {
 	scopedStructs       []scopedStructBinding
 	programBindings     map[string]ast.NoxyType
 	moduleDiscovery     *moduleDiscoveryState
+	generics            *GenericRegistry // lazy-init: use registryOrInit()
+	moduleName          string           // default "main"; setter usado nas tasks de modulo
 }
 
 type callEmission struct {
@@ -107,6 +109,7 @@ func NewWithStateAndRoot(globals map[string]ast.NoxyType, structs map[string]*as
 		currentLine:  1,
 		FileName:     fileName,
 		moduleRoot:   moduleRoot,
+		moduleName:   "main",
 	}
 	c.currentChunk.FileName = fileName
 	return c
@@ -135,6 +138,8 @@ func NewChild(parent *Compiler) *Compiler {
 		moduleRoot:      parent.moduleRoot,
 		programBindings: parent.programBindings,
 		moduleDiscovery: parent.moduleDiscovery,
+		generics:        parent.generics,
+		moduleName:      parent.moduleName,
 	}
 	c.currentChunk.FileName = parent.FileName
 	return c
@@ -641,6 +646,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, nil, nil
 
 	case *ast.StructStatement:
+		if len(n.TypeParams) > 0 {
+			if c.scopeDepth > 0 || c.enclosing != nil {
+				return nil, nil, fmt.Errorf("[line %d] declaração genérica só é permitida no top level", n.Token.Line)
+			}
+			c.registryOrInit().Structs[n.Name] = &StructTemplate{Decl: n, Module: c.moduleName}
+			return c.currentChunk, nil, nil
+		}
 		c.setLine(n.Token.Line)
 		if c.scopeDepth > 0 {
 			prior, existed := c.structs[n.Name]
@@ -1661,6 +1673,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, nil, nil
 
 	case *ast.FunctionStatement:
+		if len(n.TypeParams) > 0 {
+			if c.scopeDepth > 0 || c.enclosing != nil {
+				return nil, nil, fmt.Errorf("[line %d] declaração genérica só é permitida no top level", n.Token.Line)
+			}
+			c.registryOrInit().Funcs[n.Name] = &FuncTemplate{Decl: n, Module: c.moduleName}
+			return c.currentChunk, nil, nil
+		}
 		c.setLine(n.Token.Line)
 
 		c.globals[n.Name] = newFunctionType(n.Parameters, n.ReturnType)

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -224,10 +224,25 @@ func (c *Compiler) predeclareGlobalBindings(statements []ast.Statement) error {
 				return fmt.Errorf("[line %d] duplicate function '%s'", declaration.Token.Line, declaration.Name)
 			}
 			seen[declaration.Name] = struct{}{}
+			// Genericos (§5): um template NAO tem tipo concreto — seus params
+			// carregam TypeParamType. Registra-lo aqui o copiaria para
+			// c.programBindings, e applyProgramBindings o injetaria de volta em
+			// c.globals durante todo corpo de funcao compilado. A identidade do
+			// template vive no GenericRegistry; quem entra em globals sao as
+			// INSTANCIAS, que o pass 2 prepende como declaracoes comuns e
+			// passam por aqui normalmente.
+			if len(declaration.TypeParams) > 0 {
+				continue
+			}
 			c.globals[declaration.Name] = newFunctionType(declaration.Parameters, declaration.ReturnType)
 		case *ast.LetStmt:
 			c.globals[declaration.Name.Value] = declaration.Type
 		case *ast.StructStatement:
+			// Mesma regra do template de funcao: o construtor de um struct
+			// generico nao tem assinatura concreta antes da substituicao.
+			if len(declaration.TypeParams) > 0 {
+				continue
+			}
 			params := make([]ast.NoxyType, 0, len(declaration.FieldsList))
 			for _, field := range declaration.FieldsList {
 				params = append(params, field.Type)
@@ -249,6 +264,14 @@ func (c *Compiler) predeclareStructs(statements []ast.Statement) {
 	for _, statement := range statements {
 		definition, ok := statement.(*ast.StructStatement)
 		if ok {
+			// Genericos (§5): a tabela de structs e consultada por resolucao de
+			// campo e por runtimeTypeInfo, que precisam de tipos concretos. Um
+			// template tem campos com TypeParamType — ele fica so no
+			// GenericRegistry; as instancias monomorfizadas e que sao
+			// StructStatement comuns e entram aqui.
+			if len(definition.TypeParams) > 0 {
+				continue
+			}
 			c.structs[definition.Name] = definition
 		}
 	}

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -234,14 +234,34 @@ func (c *Compiler) predeclareGlobalBindings(statements []ast.Statement) error {
 			if len(declaration.TypeParams) > 0 {
 				continue
 			}
+			// §4, terceira familia de hooks: a assinatura pode anotar um struct
+			// generico. O predeclare e o PRIMEIRO leitor dessas anotacoes (roda
+			// antes de qualquer statement compilar), entao a resolucao tem de
+			// acontecer aqui tambem — senao o tipo publicado carregaria
+			// `Caixa<int>` enquanto o resto do programa fala `main::Caixa<int>`,
+			// e a checagem de tipos de uma chamada adiantada divergiria.
+			if err := c.resolveSignatureAnnotations(declaration.Parameters, &declaration.ReturnType, declaration.Token.Line); err != nil {
+				return err
+			}
 			c.globals[declaration.Name] = newFunctionType(declaration.Parameters, declaration.ReturnType)
 		case *ast.LetStmt:
+			resolved, err := c.resolveAnnotation(declaration.Type, declaration.Token.Line)
+			if err != nil {
+				return err
+			}
+			declaration.Type = resolved
 			c.globals[declaration.Name.Value] = declaration.Type
 		case *ast.StructStatement:
 			// Mesma regra do template de funcao: o construtor de um struct
 			// generico nao tem assinatura concreta antes da substituicao.
 			if len(declaration.TypeParams) > 0 {
 				continue
+			}
+			// Campos ja resolvidos por predeclareStructs (que roda antes); a
+			// chamada aqui e o fast path idempotente que mantem este ponto de
+			// leitura correto por si.
+			if err := c.resolveStructFieldAnnotations(declaration, declaration.Token.Line); err != nil {
+				return err
 			}
 			params := make([]ast.NoxyType, 0, len(declaration.FieldsList))
 			for _, field := range declaration.FieldsList {
@@ -260,7 +280,7 @@ func newStructFunctionType(name string, params []ast.NoxyType) *ast.FunctionType
 	}
 }
 
-func (c *Compiler) predeclareStructs(statements []ast.Statement) {
+func (c *Compiler) predeclareStructs(statements []ast.Statement) error {
 	for _, statement := range statements {
 		definition, ok := statement.(*ast.StructStatement)
 		if ok {
@@ -272,9 +292,17 @@ func (c *Compiler) predeclareStructs(statements []ast.Statement) {
 			if len(definition.TypeParams) > 0 {
 				continue
 			}
+			// §4, terceira familia de hooks: campo que anota um struct generico
+			// resolve aqui, no primeiro leitor da declaracao — a tabela de
+			// structs alimenta resolucao de campo e runtimeTypeInfo, que exigem
+			// tipos concretos e de identidade nominal final.
+			if err := c.resolveStructFieldAnnotations(definition, definition.Token.Line); err != nil {
+				return err
+			}
 			c.structs[definition.Name] = definition
 		}
 	}
+	return nil
 }
 
 func blockGuaranteesReturn(block *ast.BlockStatement) bool {

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -107,6 +107,35 @@ func callableName(expression ast.Expression) string {
 	return expression.String()
 }
 
+// arithmeticOperators sao os operadores infixos que a VM so executa sobre
+// numeros (e, no caso exclusivo de '+', tambem strings/bytes) — nunca sobre
+// struct. Usado pelo compilador para recusar 'a + b' com operando struct em
+// tempo de compilacao, em vez de deixar estourar no runtime (executor.go,
+// "operands must be numbers...").
+var arithmeticOperators = map[string]bool{
+	"+": true,
+	"-": true,
+	"*": true,
+	"/": true,
+	"%": true,
+}
+
+// structOperandName devolve o nome do primeiro operando (esquerda, depois
+// direita) cujo tipo estatico e um struct registrado em c.structs — "",
+// false quando nenhum dos dois e. Usado pelo InfixExpression para montar a
+// mensagem do catalogo §9 ("operador '+' não definido para Ponto") com o
+// nome do struct ofensor.
+func (c *Compiler) structOperandName(leftType, rightType ast.NoxyType) (string, bool) {
+	for _, t := range [...]ast.NoxyType{leftType, rightType} {
+		if prim, ok := t.(*ast.PrimitiveType); ok {
+			if _, exists := c.structs[prim.Name]; exists {
+				return prim.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
 func unwrapRefType(t ast.NoxyType) ast.NoxyType {
 	if ref, ok := t.(*ast.RefType); ok {
 		return ref.ElementType

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -247,7 +247,9 @@ func (c *Compiler) predeclareGlobalBindings(statements []ast.Statement) error {
 	for _, statement := range statements {
 		switch declaration := statement.(type) {
 		case *ast.UseStmt:
-			c.predeclareImport(declaration)
+			if err := c.predeclareImport(declaration); err != nil {
+				return err
+			}
 		case *ast.FunctionStatement:
 			if _, duplicate := seen[declaration.Name]; duplicate {
 				return fmt.Errorf("[line %d] duplicate function '%s'", declaration.Token.Line, declaration.Name)

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -1,0 +1,53 @@
+package compiler
+
+import "noxy-vm/internal/ast"
+
+// FuncTemplate guarda a declaracao original (nao compilada) de uma funcao
+// generica, junto com o modulo onde foi declarada. Monomorfizacao (Tasks
+// futuras) usa Decl para instanciar uma copia concreta por combinacao de
+// tipos observada em sites de chamada.
+type FuncTemplate struct {
+	Decl   *ast.FunctionStatement
+	Module string
+}
+
+// StructTemplate e o analogo de FuncTemplate para structs genericas.
+type StructTemplate struct {
+	Decl   *ast.StructStatement
+	Module string
+}
+
+// GenericRegistry acumula os templates genericos vistos durante a compilacao
+// de um programa (e, futuramente, de seus modulos). Declaracoes com
+// TypeParams nao-vazio nao emitem bytecode: elas apenas populam este
+// registro, para serem monomorfizadas sob demanda nos sites de uso.
+type GenericRegistry struct {
+	Funcs   map[string]*FuncTemplate
+	Structs map[string]*StructTemplate
+}
+
+// NewGenericRegistry cria um GenericRegistry vazio, pronto para uso.
+func NewGenericRegistry() *GenericRegistry {
+	return &GenericRegistry{
+		Funcs:   make(map[string]*FuncTemplate),
+		Structs: make(map[string]*StructTemplate),
+	}
+}
+
+// SetGenericState injeta um GenericRegistry existente no compilador. Usado
+// pelo REPL (que cria um *Compiler novo a cada linha, mas precisa manter os
+// templates genericos vistos em linhas anteriores) e por testes que
+// precisam inspecionar/preparar o registro antes de compilar.
+func (c *Compiler) SetGenericState(reg *GenericRegistry) {
+	c.generics = reg
+}
+
+// registryOrInit retorna o GenericRegistry do compilador, inicializando-o
+// lazily na primeira chamada. Todo acesso a c.generics dentro do pacote deve
+// passar por aqui para nao lidar com nil.
+func (c *Compiler) registryOrInit() *GenericRegistry {
+	if c.generics == nil {
+		c.generics = NewGenericRegistry()
+	}
+	return c.generics
+}

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -1,6 +1,12 @@
 package compiler
 
-import "noxy-vm/internal/ast"
+import (
+	"fmt"
+	"strings"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+)
 
 // FuncTemplate guarda a declaracao original (nao compilada) de uma funcao
 // generica, junto com o modulo onde foi declarada. Monomorfizacao (Tasks
@@ -50,4 +56,366 @@ func (c *Compiler) registryOrInit() *GenericRegistry {
 		c.generics = NewGenericRegistry()
 	}
 	return c.generics
+}
+
+// instanceQueue e a fila memoizada das declaracoes monomorfizadas descobertas
+// no pass 1 (spec §4/§5).
+//
+//   - memo guarda os nomes qualificados ja instanciados. A entrada e criada
+//     ANTES de clonar/compilar o corpo: e isso que faz recursao e referencia
+//     mutua terminarem (a segunda visita encontra a entrada e para).
+//   - ordered guarda as declaracoes sinteticas na ordem de CONCLUSAO
+//     (pos-ordem): uma instancia so entra na fila depois das instancias que o
+//     corpo dela exigiu, entao toda dependencia aparece antes de quem depende
+//     dela — inclusive structs antes das funcoes que os usam, de graca.
+//
+// O ponteiro e compartilhado entre o compilador real, o compilador
+// descartavel do pass 1, os compiladores de corpo de instancia e todos os
+// filhos (NewChild): ha exatamente uma fila por unidade de compilacao.
+type instanceQueue struct {
+	memo    map[string]bool
+	ordered []ast.Statement
+}
+
+func newInstanceQueue() *instanceQueue {
+	return &instanceQueue{memo: make(map[string]bool)}
+}
+
+// instancesOrInit e o analogo de registryOrInit para a fila de instancias.
+func (c *Compiler) instancesOrInit() *instanceQueue {
+	if c.instances == nil {
+		c.instances = newInstanceQueue()
+	}
+	return c.instances
+}
+
+// predeclareGenericTemplates registra os templates genericos do topo do
+// programa ANTES de qualquer statement ser compilado. Sem isso, um site de
+// chamada que aparece antes da declaracao do template (referencia adiante,
+// que predeclareGlobalBindings ja suporta para funcoes comuns) escaparia da
+// interceptacao e cairia no caminho normal com o tipo cru do template.
+//
+// Idempotente: o case de FunctionStatement/StructStatement registra de novo
+// com o mesmo ponteiro quando a declaracao e efetivamente compilada.
+// Declaracoes genericas ANINHADAS nao passam por aqui (a varredura e so no
+// topo) e continuam sendo rejeitadas pelos cases do Compile.
+func (c *Compiler) predeclareGenericTemplates(statements []ast.Statement) {
+	for _, statement := range statements {
+		switch declaration := statement.(type) {
+		case *ast.FunctionStatement:
+			if len(declaration.TypeParams) > 0 {
+				c.registryOrInit().Funcs[declaration.Name] = &FuncTemplate{Decl: declaration, Module: c.moduleName}
+			}
+		case *ast.StructStatement:
+			if len(declaration.TypeParams) > 0 {
+				c.registryOrInit().Structs[declaration.Name] = &StructTemplate{Decl: declaration, Module: c.moduleName}
+			}
+		}
+	}
+}
+
+// hasGenerics decide se o Program precisa do two-pass. A varredura das
+// declaracoes ja aconteceu em predeclareGenericTemplates, entao a pergunta se
+// reduz a "o registro tem algum template?" — o que tambem cobre o caso do
+// REPL/modulos, onde o registro chega populado de fora (SetGenericState) sem
+// que a linha atual declare nada generico. Programa sem genericos responde
+// false e pula o pass 1 inteiro (custo exatamente zero, §5).
+func (c *Compiler) hasGenerics() bool {
+	registry := c.registryOrInit()
+	return len(registry.Funcs) > 0 || len(registry.Structs) > 0
+}
+
+// runGenericsPass1 executa o pass 1 (§5): compila o programa inteiro num
+// compilador descartavel, jogando fora o bytecode e ficando com dois efeitos
+// colaterais — o AST compartilhado reescrito para os nomes qualificados das
+// instancias, e a fila de declaracoes monomorfizadas. As instancias sao
+// prependadas ao Program para que o pass 2 as compile pelo caminho 100%
+// normal.
+//
+// Erros do pass 1 sao propagados (nao engolidos): sao exatamente os erros de
+// inferencia e de corpo de instancia do §9.
+func (c *Compiler) runGenericsPass1(program *ast.Program) error {
+	scratch := c.newPass1Compiler()
+	if _, _, err := scratch.Compile(program); err != nil {
+		return err
+	}
+	queue := c.instancesOrInit()
+	if len(queue.ordered) == 0 {
+		return nil
+	}
+	merged := make([]ast.Statement, 0, len(queue.ordered)+len(program.Statements))
+	merged = append(merged, queue.ordered...)
+	merged = append(merged, program.Statements...)
+	program.Statements = merged
+	return nil
+}
+
+// newPass1Compiler cria um compilador descartavel que COMPARTILHA o registro
+// de templates e a fila de instancias com c, mas trabalha sobre COPIAS de
+// globals/structs — o pass 1 nao pode contaminar as tabelas que o pass 2 vai
+// construir do zero. pass1=true e o guard de recursao: o Compile(*ast.Program)
+// desse compilador nao reentra no two-pass.
+func (c *Compiler) newPass1Compiler() *Compiler {
+	globalsCopy := make(map[string]ast.NoxyType, len(c.globals))
+	for name, bindingType := range c.globals {
+		globalsCopy[name] = bindingType
+	}
+	structsCopy := make(map[string]*ast.StructStatement, len(c.structs))
+	for name, definition := range c.structs {
+		structsCopy[name] = definition
+	}
+	scratch := NewWithStateAndRoot(globalsCopy, structsCopy, c.FileName, c.moduleRoot)
+	scratch.moduleName = c.moduleName
+	scratch.generics = c.registryOrInit()
+	scratch.instances = c.instancesOrInit()
+	scratch.moduleDiscovery = c.moduleDiscovery
+	scratch.pass1 = true
+	return scratch
+}
+
+// compileGenericCallSite e o hook enumerado do §4 em compileCallExpression:
+// callee e o nome de um template generico, entao a chamada NAO segue o
+// caminho normal antes de ser monomorfizada. Infere a tupla de tipos a partir
+// dos argumentos (compilados fora de ordem, em chunk descartavel), garante a
+// instancia e REESCREVE callee.Value para o nome qualificado. Depois disso o
+// caminho normal do compileCallExpression resolve um global comum.
+func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.Identifier, tpl *FuncTemplate) error {
+	base := tpl.Decl.Name
+	line := c.currentLine
+	if !c.pass1 {
+		// Defensivo: no pass 2 os nomes ja foram reescritos e nenhum nome de
+		// template deveria alcancar um call site. Se alcancou, ha um caminho
+		// de compilacao que nao passou pelo pass 1 — erro claro em vez de
+		// bytecode com o tipo cru do template.
+		return fmt.Errorf(
+			"[line %d] chamada ao template genérico '%s' chegou ao pass 2 sem monomorfização — bug do compilador de genéricos",
+			line, base,
+		)
+	}
+
+	// O hint do `let` vale para ESTE call site e so para ele: consumimos
+	// (e limpamos) antes de compilar argumentos, que podem conter outras
+	// chamadas genericas aninhadas.
+	hint := c.genericReturnHint
+	c.genericReturnHint = nil
+
+	params := tpl.Decl.Parameters
+	if len(call.Arguments) != len(params) {
+		return fmt.Errorf(
+			"[line %d] function '%s' expects %d arguments, got %d",
+			line, base, len(params), len(call.Arguments),
+		)
+	}
+
+	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
+	for index, argument := range call.Arguments {
+		expected := params[index].Type
+		// Parametro sem parametro de tipo nao contribui binding: nao ha razao
+		// para compilar o argumento so para descobrir um tipo que nao sera
+		// unificado (o caminho normal o compila e checa logo em seguida).
+		if !containsTypeParam(expected) {
+			continue
+		}
+		actual, err := c.typeOfDiscardedExpression(argument)
+		if err != nil {
+			return err
+		}
+		if err := unify(expected, actual, bindings); err != nil {
+			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
+		}
+	}
+
+	// Hint do `let`: resolve o T que so aparece no retorno (`let xs: int[] =
+	// vazio()`). Depois dos argumentos, por decisao da spec §7 — o argumento e
+	// a ancora primaria, o alvo do target-typing e complemento.
+	if hint != nil && containsTypeParam(tpl.Decl.ReturnType) {
+		if err := unify(tpl.Decl.ReturnType, hint, bindings); err != nil {
+			return fmt.Errorf("[line %d] retorno de '%s': %v", line, base, err)
+		}
+	}
+
+	name, _, err := c.ensureFunctionInstance(tpl, bindings, line)
+	if err != nil {
+		return err
+	}
+	callee.Value = name
+	c.setLine(line)
+	return nil
+}
+
+// ensureFunctionInstance devolve (criando se preciso) a instancia
+// monomorfizada de tpl para bindings. Ordem obrigatoria da §4:
+// nome -> memo -> tipo em globals -> clone -> compila o clone em modo pass-1
+// -> enfileira. Registrar o memo e o tipo ANTES de compilar o corpo e o que
+// faz a recursao terminar: a chamada recursiva dentro do clone encontra a
+// entrada no memo e o tipo no globals, e para.
+func (c *Compiler) ensureFunctionInstance(tpl *FuncTemplate, bindings map[string]ast.NoxyType, line int) (string, *ast.FunctionType, error) {
+	base := tpl.Decl.Name
+
+	// A tupla do nome segue a ordem de DECLARACAO dos parametros de tipo
+	// (`<A, B>`), nao a ordem em que a unificacao os descobriu — e o que faz
+	// duas chamadas com a mesma tupla caírem no mesmo nome.
+	arguments := make([]ast.NoxyType, 0, len(tpl.Decl.TypeParams))
+	for _, typeParam := range tpl.Decl.TypeParams {
+		bound, ok := bindings[typeParam]
+		if !ok {
+			return "", nil, fmt.Errorf(
+				"[line %d] não foi possível inferir %s em '%s' — anote o tipo",
+				line, typeParam, base,
+			)
+		}
+		arguments = append(arguments, bound)
+	}
+	name := instanceName(tpl.Module, base, arguments)
+
+	parameterTypes := make([]ast.NoxyType, len(tpl.Decl.Parameters))
+	for index, parameter := range tpl.Decl.Parameters {
+		parameterTypes[index] = substituteType(parameter.Type, bindings)
+	}
+	instanceType := &ast.FunctionType{
+		Params: parameterTypes,
+		Return: substituteType(tpl.Decl.ReturnType, bindings),
+	}
+
+	// Sempre registra o tipo no compilador ATUAL, inclusive no acerto de memo:
+	// cada filho tem sua propria copia de globals, e quem chama a instancia
+	// precisa enxergar a assinatura para o caminho normal resolver o global.
+	c.globals[name] = instanceType
+
+	queue := c.instancesOrInit()
+	if queue.memo[name] {
+		return name, instanceType, nil
+	}
+	queue.memo[name] = true
+
+	instance := substituteFunction(tpl, bindings, name)
+	if err := c.compileInstanceBody(instance); err != nil {
+		return "", nil, instantiationChainError(displayInstanceName(base, arguments), line, err)
+	}
+	queue.ordered = append(queue.ordered, instance)
+	return name, instanceType, nil
+}
+
+// compileInstanceBody compila o clone monomorfizado imediatamente, ainda em
+// modo pass-1 (§4): e assim que a cascata generico->generico acontece antes do
+// pass 2 comecar. O bytecode e descartado — o que interessa sao os efeitos
+// colaterais: as chamadas genericas dentro do corpo ficam reescritas no clone
+// e as instancias que elas exigem entram na fila.
+//
+// O corpo compila num compilador de TOPO (nao um filho de c): o clone e uma
+// declaracao top-level e nao pode enxergar os locais do escopo onde o site de
+// chamada estava — um filho de c resolveria esses locais como upvalues e
+// inferiria tipos errados.
+func (c *Compiler) compileInstanceBody(instance *ast.FunctionStatement) error {
+	instanceCompiler := c.newPass1Compiler()
+	// programBindings carrega as declaracoes do topo do programa (funcoes,
+	// lets, structs) que applyProgramBindings injeta durante a compilacao de
+	// um corpo de funcao — sem isso, o corpo da instancia nao enxergaria as
+	// funcoes comuns do programa.
+	instanceCompiler.programBindings = c.programBindings
+	_, _, err := instanceCompiler.Compile(instance)
+	return err
+}
+
+// typeOfDiscardedExpression compila expr num chunk descartavel so para
+// descobrir seu tipo estatico, restaurando chunk e linha corrente — mesmo
+// padrao de emissao especulativa de tryCompileFusedCondition (compiler.go),
+// mas com um chunk inteiro no lugar de TruncateTo, porque aqui a expressao e
+// compilada FORA DE ORDEM (antes do callee) e o caminho normal a compila de
+// novo logo depois.
+//
+// Como isso so roda no pass 1, cujo bytecode inteiro e descartado, eventuais
+// efeitos colaterais no compilador (constantes orfas, upvalues abertos duas
+// vezes — addUpvalue deduplica) nao alcancam o bytecode final do pass 2.
+func (c *Compiler) typeOfDiscardedExpression(expr ast.Expression) (ast.NoxyType, error) {
+	savedChunk := c.currentChunk
+	savedLine := c.currentLine
+	throwaway := chunk.New()
+	throwaway.FileName = savedChunk.FileName
+	c.currentChunk = throwaway
+	_, exprType, err := c.Compile(expr)
+	c.currentChunk = savedChunk
+	c.currentLine = savedLine
+	if err != nil {
+		return nil, err
+	}
+	return exprType, nil
+}
+
+// setGenericReturnHint arma o hint de target-typing do `let` (§7, uso 1) para
+// o proximo call site generico: `let xs: int[] = vazio()` resolve o T que so
+// aparece no retorno. Fica armado apenas quando o valor e, de fato, uma
+// chamada direta a um template — assim nenhuma outra expressao consome o hint
+// por engano.
+func (c *Compiler) setGenericReturnHint(target ast.NoxyType, valueExpr ast.Expression) {
+	c.genericReturnHint = nil
+	if !c.pass1 || target == nil {
+		return
+	}
+	call, ok := valueExpr.(*ast.CallExpression)
+	if !ok {
+		return
+	}
+	callee, ok := call.Function.(*ast.Identifier)
+	if !ok {
+		return
+	}
+	if _, isTemplate := c.registryOrInit().Funcs[callee.Value]; !isTemplate {
+		return
+	}
+	c.genericReturnHint = target
+}
+
+// displayInstanceName produz o nome de exibicao do §9 — `soma<Ponto>`, SEM o
+// qualificador de modulo, que e identidade interna e nao interessa ao usuario.
+func displayInstanceName(base string, arguments []ast.NoxyType) string {
+	parts := make([]string, len(arguments))
+	for index, argument := range arguments {
+		parts[index] = argument.String()
+	}
+	return base + "<" + strings.Join(parts, ",") + ">"
+}
+
+// strippedLineError e um erro cuja mensagem perdeu o prefixo "[line N]" mas
+// que continua encadeado ao original para errors.Is/As.
+type strippedLineError struct {
+	message string
+	cause   error
+}
+
+func (e *strippedLineError) Error() string { return e.message }
+func (e *strippedLineError) Unwrap() error { return e.cause }
+
+// instantiationChainError monta a cadeia de instanciacao do §9:
+//
+//	[line 12] em soma<Ponto> (instanciado na linha 40): operador '+' não definido para Ponto
+//
+// A linha do prefixo e a linha do erro DENTRO do corpo do template (o
+// compilador ja a carrega no proprio texto do erro), e a segunda linha e o
+// site de chamada que pediu a instancia. O prefixo duplicado do erro interno e
+// removido do texto — o encadeamento com %w e preservado via Unwrap.
+func instantiationChainError(display string, instantiatedAt int, err error) error {
+	line, rest, ok := splitLinePrefix(err.Error())
+	if !ok {
+		return fmt.Errorf("[line %d] em %s (instanciado na linha %d): %w", instantiatedAt, display, instantiatedAt, err)
+	}
+	stripped := &strippedLineError{message: rest, cause: err}
+	return fmt.Errorf("[line %d] em %s (instanciado na linha %d): %w", line, display, instantiatedAt, stripped)
+}
+
+// splitLinePrefix separa o prefixo "[line N] " que todo erro do compilador
+// carrega, devolvendo N e o resto da mensagem.
+func splitLinePrefix(message string) (int, string, bool) {
+	if !strings.HasPrefix(message, "[line ") {
+		return 0, "", false
+	}
+	end := strings.Index(message, "]")
+	if end < 0 {
+		return 0, "", false
+	}
+	var line int
+	if _, err := fmt.Sscanf(message[:end+1], "[line %d]", &line); err != nil {
+		return 0, "", false
+	}
+	return line, strings.TrimLeft(message[end+1:], " "), true
 }

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -255,7 +255,11 @@ func (c *Compiler) newPass1Compiler() *Compiler {
 	scratch.moduleName = c.moduleName
 	scratch.generics = c.registryOrInit()
 	scratch.instances = c.instancesOrInit()
-	scratch.moduleDiscovery = c.moduleDiscovery
+	// discoveryState() (nao c.moduleDiscovery cru): o pass 1 tem de
+	// COMPARTILHAR o cache de modulos com o pass 2, senao cada passada
+	// recarrega do zero todo modulo importado — metade da amplificacao de
+	// startup medida em `use http select *`.
+	scratch.moduleDiscovery = c.discoveryState()
 	scratch.namespaceImports = namespaceImportsCopy
 	scratch.pass1 = true
 	return scratch

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -97,6 +97,30 @@ type instanceQueue struct {
 	// inverso da resolucao (expandInstanceNames): unificar a anotacao generica
 	// do template contra um tipo concreto que ja carrega o nome qualificado.
 	structKeys map[string]structInstanceKey
+	// depth e a profundidade de instanciacao ANINHADA corrente (quantos
+	// corpos/campos de instancia estao abertos na pilha). O memo faz recursao
+	// COMUM terminar — a segunda visita reencontra a mesma tupla e para —, mas
+	// nao faz nada por RECURSAO POLIMORFICA, onde cada nivel pede uma tupla
+	// NOVA (`func f<T>(x: T)` com `let arr: T[] = [x]` e `f(arr, ...)`
+	// instancia f<int>, f<int[]>, f<int[][]>, ...). O memo nunca acerta e o
+	// compilador nao termina. maxInstantiationDepth corta com o erro do §9.
+	depth int
+}
+
+// maxInstantiationDepth e o teto de instanciacoes generica-dentro-de-generica
+// aninhadas. Codigo real fica em um digito (uma instancia que usa outra que
+// usa outra); 64 e folgado o bastante para nunca aparecer num programa
+// legitimo e apertado o bastante para o erro chegar em milissegundos.
+const maxInstantiationDepth = 64
+
+// instantiationDepthError e a mensagem do §9 para o teto acima. Chega ao
+// usuario embrulhada na cadeia de instanciacao (instantiationChainError), que
+// mostra exatamente a torre de tuplas divergentes.
+func instantiationDepthError(line int) error {
+	return fmt.Errorf(
+		"[line %d] profundidade máxima de instanciação genérica excedida (%d) — recursão polimórfica?",
+		line, maxInstantiationDepth,
+	)
 }
 
 func newInstanceQueue() *instanceQueue {
@@ -196,9 +220,17 @@ func (c *Compiler) registerStructTemplate(name string, tpl *StructTemplate, line
 // REPL/modulos, onde o registro chega populado de fora (SetGenericState) sem
 // que a linha atual declare nada generico. Programa sem genericos responde
 // false e pula o pass 1 inteiro (custo exatamente zero, §5).
+//
+// Leitura nil-safe, nao registryOrInit: este gate roda em TODO Compile de
+// Program (programa principal, cada modulo, cada linha do REPL) e nao pode
+// alocar um GenericRegistry (dois mapas) so para descobrir que ele esta
+// vazio — mesmo cuidado que rejectBareGenericTemplateIdentifier
+// (generics_target.go) ja tomava no caminho por identificador.
 func (c *Compiler) hasGenerics() bool {
-	registry := c.registryOrInit()
-	return len(registry.Funcs) > 0 || len(registry.Structs) > 0
+	if c.generics == nil {
+		return false
+	}
+	return len(c.generics.Funcs) > 0 || len(c.generics.Structs) > 0
 }
 
 // runGenericsPass1 executa o pass 1 (§5): compila o programa inteiro num
@@ -349,7 +381,22 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 		}
 		templateSig := newFunctionType(argTpl.Decl.Parameters, argTpl.Decl.ReturnType)
 		argBindings := make(map[string]ast.NoxyType, len(argTpl.Decl.TypeParams))
-		if err := unifyBidirectional(expectedFn, templateSig, bindings, argBindings); err != nil {
+		if err := c.unifyBidirectionalAnnotated(expectedFn, templateSig, bindings, argBindings); err != nil {
+			// Mesma atribuicao por argumento do §9 que unifyPositionalArguments
+			// aplica no caminho comum (I5): um conflito estruturado sabe QUAL
+			// parametro divergiu, e argIndexOf sabe qual argumento o bindou
+			// primeiro. Sem isto, este caminho so sabia dizer "argumento N".
+			var conflict *conflictError
+			if errors.As(err, &conflict) {
+				if existingIndex, known := argIndexOf[conflict.Param]; known {
+					return fmt.Errorf(
+						"[line %d] %s inferido como %s (argumento %d) e %s (argumento %d)",
+						line, conflict.Param,
+						conflict.Existing.String(), existingIndex,
+						conflict.New.String(), index+1,
+					)
+				}
+			}
 			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
 		}
 		instName, _, err := c.ensureFunctionInstance(argTpl, argBindings, line)
@@ -574,8 +621,18 @@ func (c *Compiler) ensureFunctionInstance(tpl *FuncTemplate, bindings map[string
 		return "", nil, err
 	}
 
+	// Teto de aninhamento (§9): compilar o corpo e o passo que pode pedir
+	// OUTRA instancia. Sem o teto, recursao polimorfica (tupla nova a cada
+	// nivel, memo nunca acerta) trava o compilador em vez de errar.
+	if queue.depth >= maxInstantiationDepth {
+		return "", nil, instantiationDepthError(line)
+	}
+
 	instance := substituteFunction(tpl, bindings, name)
-	if err := c.compileInstanceBody(instance); err != nil {
+	queue.depth++
+	err = c.compileInstanceBody(instance)
+	queue.depth--
+	if err != nil {
 		return "", nil, instantiationChainError(displayInstanceName(base, arguments), line, err)
 	}
 	queue.ordered = append(queue.ordered, instance)
@@ -854,9 +911,14 @@ func collectFreeIdentifiers(decl *ast.FunctionStatement) map[string]bool {
 // collectBoundNamesInBlock/Statement/Expression povoam bound com todo nome
 // de VALOR introduzido em qualquer profundidade do corpo — espelham a
 // cobertura de nos de substituteInStatement/substituteInExpression
-// (generics_substitute.go), inclusive o guard por reflexao (panic num nó
-// sem case): um nó novo em ast tem de ganhar tratamento aqui tambem, senao
-// este walker fica cego para os bindings que esse nó introduz.
+// (generics_substitute.go), inclusive o panic no default: um nó novo em ast
+// tem de ganhar tratamento aqui tambem, senao este walker fica cego para os
+// bindings que esse nó introduz.
+//
+// A exaustividade e verificada estaticamente por
+// TestGenericWalkersCoverEveryNode (generics_walkers_guard_test.go), que
+// enumera os nós de ast.go e exige um `case` em cada walker — o panic
+// sozinho so dispararia se algum teste exercitasse exatamente o nó novo.
 func collectBoundNamesInBlock(blk *ast.BlockStatement, bound map[string]bool) {
 	if blk == nil {
 		return
@@ -967,9 +1029,10 @@ func collectBoundNamesInExpression(e ast.Expression, bound map[string]bool) {
 
 // collectFreeInBlock/Statement/Expression e o segundo passe de
 // collectFreeIdentifiers: mesma cobertura de nós que
-// collectBoundNamesInBlock/Statement/Expression, so que em vez de POVOAR
-// bound, cada *ast.Identifier encontrado em posicao de valor (leitura ou
-// alvo de atribuicao) que NAO esta em bound entra em free.
+// collectBoundNamesInBlock/Statement/Expression (e o mesmo guard estatico de
+// TestGenericWalkersCoverEveryNode), so que em vez de POVOAR bound, cada
+// *ast.Identifier encontrado em posicao de valor (leitura ou alvo de
+// atribuicao) que NAO esta em bound entra em free.
 // MemberAccessExpression.Member e uma string crua (nao um Identifier), e
 // portanto nunca contribui — `x.campo` nao exige que "campo" resolva como
 // nome solto.

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -251,6 +252,26 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	// definido. Esses argumentos ficam de lado nesta primeira passada, que
 	// resolve os parametros de tipo do CALLER pelos argumentos nao-genericos
 	// primeiro (ordem exigida pela spec).
+	// nullOnlyParams marca, por nome de parametro de tipo, se algum candidato
+	// de binding visto para ele num argumento de posicao "T" nua (nao
+	// aninhada — `x: T`, nao `x: T[]`) foi `null` ANTES de qualquer binding de
+	// verdade. unify trata null como "any/null nao contribui binding, nao
+	// falha" (§7) — silenciosamente igual a um argumento cujo tipo
+	// simplesmente nao teve nenhuma informacao. Sem esta marca,
+	// `identity(null)` e `vazio()` (T so aparece no retorno, nenhum argumento
+	// sequer tenta) cairiam na MESMA mensagem generica; a marca e o que
+	// permite compileGenericCallSite escolher a mensagem dedicada do §9 antes
+	// de delegar a ensureFunctionInstance. Uma marca nunca precisa ser
+	// desfeita: o consumidor (logo abaixo do loop) so a consulta quando o
+	// parametro AINDA esta sem binding no final — se um binding de verdade
+	// chegou depois (deste ou de outro argumento), a marca e irrelevante.
+	nullOnlyParams := make(map[string]bool)
+	// argIndexOf guarda, por nome de parametro de tipo, o indice (1-based) do
+	// PRIMEIRO argumento que efetivamente o bindou — e o que permite compor
+	// "T inferido como int (argumento 1) e string (argumento 2)" (§9) num
+	// conflito posterior, sem o unify saber nada de indices de argumento
+	// (unify e funcao pura; quem sabe a posicao e so este loop).
+	argIndexOf := make(map[string]int, len(tpl.Decl.TypeParams))
 	var templateArgs []int
 	for index, argument := range call.Arguments {
 		if _, _, isTemplateArg := c.bareFunctionTemplateArgument(argument); isTemplateArg {
@@ -268,8 +289,38 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 		if err != nil {
 			return err
 		}
+		if typeParam, isBare := expected.(*ast.TypeParamType); isBare && isNullType(actual) {
+			if _, bound := bindings[typeParam.Name]; !bound {
+				nullOnlyParams[typeParam.Name] = true
+			}
+			continue
+		}
 		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
+			var conflict *conflictError
+			if errors.As(err, &conflict) {
+				if existingIndex, known := argIndexOf[conflict.Param]; known {
+					return fmt.Errorf(
+						"[line %d] %s inferido como %s (argumento %d) e %s (argumento %d)",
+						line, conflict.Param,
+						conflict.Existing.String(), existingIndex,
+						conflict.New.String(), index+1,
+					)
+				}
+			}
 			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
+		}
+		// Registra o(s) parametro(s) que ESTE argumento bindou pela PRIMEIRA
+		// vez (um unico argumento composto — `map[K,V]` — pode bindar mais de
+		// um de uma vez). So grava na primeira ocorrencia: e o PRIMEIRO
+		// argumento que deve aparecer como "(argumento N)" do lado esquerdo
+		// de um conflito futuro.
+		for _, typeParam := range tpl.Decl.TypeParams {
+			if _, recorded := argIndexOf[typeParam]; recorded {
+				continue
+			}
+			if _, bound := bindings[typeParam]; bound {
+				argIndexOf[typeParam] = index + 1
+			}
 		}
 	}
 
@@ -305,6 +356,23 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 		if err := c.unifyAnnotation(tpl.Decl.ReturnType, hint, bindings); err != nil {
 			return fmt.Errorf("[line %d] retorno de '%s': %v", line, base, err)
 		}
+	}
+
+	// §9 "inferência só com null": intercepta ANTES de ensureFunctionInstance
+	// (cuja mensagem para parametro sem binding e a generica "não foi
+	// possível inferir T em 'f'") sempre que o binding que falta e exatamente
+	// um que so viu `null` como candidato — dá a mensagem dedicada do
+	// catalogo. Mesma ordem de tpl.Decl.TypeParams que ensureFunctionInstance
+	// usa, entao o primeiro parametro sem binding e sempre o mesmo nos dois
+	// caminhos.
+	for _, typeParam := range tpl.Decl.TypeParams {
+		if _, bound := bindings[typeParam]; bound {
+			continue
+		}
+		if nullOnlyParams[typeParam] {
+			return nullOnlyInferenceError(line, typeParam)
+		}
+		break
 	}
 
 	name, _, err := c.ensureFunctionInstance(tpl, bindings, line)
@@ -462,6 +530,18 @@ func (c *Compiler) setGenericReturnHint(target ast.NoxyType, valueExpr ast.Expre
 		return
 	}
 	c.genericReturnHint = target
+}
+
+// nullOnlyInferenceError e a mensagem dedicada do §9 para quando `null` e a
+// UNICA razao de um parametro de tipo continuar sem binding (`identity(null)`
+// sem outra ancora) — distinta da mensagem generica "não foi possível
+// inferir T em 'f'" (usada quando T simplesmente nunca teve candidato
+// nenhum, ex.: `vazio()` com T so no retorno).
+func nullOnlyInferenceError(line int, typeParam string) error {
+	return fmt.Errorf(
+		"[line %d] não foi possível inferir %s de null — anote o tipo",
+		line, typeParam,
+	)
 }
 
 // displayInstanceName produz o nome de exibicao do §9 — `soma<Ponto>`, SEM o

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -85,10 +85,25 @@ func (c *Compiler) registryOrInit() *GenericRegistry {
 type instanceQueue struct {
 	memo    map[string]bool
 	ordered []ast.Statement
+	// structInstances e o memo das instancias de STRUCT — e um mapa para a
+	// declaracao, nao um set: no acerto de memo ainda precisamos registrar a
+	// instancia em c.structs/c.globals do compilador atual (cada filho tem
+	// copias proprias dessas tabelas), e para isso a declaracao tem de estar a
+	// mao. Registrar a entrada aqui ANTES de resolver os campos e o que faz
+	// auto-referencia (`next: ref Node<T>`) terminar.
+	structInstances map[string]*ast.StructStatement
+	// structKeys guarda a tupla de cada instancia de struct para o caminho
+	// inverso da resolucao (expandInstanceNames): unificar a anotacao generica
+	// do template contra um tipo concreto que ja carrega o nome qualificado.
+	structKeys map[string]structInstanceKey
 }
 
 func newInstanceQueue() *instanceQueue {
-	return &instanceQueue{memo: make(map[string]bool)}
+	return &instanceQueue{
+		memo:            make(map[string]bool),
+		structInstances: make(map[string]*ast.StructStatement),
+		structKeys:      make(map[string]structInstanceKey),
+	}
 }
 
 // instancesOrInit devolve a fila da compilacao corrente. Dentro do pass 1 ela
@@ -240,7 +255,7 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 		if err != nil {
 			return err
 		}
-		if err := unify(expected, actual, bindings); err != nil {
+		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
 			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
 		}
 	}
@@ -249,7 +264,7 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	// vazio()`). Depois dos argumentos, por decisao da spec §7 — o argumento e
 	// a ancora primaria, o alvo do target-typing e complemento.
 	if hint != nil && containsTypeParam(tpl.Decl.ReturnType) {
-		if err := unify(tpl.Decl.ReturnType, hint, bindings); err != nil {
+		if err := c.unifyAnnotation(tpl.Decl.ReturnType, hint, bindings); err != nil {
 			return fmt.Errorf("[line %d] retorno de '%s': %v", line, base, err)
 		}
 	}
@@ -288,13 +303,28 @@ func (c *Compiler) ensureFunctionInstance(tpl *FuncTemplate, bindings map[string
 	}
 	name := instanceName(tpl.Module, base, arguments)
 
+	// A assinatura da instancia entra em globals RESOLVIDA (§4, terceira familia
+	// de hooks): um parametro `Caixa<T>` vira `main::Caixa<int>`, nao
+	// `Caixa<int>`. Sem isso o call site reescrito leria um tipo cuja identidade
+	// nominal nao existe em c.structs, e a checagem de tipos do pass 1
+	// divergiria da do pass 2 (que le a assinatura ja reescrita do clone).
+	// Resolver aqui tambem garante que a instancia de struct entre na fila ANTES
+	// da instancia de funcao que a menciona.
 	parameterTypes := make([]ast.NoxyType, len(tpl.Decl.Parameters))
 	for index, parameter := range tpl.Decl.Parameters {
-		parameterTypes[index] = substituteType(parameter.Type, bindings)
+		resolved, err := c.resolveAnnotation(substituteType(parameter.Type, bindings), line)
+		if err != nil {
+			return "", nil, err
+		}
+		parameterTypes[index] = resolved
+	}
+	resolvedReturn, err := c.resolveAnnotation(substituteType(tpl.Decl.ReturnType, bindings), line)
+	if err != nil {
+		return "", nil, err
 	}
 	instanceType := &ast.FunctionType{
 		Params: parameterTypes,
-		Return: substituteType(tpl.Decl.ReturnType, bindings),
+		Return: resolvedReturn,
 	}
 
 	// Sempre registra o tipo no compilador ATUAL, inclusive no acerto de memo:
@@ -367,6 +397,13 @@ func (c *Compiler) typeOfDiscardedExpression(expr ast.Expression) (ast.NoxyType,
 // aparece no retorno. Fica armado apenas quando o valor e, de fato, uma
 // chamada direta a um template — assim nenhuma outra expressao consome o hint
 // por engano.
+//
+// O mesmo hint serve aos dois tipos de site, com leituras diferentes: o site de
+// FUNCAO unifica a anotacao contra o tipo de retorno do template; o site de
+// CONSTRUTOR de struct le nela a tupla da instancia (applyStructHintBindings).
+// Nenhum dos dois pode consumir o hint do outro — cada um limpa o campo na
+// entrada, e o hint so e armado quando o valor do `let` e uma chamada direta ao
+// template daquele mesmo tipo.
 func (c *Compiler) setGenericReturnHint(target ast.NoxyType, valueExpr ast.Expression) {
 	c.genericReturnHint = nil
 	if !c.pass1 || target == nil {
@@ -380,7 +417,10 @@ func (c *Compiler) setGenericReturnHint(target ast.NoxyType, valueExpr ast.Expre
 	if !ok {
 		return
 	}
-	if _, isTemplate := c.registryOrInit().Funcs[callee.Value]; !isTemplate {
+	registry := c.registryOrInit()
+	_, isFunctionTemplate := registry.Funcs[callee.Value]
+	_, isStructTemplate := registry.Structs[callee.Value]
+	if !isFunctionTemplate && !isStructTemplate {
 		return
 	}
 	c.genericReturnHint = target

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -249,79 +249,33 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	// identificador NU nomeando OUTRO template de funcao (`aplica(nums,
 	// identity)`) nao pode ser compilado pelo caminho normal — o template nao
 	// existe em runtime, entao typeOfDiscardedExpression leria um global nunca
-	// definido. Esses argumentos ficam de lado nesta primeira passada, que
-	// resolve os parametros de tipo do CALLER pelos argumentos nao-genericos
-	// primeiro (ordem exigida pela spec).
-	// nullOnlyParams marca, por nome de parametro de tipo, se algum candidato
-	// de binding visto para ele num argumento de posicao "T" nua (nao
-	// aninhada — `x: T`, nao `x: T[]`) foi `null` ANTES de qualquer binding de
-	// verdade. unify trata null como "any/null nao contribui binding, nao
-	// falha" (§7) — silenciosamente igual a um argumento cujo tipo
-	// simplesmente nao teve nenhuma informacao. Sem esta marca,
-	// `identity(null)` e `vazio()` (T so aparece no retorno, nenhum argumento
-	// sequer tenta) cairiam na MESMA mensagem generica; a marca e o que
-	// permite compileGenericCallSite escolher a mensagem dedicada do §9 antes
-	// de delegar a ensureFunctionInstance. Uma marca nunca precisa ser
-	// desfeita: o consumidor (logo abaixo do loop) so a consulta quando o
-	// parametro AINDA esta sem binding no final — se um binding de verdade
-	// chegou depois (deste ou de outro argumento), a marca e irrelevante.
-	nullOnlyParams := make(map[string]bool)
-	// argIndexOf guarda, por nome de parametro de tipo, o indice (1-based) do
-	// PRIMEIRO argumento que efetivamente o bindou — e o que permite compor
-	// "T inferido como int (argumento 1) e string (argumento 2)" (§9) num
-	// conflito posterior, sem o unify saber nada de indices de argumento
-	// (unify e funcao pura; quem sabe a posicao e so este loop).
-	argIndexOf := make(map[string]int, len(tpl.Decl.TypeParams))
+	// definido. Esses argumentos sao identificados aqui (pre-passada rasa,
+	// so bareFunctionTemplateArgument) e desviados via skip da unificacao
+	// posicional comum abaixo, que resolve os parametros de tipo do CALLER
+	// pelos argumentos nao-genericos primeiro (ordem exigida pela spec) — a
+	// segunda passada, mais abaixo, cuida deles de verdade.
 	var templateArgs []int
+	skipTemplateArg := make(map[int]bool, len(call.Arguments))
 	for index, argument := range call.Arguments {
 		if _, _, isTemplateArg := c.bareFunctionTemplateArgument(argument); isTemplateArg {
 			templateArgs = append(templateArgs, index)
-			continue
+			skipTemplateArg[index] = true
 		}
-		expected := params[index].Type
-		// Parametro sem parametro de tipo nao contribui binding: nao ha razao
-		// para compilar o argumento so para descobrir um tipo que nao sera
-		// unificado (o caminho normal o compila e checa logo em seguida).
-		if !containsTypeParam(expected) {
-			continue
-		}
-		actual, err := c.typeOfDiscardedExpression(argument)
-		if err != nil {
-			return err
-		}
-		if typeParam, isBare := expected.(*ast.TypeParamType); isBare && isNullType(actual) {
-			if _, bound := bindings[typeParam.Name]; !bound {
-				nullOnlyParams[typeParam.Name] = true
-			}
-			continue
-		}
-		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
-			var conflict *conflictError
-			if errors.As(err, &conflict) {
-				if existingIndex, known := argIndexOf[conflict.Param]; known {
-					return fmt.Errorf(
-						"[line %d] %s inferido como %s (argumento %d) e %s (argumento %d)",
-						line, conflict.Param,
-						conflict.Existing.String(), existingIndex,
-						conflict.New.String(), index+1,
-					)
-				}
-			}
-			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
-		}
-		// Registra o(s) parametro(s) que ESTE argumento bindou pela PRIMEIRA
-		// vez (um unico argumento composto — `map[K,V]` — pode bindar mais de
-		// um de uma vez). So grava na primeira ocorrencia: e o PRIMEIRO
-		// argumento que deve aparecer como "(argumento N)" do lado esquerdo
-		// de um conflito futuro.
-		for _, typeParam := range tpl.Decl.TypeParams {
-			if _, recorded := argIndexOf[typeParam]; recorded {
-				continue
-			}
-			if _, bound := bindings[typeParam]; bound {
-				argIndexOf[typeParam] = index + 1
-			}
-		}
+	}
+
+	// nullOnlyParams (§9 "inferência só com null") e argIndexOf (§9
+	// "conflito de unificação" com atribuição por argumento) sao povoados por
+	// unifyPositionalArguments — maquinaria COMPARTILHADA com
+	// compileGenericConstructorSite (generics_structs.go), documentada la.
+	nullOnlyParams := make(map[string]bool)
+	argIndexOf := make(map[string]int, len(tpl.Decl.TypeParams))
+	if err := c.unifyPositionalArguments(
+		line, base, call.Arguments,
+		func(index int) ast.NoxyType { return params[index].Type },
+		func(index int) bool { return skipTemplateArg[index] },
+		tpl.Decl.TypeParams, bindings, nullOnlyParams, argIndexOf,
+	); err != nil {
+		return err
 	}
 
 	// Segunda passada: agora que os argumentos comuns ancoraram o que podiam,
@@ -362,17 +316,11 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	// (cuja mensagem para parametro sem binding e a generica "não foi
 	// possível inferir T em 'f'") sempre que o binding que falta e exatamente
 	// um que so viu `null` como candidato — dá a mensagem dedicada do
-	// catalogo. Mesma ordem de tpl.Decl.TypeParams que ensureFunctionInstance
-	// usa, entao o primeiro parametro sem binding e sempre o mesmo nos dois
-	// caminhos.
-	for _, typeParam := range tpl.Decl.TypeParams {
-		if _, bound := bindings[typeParam]; bound {
-			continue
-		}
-		if nullOnlyParams[typeParam] {
-			return nullOnlyInferenceError(line, typeParam)
-		}
-		break
+	// catalogo. missingTypeParamNullError usa a MESMA ordem de
+	// tpl.Decl.TypeParams que ensureFunctionInstance, entao o primeiro
+	// parametro sem binding e sempre o mesmo nos dois caminhos.
+	if err := missingTypeParamNullError(line, tpl.Decl.TypeParams, bindings, nullOnlyParams); err != nil {
+		return err
 	}
 
 	name, _, err := c.ensureFunctionInstance(tpl, bindings, line)
@@ -381,6 +329,123 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	}
 	callee.Value = name
 	c.setLine(line)
+	return nil
+}
+
+// unifyPositionalArguments e a maquinaria COMPARTILHADA entre os dois call
+// sites que inferem uma tupla de tipos a partir de argumentos posicionais
+// contra tipos esperados que podem conter TypeParamType —
+// compileGenericCallSite (chamada de funcao generica, acima) e
+// compileGenericConstructorSite (construtor de struct generico,
+// generics_structs.go). Por argumento:
+//
+//   - pula quando skip(index) e verdadeiro (compileGenericCallSite usa isto
+//     para desviar os argumentos-template, tratados numa segunda passada
+//     bidirecional a parte; compileGenericConstructorSite nao tem
+//     equivalente e passa skip nil);
+//   - pula quando expectedType(index) nao contem parametro de tipo nenhum
+//     (nada a unificar; nao ha razao para compilar o argumento so para
+//     descobrir um tipo que nao sera usado);
+//   - quando o tipo esperado e um `T` NU (nao aninhado — `x: T`, nao
+//     `x: T[]`) e o argumento e `null`, marca nullOnlyParams[T] em vez de
+//     unificar (§9 "inferência só com null" — unify trataria null como
+//     "não contribui binding, não falha", indistinguível de um argumento
+//     sem informação nenhuma; a marca e o que permite ao chamador, depois
+//     do loop, escolher a mensagem dedicada do catálogo via
+//     missingTypeParamNullError em vez da genérica "não foi possível
+//     inferir T em 'f'");
+//   - senao, unifica de verdade contra bindings; num conflito (unify devolve
+//     um *conflictError encadeado — errors.As), compoe a mensagem do §9 com
+//     atribuição por argumento ("T inferido como int (argumento 1) e string
+//     (argumento 2)") usando argIndexOf; sem atribuição conhecida (conflito
+//     vindo de uma posição sem argumento registrado — não deveria acontecer
+//     no uso atual, mas e defensivo), cai para a mensagem antiga com o
+//     `%v` cru;
+//   - registra em argIndexOf, para cada parametro de tipo AINDA sem entrada,
+//     o indice (1-based) deste argumento quando ele acabou de bindar esse
+//     parametro pela primeira vez (um unico argumento composto — `map[K,V]`
+//     — pode bindar mais de um de uma vez).
+//
+// bindings, nullOnlyParams e argIndexOf sao do CHAMADOR (mutados aqui,
+// consultados depois — inclusive por missingTypeParamNullError e pelas
+// passadas seguintes do chamador, como a segunda passada bidirecional de
+// compileGenericCallSite). typeParams e a lista de nomes de parametro de
+// tipo do template (tpl.Decl.TypeParams em ambos os chamadores) na ordem de
+// declaração — a mesma ordem que ensure*Instance usa, o que faz
+// missingTypeParamNullError e a checagem de aridade final apontarem sempre
+// para o mesmo parametro quando ha mais de um em aberto.
+func (c *Compiler) unifyPositionalArguments(
+	line int,
+	base string,
+	arguments []ast.Expression,
+	expectedType func(index int) ast.NoxyType,
+	skip func(index int) bool,
+	typeParams []string,
+	bindings map[string]ast.NoxyType,
+	nullOnlyParams map[string]bool,
+	argIndexOf map[string]int,
+) error {
+	for index, argument := range arguments {
+		if skip != nil && skip(index) {
+			continue
+		}
+		expected := expectedType(index)
+		if !containsTypeParam(expected) {
+			continue
+		}
+		actual, err := c.typeOfDiscardedExpression(argument)
+		if err != nil {
+			return err
+		}
+		if typeParam, isBare := expected.(*ast.TypeParamType); isBare && isNullType(actual) {
+			if _, bound := bindings[typeParam.Name]; !bound {
+				nullOnlyParams[typeParam.Name] = true
+			}
+			continue
+		}
+		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
+			var conflict *conflictError
+			if errors.As(err, &conflict) {
+				if existingIndex, known := argIndexOf[conflict.Param]; known {
+					return fmt.Errorf(
+						"[line %d] %s inferido como %s (argumento %d) e %s (argumento %d)",
+						line, conflict.Param,
+						conflict.Existing.String(), existingIndex,
+						conflict.New.String(), index+1,
+					)
+				}
+			}
+			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
+		}
+		for _, typeParam := range typeParams {
+			if _, recorded := argIndexOf[typeParam]; recorded {
+				continue
+			}
+			if _, bound := bindings[typeParam]; bound {
+				argIndexOf[typeParam] = index + 1
+			}
+		}
+	}
+	return nil
+}
+
+// missingTypeParamNullError e o gate COMPARTILHADO do §9 "inferência só com
+// null": percorre typeParams na ordem de declaração e, no primeiro parametro
+// AINDA sem binding, devolve a mensagem dedicada quando nullOnlyParams o
+// marcou — nil quando ou todos os parametros ja tem binding, ou o primeiro
+// sem binding nao foi marcado (o chamador delega para a mensagem generica de
+// ensure*Instance, que itera typeParams na MESMA ordem e portanto encontra o
+// mesmo parametro).
+func missingTypeParamNullError(line int, typeParams []string, bindings map[string]ast.NoxyType, nullOnlyParams map[string]bool) error {
+	for _, typeParam := range typeParams {
+		if _, bound := bindings[typeParam]; bound {
+			continue
+		}
+		if nullOnlyParams[typeParam] {
+			return nullOnlyInferenceError(line, typeParam)
+		}
+		break
+	}
 	return nil
 }
 

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -243,7 +243,20 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 	}
 
 	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
+
+	// §3, unificacao bidirecional (posicao 5): um argumento que e um
+	// identificador NU nomeando OUTRO template de funcao (`aplica(nums,
+	// identity)`) nao pode ser compilado pelo caminho normal — o template nao
+	// existe em runtime, entao typeOfDiscardedExpression leria um global nunca
+	// definido. Esses argumentos ficam de lado nesta primeira passada, que
+	// resolve os parametros de tipo do CALLER pelos argumentos nao-genericos
+	// primeiro (ordem exigida pela spec).
+	var templateArgs []int
 	for index, argument := range call.Arguments {
+		if _, _, isTemplateArg := c.bareFunctionTemplateArgument(argument); isTemplateArg {
+			templateArgs = append(templateArgs, index)
+			continue
+		}
 		expected := params[index].Type
 		// Parametro sem parametro de tipo nao contribui binding: nao ha razao
 		// para compilar o argumento so para descobrir um tipo que nao sera
@@ -258,6 +271,31 @@ func (c *Compiler) compileGenericCallSite(call *ast.CallExpression, callee *ast.
 		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
 			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
 		}
+	}
+
+	// Segunda passada: agora que os argumentos comuns ancoraram o que podiam,
+	// cada argumento-template tem seu parametro esperado (ja parcialmente
+	// concreto) unificado CONTRA A ASSINATURA DO PROPRIO TEMPLATE do
+	// argumento, com bindings propagando nos dois sentidos (§3). Bindings do
+	// argumento vivem num mapa PROPRIO por ocorrencia — duas passagens do
+	// mesmo template neste call site podem instanciar tuplas diferentes.
+	for _, index := range templateArgs {
+		argIdent, argTpl, _ := c.bareFunctionTemplateArgument(call.Arguments[index])
+		expected := substituteType(params[index].Type, bindings)
+		expectedFn, ok := expected.(*ast.FunctionType)
+		if !ok {
+			return noConcreteTargetError(line, argIdent.Value)
+		}
+		templateSig := newFunctionType(argTpl.Decl.Parameters, argTpl.Decl.ReturnType)
+		argBindings := make(map[string]ast.NoxyType, len(argTpl.Decl.TypeParams))
+		if err := unifyBidirectional(expectedFn, templateSig, bindings, argBindings); err != nil {
+			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
+		}
+		instName, _, err := c.ensureFunctionInstance(argTpl, argBindings, line)
+		if err != nil {
+			return err
+		}
+		argIdent.Value = instName
 	}
 
 	// Hint do `let`: resolve o T que so aparece no retorno (`let xs: int[] =

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -781,11 +781,19 @@ func (c *Compiler) validateImportedTemplateScope(tpl *FuncTemplate, arguments []
 		if !hasDefinedType {
 			// name e ele mesmo outro template generico do modulo definidor: a
 			// dependencia certa e ele estar IMPORTADO (registrado no registry
-			// do importador), nao ter um tipo em globals — templates nunca
-			// tem tipo de valor.
-			_, isFuncDep := registry.Funcs[name]
-			_, isStructDep := registry.Structs[name]
-			if isFuncDep || isStructDep {
+			// do importador) E VINDO DO MESMO MODULO DEFINIDOR — nao ter um
+			// tipo em globals (templates nunca tem tipo de valor). O registry
+			// e um mapa FLAT por nome bare (R8): sem o check de Module aqui,
+			// um template HOMONIMO importado de um modulo DIFERENTE (`use
+			// outro select ajuda` quando quem processa<T> precisa e o
+			// 'ajuda' de 'colecoes') passaria a validacao por engano — a
+			// chamada bare-name dentro do corpo clonado (compileGenericCallSite)
+			// resolveria contra ESSE template errado em silencio, exatamente
+			// a classe de bug que o §8 existe pra prevenir.
+			funcDep, isFuncDep := registry.Funcs[name]
+			structDep, isStructDep := registry.Structs[name]
+			if (isFuncDep && funcDep.Module == moduleQualifier(tpl.Module)) ||
+				(isStructDep && structDep.Module == moduleQualifier(tpl.Module)) {
 				continue
 			}
 			return fmt.Errorf(

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -69,9 +69,19 @@ func (c *Compiler) registryOrInit() *GenericRegistry {
 //     corpo dela exigiu, entao toda dependencia aparece antes de quem depende
 //     dela — inclusive structs antes das funcoes que os usam, de graca.
 //
-// O ponteiro e compartilhado entre o compilador real, o compilador
-// descartavel do pass 1, os compiladores de corpo de instancia e todos os
-// filhos (NewChild): ha exatamente uma fila por unidade de compilacao.
+// Tempo de vida: UMA COMPILACAO DE PROGRAMA, nao um compilador. A fila nasce
+// na entrada do two-pass e e solta depois do merge (runGenericsPass1). O
+// registry de templates, esse sim, pode persistir entre compilacoes (§5: o
+// REPL guarda os templates da sessao) — mas memo e ordered nao podem: herdar o
+// memo suprimiria a re-instanciacao de uma tupla cuja declaracao nao esta mais
+// na lista de statements, e herdar ordered prependaria as instancias do
+// programa anterior no programa atual. Re-instanciar por programa e tambem a
+// semantica certa para o REPL: cada linha redefine seus globals de instancia,
+// idempotentemente (§8).
+//
+// Dentro de uma compilacao o ponteiro e compartilhado entre o compilador real,
+// o compilador descartavel do pass 1, os compiladores de corpo de instancia e
+// todos os filhos (NewChild).
 type instanceQueue struct {
 	memo    map[string]bool
 	ordered []ast.Statement
@@ -81,7 +91,10 @@ func newInstanceQueue() *instanceQueue {
 	return &instanceQueue{memo: make(map[string]bool)}
 }
 
-// instancesOrInit e o analogo de registryOrInit para a fila de instancias.
+// instancesOrInit devolve a fila da compilacao corrente. Dentro do pass 1 ela
+// nunca e nil (runGenericsPass1 a instala antes de criar qualquer compilador
+// de pass 1, e newPass1Compiler/NewChild propagam o ponteiro); a lazy-init
+// aqui e so uma rede de seguranca para nao lidar com nil.
 func (c *Compiler) instancesOrInit() *instanceQueue {
 	if c.instances == nil {
 		c.instances = newInstanceQueue()
@@ -135,11 +148,18 @@ func (c *Compiler) hasGenerics() bool {
 // Erros do pass 1 sao propagados (nao engolidos): sao exatamente os erros de
 // inferencia e de corpo de instancia do §9.
 func (c *Compiler) runGenericsPass1(program *ast.Program) error {
+	// Fila NOVA por compilacao de programa, e solta no fim (inclusive em erro):
+	// nem o memo nem as declaracoes sinteticas podem atravessar dois
+	// Compile(*ast.Program) no mesmo compilador — ver o comentario de
+	// instanceQueue.
+	queue := newInstanceQueue()
+	c.instances = queue
+	defer func() { c.instances = nil }()
+
 	scratch := c.newPass1Compiler()
 	if _, _, err := scratch.Compile(program); err != nil {
 		return err
 	}
-	queue := c.instancesOrInit()
 	if len(queue.ordered) == 0 {
 		return nil
 	}

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -128,19 +128,66 @@ func (c *Compiler) instancesOrInit() *instanceQueue {
 // com o mesmo ponteiro quando a declaracao e efetivamente compilada.
 // Declaracoes genericas ANINHADAS nao passam por aqui (a varredura e so no
 // topo) e continuam sendo rejeitadas pelos cases do Compile.
-func (c *Compiler) predeclareGenericTemplates(statements []ast.Statement) {
+func (c *Compiler) predeclareGenericTemplates(statements []ast.Statement) error {
 	for _, statement := range statements {
 		switch declaration := statement.(type) {
 		case *ast.FunctionStatement:
 			if len(declaration.TypeParams) > 0 {
-				c.registryOrInit().Funcs[declaration.Name] = &FuncTemplate{Decl: declaration, Module: c.moduleName}
+				if err := c.registerFuncTemplate(declaration.Name, &FuncTemplate{Decl: declaration, Module: c.moduleName}, declaration.Token.Line); err != nil {
+					return err
+				}
 			}
 		case *ast.StructStatement:
 			if len(declaration.TypeParams) > 0 {
-				c.registryOrInit().Structs[declaration.Name] = &StructTemplate{Decl: declaration, Module: c.moduleName}
+				if err := c.registerStructTemplate(declaration.Name, &StructTemplate{Decl: declaration, Module: c.moduleName}, declaration.Token.Line); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
+}
+
+// moduleQualifier normaliza o nome de um modulo para uso como qualificador
+// de instanceName (o campo Module de FuncTemplate/StructTemplate). Hoje e
+// identidade — existe como um unico ponto de acoplamento, para que uma
+// normalizacao futura (aliases, caminhos de submodulo) nao precise caçar
+// cada site que hoje escreve `n.Module`/`declaration.Module` cru.
+func moduleQualifier(module string) string {
+	return module
+}
+
+// registerFuncTemplate insere tpl no registro sob name, recusando a colisao
+// de homonimo entre familias documentada na revisao da Task 9: instanceName
+// (generics_substitute.go) qualifica so por modulo+base+args, sem marcar se
+// a base veio de `func` ou de `struct` — um `func Foo<T>` e um `struct
+// Foo<T>` com o MESMO nome (no mesmo modulo, ou um local e outro importado)
+// produziriam o MESMO nome qualificado ao serem instanciados com a mesma
+// tupla (`main::Foo<int>`), e um sobrescreveria o c.globals/c.structs do
+// outro em silencio. Fechado aqui, na fronteira de registro (chamada tanto
+// pelas declaracoes locais quanto pelo import de templates), com um erro de
+// compilacao claro em vez de uma colisao confusa em runtime.
+func (c *Compiler) registerFuncTemplate(name string, tpl *FuncTemplate, line int) error {
+	if _, collides := c.registryOrInit().Structs[name]; collides {
+		return fmt.Errorf(
+			"[line %d] '%s' já nomeia um struct genérico — não pode também nomear uma função genérica (mesmo nome colidiria na instanciação)",
+			line, name,
+		)
+	}
+	c.registryOrInit().Funcs[name] = tpl
+	return nil
+}
+
+// registerStructTemplate e o espelho de registerFuncTemplate para structs.
+func (c *Compiler) registerStructTemplate(name string, tpl *StructTemplate, line int) error {
+	if _, collides := c.registryOrInit().Funcs[name]; collides {
+		return fmt.Errorf(
+			"[line %d] '%s' já nomeia uma função genérica — não pode também nomear um struct genérico (mesmo nome colidiria na instanciação)",
+			line, name,
+		)
+	}
+	c.registryOrInit().Structs[name] = tpl
+	return nil
 }
 
 // hasGenerics decide se o Program precisa do two-pass. A varredura das
@@ -200,11 +247,16 @@ func (c *Compiler) newPass1Compiler() *Compiler {
 	for name, definition := range c.structs {
 		structsCopy[name] = definition
 	}
+	namespaceImportsCopy := make(map[string]string, len(c.namespaceImports))
+	for name, module := range c.namespaceImports {
+		namespaceImportsCopy[name] = module
+	}
 	scratch := NewWithStateAndRoot(globalsCopy, structsCopy, c.FileName, c.moduleRoot)
 	scratch.moduleName = c.moduleName
 	scratch.generics = c.registryOrInit()
 	scratch.instances = c.instancesOrInit()
 	scratch.moduleDiscovery = c.moduleDiscovery
+	scratch.namespaceImports = namespaceImportsCopy
 	scratch.pass1 = true
 	return scratch
 }
@@ -509,6 +561,15 @@ func (c *Compiler) ensureFunctionInstance(tpl *FuncTemplate, bindings map[string
 	}
 	queue.memo[name] = true
 
+	// §8, regra de escopo de definicao: so entra em jogo para template
+	// IMPORTADO (tpl.Module != c.moduleName — o importador nao e quem
+	// define). Template local tem importador==definidor por construcao,
+	// entao a regra e trivialmente satisfeita e este gate e um no-op para
+	// todo o corpus de genericos anterior a Task 12.
+	if err := c.validateImportedTemplateScope(tpl, arguments, line); err != nil {
+		return "", nil, err
+	}
+
 	instance := substituteFunction(tpl, bindings, name)
 	if err := c.compileInstanceBody(instance); err != nil {
 		return "", nil, instantiationChainError(displayInstanceName(base, arguments), line, err)
@@ -661,4 +722,341 @@ func splitLinePrefix(message string) (int, string, bool) {
 		return 0, "", false
 	}
 	return line, strings.TrimLeft(message[end+1:], " "), true
+}
+
+// validateImportedTemplateScope implementa a regra de escopo de definicao do
+// §8, EM DUAS PARTES, para um template IMPORTADO de outro modulo
+// (tpl.Module != c.moduleName — chamada so a partir desse caso em
+// ensureFunctionInstance; template local nunca chega aqui):
+//
+//   - (a) todo identificador livre do corpo ORIGINAL do template (antes da
+//     substituicao — os TypeParams ainda sao TypeParamType, irrelevante
+//     aqui, so nomes de VALOR importam) tem de resolver no top level do
+//     modulo que o declara (discoverModuleExports do modulo definidor,
+//     que enxerga suas proprias funcoes/lets/structs/templates
+//     independente do que O IMPORTADOR selecionou) — ou ser um builtin;
+//   - (b) quando resolve la, o TIPO DECLARADO visivel no IMPORTADOR
+//     (c.globals, ja populado pelo predeclare tipado — Task 12) tem de
+//     ser IDENTICO (String()) ao tipo declarado no modulo definidor —
+//     senao um homonimo do importador seria capturado em silencio no
+//     lugar do binding certo, exatamente o risco que o §8 documenta.
+//
+// Heuristica deliberada para "e builtin" na parte (a): o pacote compiler
+// nao importa o pacote vm (evitaria um ciclo de import) e portanto nao tem
+// como enumerar os nomes nativos (`length`, `contains`, os `probe_*` de
+// teste, etc.) — e o compilador ja tolera qualquer global desconhecido em
+// tempo de compilacao hoje (Identifier caindo no global sem checar
+// c.globals — ver o case *ast.Identifier de Compile), delegando para o
+// runtime. Em vez de duplicar (e deixar desatualizada) uma lista de
+// builtins, esta funcao reproduz a MESMA tolerancia: um nome ausente do
+// modulo definidor SO vira erro quando ele resolve para ALGO no
+// importador — o UNICO caso onde existe risco real de captura silenciosa
+// por homonimo. Um nome ausente dos dois lados (o caso comum de um
+// builtin genuino) passa em silencio, como o resto do compilador já faz.
+func (c *Compiler) validateImportedTemplateScope(tpl *FuncTemplate, arguments []ast.NoxyType, line int) error {
+	if tpl.Module == "" || tpl.Module == c.moduleName {
+		return nil
+	}
+	exports, loadable := c.discoverModuleExports(tpl.Module)
+	if !loadable {
+		// Modulo ja teria falhado a carregar em outro ponto (predeclare do
+		// `use`, ou o proprio ensureFunctionInstance nao teria achado tpl no
+		// registry) — nao ha o que reportar aqui de novo.
+		return nil
+	}
+	display := displayInstanceName(tpl.Decl.Name, arguments)
+	registry := c.registryOrInit()
+	for name := range collectFreeIdentifiers(tpl.Decl) {
+		if _, declaredInModule := exports[name]; !declaredInModule {
+			if _, shadowedByImporter := c.globals[name]; shadowedByImporter {
+				return fmt.Errorf(
+					"[line %d] '%s' referencia '%s', não declarado no módulo '%s'",
+					line, display, name, tpl.Module,
+				)
+			}
+			continue // presumivelmente builtin — ver heuristica no comentario acima
+		}
+
+		definedType, hasDefinedType := c.importedBindingType(tpl.Module, name)
+		if !hasDefinedType {
+			// name e ele mesmo outro template generico do modulo definidor: a
+			// dependencia certa e ele estar IMPORTADO (registrado no registry
+			// do importador), nao ter um tipo em globals — templates nunca
+			// tem tipo de valor.
+			_, isFuncDep := registry.Funcs[name]
+			_, isStructDep := registry.Structs[name]
+			if isFuncDep || isStructDep {
+				continue
+			}
+			return fmt.Errorf(
+				"[line %d] '%s' precisa de '%s' de '%s' — adicione ao select ou use select *",
+				line, display, name, tpl.Module,
+			)
+		}
+
+		importerType, hasImporterType := c.globals[name]
+		if !hasImporterType {
+			return fmt.Errorf(
+				"[line %d] '%s' precisa de '%s' de '%s' — adicione ao select ou use select *",
+				line, display, name, tpl.Module,
+			)
+		}
+		if importerType == nil || definedType.String() != importerType.String() {
+			importerDesc := "desconhecido"
+			if importerType != nil {
+				importerDesc = importerType.String()
+			}
+			return fmt.Errorf(
+				"[line %d] '%s' tem tipo %s no importador e %s em '%s' — conflito de shadowing",
+				line, name, importerDesc, definedType.String(), tpl.Module,
+			)
+		}
+	}
+	return nil
+}
+
+// collectFreeIdentifiers devolve o conjunto de identificadores LIDOS
+// (leitura OU alvo de atribuicao — os dois exigem que o nome ja resolva
+// para um binding existente) no corpo de um template de funcao que NAO sao
+// localmente vinculados por ele (parametros, `let`, variavel de for-each,
+// parametro de lambda ou de func aninhada, nome de func/struct aninhado).
+//
+// Sobre-aproxima o conjunto de nomes vinculados numa unica passada FLAT
+// (collectBoundNamesInBlock), sem pilha de escopos: um nome local a um
+// ramo do corpo e tratado como vinculado no corpo INTEIRO. Isso so pode
+// produzir FALSOS NEGATIVOS (deixar de sinalizar uma referencia realmente
+// fora de escopo que por coincidencia tem o mesmo nome de um local em outro
+// ramo) — nunca falso positivo, que rejeitaria um template importado
+// valido. E a direcao segura para a checagem do §8.
+func collectFreeIdentifiers(decl *ast.FunctionStatement) map[string]bool {
+	bound := make(map[string]bool, len(decl.Parameters))
+	for _, param := range decl.Parameters {
+		bound[param.Name] = true
+	}
+	collectBoundNamesInBlock(decl.Body, bound)
+	free := make(map[string]bool)
+	collectFreeInBlock(decl.Body, bound, free)
+	return free
+}
+
+// collectBoundNamesInBlock/Statement/Expression povoam bound com todo nome
+// de VALOR introduzido em qualquer profundidade do corpo — espelham a
+// cobertura de nos de substituteInStatement/substituteInExpression
+// (generics_substitute.go), inclusive o guard por reflexao (panic num nó
+// sem case): um nó novo em ast tem de ganhar tratamento aqui tambem, senao
+// este walker fica cego para os bindings que esse nó introduz.
+func collectBoundNamesInBlock(blk *ast.BlockStatement, bound map[string]bool) {
+	if blk == nil {
+		return
+	}
+	for _, s := range blk.Statements {
+		collectBoundNamesInStatement(s, bound)
+	}
+}
+
+func collectBoundNamesInStatement(s ast.Statement, bound map[string]bool) {
+	if s == nil {
+		return
+	}
+	switch n := s.(type) {
+	case *ast.LetStmt:
+		bound[n.Name.Value] = true
+		collectBoundNamesInExpression(n.Value, bound)
+	case *ast.AssignStmt:
+		collectBoundNamesInExpression(n.Target, bound)
+		collectBoundNamesInExpression(n.Value, bound)
+	case *ast.ReturnStmt:
+		collectBoundNamesInExpression(n.ReturnValue, bound)
+	case *ast.DeferStmt:
+		collectBoundNamesInExpression(n.Call, bound)
+	case *ast.BreakStmt:
+		// sem nome, sem sub-no.
+	case *ast.UseStmt:
+		// sem identificador de valor vinculado por este walker.
+	case *ast.ExpressionStmt:
+		collectBoundNamesInExpression(n.Expression, bound)
+	case *ast.BlockStatement:
+		collectBoundNamesInBlock(n, bound)
+	case *ast.IfStatement:
+		collectBoundNamesInExpression(n.Condition, bound)
+		collectBoundNamesInBlock(n.Consequence, bound)
+		collectBoundNamesInBlock(n.Alternative, bound)
+	case *ast.WhileStatement:
+		collectBoundNamesInExpression(n.Condition, bound)
+		collectBoundNamesInBlock(n.Body, bound)
+	case *ast.FunctionStatement:
+		bound[n.Name] = true
+		for _, p := range n.Parameters {
+			bound[p.Name] = true
+		}
+		collectBoundNamesInBlock(n.Body, bound)
+	case *ast.ForStatement:
+		bound[n.Identifier] = true
+		collectBoundNamesInExpression(n.Collection, bound)
+		collectBoundNamesInBlock(n.Body, bound)
+	case *ast.StructStatement:
+		// struct aninhado: so o nome do TIPO, que este walker (identificadores
+		// de VALOR) nao rastreia.
+	case *ast.WhenStatement:
+		for _, clause := range n.Cases {
+			collectBoundNamesInStatement(clause.Condition, bound)
+			collectBoundNamesInBlock(clause.Body, bound)
+		}
+	default:
+		panic("collectBoundNamesInStatement: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+func collectBoundNamesInExpression(e ast.Expression, bound map[string]bool) {
+	if e == nil {
+		return
+	}
+	switch n := e.(type) {
+	case *ast.Identifier, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral,
+		*ast.BytesLiteral, *ast.NullLiteral, *ast.Boolean:
+		// sem sub-no.
+	case *ast.ZerosLiteral:
+		collectBoundNamesInExpression(n.Size, bound)
+	case *ast.PrefixExpression:
+		collectBoundNamesInExpression(n.Right, bound)
+	case *ast.InfixExpression:
+		collectBoundNamesInExpression(n.Left, bound)
+		collectBoundNamesInExpression(n.Right, bound)
+	case *ast.FunctionLiteral:
+		for _, p := range n.Parameters {
+			bound[p.Name] = true
+		}
+		collectBoundNamesInBlock(n.Body, bound)
+	case *ast.CallExpression:
+		collectBoundNamesInExpression(n.Function, bound)
+		for _, a := range n.Arguments {
+			collectBoundNamesInExpression(a, bound)
+		}
+	case *ast.ArrayLiteral:
+		for _, el := range n.Elements {
+			collectBoundNamesInExpression(el, bound)
+		}
+	case *ast.MapLiteral:
+		for i := range n.Keys {
+			collectBoundNamesInExpression(n.Keys[i], bound)
+		}
+		for i := range n.Values {
+			collectBoundNamesInExpression(n.Values[i], bound)
+		}
+	case *ast.IndexExpression:
+		collectBoundNamesInExpression(n.Left, bound)
+		collectBoundNamesInExpression(n.Index, bound)
+	case *ast.MemberAccessExpression:
+		collectBoundNamesInExpression(n.Left, bound)
+	default:
+		panic("collectBoundNamesInExpression: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+// collectFreeInBlock/Statement/Expression e o segundo passe de
+// collectFreeIdentifiers: mesma cobertura de nós que
+// collectBoundNamesInBlock/Statement/Expression, so que em vez de POVOAR
+// bound, cada *ast.Identifier encontrado em posicao de valor (leitura ou
+// alvo de atribuicao) que NAO esta em bound entra em free.
+// MemberAccessExpression.Member e uma string crua (nao um Identifier), e
+// portanto nunca contribui — `x.campo` nao exige que "campo" resolva como
+// nome solto.
+func collectFreeInBlock(blk *ast.BlockStatement, bound, free map[string]bool) {
+	if blk == nil {
+		return
+	}
+	for _, s := range blk.Statements {
+		collectFreeInStatement(s, bound, free)
+	}
+}
+
+func collectFreeInStatement(s ast.Statement, bound, free map[string]bool) {
+	if s == nil {
+		return
+	}
+	switch n := s.(type) {
+	case *ast.LetStmt:
+		collectFreeInExpression(n.Value, bound, free)
+	case *ast.AssignStmt:
+		collectFreeInExpression(n.Target, bound, free)
+		collectFreeInExpression(n.Value, bound, free)
+	case *ast.ReturnStmt:
+		collectFreeInExpression(n.ReturnValue, bound, free)
+	case *ast.DeferStmt:
+		collectFreeInExpression(n.Call, bound, free)
+	case *ast.BreakStmt:
+	case *ast.UseStmt:
+	case *ast.ExpressionStmt:
+		collectFreeInExpression(n.Expression, bound, free)
+	case *ast.BlockStatement:
+		collectFreeInBlock(n, bound, free)
+	case *ast.IfStatement:
+		collectFreeInExpression(n.Condition, bound, free)
+		collectFreeInBlock(n.Consequence, bound, free)
+		collectFreeInBlock(n.Alternative, bound, free)
+	case *ast.WhileStatement:
+		collectFreeInExpression(n.Condition, bound, free)
+		collectFreeInBlock(n.Body, bound, free)
+	case *ast.FunctionStatement:
+		collectFreeInBlock(n.Body, bound, free)
+	case *ast.ForStatement:
+		collectFreeInExpression(n.Collection, bound, free)
+		collectFreeInBlock(n.Body, bound, free)
+	case *ast.StructStatement:
+		// sem identificador de valor.
+	case *ast.WhenStatement:
+		for _, clause := range n.Cases {
+			collectFreeInStatement(clause.Condition, bound, free)
+			collectFreeInBlock(clause.Body, bound, free)
+		}
+	default:
+		panic("collectFreeInStatement: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+func collectFreeInExpression(e ast.Expression, bound, free map[string]bool) {
+	if e == nil {
+		return
+	}
+	switch n := e.(type) {
+	case *ast.Identifier:
+		if !bound[n.Value] {
+			free[n.Value] = true
+		}
+	case *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral,
+		*ast.BytesLiteral, *ast.NullLiteral, *ast.Boolean:
+		// sem sub-no.
+	case *ast.ZerosLiteral:
+		collectFreeInExpression(n.Size, bound, free)
+	case *ast.PrefixExpression:
+		collectFreeInExpression(n.Right, bound, free)
+	case *ast.InfixExpression:
+		collectFreeInExpression(n.Left, bound, free)
+		collectFreeInExpression(n.Right, bound, free)
+	case *ast.FunctionLiteral:
+		collectFreeInBlock(n.Body, bound, free)
+	case *ast.CallExpression:
+		collectFreeInExpression(n.Function, bound, free)
+		for _, a := range n.Arguments {
+			collectFreeInExpression(a, bound, free)
+		}
+	case *ast.ArrayLiteral:
+		for _, el := range n.Elements {
+			collectFreeInExpression(el, bound, free)
+		}
+	case *ast.MapLiteral:
+		for i := range n.Keys {
+			collectFreeInExpression(n.Keys[i], bound, free)
+		}
+		for i := range n.Values {
+			collectFreeInExpression(n.Values[i], bound, free)
+		}
+	case *ast.IndexExpression:
+		collectFreeInExpression(n.Left, bound, free)
+		collectFreeInExpression(n.Index, bound, free)
+	case *ast.MemberAccessExpression:
+		collectFreeInExpression(n.Left, bound, free)
+	default:
+		panic("collectFreeInExpression: nó sem case — adicione aqui e o guard passa")
+	}
 }

--- a/internal/compiler/generics_errors_test.go
+++ b/internal/compiler/generics_errors_test.go
@@ -133,6 +133,43 @@ indice_de(idades, "30")`
 	}
 }
 
+// Mesmas duas mensagens (conflito com atribuição por argumento, inferência
+// só com null), agora via o CONSTRUTOR de struct genérico
+// (compileGenericConstructorSite, generics_structs.go) — a review da Task 11
+// apontou que a primeira rodada só cobriu o call site de FUNÇÃO
+// (compileGenericCallSite), embora os dois compartilhem a mesma máquina
+// (unifyPositionalArguments/missingTypeParamNullError, generics.go).
+func TestConstructorConflictAttributesArguments(t *testing.T) {
+	src := `struct Par<T>
+    a: T
+    b: T
+end
+Par(1, "x")`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("esperava conflito de unificacao T=int vs T=string no construtor")
+	}
+	for _, want := range []string{
+		"T inferido como int (argumento 1)",
+		"string (argumento 2)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro sem %q: %v", want, err)
+		}
+	}
+}
+
+func TestConstructorNullOnlyInferenceError(t *testing.T) {
+	src := `struct Caixa<T>
+    valor: T
+end
+Caixa(null)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil || !strings.Contains(err.Error(), "não foi possível inferir T de null") {
+		t.Fatalf("esperava erro de inferencia com null no construtor, veio %v", err)
+	}
+}
+
 // §9 "Valor sem alvo concreto": TestGenericWithoutConcreteTargetIsError
 // (generics_target_test.go) ja cobre as posicoes HOOKADAS (`let` anotado com
 // `func`/`any`). Este teste cobre as posicoes que NENHUM hook intercepta —

--- a/internal/compiler/generics_errors_test.go
+++ b/internal/compiler/generics_errors_test.go
@@ -278,3 +278,54 @@ func TestRefBindingError(t *testing.T) {
 		t.Fatalf("T=ref deve ser erro de unificacao, veio %v", err)
 	}
 }
+
+// I2 da revisao final de branch: recursao POLIMORFICA (cada nivel pede uma
+// tupla NOVA, entao o memo nunca acerta) travava o compilador para sempre —
+// f<int>, f<int[]>, f<int[][]>, ... sem fim. maxInstantiationDepth corta com
+// o erro do §9, embrulhado na cadeia de instanciacao, que aqui e justamente o
+// diagnostico util: mostra a torre de tuplas divergentes.
+//
+// O teste tambem e o guard de que o corte e RAPIDO: sem ele este Compile nao
+// retorna e o pacote inteiro estoura o timeout do `go test`.
+func TestPolymorphicRecursionHitsDepthCap(t *testing.T) {
+	src := `func f<T>(x: T, n: int) -> int
+    if n <= 0 then
+        return 0
+    end
+    let arr: T[] = [x]
+    return f(arr, n - 1)
+end
+let start: int = 1
+f(start, 3)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("recursao polimorfica deveria bater no teto de profundidade")
+	}
+	for _, want := range []string{
+		"profundidade máxima de instanciação genérica excedida (64)",
+		"recursão polimórfica?",
+		"em f<int[][]> (instanciado na linha 5)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro sem %q: %v", want, err)
+		}
+	}
+}
+
+// I2, metade dos STRUCTS: o mesmo teto vale para a cadeia de campos
+// (`proximo: Caixa<T[]>` nunca fecha). ensureStructInstance tem o guard
+// gemeo em volta de resolveStructFieldAnnotations.
+func TestPolymorphicStructRecursionHitsDepthCap(t *testing.T) {
+	src := `struct Caixa<T>
+    valor: T
+    proximo: Caixa<T[]>
+end
+let c: Caixa<int> = null`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("cadeia de campos polimorfica deveria bater no teto de profundidade")
+	}
+	if !strings.Contains(err.Error(), "profundidade máxima de instanciação genérica excedida (64)") {
+		t.Fatalf("erro sem o teto de profundidade: %v", err)
+	}
+}

--- a/internal/compiler/generics_errors_test.go
+++ b/internal/compiler/generics_errors_test.go
@@ -1,0 +1,243 @@
+package compiler
+
+// Task 11: cadeia de instanciacao (wrap de erros de corpo) + catalogo
+// negativo restante do §9. A maior parte do catalogo ja tem teste das Tasks
+// 8-10 (ver generics_test.go, generics_target_test.go, generics_struct_test.go,
+// generics_twopass_test.go, generics_unify_test.go); este arquivo cobre:
+//
+//   - o exemplo LITERAL do §9 para "erro de corpo por instanciacao"
+//     (operador nao definido para struct, nao so mismatch de tipo de argumento);
+//   - a mensagem dedicada de inferencia so-com-null;
+//   - "T fora de escopo" no `let` de topo (variante do que
+//     generics_struct_test.go ja cobre para campo de struct);
+//   - `any` explicito como argumento de tipo continua legal (§7);
+//   - conflito de unificacao com atribuicao POR ARGUMENTO ("argumento 1"/"argumento 2");
+//   - identificador de template (funcao e struct) em posicao de valor NAO
+//     interceptada por nenhum hook (valor de map literal, expression
+//     statement bare) — mesma mensagem de "precisa de tipo concreto";
+//   - T bindando ref (ou prova de que isso nunca acontece silenciosamente).
+//
+// As linhas do catalogo cross-modulo (namespace, shadowing, escopo de
+// definicao, dependencia nao importada) sao escopo da Task 12
+// (.superpowers/sdd/2026-08-18-generics/task-12-brief.md) — cross-modulo
+// generico ainda nao existe nesta base, entao nao ha comportamento real para
+// testar aqui.
+
+import (
+	"strings"
+	"testing"
+)
+
+// §9, ultima linha do catalogo, com o exemplo LITERAL da spec: operador
+// aritmetico sem sentido para struct. Isto e DIFERENTE do que
+// TestInstanceBodyErrorCarriesInstantiationChain (generics_twopass_test.go)
+// ja cobre (mismatch de tipo em chamada de funcao dentro do corpo) — aqui o
+// erro vem de um operador que a VM nunca soube executar sobre struct
+// (executor.go OP_ADD cai em "operands must be numbers, strings or bytes").
+// Sem checagem em tempo de compilacao isso e um crash de RUNTIME, fora do
+// alcance de instantiationChainError (que so envolve erros de Compile) — daí
+// a checagem nova em compiler.go (structOperandName/arithmeticOperators).
+func TestBodyErrorCarriesInstantiationChain(t *testing.T) {
+	src := `struct Ponto
+    x: int
+end
+func soma<T>(a: T, b: T) -> T
+    return a + b
+end
+let p1: Ponto = Ponto(1)
+let p2: Ponto = Ponto(2)
+soma(p1, p2)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("soma<Ponto> com + deve falhar")
+	}
+	for _, want := range []string{"soma<Ponto>", "instanciado na linha"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro sem %q: %v", want, err)
+		}
+	}
+}
+
+// §9: "inferência só com null" tem mensagem DEDICADA, distinta da generica
+// "não foi possível inferir T em 'f'" — só dispara quando null é a ÚNICA
+// razão da falha (nenhum outro argumento ancorou nada).
+func TestNullOnlyInferenceError(t *testing.T) {
+	_, _, err := New().Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nid(null)"))
+	if err == nil || !strings.Contains(err.Error(), "não foi possível inferir T de null") {
+		t.Fatalf("esperava erro de inferencia com null, veio %v", err)
+	}
+}
+
+// §9 "Param de tipo fora de escopo". Comportamento real verificado
+// empiricamente (e documentado no comentário de TestTypeParamAnnotationIsRejected
+// em generics_struct_test.go, que já cobre a mensagem exata do catálogo):
+// parser.go só produz o nó *ast.TypeParamType DENTRO do escopo textual de uma
+// declaração genérica, para os nomes efetivamente listados em `<...>`
+// (p.activeTypeParams). Um `T` solto no `let` de TOPO nunca chega como
+// TypeParamType — o parser o trata como um nome de tipo comum (e
+// desconhecido), então resolveAnnotation nem entra em jogo (needsAnnotationResolution
+// responde false para *ast.PrimitiveType) e "tipo 'T' não declarado" nunca é a
+// mensagem aqui. O que ESTE teste prova é a outra metade da garantia da spec:
+// `T` fora de escopo nunca vira um tipo "de mentirinha" que aceita qualquer
+// valor silenciosamente — vira um nome de tipo comum e desconhecido, que a
+// checagem de tipos do `let` rejeita do jeito de sempre (type mismatch,
+// porque "T" nunca é "int"). Sem essa segunda garantia um usuário poderia
+// escrever `T` por engano fora de um template e ver o programa compilar
+// (aceitando qualquer valor como se T fosse `any`) em vez de falhar.
+func TestTypeParamOutOfScopeError(t *testing.T) {
+	_, _, err := New().Compile(parse("let x: T = 1"))
+	if err == nil {
+		t.Fatal("T fora de escopo deveria ser erro (nunca aceitar silenciosamente), veio nil")
+	}
+	if !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("esperava erro de tipo (T tratado como nome de tipo comum e desconhecido), veio %v", err)
+	}
+}
+
+// §7: any e legal como argumento de tipo explicito — incondicionalmente
+// (não só quando nenhum argumento bindou nada): mesmo com `Caixa(1)`
+// bindando T=int a partir do argumento, a anotação explícita `Caixa<any>`
+// prevalece (applyStructHintBindings, generics_structs.go — ver comentário
+// lá para o porquê de "any" ser um caso à parte de "argumento é âncora
+// primária").
+func TestStackAnyIsLegal(t *testing.T) {
+	// §7: any e legal como argumento de tipo explicito
+	_, _, err := New().Compile(parse("struct Caixa<T>\n    valor: T\nend\nlet c: Caixa<any> = Caixa(1)"))
+	if err != nil {
+		t.Fatalf("Caixa<any> deve compilar: %v", err)
+	}
+}
+
+// §9 "conflito de unificação" com atribuição POR ARGUMENTO: a mensagem
+// generica de TestInferenceConflictError (generics_twopass_test.go) só prova
+// "inferido como X e Y"; o catálogo pede o argumento de origem de cada lado
+// ("T inferido como int (argumento 1) e string (argumento 2)") — a mesma
+// mensagem literal do exemplo `indice_de(idades, "30")` do §9.
+func TestUnificationConflictAttributesArguments(t *testing.T) {
+	src := `func indice_de<T>(arr: T[], alvo: T) -> int
+    return 0
+end
+let idades: int[] = [30]
+indice_de(idades, "30")`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("esperava conflito de unificacao T=int vs T=string")
+	}
+	for _, want := range []string{
+		"T inferido como int (argumento 1)",
+		"string (argumento 2)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro sem %q: %v", want, err)
+		}
+	}
+}
+
+// §9 "Valor sem alvo concreto": TestGenericWithoutConcreteTargetIsError
+// (generics_target_test.go) ja cobre as posicoes HOOKADAS (`let` anotado com
+// `func`/`any`). Este teste cobre as posicoes que NENHUM hook intercepta —
+// valor de map literal e expression statement solto — onde um identificador
+// nomeando um template de FUNCAO alcancava o `case *ast.Identifier` generico
+// de compiler.go sem nenhuma reescrita, lendo um global que nunca foi
+// definido (mensagem confusa a jusante, tipicamente sobre global
+// desconhecido). O fallback fica no proprio case, disparando so quando
+// nenhum hook anterior ja rescreveu o identificador (resolveLocal/
+// resolveUpvalue vazios — mesma regra de sombreamento dos outros hooks).
+func TestUnhookedFunctionTemplateValuePositionIsError(t *testing.T) {
+	for name, src := range map[string]string{
+		"map literal value":    "func id<T>(x: T) -> T\n    return x\nend\nlet m: map[string, func] = {\"f\": id}",
+		"expression statement": "func id<T>(x: T) -> T\n    return x\nend\nid",
+	} {
+		_, _, err := New().Compile(parse(src))
+		if err == nil || !strings.Contains(err.Error(), "precisa de tipo concreto") {
+			t.Fatalf("%s: esperava erro de tipo concreto, veio %v", name, err)
+		}
+	}
+}
+
+// Mesmo tratamento (item 4 da task): struct generico bare como valor, nas
+// mesmas duas posicoes desprotegidas.
+func TestUnhookedStructTemplateValuePositionIsError(t *testing.T) {
+	for name, src := range map[string]string{
+		"map literal value":    "struct Caixa<T>\n    valor: T\nend\nlet m: map[string, func] = {\"c\": Caixa}",
+		"expression statement": "struct Caixa<T>\n    valor: T\nend\nCaixa",
+	} {
+		_, _, err := New().Compile(parse(src))
+		if err == nil || !strings.Contains(err.Error(), "precisa de tipo concreto") {
+			t.Fatalf("%s: esperava erro de tipo concreto, veio %v", name, err)
+		}
+	}
+}
+
+// As 5 posicoes HOOKADAS (§3/§4) e chamada direta continuam funcionando —
+// prova de que o fallback do case Identifier so dispara quando NENHUM hook
+// intercepta antes. `let` anotado, retorno, elemento de array, campo de
+// struct e argumento de chamada (as 5 do §3) mais a chamada direta em si
+// (callee de CallExpression).
+func TestHookedPositionsStillWorkAfterUnhookedFallback(t *testing.T) {
+	for name, src := range map[string]string{
+		"let anotado":       "func id<T>(x: T) -> T\n    return x\nend\nlet f: func(int) -> int = id",
+		"chamada direta":    "func id<T>(x: T) -> T\n    return x\nend\nid(1)",
+		"elemento de array": "func id<T>(x: T) -> T\n    return x\nend\nlet fs: (func(int) -> int)[] = [id]",
+		"argumento de chamada": `func aplica<A, B>(f: func(A) -> B, x: A) -> B
+    return f(x)
+end
+func id<T>(x: T) -> T
+    return x
+end
+aplica(id, 1)`,
+		"construtor de struct direto": "struct Caixa<T>\n    valor: T\nend\nCaixa(1)",
+	} {
+		_, _, err := New().Compile(parse(src))
+		if err != nil {
+			t.Fatalf("%s: deveria compilar, veio %v", name, err)
+		}
+	}
+	// Retorno e campo de struct: as duas posicoes restantes do §3/§4,
+	// exercitadas em programas separados (retorno de func nao-generica
+	// devolvendo o generico como valor; atribuicao a campo de struct
+	// recebendo o generico como valor).
+	returnSrc := `func id<T>(x: T) -> T
+    return x
+end
+func devolve() -> func(int) -> int
+    return id
+end
+devolve()`
+	if _, _, err := New().Compile(parse(returnSrc)); err != nil {
+		t.Fatalf("retorno hookado: deveria compilar, veio %v", err)
+	}
+	fieldSrc := `struct Handler
+    callback: func(int) -> int
+end
+func id<T>(x: T) -> T
+    return x
+end
+let h: Handler = Handler(func(v: int) -> int
+    return v
+end)
+h.callback = id`
+	if _, _, err := New().Compile(parse(fieldSrc)); err != nil {
+		t.Fatalf("campo de struct hookado: deveria compilar, veio %v", err)
+	}
+}
+
+// §9: "T bindando ref" — a spec exige que T=ref NUNCA aconteça
+// silenciosamente. Comportamento real verificado empiricamente: o `let`
+// alvo (`ref int`) e o VALOR (`r`, tipo `ref int`) batem sem generico
+// nenhum no meio — rewriteIfGenericValue so intercepta identificador NU
+// nomeando um TEMPLATE DE FUNCAO (aqui e `id`, que E chamado, entao o hook
+// de call site e quem atua, nao o de target-typing). No call site,
+// compileGenericCallSite chama typeOfDiscardedExpression(r), que retorna o
+// tipo ESTATICO de `r` — `ref int` — sem auto-deref (auto-deref so acontece
+// para PARAMETROS concretos tipados sem `ref`, e aqui o parametro e `x: T`,
+// ainda generico, unify decide). unify(T, ref int, ...) cai exatamente no
+// case `tp, ok := expected.(*ast.TypeParamType)` de generics_unify.go, que
+// rejeita `ref` como alvo de binding ANTES de qualquer outra regra —
+// exatamente a garantia que a spec pede.
+func TestRefBindingError(t *testing.T) {
+	_, _, err := New().Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nlet r: ref int = null\nlet v: ref int = id(r)"))
+	if err == nil || !strings.Contains(err.Error(), "não pode ser um tipo ref") {
+		t.Fatalf("T=ref deve ser erro de unificacao, veio %v", err)
+	}
+}

--- a/internal/compiler/generics_modules_test.go
+++ b/internal/compiler/generics_modules_test.go
@@ -1,0 +1,80 @@
+package compiler
+
+// Testes de compilador para cross-modulo de genericos (spec §8): o validator
+// (loadModuleDeclarations/discoverModuleExports, ja exercitado pela Task 5)
+// continua carregando um modulo cujo UNICO conteudo e um template — a Task 8
+// ja fazia o validator pular templates ao compilar o modulo sozinho, este
+// teste so garante que o caminho de descoberta de exports concorda. O
+// segundo teste fixa a regra do §8/R8 sobre homonimo func/struct: nomes que
+// colidem entre as duas familias de template tem de ser rejeitados na
+// REGISTRO, nao silenciosamente colidir em instanceName mais tarde.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+func TestModuleWithOnlyATemplateIsLoadable(t *testing.T) {
+	root := t.TempDir()
+	modulePath := filepath.Join(root, "soterrado.nx")
+	if err := os.WriteFile(modulePath, []byte("func primeiro<T>(arr: T[]) -> T\n    return arr[0]\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	exports, loadable := compiler.discoverModuleExports("soterrado")
+	if !loadable {
+		t.Fatal("modulo com so um template generico deveria continuar loadable")
+	}
+	if _, ok := exports["primeiro"]; !ok {
+		t.Fatal("export do template 'primeiro' nao foi descoberto")
+	}
+}
+
+// TestFuncStructTemplateHomonymCollisionIsRejected fixa a nota da revisao da
+// Task 9 (relatada no brief da Task 12): instanceName (generics_substitute.go)
+// qualifica so por modulo+base+args, sem marcar familia (func vs struct) —
+// `func Foo<T>` e `struct Foo<T>` com o MESMO nome colidiriam no MESMO nome
+// qualificado (`main::Foo<int>`) se ambos fossem instanciados com a mesma
+// tupla, um sobrescrevendo o c.globals/c.structs do outro em silencio.
+// registerFuncTemplate/registerStructTemplate (generics.go) fecham isso na
+// fronteira de REGISTRO: a segunda declaracao a reivindicar o nome, seja
+// qual for a familia, e um erro de compilacao claro.
+func TestFuncStructTemplateHomonymCollisionIsRejected(t *testing.T) {
+	t.Run("struct depois de func", func(t *testing.T) {
+		_, _, err := New().Compile(parse(`
+func Foo<T>(x: T) -> T
+    return x
+end
+struct Foo<T>
+    valor: T
+end
+`))
+		if err == nil {
+			t.Fatal("esperava erro de colisao func/struct, compilou sem erro")
+		}
+		if !strings.Contains(err.Error(), "Foo") {
+			t.Fatalf("mensagem de erro nao menciona o nome colidido: %v", err)
+		}
+	})
+
+	t.Run("func depois de struct", func(t *testing.T) {
+		_, _, err := New().Compile(parse(`
+struct Bar<T>
+    valor: T
+end
+func Bar<T>(x: T) -> T
+    return x
+end
+`))
+		if err == nil {
+			t.Fatal("esperava erro de colisao struct/func, compilou sem erro")
+		}
+		if !strings.Contains(err.Error(), "Bar") {
+			t.Fatalf("mensagem de erro nao menciona o nome colidido: %v", err)
+		}
+	})
+}

--- a/internal/compiler/generics_repl_test.go
+++ b/internal/compiler/generics_repl_test.go
@@ -1,0 +1,46 @@
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+// Task 14 (spec §5): o REPL cria um *Compiler NOVO a cada linha (correto —
+// cada linha e sua propria compilacao de Program, e o instanceQueue e por
+// Program), mas precisa persistir TRES estados entre linhas para o codigo
+// nao "esquecer" o que uma linha anterior declarou: globals (ja persistia),
+// c.structs (structs comuns E instancias de struct generico — bug de carona
+// pre-existente: sem isto, o REGISTRO da instancia feito por
+// registerStructInstance em ensureStructInstance some junto com o mapa
+// descartavel da linha) e o GenericRegistry (templates genericos, via
+// SetGenericState — sem isto, o template declarado numa linha nunca chega
+// a linha seguinte, que ve apenas um registry novo e vazio).
+//
+// Este teste exercita o CONTRATO do compilador que cmd/noxy/main.go usa —
+// nao o main.go em si (cmd/noxy nao tem testes hoje e a mudanca la e um
+// espelho direto: hoisting dos tres mapas/registry para fora do loop, com
+// SetGenericState chamado por linha).
+//
+// Sequencia: linha 1 declara o template `Caixa<T>`; linha 2 instancia
+// `Caixa<int>` num `let`; linha 3 acessa o campo `valor` da instancia. Cada
+// "linha" e um Compiler NOVO (mimetizando main.go), mas globals/structs/reg
+// sao os MESMOS mapas/ponteiro atravessando as tres iteracoes.
+func TestREPLPersistsGenericsAcrossLines(t *testing.T) {
+	globals := make(map[string]ast.NoxyType)
+	structs := make(map[string]*ast.StructStatement)
+	reg := NewGenericRegistry()
+	lines := []string{
+		"struct Caixa<T>\n    valor: T\nend",
+		"let c: Caixa<int> = Caixa(7)",
+		"c.valor",
+	}
+	for i, line := range lines {
+		c := NewWithState(globals, structs, "REPL")
+		c.SetGenericState(reg)
+		if _, _, err := c.Compile(parse(line)); err != nil {
+			t.Fatalf("linha %d (%q): %v", i+1, line, err)
+		}
+		globals = c.GetGlobals()
+	}
+}

--- a/internal/compiler/generics_struct_test.go
+++ b/internal/compiler/generics_struct_test.go
@@ -1,0 +1,240 @@
+package compiler
+
+// Terceira familia de hooks (spec §4): toda resolucao de GenericType em
+// posicao de anotacao instancia o struct. Aqui ficam os contratos de
+// compilador — validacao de aridade/escopo do §9, memoizacao por tupla e
+// ordem das declaracoes sinteticas.
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+func TestGenericStructArityError(t *testing.T) {
+	_, _, err := New().Compile(parse("struct Caixa<T>\n    valor: T\nend\nlet c: Caixa<int, string> = null"))
+	if err == nil || !strings.Contains(err.Error(), "espera 1 argumento de tipo, recebeu 2") {
+		t.Fatalf("esperava erro de aridade, veio %v", err)
+	}
+}
+
+// §9: parametro de tipo fora do template nao e um tipo. Na fonte, `T` fora de
+// uma declaracao generica nem chega como TypeParamType — o parser so produz
+// esse no dentro de um template (activeTypeParams), entao ali `T` e apenas um
+// nome de tipo desconhecido e o erro vem da checagem de tipos normal. O no
+// TypeParamType alcanca resolveAnnotation apenas por uma substituicao que
+// deixou parametro de tipo livre, e a mensagem do catalogo cobre esse caso.
+func TestTypeParamAnnotationIsRejected(t *testing.T) {
+	_, err := New().resolveAnnotation(&ast.TypeParamType{Name: "T"}, 4)
+	want := "[line 4] tipo 'T' não declarado"
+	if err == nil || err.Error() != want {
+		t.Fatalf("erro = %v, quer %q", err, want)
+	}
+	// Composicao: o parametro de tipo livre e reportado em qualquer profundidade.
+	_, err = New().resolveAnnotation(&ast.ArrayType{ElementType: &ast.TypeParamType{Name: "U"}}, 9)
+	if err == nil || err.Error() != "[line 9] tipo 'U' não declarado" {
+		t.Fatalf("erro = %v, quer o mesmo erro para U na linha 9", err)
+	}
+}
+
+// GenericType cujo Name nao e template: nao existe nada para instanciar.
+func TestUnknownGenericTypeNameError(t *testing.T) {
+	_, _, err := New().Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nlet c: Caixa<int> = null"))
+	if err == nil || !strings.Contains(err.Error(), "'Caixa' não é um tipo genérico declarado") {
+		t.Fatalf("esperava erro de template inexistente, veio %v", err)
+	}
+}
+
+// instanceStructNames lista, na ordem, as instancias de struct que o pass 1
+// prependou (instancia = nome com o qualificador de modulo, §4).
+func instanceStructNames(program *ast.Program) []string {
+	names := []string{}
+	for _, statement := range program.Statements {
+		if structDecl, ok := statement.(*ast.StructStatement); ok && strings.Contains(structDecl.Name, "::") {
+			names = append(names, structDecl.Name)
+		}
+	}
+	return names
+}
+
+// Memoizacao por tupla: a anotacao e o construtor pedem a MESMA instancia, e
+// ela e declarada uma unica vez.
+func TestGenericStructMemoizedAcrossAnnotationAndConstructor(t *testing.T) {
+	program := parse("struct Caixa<T>\n    valor: T\nend\nlet a: Caixa<int> = Caixa(1)\nlet b: Caixa<int> = Caixa(2)")
+	if _, _, err := New().Compile(program); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(instanceStructNames(program), " "); got != "main::Caixa<int>" {
+		t.Fatalf("instancias prependadas = %q, quer apenas main::Caixa<int>", got)
+	}
+}
+
+// §4/§5: cascata Caixa<Caixa<int>> resolve a instancia interna ANTES da
+// externa, e a ordem da fila (dependencia antes de dependente) e o que faz o
+// pass 2 compilar tudo pelo caminho normal.
+func TestNestedGenericStructOrdersDependencyFirst(t *testing.T) {
+	program := parse("struct Caixa<T>\n    valor: T\nend\nlet d: Caixa<Caixa<int>> = null")
+	if _, _, err := New().Compile(program); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(instanceStructNames(program), " ")
+	want := "main::Caixa<int> main::Caixa<main::Caixa<int>>"
+	if got != want {
+		t.Fatalf("ordem = %q, quer %q", got, want)
+	}
+}
+
+// Instancia de struct entra na fila antes da instancia de funcao que a usa: o
+// pass 2 compila statements em ordem e o construtor precisa existir como
+// global antes do corpo que o chama rodar.
+func TestStructInstancePrecedesFunctionInstance(t *testing.T) {
+	program := parse(`struct Caixa<T>
+    valor: T
+end
+func embala<T>(v: T) -> Caixa<T>
+    let out: Caixa<T> = Caixa(v)
+    return out
+end
+let c: Caixa<int> = embala(7)`)
+	if _, _, err := New().Compile(program); err != nil {
+		t.Fatal(err)
+	}
+	structIndex, funcIndex := -1, -1
+	for index, statement := range program.Statements {
+		switch decl := statement.(type) {
+		case *ast.StructStatement:
+			if decl.Name == "main::Caixa<int>" {
+				structIndex = index
+			}
+		case *ast.FunctionStatement:
+			if decl.Name == "main::embala<int>" {
+				funcIndex = index
+			}
+		}
+	}
+	if structIndex < 0 || funcIndex < 0 {
+		t.Fatalf("instancias nao encontradas (struct=%d, func=%d)", structIndex, funcIndex)
+	}
+	if structIndex > funcIndex {
+		t.Fatalf("struct em %d vem depois da funcao em %d", structIndex, funcIndex)
+	}
+}
+
+// §9: erro na resolucao dos CAMPOS de uma instancia carrega a cadeia de
+// instanciacao, com o nome de exibicao (sem qualificador de modulo).
+func TestFieldErrorInsideInstanceCarriesChain(t *testing.T) {
+	_, _, err := New().Compile(parse(`struct Caixa<T>
+    valor: T
+end
+struct Par<A>
+    dentro: Caixa<A, A>
+end
+let p: Par<int>`))
+	if err == nil {
+		t.Fatal("esperava erro de aridade dentro do campo da instancia")
+	}
+	for _, fragment := range []string{"em Par<int> (instanciado na linha 7)", "espera 1 argumento de tipo, recebeu 2"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("erro %q nao contem %q", err.Error(), fragment)
+		}
+	}
+}
+
+// structConstant acha a definicao de struct que o pass 2 emitiu como constante
+// para um nome de instancia.
+func structConstant(t *testing.T, code *chunk.Chunk, name string) *value.ObjStruct {
+	t.Helper()
+	for _, constant := range code.Constants {
+		definition, ok := constant.Obj.(*value.ObjStruct)
+		if ok && definition.Name == name {
+			return definition
+		}
+	}
+	t.Fatalf("definicao de struct %q nao encontrada nas constantes", name)
+	return nil
+}
+
+// §10: a instancia e um StructStatement comum pos-substituicao, entao ela sai do
+// pass 2 com tudo que um struct escrito a mao tem — tipo de construtor com a
+// identidade nominal qualificada e JSONDynamicFields para os campos `any`
+// (inclusive quando o `any` vem do argumento de tipo).
+func TestGenericStructInstanceIsAnOrdinaryStruct(t *testing.T) {
+	code, _, err := New().Compile(parse(`struct Caixa<T>
+    valor: T,
+    extra: any
+end
+let c: Caixa<int> = Caixa(1, null)
+let d: Caixa<any>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	concrete := structConstant(t, code, "main::Caixa<int>")
+	if concrete.JSONDynamicFields["valor"] {
+		t.Fatal("campo 'valor' de Caixa<int> nao deveria ser dinamico")
+	}
+	if !concrete.JSONDynamicFields["extra"] {
+		t.Fatal("campo 'extra' (any) deveria estar em JSONDynamicFields")
+	}
+	if concrete.ConstructorType == nil || concrete.ConstructorType.Return == nil {
+		t.Fatal("instancia sem tipo de construtor")
+	}
+	if got := concrete.ConstructorType.Return.Name; got != "main::Caixa<int>" {
+		t.Fatalf("retorno do construtor = %q, quer main::Caixa<int>", got)
+	}
+	// T=any: a substituicao propaga a dinamicidade para o campo do parametro.
+	if !structConstant(t, code, "main::Caixa<any>").JSONDynamicFields["valor"] {
+		t.Fatal("campo 'valor' de Caixa<any> deveria ser dinamico")
+	}
+}
+
+// Instancia pedida DENTRO de um corpo de funcao: o compilador do corpo e um
+// filho com copias proprias de structs/globals, e e nele que a instancia tem de
+// ficar visivel (member access e construtor) — mesmo quando o memo ja foi criado
+// por outro compilador.
+func TestGenericStructInstanceVisibleInsideFunctionBody(t *testing.T) {
+	if _, _, err := New().Compile(parse(`struct Caixa<T>
+    valor: T
+end
+let global: Caixa<int> = Caixa(1)
+func soma() -> int
+    let local: Caixa<int> = Caixa(41)
+    return local.valor + global.valor
+end
+soma()`)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A anotacao e reescrita in-place para o nome qualificado da instancia: e o
+// que faz o pass 2 (e a validacao CoW de runtime) tratar a instancia como um
+// struct nominal comum.
+func TestAnnotationRewrittenToQualifiedName(t *testing.T) {
+	program := parse("struct Caixa<T>\n    valor: T\nend\nlet xs: Caixa<int>[] = []")
+	c := New()
+	if _, _, err := c.Compile(program); err != nil {
+		t.Fatal(err)
+	}
+	var letStmt *ast.LetStmt
+	for _, statement := range program.Statements {
+		if candidate, ok := statement.(*ast.LetStmt); ok && candidate.Name.Value == "xs" {
+			letStmt = candidate
+		}
+	}
+	if letStmt == nil {
+		t.Fatal("let 'xs' desapareceu do programa")
+	}
+	arrayType, ok := letStmt.Type.(*ast.ArrayType)
+	if !ok {
+		t.Fatalf("tipo do let = %T, quer *ast.ArrayType", letStmt.Type)
+	}
+	element, ok := arrayType.ElementType.(*ast.PrimitiveType)
+	if !ok || element.Name != "main::Caixa<int>" {
+		t.Fatalf("elemento = %s, quer main::Caixa<int>", arrayType.ElementType.String())
+	}
+	if _, registered := c.structs["main::Caixa<int>"]; !registered {
+		t.Fatal("instancia nao registrada em c.structs")
+	}
+}

--- a/internal/compiler/generics_structs.go
+++ b/internal/compiler/generics_structs.go
@@ -1,0 +1,493 @@
+package compiler
+
+// Terceira familia de hooks da spec §4: TODA resolucao de GenericType em
+// posicao de anotacao de tipo e um site de instanciacao de struct. Sem call
+// site e sem target-typing, `let xs: Caixa<int>[] = []` ja exige que
+// main::Caixa<int> exista em c.structs (resolucao de campo por member access) e
+// tenha runtime type info completa (validacao CoW). Este arquivo concentra a
+// maquinaria: resolveAnnotation (o hook), ensureStructInstance (a
+// monomorfizacao) e o site de construtor `Caixa(41)`.
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// structInstanceKey guarda a tupla de tipos que gerou uma instancia de struct.
+// Serve para o caminho INVERSO da resolucao: um tipo concreto observado num
+// site de chamada ja carrega o nome qualificado (`main::Caixa<int>`), mas a
+// anotacao do template contra a qual ele sera unificado esta escrita na forma
+// generica (`Caixa<T>`). Com a tupla em maos, expandInstanceNames reconstroi a
+// forma generica e unify casa os dois sem precisar conhecer tabela nenhuma.
+type structInstanceKey struct {
+	Base string
+	Args []ast.NoxyType
+}
+
+// resolveAnnotation percorre uma anotacao de tipo e devolve a anotacao
+// equivalente com todo GenericType substituido pelo nome QUALIFICADO da
+// instancia correspondente (`Caixa<int>` -> `main::Caixa<int>`), instanciando o
+// struct pelo caminho memoizado do §4. A estrutura externa e preservada:
+// `Caixa<int>[]`, `ref Node<int>`, `map[string, Caixa<int>]` e assinaturas de
+// funcao voltam com a mesma forma, so com o miolo resolvido.
+//
+// Erros (§9):
+//   - GenericType cujo Name nao e um template em escopo: nao ha o que instanciar.
+//   - aridade divergente do template: "'Caixa' espera 1 argumento de tipo, recebeu 2".
+//   - TypeParamType: `T` fora de uma declaracao generica nao e um tipo
+//     ("tipo 'T' não declarado"). Dentro de template isso nao acontece: templates
+//     nao sao compilados, so seus clones — e no clone T ja foi substituido.
+//
+// Fast path: anotacao sem GenericType nem TypeParamType volta pelo MESMO
+// ponteiro, sem alocar. E o que mantem o custo de programa sem genericos em
+// exatamente zero (§5) mesmo com o hook em todo ponto de entrada de anotacao.
+func (c *Compiler) resolveAnnotation(t ast.NoxyType, line int) (ast.NoxyType, error) {
+	if !needsAnnotationResolution(t) {
+		return t, nil
+	}
+	switch n := t.(type) {
+	case *ast.GenericType:
+		template, isTemplate := c.registryOrInit().Structs[n.Name]
+		if !isTemplate {
+			return nil, fmt.Errorf("[line %d] '%s' não é um tipo genérico declarado", line, n.Name)
+		}
+		if len(n.Args) != len(template.Decl.TypeParams) {
+			return nil, typeArgumentArityError(line, n.Name, len(template.Decl.TypeParams), len(n.Args))
+		}
+		// Args ANTES da instancia: `Caixa<Caixa<int>>` resolve o interno
+		// primeiro, entao main::Caixa<int> entra na fila antes de quem depende
+		// dele (§4 — a ordem de dependencia sai da ordem de criacao).
+		args := make([]ast.NoxyType, len(n.Args))
+		for index, argument := range n.Args {
+			resolved, err := c.resolveAnnotation(argument, line)
+			if err != nil {
+				return nil, err
+			}
+			args[index] = resolved
+		}
+		name, err := c.ensureStructInstance(template, args, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.PrimitiveType{Name: name}, nil
+
+	case *ast.TypeParamType:
+		return nil, fmt.Errorf("[line %d] tipo '%s' não declarado", line, n.Name)
+
+	case *ast.ArrayType:
+		element, err := c.resolveAnnotation(n.ElementType, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ArrayType{ElementType: element, Size: n.Size}, nil
+
+	case *ast.MapType:
+		key, err := c.resolveAnnotation(n.KeyType, line)
+		if err != nil {
+			return nil, err
+		}
+		mapValue, err := c.resolveAnnotation(n.ValueType, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.MapType{KeyType: key, ValueType: mapValue}, nil
+
+	case *ast.RefType:
+		element, err := c.resolveAnnotation(n.ElementType, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.RefType{ElementType: element}, nil
+
+	case *ast.ChanType:
+		element, err := c.resolveAnnotation(n.ElementType, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ChanType{ElementType: element}, nil
+
+	case *ast.FunctionType:
+		params := make([]ast.NoxyType, len(n.Params))
+		for index, param := range n.Params {
+			resolved, err := c.resolveAnnotation(param, line)
+			if err != nil {
+				return nil, err
+			}
+			params[index] = resolved
+		}
+		result, err := c.resolveAnnotation(n.Return, line)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.FunctionType{Params: params, Return: result}, nil
+
+	default:
+		return t, nil
+	}
+}
+
+// needsAnnotationResolution responde se t carrega, em qualquer profundidade,
+// algum no que resolveAnnotation precisa tocar: GenericType (instancia a criar)
+// ou TypeParamType (erro de escopo). Anotacao de programa sem genericos
+// responde false na primeira olhada e volta intocada.
+func needsAnnotationResolution(t ast.NoxyType) bool {
+	switch n := t.(type) {
+	case *ast.GenericType, *ast.TypeParamType:
+		return true
+	case *ast.ArrayType:
+		return needsAnnotationResolution(n.ElementType)
+	case *ast.MapType:
+		return needsAnnotationResolution(n.KeyType) || needsAnnotationResolution(n.ValueType)
+	case *ast.RefType:
+		return needsAnnotationResolution(n.ElementType)
+	case *ast.ChanType:
+		return needsAnnotationResolution(n.ElementType)
+	case *ast.FunctionType:
+		for _, param := range n.Params {
+			if needsAnnotationResolution(param) {
+				return true
+			}
+		}
+		return needsAnnotationResolution(n.Return)
+	default:
+		return false
+	}
+}
+
+// resolveSignatureAnnotations resolve as anotacoes de uma assinatura de funcao
+// NAO-generica, in-place: os parametros e o tipo de retorno passam a nomear
+// instancias qualificadas. In-place e o ponto — o pass 2 compila o MESMO AST e
+// tem de ver os nomes ja reescritos (§4, item 4).
+func (c *Compiler) resolveSignatureAnnotations(params []*ast.Parameter, returnType *ast.NoxyType, line int) error {
+	for _, param := range params {
+		resolved, err := c.resolveAnnotation(param.Type, line)
+		if err != nil {
+			return err
+		}
+		param.Type = resolved
+	}
+	resolved, err := c.resolveAnnotation(*returnType, line)
+	if err != nil {
+		return err
+	}
+	*returnType = resolved
+	return nil
+}
+
+// resolveStructFieldAnnotations resolve as anotacoes dos campos de um struct
+// (in-place, nos DOIS espelhos: FieldsList, a fonte ordenada, e Fields, o mapa
+// por nome — divergir os dois faria resolucao de campo e runtime type info
+// discordarem). Serve tanto para struct comum que menciona um generico
+// (`struct Caixa_de_caixas  c: Caixa<int> end`) quanto para os campos de uma
+// instancia recem-clonada.
+func (c *Compiler) resolveStructFieldAnnotations(definition *ast.StructStatement, line int) error {
+	fields := make(map[string]ast.NoxyType, len(definition.FieldsList))
+	for _, field := range definition.FieldsList {
+		resolved, err := c.resolveAnnotation(field.Type, line)
+		if err != nil {
+			return err
+		}
+		field.Type = resolved
+		fields[field.Name] = resolved
+	}
+	definition.Fields = fields
+	return nil
+}
+
+// ensureStructInstance devolve (criando se preciso) o nome qualificado da
+// instancia monomorfizada de tpl para args. Ordem obrigatoria do §4, gemea de
+// ensureFunctionInstance: nome -> memo -> clone -> REGISTRA o clone (memo,
+// c.structs e c.globals) -> so DEPOIS resolve as anotacoes dos campos ->
+// enfileira. Registrar antes de resolver os campos e o que faz auto-referencia
+// terminar: o campo `next: ref Node<T>` reentra aqui, encontra o memo e para.
+//
+// A instancia entra em queue.ordered depois de tudo que os campos dela
+// exigiram, entao dependencia sempre precede dependente; e como structs sao
+// criados durante a resolucao das assinaturas/corpos das instancias de funcao,
+// eles tambem precedem naturalmente as funcoes que os usam.
+func (c *Compiler) ensureStructInstance(tpl *StructTemplate, args []ast.NoxyType, line int) (string, error) {
+	base := tpl.Decl.Name
+	if len(args) != len(tpl.Decl.TypeParams) {
+		return "", typeArgumentArityError(line, base, len(tpl.Decl.TypeParams), len(args))
+	}
+	name := instanceName(tpl.Module, base, args)
+	if !c.pass1 {
+		// Defensivo, gemeo do guard de compileGenericCallSite: no pass 2 toda
+		// anotacao alcancavel ja foi reescrita pelo pass 1. Se um GenericType
+		// chegou aqui, existe caminho de compilacao que nao passou pelo pass 1 —
+		// e instanciar agora registraria o struct sem NUNCA emitir a declaracao
+		// (a fila do pass 2 e descartada), virando "undefined global" em runtime.
+		return "", fmt.Errorf(
+			"[line %d] anotação de tipo genérico '%s' chegou ao pass 2 sem monomorfização — bug do compilador de genéricos",
+			line, displayInstanceName(base, args),
+		)
+	}
+
+	queue := c.instancesOrInit()
+	if instance, memoized := queue.structInstances[name]; memoized {
+		// Registro SEMPRE no compilador atual, inclusive no acerto de memo: cada
+		// filho tem sua propria copia de structs/globals, e quem usa a instancia
+		// precisa enxergar os campos (member access) e o construtor (call site).
+		c.registerStructInstance(instance)
+		return name, nil
+	}
+
+	bindings := make(map[string]ast.NoxyType, len(args))
+	for index, typeParam := range tpl.Decl.TypeParams {
+		bindings[typeParam] = args[index]
+	}
+	instance := substituteStruct(tpl, bindings, name)
+	queue.structInstances[name] = instance
+	queue.structKeys[name] = structInstanceKey{Base: base, Args: args}
+	c.registerStructInstance(instance)
+
+	if err := c.resolveStructFieldAnnotations(instance, line); err != nil {
+		return "", instantiationChainError(displayInstanceName(base, args), line, err)
+	}
+	// Re-registra: os campos mudaram (GenericType -> nome qualificado) e o tipo
+	// do construtor derivado deles tem de acompanhar.
+	c.registerStructInstance(instance)
+	queue.ordered = append(queue.ordered, instance)
+	return name, nil
+}
+
+// registerStructInstance faz a instancia existir para o compilador atual: a
+// declaracao em c.structs (resolucao de campo, runtime type info) e o tipo do
+// construtor em c.globals (o call site reescrito resolve um global comum).
+func (c *Compiler) registerStructInstance(instance *ast.StructStatement) {
+	c.structs[instance.Name] = instance
+	params := make([]ast.NoxyType, len(instance.FieldsList))
+	for index, field := range instance.FieldsList {
+		params[index] = field.Type
+	}
+	c.globals[instance.Name] = newStructFunctionType(instance.Name, params)
+}
+
+// compileGenericConstructorSite e o hook de call site do §4 para construtor de
+// struct generico: `Caixa(41)`. Infere a tupla unificando os tipos dos CAMPOS
+// (que sao os parametros do construtor posicional) contra os tipos dos
+// argumentos, com o hint da anotacao do `let` como complemento para o que os
+// argumentos nao ancorarem (`Caixa([])` com `let c: Caixa<int>`), e reescreve o
+// identificador para o nome qualificado. Depois disso o caminho normal de
+// compileCallExpression resolve um global comum.
+func (c *Compiler) compileGenericConstructorSite(call *ast.CallExpression, callee *ast.Identifier, tpl *StructTemplate) error {
+	base := tpl.Decl.Name
+	line := c.currentLine
+	if !c.pass1 {
+		return fmt.Errorf(
+			"[line %d] construtor do template genérico '%s' chegou ao pass 2 sem monomorfização — bug do compilador de genéricos",
+			line, base,
+		)
+	}
+
+	// O hint vale para ESTE site e so para ele: consumimos antes de compilar os
+	// argumentos, que podem conter outros construtores genericos aninhados
+	// (`Caixa(Caixa(9))`).
+	hint := c.genericReturnHint
+	c.genericReturnHint = nil
+
+	fields := tpl.Decl.FieldsList
+	if len(call.Arguments) != len(fields) {
+		return fmt.Errorf(
+			"[line %d] function '%s' expects %d arguments, got %d",
+			line, base, len(fields), len(call.Arguments),
+		)
+	}
+
+	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
+	for index, argument := range call.Arguments {
+		expected := fields[index].Type
+		if !containsTypeParam(expected) {
+			continue
+		}
+		actual, err := c.typeOfDiscardedExpression(argument)
+		if err != nil {
+			return err
+		}
+		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
+			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
+		}
+	}
+
+	// Hint do `let` depois dos argumentos (§7: o argumento e a ancora primaria).
+	// A anotacao ja E a tupla, posicao a posicao — nao ha o que unificar, so
+	// preencher o que ficou em aberto.
+	c.applyStructHintBindings(tpl, hint, bindings, line)
+
+	args := make([]ast.NoxyType, 0, len(tpl.Decl.TypeParams))
+	for _, typeParam := range tpl.Decl.TypeParams {
+		bound, ok := bindings[typeParam]
+		if !ok {
+			return fmt.Errorf(
+				"[line %d] não foi possível inferir %s em '%s' — anote o tipo",
+				line, typeParam, base,
+			)
+		}
+		args = append(args, bound)
+	}
+
+	name, err := c.ensureStructInstance(tpl, args, line)
+	if err != nil {
+		return err
+	}
+	callee.Value = name
+	c.setLine(line)
+	return nil
+}
+
+// applyStructHintBindings completa bindings com os argumentos de tipo escritos
+// na anotacao do `let` que envolve o site de construtor. So preenche parametro
+// de tipo AINDA em aberto: o argumento e a ancora primaria (§7), e um conflito
+// entre argumento e anotacao aparece adiante como erro de tipo do `let`, com a
+// mensagem do caminho normal.
+//
+// A anotacao chega em uma de duas formas, dependendo de quem a resolveu
+// primeiro (o predeclare do topo do programa ou o proprio case do `let`):
+// `Caixa<int>` crua ou `main::Caixa<int>` ja qualificada. expandInstanceNames
+// normaliza as duas para a forma generica, que e onde a tupla esta legivel.
+func (c *Compiler) applyStructHintBindings(tpl *StructTemplate, hint ast.NoxyType, bindings map[string]ast.NoxyType, line int) {
+	if hint == nil {
+		return
+	}
+	annotation, ok := c.expandInstanceNames(hint).(*ast.GenericType)
+	if !ok || annotation.Name != tpl.Decl.Name || len(annotation.Args) != len(tpl.Decl.TypeParams) {
+		return
+	}
+	for index, typeParam := range tpl.Decl.TypeParams {
+		if _, bound := bindings[typeParam]; bound {
+			continue
+		}
+		// A anotacao pode nomear outro generico (`Caixa<Caixa<int>>`): resolve o
+		// argumento para o nome qualificado antes de bindar, para que a tupla
+		// deste site seja identica a que a propria anotacao produz.
+		resolved, err := c.resolveAnnotation(annotation.Args[index], line)
+		if err != nil {
+			// Anotacao invalida nao vira erro AQUI: a resolucao da propria
+			// anotacao do `let` (que roda no mesmo statement) reporta com o
+			// contexto certo. Aqui so deixamos o parametro em aberto.
+			return
+		}
+		bindings[typeParam] = resolved
+	}
+}
+
+// unifyAnnotation unifica um tipo de TEMPLATE (expected, escrito na forma
+// generica — pode conter `Caixa<T>`) contra um tipo CONCRETO observado no site
+// (actual, que ja carrega nomes qualificados de instancia, `main::Caixa<int>`).
+// Sem tradutor, essas duas formas nunca casariam: o template diz `Caixa<T>` e o
+// mundo diz `main::Caixa<int>`. Antes de unificar, os nomes de instancia em
+// actual sao re-expandidos para GenericType a partir da tupla memoizada, e
+// unify (funcao pura, sem acesso a tabela nenhuma) faz o resto.
+func (c *Compiler) unifyAnnotation(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) error {
+	if containsGenericType(expected) {
+		actual = c.expandInstanceNames(actual)
+	}
+	return unify(expected, actual, bindings)
+}
+
+// expandInstanceNames reconstroi a forma generica de todo nome de instancia
+// dentro de t (`main::Caixa<int>` -> `Caixa<int>`, recursivamente nos args).
+// Tipo que nao contem instancia nenhuma volta pelo mesmo ponteiro.
+func (c *Compiler) expandInstanceNames(t ast.NoxyType) ast.NoxyType {
+	switch n := t.(type) {
+	case *ast.PrimitiveType:
+		key, ok := c.structInstanceKey(n.Name)
+		if !ok {
+			return t
+		}
+		args := make([]ast.NoxyType, len(key.Args))
+		for index, argument := range key.Args {
+			args[index] = c.expandInstanceNames(argument)
+		}
+		return &ast.GenericType{Name: key.Base, Args: args}
+	case *ast.ArrayType:
+		return &ast.ArrayType{ElementType: c.expandInstanceNames(n.ElementType), Size: n.Size}
+	case *ast.MapType:
+		return &ast.MapType{
+			KeyType:   c.expandInstanceNames(n.KeyType),
+			ValueType: c.expandInstanceNames(n.ValueType),
+		}
+	case *ast.RefType:
+		return &ast.RefType{ElementType: c.expandInstanceNames(n.ElementType)}
+	case *ast.ChanType:
+		return &ast.ChanType{ElementType: c.expandInstanceNames(n.ElementType)}
+	case *ast.FunctionType:
+		params := make([]ast.NoxyType, len(n.Params))
+		for index, param := range n.Params {
+			params[index] = c.expandInstanceNames(param)
+		}
+		return &ast.FunctionType{Params: params, Return: c.expandInstanceNames(n.Return)}
+	default:
+		return t
+	}
+}
+
+// structInstanceKey consulta a tupla que gerou uma instancia de struct. So
+// existe durante a compilacao de um programa (a fila vive por Compile de
+// Program, §5); fora dela nao ha instancia para expandir.
+func (c *Compiler) structInstanceKey(name string) (structInstanceKey, bool) {
+	if c.instances == nil {
+		return structInstanceKey{}, false
+	}
+	key, ok := c.instances.structKeys[name]
+	return key, ok
+}
+
+// containsGenericType responde se t carrega um GenericType em qualquer
+// profundidade — ou seja, se t e uma anotacao de template que menciona um
+// struct generico e portanto precisa da re-expansao de unifyAnnotation.
+func containsGenericType(t ast.NoxyType) bool {
+	switch n := t.(type) {
+	case *ast.GenericType:
+		return true
+	case *ast.ArrayType:
+		return containsGenericType(n.ElementType)
+	case *ast.MapType:
+		return containsGenericType(n.KeyType) || containsGenericType(n.ValueType)
+	case *ast.RefType:
+		return containsGenericType(n.ElementType)
+	case *ast.ChanType:
+		return containsGenericType(n.ElementType)
+	case *ast.FunctionType:
+		for _, param := range n.Params {
+			if containsGenericType(param) {
+				return true
+			}
+		}
+		return containsGenericType(n.Return)
+	default:
+		return false
+	}
+}
+
+// typeArgumentArityError e a mensagem de aridade de argumentos de tipo do §9:
+// "'Caixa' espera 1 argumento de tipo, recebeu 2".
+func typeArgumentArityError(line int, name string, want, got int) error {
+	noun := "argumentos"
+	if want == 1 {
+		noun = "argumento"
+	}
+	return fmt.Errorf("[line %d] '%s' espera %d %s de tipo, recebeu %d", line, name, want, noun, got)
+}
+
+// forEachElementType diz o tipo da variavel de um for-each a partir do tipo da
+// colecao, quando ele e estaticamente conhecido (ruling R5). Array itera
+// elementos; map itera CHAVES (o compilador reescreve `for k in m` para iterar
+// `keys(m)`, ver o case de ForStatement). Colecao de tipo desconhecido, string,
+// ou array/map com elemento nao inferido continuam com variavel sem tipo — nil
+// aqui e "nao sei", que e exatamente o comportamento anterior.
+//
+// Tipar a variavel do laco nao e cosmetico para genericos: e a unica ancora de
+// inferencia de `identity(v)` dentro de um for-each — sem ela o argumento chega
+// a unificacao como nil e T fica sem binding.
+func forEachElementType(collection ast.NoxyType) ast.NoxyType {
+	switch typed := unwrapRefType(collection).(type) {
+	case *ast.ArrayType:
+		return typed.ElementType
+	case *ast.MapType:
+		return typed.KeyType
+	default:
+		return nil
+	}
+}

--- a/internal/compiler/generics_structs.go
+++ b/internal/compiler/generics_structs.go
@@ -295,25 +295,37 @@ func (c *Compiler) compileGenericConstructorSite(call *ast.CallExpression, calle
 		)
 	}
 
+	// unifyPositionalArguments/missingTypeParamNullError sao a maquinaria
+	// COMPARTILHADA com compileGenericCallSite (generics.go, documentada
+	// la): mesma unificacao posicional campo-a-campo, mesmo rastreio de
+	// nullOnlyParams (§9 "inferência só com null" — `Caixa(null)`) e
+	// argIndexOf (§9 "conflito de unificação" com atribuição por argumento).
+	// skip fica nil — construtor de struct nao tem o equivalente aos
+	// argumentos-template de compileGenericCallSite (campo posicional e
+	// sempre um valor, nunca um template de funcao nu).
 	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
-	for index, argument := range call.Arguments {
-		expected := fields[index].Type
-		if !containsTypeParam(expected) {
-			continue
-		}
-		actual, err := c.typeOfDiscardedExpression(argument)
-		if err != nil {
-			return err
-		}
-		if err := c.unifyAnnotation(expected, actual, bindings); err != nil {
-			return fmt.Errorf("[line %d] argumento %d de '%s': %v", line, index+1, base, err)
-		}
+	nullOnlyParams := make(map[string]bool)
+	argIndexOf := make(map[string]int, len(tpl.Decl.TypeParams))
+	if err := c.unifyPositionalArguments(
+		line, base, call.Arguments,
+		func(index int) ast.NoxyType { return fields[index].Type },
+		nil,
+		tpl.Decl.TypeParams, bindings, nullOnlyParams, argIndexOf,
+	); err != nil {
+		return err
 	}
 
 	// Hint do `let` depois dos argumentos (§7: o argumento e a ancora primaria).
 	// A anotacao ja E a tupla, posicao a posicao — nao ha o que unificar, so
 	// preencher o que ficou em aberto.
 	c.applyStructHintBindings(tpl, hint, bindings, line)
+
+	// §9 "inferência só com null": mesmo gate de compileGenericCallSite,
+	// ANTES da checagem de aridade generica abaixo (cuja mensagem, para
+	// construtor, e "não foi possível inferir %s em '%s'").
+	if err := missingTypeParamNullError(line, tpl.Decl.TypeParams, bindings, nullOnlyParams); err != nil {
+		return err
+	}
 
 	args := make([]ast.NoxyType, 0, len(tpl.Decl.TypeParams))
 	for _, typeParam := range tpl.Decl.TypeParams {

--- a/internal/compiler/generics_structs.go
+++ b/internal/compiler/generics_structs.go
@@ -337,10 +337,21 @@ func (c *Compiler) compileGenericConstructorSite(call *ast.CallExpression, calle
 }
 
 // applyStructHintBindings completa bindings com os argumentos de tipo escritos
-// na anotacao do `let` que envolve o site de construtor. So preenche parametro
-// de tipo AINDA em aberto: o argumento e a ancora primaria (§7), e um conflito
-// entre argumento e anotacao aparece adiante como erro de tipo do `let`, com a
-// mensagem do caminho normal.
+// na anotacao do `let` que envolve o site de construtor. Regra geral: so
+// preenche parametro de tipo AINDA em aberto — o argumento e a ancora
+// primaria (§7), e um conflito entre argumento e anotacao aparece adiante
+// como erro de tipo do `let`, com a mensagem do caminho normal.
+//
+// Excecao deliberada (§7: "any é legal como argumento de tipo explícito" é
+// uma regra incondicional, não qualificada por "só quando nada mais
+// bindou"): quando a anotacao pede `any` explicitamente para um parametro,
+// esse `any` PREVALECE mesmo sobre um binding ja inferido do argumento —
+// `Caixa<any> = Caixa(1)` produz a instancia `Caixa<any>` (campo `any`
+// aceita o `1` normalmente pelo caminho comum de checagem de tipos), em vez
+// de conflitar com `Caixa<int>` inferido do argumento sozinho. A checagem e
+// sintatica direta (isAny do proprio no da anotacao, sem resolveAnnotation)
+// porque `any` nunca e GenericType — não ha instanciacao/efeito colateral a
+// evitar ao inspeciona-lo cedo, ao contrario do caso geral abaixo.
 //
 // A anotacao chega em uma de duas formas, dependendo de quem a resolveu
 // primeiro (o predeclare do topo do programa ou o proprio case do `let`):
@@ -355,6 +366,10 @@ func (c *Compiler) applyStructHintBindings(tpl *StructTemplate, hint ast.NoxyTyp
 		return
 	}
 	for index, typeParam := range tpl.Decl.TypeParams {
+		if isAny(annotation.Args[index]) {
+			bindings[typeParam] = annotation.Args[index]
+			continue
+		}
 		if _, bound := bindings[typeParam]; bound {
 			continue
 		}

--- a/internal/compiler/generics_structs.go
+++ b/internal/compiler/generics_structs.go
@@ -233,6 +233,13 @@ func (c *Compiler) ensureStructInstance(tpl *StructTemplate, args []ast.NoxyType
 		return name, nil
 	}
 
+	// Teto de aninhamento (§9), gemeo do de ensureFunctionInstance: resolver
+	// os campos e o passo que pode pedir OUTRA instancia (`campo: Caixa<T[]>`
+	// numa cadeia que nunca fecha).
+	if queue.depth >= maxInstantiationDepth {
+		return "", instantiationDepthError(line)
+	}
+
 	bindings := make(map[string]ast.NoxyType, len(args))
 	for index, typeParam := range tpl.Decl.TypeParams {
 		bindings[typeParam] = args[index]
@@ -242,7 +249,10 @@ func (c *Compiler) ensureStructInstance(tpl *StructTemplate, args []ast.NoxyType
 	queue.structKeys[name] = structInstanceKey{Base: base, Args: args}
 	c.registerStructInstance(instance)
 
-	if err := c.resolveStructFieldAnnotations(instance, line); err != nil {
+	queue.depth++
+	err := c.resolveStructFieldAnnotations(instance, line)
+	queue.depth--
+	if err != nil {
 		return "", instantiationChainError(displayInstanceName(base, args), line, err)
 	}
 	// Re-registra: os campos mudaram (GenericType -> nome qualificado) e o tipo
@@ -445,6 +455,16 @@ func (c *Compiler) expandInstanceNames(t ast.NoxyType) ast.NoxyType {
 			params[index] = c.expandInstanceNames(param)
 		}
 		return &ast.FunctionType{Params: params, Return: c.expandInstanceNames(n.Return)}
+	case *ast.GenericType:
+		// Forma generica JA expandida no topo, mas com argumentos que podem
+		// carregar nomes de instancia (`Pilha<main::Caixa<int>>`): recursa nos
+		// args para que os dois lados de uma unificacao usem a mesma grafia em
+		// toda profundidade.
+		args := make([]ast.NoxyType, len(n.Args))
+		for index, argument := range n.Args {
+			args[index] = c.expandInstanceNames(argument)
+		}
+		return &ast.GenericType{Name: n.Name, Args: args}
 	default:
 		return t
 	}

--- a/internal/compiler/generics_substitute.go
+++ b/internal/compiler/generics_substitute.go
@@ -1,0 +1,236 @@
+package compiler
+
+import (
+	"strings"
+
+	"noxy-vm/internal/ast"
+)
+
+// instanceName monta o nome qualificado de uma instancia monomorfizada:
+// "<modulo>::<base><arg1,arg2,...>", com args por String() e separados por
+// virgula SEM espaco (deliberadamente diferente de GenericType.String(), que
+// usa ", " — instanceName produz um identificador estavel para uso como
+// chave de registro/global, nao uma representacao "bonita" de tipo).
+func instanceName(module, base string, args []ast.NoxyType) string {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = a.String()
+	}
+	return module + "::" + base + "<" + strings.Join(parts, ",") + ">"
+}
+
+// substituteType clona t substituindo todo TypeParamType cujo nome tenha
+// binding em b pelo tipo bindado (tambem clonado, para nao compartilhar nos
+// entre instancias). TypeParamType sem binding e preservado como esta
+// (parametro de tipo ainda livre — nao deveria ocorrer em uso normal, ja que
+// b cobre todos os TypeParams do template, mas preferimos preservar a
+// deixar nil).
+//
+// GenericType mantem sua forma (Name + Args substituidos): mesmo que todos
+// os Args fiquem concretos apos a substituicao, a resolucao para o nome
+// qualificado da instancia (e.g. GenericType{Node, [int]} -> "main::Node<int>")
+// acontece na Task 9, nao aqui.
+func substituteType(t ast.NoxyType, b map[string]ast.NoxyType) ast.NoxyType {
+	if t == nil {
+		return nil
+	}
+	switch n := t.(type) {
+	case *ast.TypeParamType:
+		if bound, ok := b[n.Name]; ok {
+			return ast.CloneType(bound)
+		}
+		return &ast.TypeParamType{Name: n.Name}
+	case *ast.PrimitiveType:
+		return &ast.PrimitiveType{Name: n.Name}
+	case *ast.ArrayType:
+		return &ast.ArrayType{ElementType: substituteType(n.ElementType, b), Size: n.Size}
+	case *ast.MapType:
+		return &ast.MapType{KeyType: substituteType(n.KeyType, b), ValueType: substituteType(n.ValueType, b)}
+	case *ast.RefType:
+		return &ast.RefType{ElementType: substituteType(n.ElementType, b)}
+	case *ast.ChanType:
+		return &ast.ChanType{ElementType: substituteType(n.ElementType, b)}
+	case *ast.FunctionType:
+		params := make([]ast.NoxyType, len(n.Params))
+		for i, p := range n.Params {
+			params[i] = substituteType(p, b)
+		}
+		return &ast.FunctionType{Params: params, Return: substituteType(n.Return, b)}
+	case *ast.GenericType:
+		args := make([]ast.NoxyType, len(n.Args))
+		for i, a := range n.Args {
+			args[i] = substituteType(a, b)
+		}
+		return &ast.GenericType{Name: n.Name, Args: args}
+	default:
+		return t
+	}
+}
+
+// substituteFunction clona tpl.Decl (Task 2), zera TypeParams, renomeia para
+// name e substitui, in-place no clone, todo campo de tipo alcancavel a
+// partir da declaracao: Parameters, ReturnType e toda anotacao de tipo no
+// corpo (LetStmt.Type, FunctionLiteral aninhado, etc. — via
+// substituteInBlock/substituteInStatement/substituteInExpression). O
+// template original (tpl.Decl) nunca e tocado.
+func substituteFunction(tpl *FuncTemplate, b map[string]ast.NoxyType, name string) *ast.FunctionStatement {
+	clone := ast.CloneStatement(tpl.Decl).(*ast.FunctionStatement)
+	clone.Name = name
+	clone.TypeParams = nil
+	for _, p := range clone.Parameters {
+		p.Type = substituteType(p.Type, b)
+	}
+	clone.ReturnType = substituteType(clone.ReturnType, b)
+	substituteInBlock(clone.Body, b)
+	return clone
+}
+
+// substituteStruct e o analogo de substituteFunction para structs: clona
+// tpl.Decl, zera TypeParams, renomeia e substitui os tipos nos dois
+// espelhos de campos (FieldsList, a fonte de verdade ordenada, e Fields, o
+// mapa por nome) de forma consistente — ambos apontam para os mesmos nos de
+// tipo apos a substituicao.
+func substituteStruct(tpl *StructTemplate, b map[string]ast.NoxyType, name string) *ast.StructStatement {
+	clone := ast.CloneStatement(tpl.Decl).(*ast.StructStatement)
+	clone.Name = name
+	clone.TypeParams = nil
+	fields := make(map[string]ast.NoxyType, len(clone.FieldsList))
+	for _, f := range clone.FieldsList {
+		f.Type = substituteType(f.Type, b)
+		fields[f.Name] = f.Type
+	}
+	clone.Fields = fields
+	return clone
+}
+
+// substituteInBlock percorre cada statement de um bloco substituindo campos
+// de tipo in-place. Usado para o corpo de funcoes (substituteFunction) e
+// recursivamente para blocos aninhados (if/while/for/when/func literal).
+func substituteInBlock(blk *ast.BlockStatement, b map[string]ast.NoxyType) {
+	if blk == nil {
+		return
+	}
+	for _, s := range blk.Statements {
+		substituteInStatement(s, b)
+	}
+}
+
+// substituteInStatement anda no clone de um statement trocando somente
+// campos de tipo (NoxyType), recursando em sub-statements/expressions para
+// alcancar anotacoes aninhadas (ex.: let dentro de if dentro de while).
+// Cobre todo case de ast.CloneStatement — nó sem case aqui e bug (panic),
+// espelhando o guard do cloner.
+func substituteInStatement(s ast.Statement, b map[string]ast.NoxyType) {
+	if s == nil {
+		return
+	}
+	switch n := s.(type) {
+	case *ast.LetStmt:
+		n.Type = substituteType(n.Type, b)
+		substituteInExpression(n.Value, b)
+	case *ast.AssignStmt:
+		substituteInExpression(n.Target, b)
+		substituteInExpression(n.Value, b)
+	case *ast.ReturnStmt:
+		substituteInExpression(n.ReturnValue, b)
+	case *ast.DeferStmt:
+		substituteInExpression(n.Call, b)
+	case *ast.BreakStmt:
+		// sem tipo, sem sub-no.
+	case *ast.UseStmt:
+		// sem tipo, sem sub-no.
+	case *ast.ExpressionStmt:
+		substituteInExpression(n.Expression, b)
+	case *ast.BlockStatement:
+		substituteInBlock(n, b)
+	case *ast.IfStatement:
+		substituteInExpression(n.Condition, b)
+		substituteInBlock(n.Consequence, b)
+		substituteInBlock(n.Alternative, b)
+	case *ast.WhileStatement:
+		substituteInExpression(n.Condition, b)
+		substituteInBlock(n.Body, b)
+	case *ast.FunctionStatement:
+		// func aninhado (se o parser permitir): substitui seus proprios
+		// campos de tipo tambem, pelo mesmo binding do escopo externo.
+		for _, p := range n.Parameters {
+			p.Type = substituteType(p.Type, b)
+		}
+		n.ReturnType = substituteType(n.ReturnType, b)
+		substituteInBlock(n.Body, b)
+	case *ast.ForStatement:
+		substituteInExpression(n.Collection, b)
+		substituteInBlock(n.Body, b)
+	case *ast.StructStatement:
+		// struct aninhado (se o parser permitir): mesma logica dos dois
+		// espelhos de substituteStruct.
+		fields := make(map[string]ast.NoxyType, len(n.FieldsList))
+		for _, f := range n.FieldsList {
+			f.Type = substituteType(f.Type, b)
+			fields[f.Name] = f.Type
+		}
+		n.Fields = fields
+	case *ast.WhenStatement:
+		for _, c := range n.Cases {
+			substituteInStatement(c.Condition, b)
+			substituteInBlock(c.Body, b)
+		}
+	default:
+		panic("substituteInStatement: nó sem case — adicione aqui e o guard passa")
+	}
+}
+
+// substituteInExpression e o analogo de substituteInStatement para
+// expressoes: a unica expressao com campos de tipo diretos e FunctionLiteral
+// (Parameters/ReturnType); as demais so precisam de recursao estrutural para
+// alcancar FunctionLiteral/LetStmt aninhados em profundidade.
+func substituteInExpression(e ast.Expression, b map[string]ast.NoxyType) {
+	if e == nil {
+		return
+	}
+	switch n := e.(type) {
+	case *ast.Identifier, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral,
+		*ast.BytesLiteral, *ast.NullLiteral, *ast.Boolean:
+		// sem tipo, sem sub-no.
+	case *ast.ZerosLiteral:
+		substituteInExpression(n.Size, b)
+	case *ast.PrefixExpression:
+		substituteInExpression(n.Right, b)
+	case *ast.InfixExpression:
+		substituteInExpression(n.Left, b)
+		substituteInExpression(n.Right, b)
+	case *ast.FunctionLiteral:
+		for _, p := range n.Parameters {
+			p.Type = substituteType(p.Type, b)
+		}
+		n.ReturnType = substituteType(n.ReturnType, b)
+		substituteInBlock(n.Body, b)
+	case *ast.CallExpression:
+		substituteInExpression(n.Function, b)
+		for _, a := range n.Arguments {
+			substituteInExpression(a, b)
+		}
+	case *ast.ArrayLiteral:
+		for _, el := range n.Elements {
+			substituteInExpression(el, b)
+		}
+	case *ast.MapLiteral:
+		// Keys/Values sao os espelhos ordenados; Pairs mapeia por
+		// identidade de ponteiro para os mesmos nos — mutar os nos
+		// apontados por Keys/Values in-place mantem Pairs consistente sem
+		// reconstrucao.
+		for i := range n.Keys {
+			substituteInExpression(n.Keys[i], b)
+		}
+		for i := range n.Values {
+			substituteInExpression(n.Values[i], b)
+		}
+	case *ast.IndexExpression:
+		substituteInExpression(n.Left, b)
+		substituteInExpression(n.Index, b)
+	case *ast.MemberAccessExpression:
+		substituteInExpression(n.Left, b)
+	default:
+		panic("substituteInExpression: nó sem case — adicione aqui e o guard passa")
+	}
+}

--- a/internal/compiler/generics_substitute.go
+++ b/internal/compiler/generics_substitute.go
@@ -118,8 +118,14 @@ func substituteInBlock(blk *ast.BlockStatement, b map[string]ast.NoxyType) {
 // substituteInStatement anda no clone de um statement trocando somente
 // campos de tipo (NoxyType), recursando em sub-statements/expressions para
 // alcancar anotacoes aninhadas (ex.: let dentro de if dentro de while).
-// Cobre todo case de ast.CloneStatement — nó sem case aqui e bug (panic),
-// espelhando o guard do cloner.
+// Cobre todo case de ast.CloneStatement — nó sem case aqui e bug (panic).
+//
+// A exaustividade e verificada estaticamente por
+// TestGenericWalkersCoverEveryNode (generics_walkers_guard_test.go), o
+// equivalente para estes walkers do que ast.TestClonerCoversEveryNode e para
+// o cloner: o panic sozinho so dispara se algum teste exercitar exatamente o
+// nó novo, e um nó esquecido aqui significa instancia com anotacao NAO
+// substituida — TypeParamType vazando para o pass 2.
 func substituteInStatement(s ast.Statement, b map[string]ast.NoxyType) {
 	if s == nil {
 		return

--- a/internal/compiler/generics_substitute_test.go
+++ b/internal/compiler/generics_substitute_test.go
@@ -1,0 +1,56 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"testing"
+)
+
+func TestInstanceName(t *testing.T) {
+	got := instanceName("main", "first", []ast.NoxyType{tInt()})
+	if got != "main::first<int>" {
+		t.Fatalf("instanceName = %q", got)
+	}
+	got = instanceName("colecoes", "map", []ast.NoxyType{tInt(), tString()})
+	if got != "colecoes::map<int,string>" {
+		t.Fatalf("instanceName = %q", got)
+	}
+}
+
+func TestSubstituteFunctionRewritesAllTypePositions(t *testing.T) {
+	prog := parse("func first<T>(arr: T[]) -> T\n    let tmp: T = arr[0]\n    return tmp\nend")
+	tpl := &FuncTemplate{Decl: prog.Statements[0].(*ast.FunctionStatement), Module: "main"}
+	inst := substituteFunction(tpl, map[string]ast.NoxyType{"T": tInt()}, "main::first<int>")
+	if inst.Name != "main::first<int>" || len(inst.TypeParams) != 0 {
+		t.Fatalf("instancia mal formada: %s %v", inst.Name, inst.TypeParams)
+	}
+	if inst.Parameters[0].Type.String() != "int[]" {
+		t.Fatalf("param = %s", inst.Parameters[0].Type.String())
+	}
+	if inst.ReturnType.String() != "int" {
+		t.Fatalf("retorno = %s", inst.ReturnType.String())
+	}
+	let := inst.Body.Statements[0].(*ast.LetStmt)
+	if let.Type.String() != "int" {
+		t.Fatalf("let interno = %s (anotacao do corpo nao substituida)", let.Type.String())
+	}
+	// original intacto (clone, nao mutacao)
+	if tpl.Decl.Parameters[0].Type.String() != "T[]" {
+		t.Fatal("template original foi mutado")
+	}
+}
+
+func TestSubstituteStructBothMirrors(t *testing.T) {
+	prog := parse("struct Node<T>\n    value: T,\n    next: ref Node<T>\nend")
+	tpl := &StructTemplate{Decl: prog.Statements[0].(*ast.StructStatement), Module: "main"}
+	inst := substituteStruct(tpl, map[string]ast.NoxyType{"T": tInt()}, "main::Node<int>")
+	if inst.FieldsList[0].Type.String() != "int" {
+		t.Fatalf("value = %s", inst.FieldsList[0].Type.String())
+	}
+	if inst.Fields["value"].String() != "int" {
+		t.Fatalf("espelho Fields nao substituido: %s", inst.Fields["value"].String())
+	}
+	// auto-referencia: ref Node<T> vira ref Node<int> (GenericType com arg concreto)
+	if inst.FieldsList[1].Type.String() != "ref Node<int>" {
+		t.Fatalf("next = %s", inst.FieldsList[1].Type.String())
+	}
+}

--- a/internal/compiler/generics_target.go
+++ b/internal/compiler/generics_target.go
@@ -1,0 +1,302 @@
+package compiler
+
+// Target-typing (spec §3): toda função que existe em runtime é valor de
+// primeira classe; o template nunca é. A instanciação acontece no ponto em
+// que a genérica vira valor, guiada pelo tipo alvo — este arquivo concentra
+// as cinco posições enumeradas no §4 (`let` anotado, `return`, elemento de
+// array literal, atribuição a campo, argumento de chamada) e o catálogo de
+// erro do §9 para quando não há alvo concreto.
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// instantiateForTarget e o hook central do §3: quando name nomeia um template
+// de FUNÇÃO visível (não sombreado por local/upvalue) e target e um
+// *ast.FunctionType concreto (sem TypeParamType, após qualquer substituição
+// já feita pelo chamador), unifica a assinatura do template contra target,
+// garante a instância (ensureFunctionInstance) e devolve o nome qualificado
+// para o chamador reescrever o identificador no AST.
+//
+// O segundo retorno (achouTemplate) distingue "não é o caso" de "é o caso e
+// deu erro": false quando name não nomeia um template de função (ou está
+// sombreado) — o chamador segue o caminho normal sem tocar em nada. true com
+// err != nil é o erro do §9 (sem alvo concreto, ou falha de unificação);
+// true com err == nil é o nome qualificado pronto para a reescrita.
+//
+// Só atua no pass 1 (§4): no pass 2 o AST já foi inteiramente reescrito pelo
+// pass 1 (que compila o programa inteiro), então nenhum nome de template
+// deveria alcançar esta função ali — o guard devolve "não encontrado" em vez
+// de arriscar reinstanciar às cegas fora da janela em que a fila de
+// instâncias (c.instances) está de fato ligada ao Program sendo montado.
+func (c *Compiler) instantiateForTarget(name string, target ast.NoxyType, line int) (string, bool, error) {
+	if !c.pass1 {
+		return "", false, nil
+	}
+	tpl, isTemplate := c.registryOrInit().Funcs[name]
+	if !isTemplate || c.isShadowedByLocal(name) {
+		return "", false, nil
+	}
+
+	targetFn, ok := target.(*ast.FunctionType)
+	if !ok || containsTypeParam(targetFn) {
+		return "", true, noConcreteTargetError(line, name)
+	}
+
+	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
+	templateSig := newFunctionType(tpl.Decl.Parameters, tpl.Decl.ReturnType)
+	if err := unify(templateSig, targetFn, bindings); err != nil {
+		return "", true, fmt.Errorf("[line %d] %v", line, err)
+	}
+
+	instName, _, err := c.ensureFunctionInstance(tpl, bindings, line)
+	if err != nil {
+		return "", true, err
+	}
+	return instName, true, nil
+}
+
+// rewriteIfGenericValue e o ponto de entrada comum das quatro posições
+// "simples" do §3 (`let`, `return`, elemento de array, campo): quando expr é
+// um *ast.Identifier nomeando um template de função, instancia contra target
+// e reescreve expr.Value in-place para o nome qualificado; devolve o erro do
+// §9 quando não há alvo concreto. Quando expr não é esse caso (não é
+// Identifier, ou o identificador não nomeia um template), é um no-op — o
+// chamador segue o caminho normal de compilação.
+func (c *Compiler) rewriteIfGenericValue(expr ast.Expression, target ast.NoxyType) error {
+	ident, ok := expr.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	qualified, isTemplate, err := c.instantiateForTarget(ident.Value, target, ident.Token.Line)
+	if !isTemplate {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	ident.Value = qualified
+	return nil
+}
+
+// isShadowedByLocal reporta se name resolve para um local ou upvalue no
+// escopo atual — um binding mais interno vence sobre um template homônimo,
+// mesma regra do sombreamento em call sites (compileCallExpression).
+func (c *Compiler) isShadowedByLocal(name string) bool {
+	if slot, _ := c.resolveLocal(name); slot != -1 {
+		return true
+	}
+	if slot, _ := c.resolveUpvalue(name); slot != -1 {
+		return true
+	}
+	return false
+}
+
+// setArrayElementHint arma o alvo de elemento de array do §3 (posição 3): o
+// tipo de elemento da anotação do `let` quando o valor é, de fato, um array
+// literal direto. Mesma disciplina de setGenericReturnHint — só arma quando o
+// valor É o caso que o hint serve, para nenhuma outra expressão o consumir
+// por engano.
+func (c *Compiler) setArrayElementHint(target ast.NoxyType, valueExpr ast.Expression) {
+	c.arrayElementHint = nil
+	if !c.pass1 || target == nil {
+		return
+	}
+	arrayTarget, ok := target.(*ast.ArrayType)
+	if !ok {
+		return
+	}
+	if _, ok := valueExpr.(*ast.ArrayLiteral); !ok {
+		return
+	}
+	c.arrayElementHint = arrayTarget.ElementType
+}
+
+// bareFunctionTemplateArgument reporta se expr é um *ast.Identifier nomeando
+// um template de FUNÇÃO visível (não sombreado) — a forma que não pode
+// compilar pelo caminho normal (o template não existe em runtime, e
+// c.Compile de um Identifier assim leria um global nunca definido). Usado
+// pelo argumento de chamada do §3 (posição 5) para separar, num call site
+// genérico, os argumentos que precisam de unificação bidirecional dos
+// argumentos comuns que ancoram bindings pelo caminho de sempre.
+func (c *Compiler) bareFunctionTemplateArgument(expr ast.Expression) (*ast.Identifier, *FuncTemplate, bool) {
+	ident, ok := expr.(*ast.Identifier)
+	if !ok {
+		return nil, nil, false
+	}
+	tpl, isTemplate := c.registryOrInit().Funcs[ident.Value]
+	if !isTemplate || c.isShadowedByLocal(ident.Value) {
+		return nil, nil, false
+	}
+	return ident, tpl, true
+}
+
+// noConcreteTargetError e a mensagem verbatim do §9 para um identificador de
+// template de função em posição de valor sem alvo concreto (`func` nu, `any`,
+// ou corrente sem âncora).
+func noConcreteTargetError(line int, name string) error {
+	return fmt.Errorf(
+		"[line %d] função genérica '%s' precisa de tipo concreto — anote a assinatura completa ou chame diretamente",
+		line, name,
+	)
+}
+
+// unifyBidirectional e a versão "dois lados" de unify, exigida pela
+// unificação bidirecional do §3 (posição 5, argumento de chamada): expected
+// pode conter TypeParamType do template do CALLER (bindings em
+// callerBindings — ex.: B em aplica<A,B>) e actual pode conter TypeParamType
+// do template do PRÓPRIO ARGUMENTO (bindings em argBindings — ex.: T em
+// identity<T>). Nenhuma das duas assinaturas está totalmente concreta ainda:
+// `func(int) -> B` (A já resolvido para int pelos argumentos não-genéricos,
+// mas B ainda livre) contra `func(T) -> T`.
+//
+// Em cada posição da recursão, um TypeParamType já resolvido no SEU PRÓPRIO
+// lado é primeiro substituído pelo tipo concreto conhecido — é isso que
+// permite `T=int`, descoberto na posição de parâmetro, aparecer concreto
+// quando a recursão chega na posição de retorno e precisa bindar B=int.
+//
+// Regras por par de nós, depois da resolução:
+//   - os dois TypeParamType ainda não resolvidos: nada a fazer agora — se
+//     nenhuma outra posição os resolver, a checagem de aridade final em
+//     ensureFunctionInstance (chamada pelo caller) denuncia com "não foi
+//     possível inferir".
+//   - só expected é TypeParamType (não resolvido): binda em callerBindings.
+//   - só actual é TypeParamType (não resolvido): binda em argBindings, papéis
+//     trocados.
+//   - os dois concretos: mesma recursão estrutural e mesmas folgas de
+//     compatibilidade de unify (any/null não bindam, `func` nu aceita
+//     qualquer chamável).
+func unifyBidirectional(expected, actual ast.NoxyType, callerBindings, argBindings map[string]ast.NoxyType) error {
+	if expected == nil || actual == nil {
+		return nil
+	}
+
+	if tp, ok := expected.(*ast.TypeParamType); ok {
+		if bound, ok := callerBindings[tp.Name]; ok {
+			expected = bound
+		}
+	}
+	if tp, ok := actual.(*ast.TypeParamType); ok {
+		if bound, ok := argBindings[tp.Name]; ok {
+			actual = bound
+		}
+	}
+
+	expTP, expIsTP := expected.(*ast.TypeParamType)
+	actTP, actIsTP := actual.(*ast.TypeParamType)
+
+	switch {
+	case expIsTP && actIsTP:
+		// Nenhum lado resolvido ainda por esta posição; outra posição da
+		// mesma assinatura (ou o hint do `let`) pode resolver depois.
+		return nil
+	case expIsTP:
+		return bindTypeParam(callerBindings, expTP.Name, actual)
+	case actIsTP:
+		return bindTypeParam(argBindings, actTP.Name, expected)
+	}
+
+	// Ambos concretos: mesmas folgas de compatibilidade de unify (comentário
+	// em generics_unify.go explica cada uma).
+	if isAny(expected) || isAny(actual) || isNullType(actual) {
+		return nil
+	}
+	if isBareFunctionType(expected) {
+		if isCallableType(actual) {
+			return nil
+		}
+		return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+	}
+
+	switch exp := expected.(type) {
+	case *ast.PrimitiveType:
+		act, ok := actual.(*ast.PrimitiveType)
+		if !ok || act.Name != exp.Name {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return nil
+
+	case *ast.ArrayType:
+		act, ok := actual.(*ast.ArrayType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unifyBidirectional(exp.ElementType, act.ElementType, callerBindings, argBindings)
+
+	case *ast.MapType:
+		act, ok := actual.(*ast.MapType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		if err := unifyBidirectional(exp.KeyType, act.KeyType, callerBindings, argBindings); err != nil {
+			return err
+		}
+		return unifyBidirectional(exp.ValueType, act.ValueType, callerBindings, argBindings)
+
+	case *ast.RefType:
+		act, ok := actual.(*ast.RefType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unifyBidirectional(exp.ElementType, act.ElementType, callerBindings, argBindings)
+
+	case *ast.ChanType:
+		act, ok := actual.(*ast.ChanType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unifyBidirectional(exp.ElementType, act.ElementType, callerBindings, argBindings)
+
+	case *ast.FunctionType:
+		act, ok := actual.(*ast.FunctionType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		if len(exp.Params) != len(act.Params) {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		for i, p := range exp.Params {
+			if err := unifyBidirectional(p, act.Params[i], callerBindings, argBindings); err != nil {
+				return err
+			}
+		}
+		return unifyBidirectional(exp.Return, act.Return, callerBindings, argBindings)
+
+	case *ast.GenericType:
+		act, ok := actual.(*ast.GenericType)
+		if !ok || exp.Name != act.Name || len(exp.Args) != len(act.Args) {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		for i, a := range exp.Args {
+			if err := unifyBidirectional(a, act.Args[i], callerBindings, argBindings); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+	}
+}
+
+// bindTypeParam aplica a um bindings map as mesmas regras do case
+// TypeParamType de unify: ref é proibido como alvo de binding, any/null não
+// contribuem binding, e um binding já existente que diverge é conflito.
+func bindTypeParam(bindings map[string]ast.NoxyType, name string, value ast.NoxyType) error {
+	if _, isRef := value.(*ast.RefType); isRef {
+		return fmt.Errorf("%s não pode ser um tipo ref (tentativa de bindar %s)", name, value.String())
+	}
+	if isAny(value) || isNullType(value) {
+		return nil
+	}
+	if existing, ok := bindings[name]; ok {
+		if existing.String() != value.String() {
+			return fmt.Errorf("%s inferido como %s e %s", name, existing.String(), value.String())
+		}
+		return nil
+	}
+	bindings[name] = ast.CloneType(value)
+	return nil
+}

--- a/internal/compiler/generics_target.go
+++ b/internal/compiler/generics_target.go
@@ -47,7 +47,14 @@ func (c *Compiler) instantiateForTarget(name string, target ast.NoxyType, line i
 
 	bindings := make(map[string]ast.NoxyType, len(tpl.Decl.TypeParams))
 	templateSig := newFunctionType(tpl.Decl.Parameters, tpl.Decl.ReturnType)
-	if err := unify(templateSig, targetFn, bindings); err != nil {
+	// unifyAnnotation, nao unify cru (I5): a assinatura do template escreve
+	// `Pilha<T>` (GenericType) e o alvo carrega o nome QUALIFICADO da
+	// instancia (`main::Pilha<int>`). Sem a ponte de expandInstanceNames as
+	// duas formas nunca casam e `func f<T>(p: Pilha<T>)` em posicao de valor
+	// falhava com "esperava main::Pilha<int>, encontrado Pilha<T>" — a
+	// mesma divergencia que o caminho principal (unifyPositionalArguments) ja
+	// resolvia via unifyAnnotation.
+	if err := c.unifyAnnotation(templateSig, targetFn, bindings); err != nil {
 		return "", true, fmt.Errorf("[line %d] %v", line, err)
 	}
 
@@ -215,6 +222,27 @@ func (c *Compiler) rejectBareGenericTemplateIdentifier(identifier *ast.Identifie
 //   - os dois concretos: mesma recursão estrutural e mesmas folgas de
 //     compatibilidade de unify (any/null não bindam, `func` nu aceita
 //     qualquer chamável).
+// unifyBidirectionalAnnotated e unifyBidirectional com a MESMA ponte de nomes
+// de instancia que unifyAnnotation aplica no caminho principal (I5). Aqui os
+// dois lados podem trazer as duas formas: expected sai de
+// substituteType(parametro do template do CALLER, bindings) — anotacao
+// generica (`func(A) -> B`) com os bindings ja concretos e QUALIFICADOS
+// (`main::Pilha<int>`) —, e actual e a assinatura CRUA do template do
+// argumento (`func(Pilha<T>) -> T`). Sem expandir os dois, `func f<T>(p:
+// Pilha<T>)` passado como argumento falhava com "esperava main::Pilha<int>,
+// encontrado Pilha<T>", uma comparacao entre duas grafias do MESMO tipo.
+//
+// expandInstanceNames devolve o mesmo ponteiro quando nao ha instancia
+// nenhuma a reescrever, entao o caso comum (sem struct generico envolvido)
+// nao paga alocacao.
+func (c *Compiler) unifyBidirectionalAnnotated(expected, actual ast.NoxyType, callerBindings, argBindings map[string]ast.NoxyType) error {
+	return unifyBidirectional(
+		c.expandInstanceNames(expected),
+		c.expandInstanceNames(actual),
+		callerBindings, argBindings,
+	)
+}
+
 func unifyBidirectional(expected, actual ast.NoxyType, callerBindings, argBindings map[string]ast.NoxyType) error {
 	if expected == nil || actual == nil {
 		return nil
@@ -331,6 +359,14 @@ func unifyBidirectional(expected, actual ast.NoxyType, callerBindings, argBindin
 // bindTypeParam aplica a um bindings map as mesmas regras do case
 // TypeParamType de unify: ref é proibido como alvo de binding, any/null não
 // contribuem binding, e um binding já existente que diverge é conflito.
+//
+// O conflito devolve *conflictError (I5), o MESMO tipo estruturado que unify
+// devolve — não um fmt.Errorf com o texto igual. A mensagem é idêntica
+// (conflictError.Error() produz "T inferido como X e Y"), mas só o tipo
+// estruturado deixa o chamador extrair Param/Existing/New via errors.As e
+// compor a atribuição por argumento do §9 ("... (argumento 1) e ...
+// (argumento 2)"). Com fmt.Errorf, a passada bidirecional de
+// compileGenericCallSite ficava permanentemente fora dessa atribuição.
 func bindTypeParam(bindings map[string]ast.NoxyType, name string, value ast.NoxyType) error {
 	if _, isRef := value.(*ast.RefType); isRef {
 		return fmt.Errorf("%s não pode ser um tipo ref (tentativa de bindar %s)", name, value.String())
@@ -340,7 +376,7 @@ func bindTypeParam(bindings map[string]ast.NoxyType, name string, value ast.Noxy
 	}
 	if existing, ok := bindings[name]; ok {
 		if existing.String() != value.String() {
-			return fmt.Errorf("%s inferido como %s e %s", name, existing.String(), value.String())
+			return &conflictError{Param: name, Existing: existing, New: value}
 		}
 		return nil
 	}

--- a/internal/compiler/generics_target.go
+++ b/internal/compiler/generics_target.go
@@ -143,6 +143,53 @@ func noConcreteTargetError(line int, name string) error {
 	)
 }
 
+// noConcreteStructTargetError e o par de noConcreteTargetError para STRUCT
+// genérico: identificador nomeando um template de struct em posição de valor
+// sem nada de onde tirar a tupla de argumentos de tipo (nem chamada de
+// construtor — que passaria pelo hook de compileGenericConstructorSite —, nem
+// anotação de `let` que instancie via resolveAnnotation).
+func noConcreteStructTargetError(line int, name string) error {
+	return fmt.Errorf(
+		"[line %d] struct genérico '%s' precisa de tipo concreto — anote os argumentos de tipo ou construa diretamente",
+		line, name,
+	)
+}
+
+// rejectBareGenericTemplateIdentifier e o fallback do §9 para as posições de
+// valor que NENHUM hook do §3/§4 intercepta antes de alcançar o case
+// genérico de Identifier em compiler.go (Compile) — valor de map literal,
+// expression statement solto. As cinco posições hookadas (§3: `let`
+// anotado, `return`, elemento de array, campo de struct, argumento de
+// chamada) e o call site direto (§4, callee de CallExpression, para função
+// OU construtor de struct) já reescrevem identifier.Value para o nome
+// qualificado da instância ANTES de qualquer Compile(identifier) acontecer —
+// nesses casos identifier.Value não é mais chave de nenhum dos dois mapas do
+// registry e esta função é um no-op.
+//
+// Quando o identificador NOMEIA um template e chegou aqui intocado, a
+// causa é sempre a mesma: nenhum hook cobre esta posição, e compilar
+// normalmente leria um global que nunca foi definido (template nunca emite
+// bytecode) — mensagem confusa a jusante em vez do erro claro do catálogo.
+// Chamador (compiler.go, case *ast.Identifier) só invoca isto depois que
+// resolveLocal/resolveUpvalue já falharam, então a mesma regra de
+// sombreamento das outras famílias de hook vale aqui de graça.
+//
+// c.generics pode ser nil (programa sem declaração genérica nenhuma, §5): o
+// guard evita alocar o registry lazily (registryOrInit) só para descobrir
+// que está vazio — custo zero por identificador em programa comum.
+func (c *Compiler) rejectBareGenericTemplateIdentifier(identifier *ast.Identifier) error {
+	if c.generics == nil {
+		return nil
+	}
+	if _, isFuncTemplate := c.generics.Funcs[identifier.Value]; isFuncTemplate {
+		return noConcreteTargetError(identifier.Token.Line, identifier.Value)
+	}
+	if _, isStructTemplate := c.generics.Structs[identifier.Value]; isStructTemplate {
+		return noConcreteStructTargetError(identifier.Token.Line, identifier.Value)
+	}
+	return nil
+}
+
 // unifyBidirectional e a versão "dois lados" de unify, exigida pela
 // unificação bidirecional do §3 (posição 5, argumento de chamada): expected
 // pode conter TypeParamType do template do CALLER (bindings em

--- a/internal/compiler/generics_target_test.go
+++ b/internal/compiler/generics_target_test.go
@@ -1,0 +1,36 @@
+package compiler
+
+// §9: catalogo de erros do target-typing (§3) — identificador de template de
+// funcao em posicao de valor sem alvo concreto (`func` nu, `any`) e corrente
+// de genericos sem ancora (`compose(id, id)`, nada fixa o tipo do meio).
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenericWithoutConcreteTargetIsError(t *testing.T) {
+	for _, src := range []string{
+		"func id<T>(x: T) -> T\n    return x\nend\nlet g: func = id",
+		"func id<T>(x: T) -> T\n    return x\nend\nlet h: any = id",
+	} {
+		_, _, err := New().Compile(parse(src))
+		if err == nil || !strings.Contains(err.Error(), "precisa de tipo concreto") {
+			t.Fatalf("fonte %q: esperava erro de alvo, veio %v", src, err)
+		}
+	}
+}
+
+func TestUnanchoredGenericChainIsError(t *testing.T) {
+	src := `func id<T>(x: T) -> T
+    return x
+end
+func compose<A, B, C>(f: func(A) -> B, g: func(B) -> C) -> int
+    return 0
+end
+compose(id, id)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil || !strings.Contains(err.Error(), "anote o tipo") {
+		t.Fatalf("corrente sem ancora deve pedir anotacao, veio %v", err)
+	}
+}

--- a/internal/compiler/generics_target_test.go
+++ b/internal/compiler/generics_target_test.go
@@ -5,8 +5,11 @@ package compiler
 // de genericos sem ancora (`compose(id, id)`, nada fixa o tipo do meio).
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"noxy-vm/internal/ast"
 )
 
 func TestGenericWithoutConcreteTargetIsError(t *testing.T) {
@@ -32,5 +35,97 @@ compose(id, id)`
 	_, _, err := New().Compile(parse(src))
 	if err == nil || !strings.Contains(err.Error(), "anote o tipo") {
 		t.Fatalf("corrente sem ancora deve pedir anotacao, veio %v", err)
+	}
+}
+
+// I5 (1) da revisao final de branch: as duas rotas de target-typing que
+// unificam uma assinatura de TEMPLATE contra um tipo CONCRETO precisam da
+// mesma ponte de nomes de instancia que o caminho principal
+// (unifyAnnotation/expandInstanceNames) — o template escreve `Caixa<T>` e o
+// mundo escreve `main::Caixa<int>`. Antes, um parametro de struct generico
+// fazia as duas rotas falharem com "esperava main::Caixa<int>, encontrado
+// Caixa<T>" (ou o inverso): uma comparacao entre duas grafias do MESMO tipo.
+func TestGenericStructParamUnifiesThroughValuePositions(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// Rota unifyBidirectional (posicao 5 do §3: argumento de chamada
+			// de OUTRA generica).
+			name: "argumento de chamada generica",
+			src: `struct Caixa<T>
+    valor: T
+end
+func pega<T>(c: Caixa<T>) -> T
+    return c.valor
+end
+func aplica<A, B>(x: A, fn: func(A) -> B) -> B
+    return fn(x)
+end
+let c: Caixa<int> = Caixa(42)
+aplica(c, pega)`,
+		},
+		{
+			// Rota instantiateForTarget (posicao 1 do §3: `let` anotado).
+			name: "let anotado com tipo de funcao",
+			src: `struct Caixa<T>
+    valor: T
+end
+func pega<T>(c: Caixa<T>) -> T
+    return c.valor
+end
+let cx: Caixa<int> = Caixa(7)
+let f: func(Caixa<int>) -> int = pega`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := New().Compile(parse(tt.src)); err != nil {
+				t.Fatalf("deveria instanciar pega<int>, veio %v", err)
+			}
+		})
+	}
+}
+
+// I5 (2a): bindTypeParam devolve *conflictError, o mesmo tipo estruturado que
+// unify devolve — nao um fmt.Errorf com texto igual. Sem o tipo, nenhum
+// chamador consegue extrair Param/Existing/New via errors.As para compor a
+// atribuicao por argumento do §9.
+func TestBindTypeParamConflictIsStructured(t *testing.T) {
+	bindings := map[string]ast.NoxyType{"T": &ast.PrimitiveType{Name: "int"}}
+	err := bindTypeParam(bindings, "T", &ast.PrimitiveType{Name: "string"})
+	if err == nil {
+		t.Fatal("binding divergente deveria conflitar")
+	}
+	var conflict *conflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("erro = %T (%v), quer *conflictError", err, err)
+	}
+	if conflict.Param != "T" || conflict.Existing.String() != "int" || conflict.New.String() != "string" {
+		t.Fatalf("conflito = {%s, %s, %s}", conflict.Param, conflict.Existing, conflict.New)
+	}
+	if !strings.Contains(err.Error(), "T inferido como int e string") {
+		t.Fatalf("mensagem mudou: %v", err)
+	}
+}
+
+// I5 (2b): erro vindo da passada BIDIRECIONAL carrega a atribuicao por
+// argumento — antes o unico contexto era o indice do argumento-template, sem
+// nenhum caminho para a mensagem "(argumento N) e (argumento M)" do §9.
+func TestBidirectionalArgumentErrorCarriesArgumentAttribution(t *testing.T) {
+	src := `func par<T>(a: T, b: T) -> T
+    return a
+end
+func aplica<A, B>(x: A, fn: func(A, string) -> B) -> B
+    return fn(x, "s")
+end
+aplica(1, par)`
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("par<T> nao pode casar com func(int, string) -> B")
+	}
+	if !strings.Contains(err.Error(), "argumento 2 de 'aplica'") {
+		t.Fatalf("erro %v sem atribuicao de argumento", err)
 	}
 }

--- a/internal/compiler/generics_test.go
+++ b/internal/compiler/generics_test.go
@@ -1,0 +1,52 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+func TestGenericFunctionDeclarationEmitsNothing(t *testing.T) {
+	code, _, err := New().Compile(parse("func first<T>(arr: T[]) -> T\n    return arr[0]\nend"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsOpcode(code.Code, chunk.OP_CLOSURE) {
+		t.Fatal("template de funcao nao deve emitir OP_CLOSURE")
+	}
+	if containsOpcode(code.Code, chunk.OP_SET_GLOBAL) {
+		t.Fatal("template de funcao nao deve emitir OP_SET_GLOBAL")
+	}
+}
+
+func TestGenericStructDeclarationEmitsNothing(t *testing.T) {
+	code, _, err := New().Compile(parse("struct Stack<T>\n    items: T[]\nend"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsOpcode(code.Code, chunk.OP_SET_GLOBAL) {
+		t.Fatal("template de struct nao deve emitir OP_SET_GLOBAL")
+	}
+}
+
+func TestTemplateRegisteredInRegistry(t *testing.T) {
+	c := New()
+	if _, _, err := c.Compile(parse("func first<T>(arr: T[]) -> T\n    return arr[0]\nend")); err != nil {
+		t.Fatal(err)
+	}
+	tpl, ok := c.registryOrInit().Funcs["first"]
+	if !ok {
+		t.Fatal("template 'first' nao registrado")
+	}
+	if tpl.Module != "main" {
+		t.Fatalf("Module = %q, quer main", tpl.Module)
+	}
+}
+
+func TestNestedGenericDeclarationIsError(t *testing.T) {
+	_, _, err := New().Compile(parse("func outer()\n    func inner<T>(x: T) -> T\n        return x\n    end\nend"))
+	if err == nil || !strings.Contains(err.Error(), "top level") {
+		t.Fatalf("esperava erro de genericos aninhados, veio %v", err)
+	}
+}

--- a/internal/compiler/generics_twopass_test.go
+++ b/internal/compiler/generics_twopass_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"noxy-vm/internal/ast"
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
 )
@@ -103,14 +104,109 @@ f("abc")`))
 	}
 }
 
-// §5: programa sem genericos nao paga pass 1 — nenhuma fila de instancias
-// chega a ser criada.
+// §5: programa sem genericos nao paga pass 1 — o AST sai intocado e nenhuma
+// fila de instancias sobra no compilador.
 func TestNonGenericProgramSkipsPassOne(t *testing.T) {
 	c := New()
-	if _, _, err := c.Compile(parse("func f(x: int) -> int\n    return x\nend\nf(1)")); err != nil {
+	program := parse("func f(x: int) -> int\n    return x\nend\nf(1)")
+	before := len(program.Statements)
+	if _, _, err := c.Compile(program); err != nil {
 		t.Fatal(err)
 	}
+	if c.hasGenerics() {
+		t.Fatal("programa sem genericos populou o registry (gate do pass 1)")
+	}
+	if len(program.Statements) != before {
+		t.Fatalf("statements = %d, quer %d (pass 1 prependou algo)", len(program.Statements), before)
+	}
 	if c.instances != nil {
-		t.Fatal("programa sem genericos criou fila de instancias (pass 1 rodou)")
+		t.Fatal("fila de instancias sobrou no compilador")
+	}
+}
+
+// instanceDeclNames lista, na ordem, as declaracoes sinteticas que o pass 1
+// prependou a um Program (instancias sao as unicas funcoes com "::" no nome —
+// identificador de usuario nunca contem o qualificador de modulo, §4).
+func instanceDeclNames(program *ast.Program) []string {
+	names := []string{}
+	for _, statement := range program.Statements {
+		if fn, ok := statement.(*ast.FunctionStatement); ok && strings.Contains(fn.Name, "::") {
+			names = append(names, fn.Name)
+		}
+	}
+	return names
+}
+
+func countInstanceFunctions(code *chunk.Chunk, name string) int {
+	count := 0
+	for _, constant := range code.Constants {
+		if constant.Type == value.VAL_FUNCTION && constant.Obj.(*value.ObjFunction).Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+// A fila (memo + ordered) vive por COMPILACAO DE PROGRAMA, nao por compilador.
+// O registry persiste entre compilacoes (§5: REPL guarda templates na sessao),
+// entao um segundo Compile no mesmo compilador precisa: (a) NAO herdar as
+// declaracoes sinteticas do programa anterior, e (b) re-instanciar do zero uma
+// tupla que o memo do programa anterior ja tinha visto.
+func TestInstanceQueueIsScopedPerProgramCompile(t *testing.T) {
+	c := New()
+	first := parse("func id<T>(x: T) -> T\n    return x\nend\nid(1)\nid(\"a\")")
+	firstCode, _, err := c.Compile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(instanceDeclNames(first), " "); got != "main::id<int> main::id<string>" {
+		t.Fatalf("programa 1 prependou %q", got)
+	}
+	// O chunk do compilador e cumulativo entre Compile: medimos o DELTA que o
+	// programa 2 emite, nao o total.
+	stringsBefore := countInstanceFunctions(firstCode, "main::id<string>")
+
+	second := parse("id(2)")
+	secondCode, _, err := c.Compile(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// (a) nada do programa 1 vaza para o programa 2 — nem no AST, nem no
+	// bytecode emitido pela segunda compilacao.
+	if got := strings.Join(instanceDeclNames(second), " "); got != "main::id<int>" {
+		t.Fatalf("programa 2 prependou %q, quer apenas main::id<int>", got)
+	}
+	if delta := countInstanceFunctions(secondCode, "main::id<string>") - stringsBefore; delta != 0 {
+		t.Fatalf("programa 2 emitiu %d closures de main::id<string> (vazamento do programa 1)", delta)
+	}
+	// (b) a tupla usada nos dois programas e re-instanciada no segundo, apesar
+	// de o memo do primeiro ja te-la visto.
+	if c.instances != nil {
+		t.Fatal("fila de instancias sobrou no compilador depois do merge")
+	}
+}
+
+// Finding 2: templates genericos nunca entram em c.globals/c.structs pelo
+// predeclare — o tipo deles carrega TypeParamType e applyProgramBindings o
+// injetaria em c.globals durante TODO corpo de funcao. A identidade deles vive
+// so no GenericRegistry.
+func TestPredeclareSkipsGenericTemplates(t *testing.T) {
+	c := New()
+	program := parse("func id<T>(x: T) -> T\n    return x\nend\nstruct Caixa<T>\n    item: T\nend\nid(1)")
+	if _, _, err := c.Compile(program); err != nil {
+		t.Fatal(err)
+	}
+	if _, leaked := c.programBindings["id"]; leaked {
+		t.Fatal("template de funcao 'id' vazou para programBindings (tipo cru com TypeParamType)")
+	}
+	if _, leaked := c.programBindings["Caixa"]; leaked {
+		t.Fatal("template de struct 'Caixa' vazou para programBindings")
+	}
+	if _, leaked := c.structs["Caixa"]; leaked {
+		t.Fatal("template de struct 'Caixa' vazou para c.structs")
+	}
+	// A instancia, essa sim, e uma declaracao comum e predeclara normalmente.
+	if _, ok := c.programBindings["main::id<int>"]; !ok {
+		t.Fatal("instancia main::id<int> nao chegou a programBindings")
 	}
 }

--- a/internal/compiler/generics_twopass_test.go
+++ b/internal/compiler/generics_twopass_test.go
@@ -1,0 +1,116 @@
+package compiler
+
+// Contratos do two-pass (spec §4/§5): memoizacao por tupla de tipos,
+// igualdade de bytecode com a versao escrita a mao (§11) e erros de
+// inferencia (§9).
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+func TestMemoizationSingleInstance(t *testing.T) {
+	c := New()
+	code, _, err := c.Compile(parse("func id<T>(x: T) -> T\n    return x\nend\nid(1)\nid(2)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, k := range code.Constants {
+		if k.Type == value.VAL_FUNCTION && k.Obj.(*value.ObjFunction).Name == "main::id<int>" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("main::id<int> aparece %d vezes nos constants, quer 1 (memo)", count)
+	}
+}
+
+// O teste mais forte da spec (§11): bytecode da instancia == bytecode da
+// versao escrita a mao (modulo nome). Prova executavel do custo-zero.
+func TestMonomorphizedBytecodeEqualsHandwritten(t *testing.T) {
+	generic := compiledFunction(t, "func first<T>(arr: T[]) -> T\n    return arr[0]\nend\nlet xs: int[] = [1]\nfirst(xs)", "main::first<int>")
+	hand := compiledFunction(t, "func first_int(arr: int[]) -> int\n    return arr[0]\nend\nlet xs: int[] = [1]\nfirst_int(xs)", "first_int")
+	genericCode := generic.Chunk.(*chunk.Chunk).Code
+	handCode := hand.Chunk.(*chunk.Chunk).Code
+	if len(genericCode) != len(handCode) {
+		t.Fatalf("tamanhos diferem: generico %d, a mao %d", len(genericCode), len(handCode))
+	}
+	for i := range genericCode {
+		if genericCode[i] != handCode[i] {
+			t.Fatalf("bytecode diverge no offset %d: %d vs %d", i, genericCode[i], handCode[i])
+		}
+	}
+}
+
+func TestInferenceConflictError(t *testing.T) {
+	_, _, err := New().Compile(parse("func pick<T>(a: T, b: T) -> T\n    return a\nend\npick(1, \"x\")"))
+	if err == nil || !strings.Contains(err.Error(), "inferido como") {
+		t.Fatalf("esperava conflito T=int vs T=string, veio %v", err)
+	}
+}
+
+// §9: T que nao aparece em nenhum parametro e nao tem hint do `let` e erro de
+// inferencia com a mensagem exata do catalogo — nunca `any` implicito.
+func TestInferenceWithoutAnchorError(t *testing.T) {
+	_, _, err := New().Compile(parse("func vazio<T>() -> T[]\n    let out: T[] = []\n    return out\nend\nvazio()"))
+	want := "[line 5] não foi possível inferir T em 'vazio' — anote o tipo"
+	if err == nil || err.Error() != want {
+		t.Fatalf("erro = %v, quer %q", err, want)
+	}
+}
+
+// §7 uso 1: a anotacao do `let` envolvente ancora o T que so aparece no
+// retorno. O mesmo programa sem anotacao e o erro do teste acima.
+func TestLetAnnotationAnchorsReturnOnlyTypeParam(t *testing.T) {
+	fn := compiledFunction(t,
+		"func vazio<T>() -> T[]\n    let out: T[] = []\n    return out\nend\nlet xs: int[] = vazio()",
+		"main::vazio<int>")
+	if fn.Arity != 0 {
+		t.Fatalf("aridade = %d", fn.Arity)
+	}
+}
+
+// §9: erro dentro do corpo de uma instancia carrega a cadeia de
+// instanciacao — linha do erro no template + linha do site de chamada.
+func TestInstanceBodyErrorCarriesInstantiationChain(t *testing.T) {
+	_, _, err := New().Compile(parse(`func precisa_int(x: int) -> int
+    return x
+end
+func f<T>(v: T) -> int
+    return precisa_int(v)
+end
+f("abc")`))
+	if err == nil {
+		t.Fatal("esperava erro de corpo da instancia")
+	}
+	message := err.Error()
+	if !strings.HasPrefix(message, "[line ") {
+		t.Fatalf("erro %q nao comeca com a linha do corpo", message)
+	}
+	for _, fragment := range []string{"em f<string> (instanciado na linha 7):", "expected int, got string"} {
+		if !strings.Contains(message, fragment) {
+			t.Fatalf("erro %q nao contem %q", message, fragment)
+		}
+	}
+	// O prefixo "[line N]" do erro interno e levantado para o prefixo da
+	// cadeia, nao duplicado no meio da mensagem.
+	if count := strings.Count(message, "[line "); count != 1 {
+		t.Fatalf("erro %q tem %d prefixos de linha, quer 1", message, count)
+	}
+}
+
+// §5: programa sem genericos nao paga pass 1 — nenhuma fila de instancias
+// chega a ser criada.
+func TestNonGenericProgramSkipsPassOne(t *testing.T) {
+	c := New()
+	if _, _, err := c.Compile(parse("func f(x: int) -> int\n    return x\nend\nf(1)")); err != nil {
+		t.Fatal(err)
+	}
+	if c.instances != nil {
+		t.Fatal("programa sem genericos criou fila de instancias (pass 1 rodou)")
+	}
+}

--- a/internal/compiler/generics_twopass_test.go
+++ b/internal/compiler/generics_twopass_test.go
@@ -47,6 +47,78 @@ func TestMonomorphizedBytecodeEqualsHandwritten(t *testing.T) {
 	}
 }
 
+// M6 da revisao final de branch: o teste acima compara SO Code, e sobre um
+// corpo (`return arr[0]`) que nao emite nenhum opcode tipado nem povoa a
+// tabela de constantes — ou seja, nao prova a manchete da spec §1 ("o codigo
+// dentro da generica e tao especializado quanto o escrito a mao"). Este par
+// fecha as duas lacunas:
+//
+//   - corpo com aritmetica de int, e a asserção de que OP_ADD_INT (a
+//     especializacao que o compilador so emite quando SABE que os dois lados
+//     sao int) aparece DENTRO do corpo monomorfizado. Se a instancia
+//     compilasse com o tipo cru do template, `a + b` cairia no OP_ADD
+//     generico;
+//   - comparacao da tabela de CONSTANTES alem do Code: dois chunks podem ter
+//     bytes identicos e indices apontando para constantes diferentes.
+func TestMonomorphizedBytecodeMatchesHandwrittenWithTypedOpcodes(t *testing.T) {
+	const body = `
+    let rotulo: string = "soma"
+    print(rotulo)
+    return a + b + 7
+end
+`
+	generic := compiledFunction(t,
+		"func soma<T>(a: T, b: T) -> T"+body+"let total: int = soma(2, 3)",
+		"main::soma<int>")
+	hand := compiledFunction(t,
+		"func soma_int(a: int, b: int) -> int"+body+"let total: int = soma_int(2, 3)",
+		"soma_int")
+
+	genericChunk := generic.Chunk.(*chunk.Chunk)
+	handChunk := hand.Chunk.(*chunk.Chunk)
+
+	if !containsOpcode(handChunk.Code, chunk.OP_ADD_INT) {
+		t.Fatal("a versao a mao nao emitiu OP_ADD_INT — o teste perdeu o alvo")
+	}
+	if !containsOpcode(genericChunk.Code, chunk.OP_ADD_INT) {
+		t.Fatal("instancia sem OP_ADD_INT: `a + b` compilou com o tipo cru do template (§1)")
+	}
+	// containsOpcode e uma varredura de bytes crua (pode casar com um operando).
+	// O contraprova abaixo mostra que, para ESTE formato de corpo, a presenca
+	// do byte discrimina de verdade: a mesma funcao instanciada com float
+	// (que nao tem opcode aritmetico especializado) nao o contem.
+	floatInstance := compiledFunction(t,
+		"func somaf<T>(a: T, b: T) -> T\n    let rotulo: string = \"soma\"\n    print(rotulo)\n    return a + b + 7.0\nend\nlet total: float = somaf(2.0, 3.0)",
+		"main::somaf<float>")
+	if containsOpcode(floatInstance.Chunk.(*chunk.Chunk).Code, chunk.OP_ADD_INT) {
+		t.Fatal("a instancia float contem o byte de OP_ADD_INT — a sonda nao discrimina neste corpo")
+	}
+
+	if len(genericChunk.Code) != len(handChunk.Code) {
+		t.Fatalf("tamanhos de Code diferem: generico %d, a mao %d", len(genericChunk.Code), len(handChunk.Code))
+	}
+	for index := range genericChunk.Code {
+		if genericChunk.Code[index] != handChunk.Code[index] {
+			t.Fatalf("Code diverge no offset %d: %d vs %d", index, genericChunk.Code[index], handChunk.Code[index])
+		}
+	}
+
+	if len(genericChunk.Constants) != len(handChunk.Constants) {
+		t.Fatalf("tabelas de constantes diferem em tamanho: generico %d, a mao %d",
+			len(genericChunk.Constants), len(handChunk.Constants))
+	}
+	for index := range genericChunk.Constants {
+		got, want := genericChunk.Constants[index], handChunk.Constants[index]
+		if got.Type != want.Type || got.String() != want.String() {
+			t.Fatalf("constante %d diverge: generico %v (%s), a mao %v (%s)",
+				index, got.Type, got.String(), want.Type, want.String())
+		}
+	}
+	if len(genericChunk.Constants) == 0 {
+		t.Fatal("corpo nao povoou a tabela de constantes — a comparacao seria vazia")
+	}
+}
+
 func TestInferenceConflictError(t *testing.T) {
 	_, _, err := New().Compile(parse("func pick<T>(a: T, b: T) -> T\n    return a\nend\npick(1, \"x\")"))
 	if err == nil || !strings.Contains(err.Error(), "inferido como") {

--- a/internal/compiler/generics_unify.go
+++ b/internal/compiler/generics_unify.go
@@ -25,6 +25,28 @@ import (
 //     "esperava".
 //   - GenericType unifica Args ponto a ponto (mesmo Name e aridade).
 //
+// Compatibilidade "nunca mais estrita que areTypesCompatible": unify é
+// consumida durante a inferência de tipos em sites de chamada genéricos, e
+// não pode rejeitar uma chamada que o checador de tipos "de verdade"
+// (Compiler.areTypesCompatible, compiler.go) aceitaria — isso quebraria
+// chamadas estruturalmente válidas. Por isso, na posição expected concreta
+// (fora de um TypeParamType), replicamos as mesmas três folgas de
+// areTypesCompatible antes de comparar construtor a construtor: expected
+// "any" aceita qualquer actual; actual "any" ou "null" nunca é erro (não
+// binda, não falha); expected "func" (bare) aceita qualquer actual chamável
+// (isCallableType: FunctionType ou "func" bare). Reusamos os helpers de
+// pacote isAny/isNullType/isBareFunctionType/isCallableType (definidos em
+// compiler.go e function_types.go) para não duplicar essas regras com uma
+// semântica levemente diferente.
+//
+// O que NÃO replicamos aqui é Compiler.acceptsNull (que decide se um actual
+// null é aceito por um expected nomeado consultando c.structs) — unify é uma
+// função pura, sem acesso à tabela de structs do compilador. Nesses casos
+// "não temos certeza": preferimos não bindar e não errar, e deixar a
+// checagem de tipos da pass 2 (com o *Compiler completo) decidir depois. Ou
+// seja, unify pode ser mais permissiva que areTypesCompatible em casos que
+// dependem de contexto que ela não tem — nunca mais estrita.
+//
 // nil: expected ou actual nil é tratado conservadoramente — sem binding, sem
 // erro. Ambos os lados nil não deveriam ocorrer em uso real (a spec exige
 // tipos resolvidos antes de chamar unify); optamos por não travar aqui e
@@ -39,7 +61,7 @@ func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) erro
 		if _, isRef := actual.(*ast.RefType); isRef {
 			return fmt.Errorf("%s não pode ser um tipo ref (tentativa de bindar %s)", tp.Name, actual.String())
 		}
-		if isAnyOrNull(actual) {
+		if isAny(actual) || isNullType(actual) {
 			return nil
 		}
 		if existing, ok := bindings[tp.Name]; ok {
@@ -50,6 +72,22 @@ func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) erro
 		}
 		bindings[tp.Name] = ast.CloneType(actual)
 		return nil
+	}
+
+	// expected concreto: folgas de compatibilidade que espelham
+	// areTypesCompatible antes de exigir casamento de construtor (ver
+	// comentário da função).
+	if isAny(expected) {
+		return nil
+	}
+	if isAny(actual) || isNullType(actual) {
+		return nil
+	}
+	if isBareFunctionType(expected) {
+		if isCallableType(actual) {
+			return nil
+		}
+		return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
 	}
 
 	switch exp := expected.(type) {
@@ -124,17 +162,6 @@ func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) erro
 	default:
 		return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
 	}
-}
-
-// isAnyOrNull reporta se t é o primitivo "any" ou "null" — os únicos tipos
-// concretos que, em posição actual, não contribuem binding para um
-// TypeParamType (spec §7).
-func isAnyOrNull(t ast.NoxyType) bool {
-	pt, ok := t.(*ast.PrimitiveType)
-	if !ok {
-		return false
-	}
-	return pt.Name == "any" || pt.Name == "null"
 }
 
 // containsTypeParam reporta se t contém, em qualquer profundidade, um

--- a/internal/compiler/generics_unify.go
+++ b/internal/compiler/generics_unify.go
@@ -6,6 +6,26 @@ import (
 	"noxy-vm/internal/ast"
 )
 
+// conflictError e o erro estruturado que unify devolve quando um parametro de
+// tipo ja tem binding e o novo valor observado diverge (comparacao por
+// String()). Error() produz exatamente a mesma mensagem "T inferido como X e
+// Y" que TestUnifyTable/TestInferenceConflictError ja verificam por
+// substring — nada muda para quem so olha err.Error(). O que o tipo
+// estruturado acrescenta e os campos Param/Existing/New, que um chamador com
+// mais contexto (compileGenericCallSite, generics.go) pode extrair via
+// errors.As para compor a mensagem do §9 com atribuicao por argumento ("T
+// inferido como int (argumento 1) e string (argumento 2)") sem parsear
+// texto.
+type conflictError struct {
+	Param    string
+	Existing ast.NoxyType
+	New      ast.NoxyType
+}
+
+func (e *conflictError) Error() string {
+	return fmt.Sprintf("%s inferido como %s e %s", e.Param, e.Existing.String(), e.New.String())
+}
+
 // unify casa estruturalmente expected (um tipo de template, possivelmente
 // contendo TypeParamType) contra actual (um tipo concreto observado num site
 // de chamada), acumulando bindings de parâmetro de tipo em bindings.
@@ -66,7 +86,7 @@ func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) erro
 		}
 		if existing, ok := bindings[tp.Name]; ok {
 			if existing.String() != actual.String() {
-				return fmt.Errorf("%s inferido como %s e %s", tp.Name, existing.String(), actual.String())
+				return &conflictError{Param: tp.Name, Existing: existing, New: actual}
 			}
 			return nil
 		}

--- a/internal/compiler/generics_unify.go
+++ b/internal/compiler/generics_unify.go
@@ -1,0 +1,179 @@
+package compiler
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// unify casa estruturalmente expected (um tipo de template, possivelmente
+// contendo TypeParamType) contra actual (um tipo concreto observado num site
+// de chamada), acumulando bindings de parâmetro de tipo em bindings.
+//
+// Regras (§7 da spec):
+//   - TypeParamType em posição expected binda actual (uma cópia via
+//     ast.CloneType, para não compartilhar nós entre o template e a
+//     instância inferida).
+//   - actual == ref é proibido como alvo de binding: erro "não pode ser um
+//     tipo ref".
+//   - actual any/null não contribui binding (não é erro; unify retorna nil
+//     sem tocar em bindings).
+//   - Se T já tem binding e o novo valor diverge (comparação por String()),
+//     erro de conflito contendo "inferido como".
+//   - expected concreto (sem TypeParamType) delega para comparação
+//     estrutural por construtor; mismatch de construtor é erro contendo
+//     "esperava".
+//   - GenericType unifica Args ponto a ponto (mesmo Name e aridade).
+//
+// nil: expected ou actual nil é tratado conservadoramente — sem binding, sem
+// erro. Ambos os lados nil não deveriam ocorrer em uso real (a spec exige
+// tipos resolvidos antes de chamar unify); optamos por não travar aqui e
+// deixar validações posteriores (Tasks 8/10/11) pegarem tipos ausentes com
+// mensagens mais específicas ao contexto delas.
+func unify(expected, actual ast.NoxyType, bindings map[string]ast.NoxyType) error {
+	if expected == nil || actual == nil {
+		return nil
+	}
+
+	if tp, ok := expected.(*ast.TypeParamType); ok {
+		if _, isRef := actual.(*ast.RefType); isRef {
+			return fmt.Errorf("%s não pode ser um tipo ref (tentativa de bindar %s)", tp.Name, actual.String())
+		}
+		if isAnyOrNull(actual) {
+			return nil
+		}
+		if existing, ok := bindings[tp.Name]; ok {
+			if existing.String() != actual.String() {
+				return fmt.Errorf("%s inferido como %s e %s", tp.Name, existing.String(), actual.String())
+			}
+			return nil
+		}
+		bindings[tp.Name] = ast.CloneType(actual)
+		return nil
+	}
+
+	switch exp := expected.(type) {
+	case *ast.PrimitiveType:
+		act, ok := actual.(*ast.PrimitiveType)
+		if !ok || act.Name != exp.Name {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return nil
+
+	case *ast.ArrayType:
+		act, ok := actual.(*ast.ArrayType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unify(exp.ElementType, act.ElementType, bindings)
+
+	case *ast.MapType:
+		act, ok := actual.(*ast.MapType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		if err := unify(exp.KeyType, act.KeyType, bindings); err != nil {
+			return err
+		}
+		return unify(exp.ValueType, act.ValueType, bindings)
+
+	case *ast.RefType:
+		act, ok := actual.(*ast.RefType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unify(exp.ElementType, act.ElementType, bindings)
+
+	case *ast.ChanType:
+		act, ok := actual.(*ast.ChanType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		return unify(exp.ElementType, act.ElementType, bindings)
+
+	case *ast.FunctionType:
+		act, ok := actual.(*ast.FunctionType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		if len(exp.Params) != len(act.Params) {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		for i, p := range exp.Params {
+			if err := unify(p, act.Params[i], bindings); err != nil {
+				return err
+			}
+		}
+		return unify(exp.Return, act.Return, bindings)
+
+	case *ast.GenericType:
+		act, ok := actual.(*ast.GenericType)
+		if !ok {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		if exp.Name != act.Name || len(exp.Args) != len(act.Args) {
+			return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+		}
+		for i, a := range exp.Args {
+			if err := unify(a, act.Args[i], bindings); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("esperava %s, encontrado %s", expected.String(), actual.String())
+	}
+}
+
+// isAnyOrNull reporta se t é o primitivo "any" ou "null" — os únicos tipos
+// concretos que, em posição actual, não contribuem binding para um
+// TypeParamType (spec §7).
+func isAnyOrNull(t ast.NoxyType) bool {
+	pt, ok := t.(*ast.PrimitiveType)
+	if !ok {
+		return false
+	}
+	return pt.Name == "any" || pt.Name == "null"
+}
+
+// containsTypeParam reporta se t contém, em qualquer profundidade, um
+// TypeParamType — ou seja, se t ainda é um tipo de template não instanciado.
+// Exportado dentro do pacote (nome exato containsTypeParam) porque Tasks
+// 8/10/11 consomem esta função para decidir quando delegar para unify em vez
+// de comparação estrutural direta.
+func containsTypeParam(t ast.NoxyType) bool {
+	if t == nil {
+		return false
+	}
+	switch n := t.(type) {
+	case *ast.TypeParamType:
+		return true
+	case *ast.PrimitiveType:
+		return false
+	case *ast.ArrayType:
+		return containsTypeParam(n.ElementType)
+	case *ast.MapType:
+		return containsTypeParam(n.KeyType) || containsTypeParam(n.ValueType)
+	case *ast.RefType:
+		return containsTypeParam(n.ElementType)
+	case *ast.ChanType:
+		return containsTypeParam(n.ElementType)
+	case *ast.FunctionType:
+		for _, p := range n.Params {
+			if containsTypeParam(p) {
+				return true
+			}
+		}
+		return containsTypeParam(n.Return)
+	case *ast.GenericType:
+		for _, a := range n.Args {
+			if containsTypeParam(a) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/compiler/generics_unify_test.go
+++ b/internal/compiler/generics_unify_test.go
@@ -40,6 +40,16 @@ func TestUnifyTable(t *testing.T) {
 		{"null nao binda", tParam("T"), tNull(), map[string]string{}, ""},
 		{"T nao binda ref", tParam("T"), &ast.RefType{ElementType: tInt()}, nil, "não pode ser um tipo ref"},
 		{"construtor divergente", tArr(tParam("T")), tInt(), nil, "esperava"},
+		{"map[T,any] contra map[int,string]: any folgado no leaf nao erra",
+			&ast.MapType{KeyType: tParam("T"), ValueType: tAny()},
+			&ast.MapType{KeyType: tInt(), ValueType: tString()},
+			map[string]string{"T": "int"}, ""},
+		{"ref int contra null: null folgado nao erra",
+			&ast.RefType{ElementType: tInt()}, tNull(), map[string]string{}, ""},
+		{"func bare contra FunctionType: callable folgado nao erra",
+			&ast.PrimitiveType{Name: "func"},
+			&ast.FunctionType{Params: []ast.NoxyType{tInt()}, Return: tString()},
+			map[string]string{}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/compiler/generics_unify_test.go
+++ b/internal/compiler/generics_unify_test.go
@@ -1,0 +1,75 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+func tInt() ast.NoxyType               { return &ast.PrimitiveType{Name: "int"} }
+func tString() ast.NoxyType            { return &ast.PrimitiveType{Name: "string"} }
+func tAny() ast.NoxyType               { return &ast.PrimitiveType{Name: "any"} }
+func tNull() ast.NoxyType              { return &ast.PrimitiveType{Name: "null"} }
+func tParam(n string) ast.NoxyType     { return &ast.TypeParamType{Name: n} }
+func tArr(e ast.NoxyType) ast.NoxyType { return &ast.ArrayType{ElementType: e} }
+
+func TestUnifyTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected ast.NoxyType
+		actual   ast.NoxyType
+		want     map[string]string // binding esperado (String())
+		errPart  string            // "" = sem erro
+	}{
+		{"T contra int", tParam("T"), tInt(), map[string]string{"T": "int"}, ""},
+		{"T[] contra int[]", tArr(tParam("T")), tArr(tInt()), map[string]string{"T": "int"}, ""},
+		{"map[K,V]", &ast.MapType{KeyType: tParam("K"), ValueType: tParam("V")},
+			&ast.MapType{KeyType: tString(), ValueType: tInt()},
+			map[string]string{"K": "string", "V": "int"}, ""},
+		{"func(A)->B", &ast.FunctionType{Params: []ast.NoxyType{tParam("A")}, Return: tParam("B")},
+			&ast.FunctionType{Params: []ast.NoxyType{tInt()}, Return: tString()},
+			map[string]string{"A": "int", "B": "string"}, ""},
+		{"chan T", &ast.ChanType{ElementType: tParam("T")}, &ast.ChanType{ElementType: tInt()},
+			map[string]string{"T": "int"}, ""},
+		{"GenericType args", &ast.GenericType{Name: "Stack", Args: []ast.NoxyType{tParam("T")}},
+			&ast.GenericType{Name: "Stack", Args: []ast.NoxyType{tInt()}},
+			map[string]string{"T": "int"}, ""},
+		{"conflito", tParam("T"), tInt(), nil, ""}, // preparado abaixo com segundo unify
+		{"any nao binda", tParam("T"), tAny(), map[string]string{}, ""},
+		{"null nao binda", tParam("T"), tNull(), map[string]string{}, ""},
+		{"T nao binda ref", tParam("T"), &ast.RefType{ElementType: tInt()}, nil, "não pode ser um tipo ref"},
+		{"construtor divergente", tArr(tParam("T")), tInt(), nil, "esperava"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := map[string]ast.NoxyType{}
+			err := unify(tc.expected, tc.actual, b)
+			if tc.name == "conflito" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = unify(tc.expected, tString(), b) // T=int já bindado; string conflita
+				if err == nil || !strings.Contains(err.Error(), "inferido como") {
+					t.Fatalf("esperava conflito, veio %v", err)
+				}
+				return
+			}
+			if tc.errPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errPart) {
+					t.Fatalf("esperava erro contendo %q, veio %v", tc.errPart, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			for k, v := range tc.want {
+				got, ok := b[k]
+				if !ok || got.String() != v {
+					t.Fatalf("binding %s = %v, quer %s", k, got, v)
+				}
+			}
+		})
+	}
+}

--- a/internal/compiler/generics_walkers_guard_test.go
+++ b/internal/compiler/generics_walkers_guard_test.go
@@ -1,0 +1,140 @@
+package compiler
+
+// Guard por reflexão dos WALKERS EXAUSTIVOS de genéricos (I4 da revisão final
+// de branch), irmão de ast.TestClonerCoversEveryNode.
+//
+// substituteInStatement/substituteInExpression (generics_substitute.go) e
+// collectBoundNamesIn*/collectFreeIn* (generics.go) fazem `panic` no default —
+// a disciplina certa (nó novo = falha barulhenta, não substituição silenciosa
+// pela metade), mas um panic só dispara se algum teste exercitar exatamente o
+// nó novo. Os comentários desses walkers já afirmavam ter cobertura de guard;
+// até este arquivo existir, não tinham: só o cloner era guardado, em
+// internal/ast/clone_test.go.
+//
+// O guard enumera os nós de ast.go (tipos com receiver statementNode /
+// expressionNode) e exige um `case` para cada um em CADA walker,
+// individualmente — checagem por função, não por arquivo: generics.go abriga
+// dois walkers de statement e dois de expression, e um `strings.Contains` no
+// arquivo inteiro daria por coberto um nó que só um deles trata.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+// astNodeNames devolve os nós concretos de internal/ast/ast.go separados em
+// statements e expressions, pela mesma análise de fonte que
+// ast.TestClonerCoversEveryNode usa (receiver de statementNode/expressionNode).
+func astNodeNames(t *testing.T) (statements, expressions map[string]bool) {
+	t.Helper()
+	statements = map[string]bool{}
+	expressions = map[string]bool{}
+
+	parsed, err := parser.ParseFile(token.NewFileSet(), filepath.Join("..", "ast", "ast.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("ast.go ilegivel: %v", err)
+	}
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+			return true
+		}
+		var target map[string]bool
+		switch fn.Name.Name {
+		case "statementNode":
+			target = statements
+		case "expressionNode":
+			target = expressions
+		default:
+			return true
+		}
+		star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := star.X.(*ast.Ident); ok {
+			target[ident.Name] = true
+		}
+		return true
+	})
+
+	if len(statements) == 0 || len(expressions) == 0 {
+		t.Fatalf("analise de ast.go nao achou nós (statements=%d, expressions=%d)", len(statements), len(expressions))
+	}
+	return statements, expressions
+}
+
+// typeSwitchCases devolve os nomes de tipo `*ast.X` que aparecem em algum
+// `case` de type switch dentro da função funcName do arquivo file. Um case
+// com vários tipos (`case *ast.Identifier, *ast.IntegerLiteral:`) contribui
+// todos eles.
+func typeSwitchCases(t *testing.T, file, funcName string) map[string]bool {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	if err != nil {
+		t.Fatalf("%s ilegivel: %v", file, err)
+	}
+
+	covered := map[string]bool{}
+	found := false
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != funcName {
+			continue
+		}
+		found = true
+		ast.Inspect(fn, func(n ast.Node) bool {
+			clause, ok := n.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				star, ok := expr.(*ast.StarExpr)
+				if !ok {
+					continue
+				}
+				selector, ok := star.X.(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+				if pkg, ok := selector.X.(*ast.Ident); ok && pkg.Name == "ast" {
+					covered[selector.Sel.Name] = true
+				}
+			}
+			return true
+		})
+	}
+	if !found {
+		t.Fatalf("%s nao declara %s — o guard ficou apontando para um nome morto", file, funcName)
+	}
+	return covered
+}
+
+func TestGenericWalkersCoverEveryNode(t *testing.T) {
+	statements, expressions := astNodeNames(t)
+
+	walkers := []struct {
+		file     string
+		function string
+		nodes    map[string]bool
+	}{
+		{"generics_substitute.go", "substituteInStatement", statements},
+		{"generics_substitute.go", "substituteInExpression", expressions},
+		{"generics.go", "collectBoundNamesInStatement", statements},
+		{"generics.go", "collectBoundNamesInExpression", expressions},
+		{"generics.go", "collectFreeInStatement", statements},
+		{"generics.go", "collectFreeInExpression", expressions},
+	}
+
+	for _, walker := range walkers {
+		covered := typeSwitchCases(t, walker.file, walker.function)
+		for name := range walker.nodes {
+			if !covered[name] {
+				t.Errorf("%s (%s) sem case para *ast.%s — o walker fica cego para esse nó (panic em runtime, no melhor caso)", walker.function, walker.file, name)
+			}
+		}
+	}
+}

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -11,16 +11,68 @@ import (
 	"strings"
 )
 
+// moduleDiscoveryState e o estado compartilhado da descoberta de modulos
+// dentro de UMA arvore de compiladores:
+//
+//   - active e o guard de ciclo (um modulo em carga nao pode ser recarregado
+//     por dentro da propria carga);
+//   - loaded e a MEMOIZACAO de loadModuleDeclarations. Sem ela, cada `use`
+//     paga um parse + um Compile completo de validacao do modulo (e,
+//     recursivamente, dos modulos que ele importa) UMA VEZ POR CHAMADOR:
+//     predeclareImportedTemplates (discoverModuleExports +
+//     moduleTopLevelBindings), predeclareImport (idem) e o case *ast.UseStmt
+//     de compiler.go — tudo isso dobrado pelo two-pass dos genericos. Medido
+//     em `use http select *`: 1,4s -> 12,3s. Com o memo o custo volta a UMA
+//     carga por modulo por compilacao.
 type moduleDiscoveryState struct {
 	active map[string]bool
+	loaded map[string]loadedModule
+}
+
+// loadedModule e o resultado memoizado de loadModuleDeclarations: o Program
+// ja parseado E VALIDADO (parseModuleDeclarations roda validator.Compile
+// antes de devolver) ou, para modulo de diretorio, a lista de submodulos.
+//
+// Compartilhar o MESMO *ast.Program entre chamadores e seguro porque a
+// mutacao in-place que o pipeline faz nele (resolveSignatureAnnotations /
+// resolveStructFieldAnnotations, e o merge das instancias monomorfizadas de
+// runGenericsPass1) acontece INTEIRA dentro de parseModuleDeclarations, antes
+// do primeiro retorno — o codigo anterior a este memo ja devolvia o AST
+// pos-mutacao a todo chamador, so que reconstruido do zero a cada vez. Os
+// consumidores (discoverModuleExports, discoverModuleStructs,
+// moduleTopLevelBindings, importBindingFrom) apenas LEEM as declaracoes; o
+// unico que guarda um ponteiro para dentro do modulo e importBindingFrom, ao
+// registrar um template no GenericRegistry, e a monomorfizacao sempre trabalha
+// sobre um CLONE (substituteFunction/substituteStruct) — nunca sobre tpl.Decl.
+type loadedModule struct {
+	program        *ast.Program
+	directoryNames []string
+}
+
+func newModuleDiscoveryState() *moduleDiscoveryState {
+	return &moduleDiscoveryState{
+		active: make(map[string]bool),
+		loaded: make(map[string]loadedModule),
+	}
+}
+
+// discoveryState devolve — criando na primeira chamada — o estado de
+// descoberta deste compilador. Criar UMA VEZ e guardar em c.moduleDiscovery e
+// o que faz o memo de loadModuleDeclarations valer entre os varios chamadores
+// de um mesmo `use` (antes, cada um fabricava um estado descartavel e o memo
+// morreria junto com ele). NewChild e newPass1Compiler propagam o ponteiro,
+// entao a arvore inteira de uma compilacao compartilha um unico cache — o
+// filho de NewChild (corpo de funcao, onde um `use` aninhado tambem compila) e
+// o compilador descartavel do pass 1 dos genericos inclusos.
+func (c *Compiler) discoveryState() *moduleDiscoveryState {
+	if c.moduleDiscovery == nil {
+		c.moduleDiscovery = newModuleDiscoveryState()
+	}
+	return c.moduleDiscovery
 }
 
 func (c *Compiler) discoverModuleExports(module string) (map[string]struct{}, bool) {
-	state := c.moduleDiscovery
-	if state == nil {
-		state = &moduleDiscoveryState{active: make(map[string]bool)}
-	}
-	return c.discoverModuleExportsWithState(module, state)
+	return c.discoverModuleExportsWithState(module, c.discoveryState())
 }
 
 func (c *Compiler) discoverModuleExportsWithState(module string, state *moduleDiscoveryState) (map[string]struct{}, bool) {
@@ -95,11 +147,7 @@ func (c *Compiler) discoverModuleStructs(module string) (map[string]*ast.StructS
 	// validator compile spawned to check a nested use statement would start
 	// its own independent, equally cycle-blind discovery, recursing without
 	// bound.
-	state := c.moduleDiscovery
-	if state == nil {
-		state = &moduleDiscoveryState{active: make(map[string]bool)}
-	}
-	return c.discoverModuleStructsWithState(module, state)
+	return c.discoverModuleStructsWithState(module, c.discoveryState())
 }
 
 func (c *Compiler) discoverModuleStructsWithState(module string, state *moduleDiscoveryState) (map[string]*ast.StructStatement, bool) {
@@ -242,11 +290,7 @@ func (c *Compiler) predeclareImportedTemplates(statements []ast.Statement) error
 // in-place durante esse Compile — o mesmo mecanismo que faz o proprio
 // modulo compilar corretamente sozinho.
 func (c *Compiler) moduleTopLevelBindings(module string) (map[string]ast.Statement, bool) {
-	state := c.moduleDiscovery
-	if state == nil {
-		state = &moduleDiscoveryState{active: make(map[string]bool)}
-	}
-	program, _, ok := c.loadModuleDeclarations(module, state)
+	program, _, ok := c.loadModuleDeclarations(module, c.discoveryState())
 	if !ok {
 		return nil, false
 	}
@@ -387,13 +431,38 @@ func isModuleTemplateDeclaration(declarations map[string]ast.Statement, name str
 	}
 }
 
+// loadModuleDeclarations resolve, parseia e VALIDA um modulo, memoizando o
+// resultado em state.loaded (ver moduleDiscoveryState).
+//
+// So SUCESSOS entram no cache. Uma falha pode ser CONTEXTUAL: o guard de
+// ciclo (state.active) faz um modulo que carrega perfeitamente sozinho
+// devolver false quando alcancado por dentro da propria carga, e memoizar
+// esse false condenaria o modulo pelo resto da compilacao. O inverso nao
+// existe — estar dentro de uma recursao so pode fazer FALHAR, nunca
+// suceder —, entao um sucesso e sempre valido para qualquer contexto.
 func (c *Compiler) loadModuleDeclarations(module string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
+	if cached, hit := state.loaded[module]; hit {
+		return cached.program, cached.directoryNames, true
+	}
 	if state.active[module] {
 		return nil, nil, false
 	}
 	state.active[module] = true
 	defer delete(state.active, module)
 
+	program, directoryNames, ok := c.resolveModuleDeclarations(module, state)
+	if ok {
+		if state.loaded == nil {
+			state.loaded = make(map[string]loadedModule)
+		}
+		state.loaded[module] = loadedModule{program: program, directoryNames: directoryNames}
+	}
+	return program, directoryNames, ok
+}
+
+// resolveModuleDeclarations e o corpo nao-memoizado de loadModuleDeclarations:
+// procura o arquivo/diretorio/embed do modulo e delega o parse+validacao.
+func (c *Compiler) resolveModuleDeclarations(module string, state *moduleDiscoveryState) (*ast.Program, []string, bool) {
 	pathName := strings.ReplaceAll(module, ".", string(filepath.Separator))
 	for _, candidate := range c.moduleFileCandidates(pathName) {
 		info, err := os.Stat(candidate)

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"maps"
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/lexer"
@@ -196,6 +197,60 @@ func (c *Compiler) importModuleStructs(module string, names []string) {
 			c.structs[name] = definition
 		}
 	}
+}
+
+// rejectNestedTemplateImport recusa, com a mensagem acionavel do §9, um `use`
+// ANINHADO (dentro de corpo de funcao ou de lambda — c.enclosing != nil) que
+// traga um template generico para o escopo.
+//
+// Por que e um erro e nao uma feature: a decisao "este programa precisa do
+// two-pass?" (hasGenerics em Compile(*ast.Program)) e tomada UMA VEZ, na
+// entrada, olhando so os `use` do TOPO (predeclareImportedTemplates varre
+// statements de topo). Um `use` aninhado registra o template no meio da
+// compilacao, DEPOIS que essa decisao ja passou: no pass 1 nada acontece
+// (aquele programa nem entrou no two-pass) e no pass 2 a chamada bate no
+// guard defensivo de compileGenericCallSite, que acusa "bug do compilador de
+// genéricos" com a linha errada — mensagem inutil para quem escreveu o
+// programa. Suportar de verdade exigiria redecidir o two-pass a cada `use`
+// aninhado; ate la, o erro claro (com a saida obvia: mover o `use` para o
+// topo) vale mais que o falso relato de bug.
+//
+// A forma de NAMESPACE (`use m [as alias]`) nunca importa nome nenhum (§8) e
+// portanto nunca traz template: passa direto. Modulo que nao carrega tambem
+// passa direto (bindings vazio) — a tolerancia que
+// TestFunctionBodyOnlyWildcardDoesNotAffectModuleLoadability exige.
+func (c *Compiler) rejectNestedTemplateImport(declaration *ast.UseStmt) error {
+	if c.enclosing == nil {
+		return nil
+	}
+	var names []string
+	switch {
+	case declaration.SelectAll:
+		exports, _ := c.discoverModuleExports(declaration.Module)
+		names = make([]string, 0, len(exports))
+		for name := range exports {
+			names = append(names, name)
+		}
+	case len(declaration.Selectors) > 0:
+		names = declaration.Selectors
+	default:
+		return nil
+	}
+	bindings, _ := c.moduleTopLevelBindings(declaration.Module)
+	for _, name := range names {
+		if isModuleTemplateDeclaration(bindings, name) {
+			return nestedTemplateImportError(declaration.Token.Line)
+		}
+	}
+	return nil
+}
+
+// nestedTemplateImportError e a mensagem verbatim do §9 para o caso acima.
+func nestedTemplateImportError(line int) error {
+	return fmt.Errorf(
+		"[line %d] template genérico importado dentro de corpo de função não é suportado — mova o 'use' para o top level",
+		line,
+	)
 }
 
 func (c *Compiler) predeclareImport(declaration *ast.UseStmt) error {

--- a/internal/compiler/module_exports.go
+++ b/internal/compiler/module_exports.go
@@ -150,16 +150,22 @@ func (c *Compiler) importModuleStructs(module string, names []string) {
 	}
 }
 
-func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
+func (c *Compiler) predeclareImport(declaration *ast.UseStmt) error {
 	switch {
 	case declaration.SelectAll:
 		exports, _ := c.discoverModuleExports(declaration.Module)
+		bindings, _ := c.moduleTopLevelBindings(declaration.Module)
 		for name := range exports {
-			c.globals[name] = nil
+			if err := c.importBindingFrom(declaration.Module, bindings, name); err != nil {
+				return err
+			}
 		}
 	case len(declaration.Selectors) > 0:
+		bindings, _ := c.moduleTopLevelBindings(declaration.Module)
 		for _, name := range declaration.Selectors {
-			c.globals[name] = nil
+			if err := c.importBindingFrom(declaration.Module, bindings, name); err != nil {
+				return err
+			}
 		}
 	default:
 		name := declaration.Alias
@@ -167,7 +173,217 @@ func (c *Compiler) predeclareImport(declaration *ast.UseStmt) {
 			parts := strings.Split(declaration.Module, ".")
 			name = parts[len(parts)-1]
 		}
+		c.importNamespace(declaration.Module, name)
+	}
+	return nil
+}
+
+// predeclareImportedTemplates registra SO os templates genericos que os
+// `use` statements do TOPO do programa importam (select*/select — a forma
+// de namespace nunca importa template nenhum, §8). Precisa rodar ANTES da
+// decisao hasGenerics()/runGenericsPass1 em Compile(*ast.Program): aquela
+// decisao so olha se o registry ja tem alguma entrada, e o predeclare
+// "de verdade" dos imports (predeclareGlobalBindings -> predeclareImport,
+// que tambem cataloga os globals tipados para programBindings) so roda
+// DEPOIS dessa decisao. Sem este passo adiantado, um programa que so usa
+// genericos IMPORTADOS (nenhum declarado localmente) nunca aciona o
+// two-pass — e a interceptacao de call site em compileCallExpression, que
+// olha o registry sem checar c.pass1, encontraria o template e chamaria
+// compileGenericCallSite fora do pass 1, batendo no erro defensivo "chegou
+// ao pass 2 sem monomorfização" (exatamente o bug pego pelo TDD deste
+// arquivo). Idempotente com a passada completa que roda depois — registrar
+// o mesmo template duas vezes so troca o ponteiro do AST (reparse) por um
+// estruturalmente identico, sem efeito observavel.
+func (c *Compiler) predeclareImportedTemplates(statements []ast.Statement) error {
+	for _, statement := range statements {
+		declaration, ok := statement.(*ast.UseStmt)
+		if !ok {
+			continue
+		}
+		switch {
+		case declaration.SelectAll:
+			exports, _ := c.discoverModuleExports(declaration.Module)
+			bindings, _ := c.moduleTopLevelBindings(declaration.Module)
+			for name := range exports {
+				if !isModuleTemplateDeclaration(bindings, name) {
+					continue
+				}
+				if err := c.importBindingFrom(declaration.Module, bindings, name); err != nil {
+					return err
+				}
+			}
+		case len(declaration.Selectors) > 0:
+			bindings, _ := c.moduleTopLevelBindings(declaration.Module)
+			for _, name := range declaration.Selectors {
+				if !isModuleTemplateDeclaration(bindings, name) {
+					continue
+				}
+				if err := c.importBindingFrom(declaration.Module, bindings, name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// moduleTopLevelBindings analisa (e valida, via loadModuleDeclarations, que
+// ja roda um Compile completo do modulo num validator descartavel — ver
+// parseModuleDeclarations) `module` UMA VEZ e indexa suas declaracoes de
+// topo (func, struct, let) por nome. Existe para que um `use m select *`
+// com N exports nao repita o parse+validate completo do modulo N vezes —
+// cada chamador (predeclareImport, o case *ast.UseStmt de compiler.go)
+// busca aqui uma unica vez por `use` e consulta o mapa por nome depois.
+//
+// As anotacoes de tipo dentro das declaracoes devolvidas ja saem
+// RESOLVIDAS (nomes de instancia qualificados no lugar de GenericType cru):
+// loadModuleDeclarations roda validator.Compile(program) antes de devolver,
+// e resolveSignatureAnnotations/resolveStructFieldAnnotations mutam o AST
+// in-place durante esse Compile — o mesmo mecanismo que faz o proprio
+// modulo compilar corretamente sozinho.
+func (c *Compiler) moduleTopLevelBindings(module string) (map[string]ast.Statement, bool) {
+	state := c.moduleDiscovery
+	if state == nil {
+		state = &moduleDiscoveryState{active: make(map[string]bool)}
+	}
+	program, _, ok := c.loadModuleDeclarations(module, state)
+	if !ok {
+		return nil, false
+	}
+	declarations := make(map[string]ast.Statement)
+	if program == nil {
+		// Modulo de diretorio: sem declaracoes de topo proprias.
+		return declarations, true
+	}
+	for _, statement := range program.Statements {
+		switch declaration := statement.(type) {
+		case *ast.FunctionStatement:
+			declarations[declaration.Name] = declaration
+		case *ast.StructStatement:
+			declarations[declaration.Name] = declaration
+		case *ast.LetStmt:
+			declarations[declaration.Name.Value] = declaration
+		}
+	}
+	return declarations, true
+}
+
+// importBindingFrom registra UM nome importado de module no compilador
+// atual (§8, predeclare tipado + import de templates, R8):
+//
+//   - template generico (TypeParams>0): entra no GenericRegistry com
+//     Module = moduleQualifier(module) — NAO em c.globals, que e so para
+//     valores em runtime. E o registro que faz `use colecoes select
+//     processa` disparar compileGenericCallSite/compileGenericConstructorSite
+//     para "processa" como se fosse um template local, so que instanciando
+//     com Module="colecoes" (identidade de instancia distinta de um
+//     template homonimo de outro modulo — R8).
+//   - func/let/struct comum: entra em c.globals com o TIPO DECLARADO (nao
+//     mais apagado para nil) — e a mudanca central do §8 que destrava
+//     inferencia sobre dado importado (TestImportedDataInference).
+//   - nome que declarations nao resolve (submodulo de diretorio, export
+//     vindo de um `use` aninhado sem entrada propria aqui): mantem o
+//     comportamento anterior a Task 12 (tipo apagado) em vez de quebrar o
+//     import — degrada, nao regride.
+func (c *Compiler) importBindingFrom(module string, declarations map[string]ast.Statement, name string) error {
+	switch declaration := declarations[name].(type) {
+	case *ast.FunctionStatement:
+		if len(declaration.TypeParams) > 0 {
+			return c.registerFuncTemplate(name, &FuncTemplate{Decl: declaration, Module: moduleQualifier(module)}, declaration.Token.Line)
+		}
+		c.globals[name] = newFunctionType(declaration.Parameters, declaration.ReturnType)
+	case *ast.StructStatement:
+		if len(declaration.TypeParams) > 0 {
+			return c.registerStructTemplate(name, &StructTemplate{Decl: declaration, Module: moduleQualifier(module)}, declaration.Token.Line)
+		}
+		params := make([]ast.NoxyType, len(declaration.FieldsList))
+		for index, field := range declaration.FieldsList {
+			params[index] = field.Type
+		}
+		c.globals[name] = newStructFunctionType(declaration.Name, params)
+	case *ast.LetStmt:
+		c.globals[name] = declaration.Type
+	default:
 		c.globals[name] = nil
+	}
+	return nil
+}
+
+// importedBindingType devolve o tipo declarado, no modulo definidor, de um
+// binding NAO-generico exportado por module — a metade "modulo definidor"
+// da checagem de identidade do §8 (validateImportedTemplateScope, em
+// generics.go): o mesmo dado que importBindingFrom usa para popular
+// c.globals no IMPORTADOR, olhado da perspectiva de quem define. ok=false
+// para um nome que e um template generico (sem tipo de valor — ver
+// validateImportedTemplateScope, que trata esse caso separadamente
+// consultando o registry) ou que module simplesmente nao declara.
+func (c *Compiler) importedBindingType(module, name string) (ast.NoxyType, bool) {
+	bindings, ok := c.moduleTopLevelBindings(module)
+	if !ok {
+		return nil, false
+	}
+	switch declaration := bindings[name].(type) {
+	case *ast.FunctionStatement:
+		if len(declaration.TypeParams) > 0 {
+			return nil, false
+		}
+		return newFunctionType(declaration.Parameters, declaration.ReturnType), true
+	case *ast.StructStatement:
+		if len(declaration.TypeParams) > 0 {
+			return nil, false
+		}
+		params := make([]ast.NoxyType, len(declaration.FieldsList))
+		for index, field := range declaration.FieldsList {
+			params[index] = field.Type
+		}
+		return newStructFunctionType(declaration.Name, params), true
+	case *ast.LetStmt:
+		return declaration.Type, true
+	default:
+		return nil, false
+	}
+}
+
+// importNamespace registra `use m [as alias]` (forma de namespace, sem
+// select): o modulo entra em c.globals como objeto opaco (sem tipo
+// estatico — nao ha "tipo de modulo" na linguagem, e por isso o nome
+// continua apagado para nil aqui, ao contrario de importBindingFrom) e o
+// par alias->modulo fica em c.namespaceImports, para que compileCallExpression
+// recuse `m.processa(...)` em tempo de compilacao (§8/§9: "não é acessível
+// via namespace") em vez de falhar em runtime com uma mensagem generica de
+// propriedade nao encontrada.
+func (c *Compiler) importNamespace(module, bindName string) {
+	c.globals[bindName] = nil
+	if c.namespaceImports == nil {
+		c.namespaceImports = make(map[string]string)
+	}
+	c.namespaceImports[bindName] = module
+}
+
+// moduleExportsGenericTemplateName responde se module declara, no seu top
+// level, um template generico (func ou struct) chamado name — a consulta
+// que o erro de namespace do §9 faz antes de recusar `m.name(...)`.
+func (c *Compiler) moduleExportsGenericTemplateName(module, name string) bool {
+	bindings, ok := c.moduleTopLevelBindings(module)
+	if !ok {
+		return false
+	}
+	return isModuleTemplateDeclaration(bindings, name)
+}
+
+// isModuleTemplateDeclaration responde se declarations[name] e um template
+// generico (func ou struct com TypeParams>0) — usado tanto pelo erro de
+// namespace quanto pelo case *ast.UseStmt de compiler.go (para pular o
+// GET_PROPERTY de runtime num `select` que nomeia um template, que nunca
+// tem chave no ExportMap do modulo).
+func isModuleTemplateDeclaration(declarations map[string]ast.Statement, name string) bool {
+	switch declaration := declarations[name].(type) {
+	case *ast.FunctionStatement:
+		return len(declaration.TypeParams) > 0
+	case *ast.StructStatement:
+		return len(declaration.TypeParams) > 0
+	default:
+		return false
 	}
 }
 

--- a/internal/compiler/module_exports_test.go
+++ b/internal/compiler/module_exports_test.go
@@ -255,6 +255,83 @@ func TestFunctionBodyOnlyWildcardDoesNotAffectModuleLoadability(t *testing.T) {
 	}
 }
 
+// C1: loadModuleDeclarations e memoizado por moduleDiscoveryState, e o
+// estado vive no compilador (discoveryState()) em vez de ser fabricado
+// descartavel a cada chamada. Sem o memo, um unico `use` pagava um parse +
+// um Compile completo de validacao POR CHAMADOR — predeclareImportedTemplates
+// (discoverModuleExports + moduleTopLevelBindings), predeclareImport e o case
+// *ast.UseStmt de compiler.go —, tudo dobrado pelo two-pass dos genericos:
+// `use http select *` foi de 1,4s para 12,3s de startup.
+//
+// Duas provas: identidade de ponteiro do AST devolvido e sobrevivencia a
+// remocao do arquivo entre as duas chamadas (um reparse falharia).
+func TestModuleDeclarationsAreMemoizedPerCompiler(t *testing.T) {
+	root := t.TempDir()
+	modulePath := filepath.Join(root, "dep.nx")
+	if err := os.WriteFile(modulePath, []byte("func delete(url: string) -> void\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+
+	first, _, loadable := compiler.loadModuleDeclarations("dep", compiler.discoveryState())
+	if !loadable || first == nil {
+		t.Fatal("primeira carga de 'dep' falhou")
+	}
+	if err := os.Remove(modulePath); err != nil {
+		t.Fatal(err)
+	}
+
+	second, _, loadable := compiler.loadModuleDeclarations("dep", compiler.discoveryState())
+	if !loadable {
+		t.Fatal("segunda carga foi ao disco (arquivo removido) em vez de acertar o memo")
+	}
+	if first != second {
+		t.Fatal("segunda carga devolveu outro AST — o memo nao e compartilhado entre chamadas")
+	}
+	exports, loadable := compiler.discoverModuleExports("dep")
+	if !loadable {
+		t.Fatal("discoverModuleExports nao aproveitou o memo")
+	}
+	if _, hasDelete := exports["delete"]; !hasDelete {
+		t.Fatalf("exports memoizados = %v, quer 'delete'", exports)
+	}
+}
+
+// C1, segunda metade: o compilador descartavel do pass 1 dos genericos
+// compartilha o cache com o pass 2 (newPass1Compiler usa discoveryState()).
+// Se cada passada tivesse cache proprio, todo modulo importado seria
+// carregado duas vezes num programa com genericos. A prova e de identidade: o
+// template registrado no fim da compilacao aponta para uma declaracao DENTRO
+// do Program memoizado, ou seja, so existiu um AST do modulo.
+func TestGenericsTwoPassSharesModuleCache(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "dep.nx"), []byte("func ident<T>(x: T) -> T\n    return x\nend\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	compiler := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"))
+	if _, _, err := compiler.Compile(parse("use dep select ident\nident(1)")); err != nil {
+		t.Fatal(err)
+	}
+
+	cached, memoized := compiler.discoveryState().loaded["dep"]
+	if !memoized || cached.program == nil {
+		t.Fatal("modulo 'dep' nao ficou memoizado apos a compilacao")
+	}
+	template, registered := compiler.registryOrInit().Funcs["ident"]
+	if !registered {
+		t.Fatal("template importado 'ident' nao chegou ao registry")
+	}
+	found := false
+	for _, statement := range cached.program.Statements {
+		if statement == ast.Statement(template.Decl) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("o template registrado nao aponta para o AST memoizado — pass 1 e pass 2 recarregaram o modulo separadamente")
+	}
+}
+
 func TestNestedModuleDiscoveryUsesProgramRoot(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/parser/generics_parser_test.go
+++ b/internal/parser/generics_parser_test.go
@@ -1,0 +1,56 @@
+package parser
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+	"testing"
+)
+
+func parseProgramNoErrors(t *testing.T, src string) *ast.Program {
+	t.Helper()
+	p := New(lexer.New(src))
+	prog := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("erros de parse: %v", errs)
+	}
+	return prog
+}
+
+func TestParseGenericFunctionDeclaration(t *testing.T) {
+	prog := parseProgramNoErrors(t, "func first<T>(arr: T[]) -> T\n    return arr[0]\nend")
+	fn := prog.Statements[0].(*ast.FunctionStatement)
+	if len(fn.TypeParams) != 1 || fn.TypeParams[0] != "T" {
+		t.Fatalf("TypeParams = %v, quer [T]", fn.TypeParams)
+	}
+	arr := fn.Parameters[0].Type.(*ast.ArrayType)
+	if _, ok := arr.ElementType.(*ast.TypeParamType); !ok {
+		t.Fatalf("param deve ser T[] com TypeParamType, veio %T", arr.ElementType)
+	}
+	if _, ok := fn.ReturnType.(*ast.TypeParamType); !ok {
+		t.Fatalf("retorno deve ser TypeParamType, veio %T", fn.ReturnType)
+	}
+}
+
+func TestParseGenericStructDeclaration(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Pair<A, B>\n    left: A,\n    right: B\nend")
+	st := prog.Statements[0].(*ast.StructStatement)
+	if len(st.TypeParams) != 2 || st.TypeParams[0] != "A" || st.TypeParams[1] != "B" {
+		t.Fatalf("TypeParams = %v, quer [A B]", st.TypeParams)
+	}
+	if _, ok := st.FieldsList[0].Type.(*ast.TypeParamType); !ok {
+		t.Fatalf("campo left deve ser TypeParamType, veio %T", st.FieldsList[0].Type)
+	}
+}
+
+func TestTypeParamScopeEndsWithDeclaration(t *testing.T) {
+	// Depois do template, T fora de escopo volta a ser tipo comum (struct/nome)
+	prog := parseProgramNoErrors(t, "func id<T>(x: T) -> T\n    return x\nend\nlet a: int = 1")
+	if len(prog.Statements) != 2 {
+		t.Fatalf("esperava 2 statements, veio %d", len(prog.Statements))
+	}
+}
+
+// TestGenericSelfReferenceInStruct exige GenericType em posicao de tipo
+// (Stack<T> como anotacao), que e' implementado na Task 4. Movido para
+// internal/parser/generics_parser_test.go da Task 4 por decisao do brief da
+// Task 3 (§ "mover para Task 4 se ainda falhar ao fim desta").

--- a/internal/parser/generics_parser_test.go
+++ b/internal/parser/generics_parser_test.go
@@ -51,6 +51,59 @@ func TestTypeParamScopeEndsWithDeclaration(t *testing.T) {
 }
 
 // TestGenericSelfReferenceInStruct exige GenericType em posicao de tipo
-// (Stack<T> como anotacao), que e' implementado na Task 4. Movido para
-// internal/parser/generics_parser_test.go da Task 4 por decisao do brief da
-// Task 3 (§ "mover para Task 4 se ainda falhar ao fim desta").
+// (Stack<T> como anotacao). Relocado da Task 3 para a Task 4 por decisao do
+// brief da Task 3 (§ "mover para Task 4 se ainda falhar ao fim desta"), pois
+// so a Task 4 implementa GenericType em posicao de anotacao.
+func TestGenericSelfReferenceInStruct(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Node<T>\n    value: T,\n    next: ref Node<T>\nend")
+	st := prog.Statements[0].(*ast.StructStatement)
+	next := st.FieldsList[1].Type.(*ast.RefType)
+	g := next.ElementType.(*ast.GenericType)
+	if g.Name != "Node" {
+		t.Fatalf("auto-referencia Node<T>, veio %s", g.String())
+	}
+	if _, ok := g.Args[0].(*ast.TypeParamType); !ok {
+		t.Fatalf("arg de Node<T> deve ser TypeParamType, veio %T", g.Args[0])
+	}
+}
+
+func TestParseGenericTypeAnnotation(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<int> = null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	g := let.Type.(*ast.GenericType)
+	if g.String() != "Stack<int>" {
+		t.Fatalf("tipo = %s, quer Stack<int>", g.String())
+	}
+}
+
+func TestParseNestedGenericTypeSplitsShiftRight(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<Stack<int>> = null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	if got := let.Type.String(); got != "Stack<Stack<int>>" {
+		t.Fatalf("tipo = %s", got)
+	}
+}
+
+func TestParseGenericTypeSplitsGTEBeforeAssign(t *testing.T) {
+	// sem espaco entre > e = : lexa GTE e o parser precisa dividir
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet s: Stack<int>= null")
+	let := prog.Statements[1].(*ast.LetStmt)
+	if got := let.Type.String(); got != "Stack<int>" {
+		t.Fatalf("tipo = %s", got)
+	}
+	if let.Value == nil {
+		t.Fatal("valor do let perdido no split de GTE")
+	}
+}
+
+func TestGenericTypeComposesWithArrayAndRef(t *testing.T) {
+	prog := parseProgramNoErrors(t, "struct Stack<T>\n    items: T[]\nend\nlet a: Stack<int>[] = []\nlet r: ref Stack<int> = null")
+	arr := prog.Statements[1].(*ast.LetStmt).Type.(*ast.ArrayType)
+	if arr.ElementType.String() != "Stack<int>" {
+		t.Fatalf("elemento = %s", arr.ElementType.String())
+	}
+	ref := prog.Statements[2].(*ast.LetStmt).Type.(*ast.RefType)
+	if ref.ElementType.String() != "Stack<int>" {
+		t.Fatalf("ref elemento = %s", ref.ElementType.String())
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -18,6 +18,11 @@ type Parser struct {
 	infixParseFns  map[token.TokenType]func(ast.Expression) ast.Expression
 
 	errors []string
+
+	// activeTypeParams contem os nomes de parametros de tipo (T, U, ...) em
+	// escopo durante o parse de uma declaracao generica (func ou struct).
+	// nil quando fora de uma declaracao generica.
+	activeTypeParams map[string]bool
 }
 
 func New(l *lexer.Lexer) *Parser {
@@ -693,6 +698,9 @@ func (p *Parser) parseAtomicType() ast.NoxyType {
 	case token.BYTES: // This is Literal 'b"..."'.
 		t = &ast.PrimitiveType{Name: "bytes"}
 	case token.IDENTIFIER:
+		if p.activeTypeParams[p.curToken.Literal] {
+			return &ast.TypeParamType{Name: p.curToken.Literal}
+		}
 		name := p.curToken.Literal
 		// Support dot notation for types (e.g. io.File)
 		for p.peekTokenIs(token.DOT) {
@@ -1089,6 +1097,28 @@ func (p *Parser) parseCaseBody() *ast.BlockStatement {
 	return block
 }
 
+// parseTypeParameters consome <T, U> apos o nome de uma declaracao generica.
+// curToken esta no nome; ao retornar, curToken esta no GT final.
+func (p *Parser) parseTypeParameters() []string {
+	p.nextToken() // eat <
+	names := []string{}
+	for {
+		if !p.expectPeek(token.IDENTIFIER) {
+			return nil
+		}
+		names = append(names, p.curToken.Literal)
+		if p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			continue
+		}
+		break
+	}
+	if !p.expectPeek(token.GT) {
+		return nil
+	}
+	return names
+}
+
 func (p *Parser) parseFunctionStatement() *ast.FunctionStatement {
 	stmt := &ast.FunctionStatement{Token: p.curToken}
 
@@ -1096,6 +1126,19 @@ func (p *Parser) parseFunctionStatement() *ast.FunctionStatement {
 		return nil
 	}
 	stmt.Name = p.curToken.Literal
+
+	// Parametros de tipo opcionais: func nome<T, U>(...)
+	if p.peekTokenIs(token.LT) {
+		stmt.TypeParams = p.parseTypeParameters()
+		if stmt.TypeParams == nil {
+			return nil
+		}
+		p.activeTypeParams = map[string]bool{}
+		for _, name := range stmt.TypeParams {
+			p.activeTypeParams[name] = true
+		}
+		defer func() { p.activeTypeParams = nil }()
+	}
 
 	if !p.expectPeek(token.LPAREN) {
 		return nil
@@ -1440,9 +1483,22 @@ func (p *Parser) parseStructStatement() *ast.StructStatement {
 	}
 	stmt.Name = p.curToken.Literal
 
+	// Parametros de tipo opcionais: struct Nome<T, U>
+	if p.peekTokenIs(token.LT) {
+		stmt.TypeParams = p.parseTypeParameters()
+		if stmt.TypeParams == nil {
+			return nil
+		}
+		p.activeTypeParams = map[string]bool{}
+		for _, name := range stmt.TypeParams {
+			p.activeTypeParams[name] = true
+		}
+		defer func() { p.activeTypeParams = nil }()
+	}
+
 	stmt.FieldsList = []*ast.StructField{}
 
-	p.nextToken() // move past Name.
+	p.nextToken() // move past Name (or GT, when generic).
 
 	for !p.curTokenIs(token.END) && !p.curTokenIs(token.EOF) {
 		if p.curTokenIs(token.NEWLINE) || p.curTokenIs(token.COMMA) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -23,6 +23,11 @@ type Parser struct {
 	// escopo durante o parse de uma declaracao generica (func ou struct).
 	// nil quando fora de uma declaracao generica.
 	activeTypeParams map[string]bool
+
+	// pendingTokens e' uma fila de tokens sinteticos gerados por
+	// splitCompositeGT (ex.: SHIFT_RIGHT dividido em dois GT). nextToken
+	// drena esta fila antes de pedir um novo token ao lexer.
+	pendingTokens []token.Token
 }
 
 func New(l *lexer.Lexer) *Parser {
@@ -98,6 +103,11 @@ func (p *Parser) peekError(t token.TokenType) {
 
 func (p *Parser) nextToken() {
 	p.curToken = p.peekToken
+	if len(p.pendingTokens) > 0 {
+		p.peekToken = p.pendingTokens[0]
+		p.pendingTokens = p.pendingTokens[1:]
+		return
+	}
 	p.peekToken = p.l.NextToken()
 }
 
@@ -710,6 +720,29 @@ func (p *Parser) parseAtomicType() ast.NoxyType {
 			}
 			name += "." + p.curToken.Literal
 		}
+		// Tipo generico em posicao de anotacao: Nome<arg1, arg2>
+		if p.peekTokenIs(token.LT) {
+			p.nextToken() // eat nome; curToken = <
+			args := []ast.NoxyType{}
+			for {
+				p.nextToken() // avanca para o inicio do proximo tipo
+				arg := p.parseType()
+				if arg == nil {
+					return nil
+				}
+				args = append(args, arg)
+				p.splitCompositeGT() // divide >> ou >= pendentes ANTES de checar peek
+				if p.peekTokenIs(token.COMMA) {
+					p.nextToken()
+					continue
+				}
+				break
+			}
+			if !p.expectPeek(token.GT) {
+				return nil
+			}
+			return &ast.GenericType{Name: name, Args: args}
+		}
 		t = &ast.PrimitiveType{Name: name}
 	case token.MAP:
 		// map[key, val]
@@ -742,6 +775,24 @@ func (p *Parser) parseAtomicType() ast.NoxyType {
 		return nil
 	}
 	return t
+}
+
+// splitCompositeGT divide tokens compostos que contem '>' quando estamos
+// esperando fechar uma lista de argumentos de tipo (truque C#/Java):
+//
+//	>>  ->  > + >   (Stack<Stack<int>>)
+//	>=  ->  > + =   (let s: Stack<int>= v)
+func (p *Parser) splitCompositeGT() {
+	switch p.peekToken.Type {
+	case token.SHIFT_RIGHT:
+		gt := token.Token{Type: token.GT, Literal: ">", Line: p.peekToken.Line, Column: p.peekToken.Column}
+		p.pendingTokens = append([]token.Token{gt}, p.pendingTokens...)
+		p.peekToken = gt
+	case token.GTE:
+		assign := token.Token{Type: token.ASSIGN, Literal: "=", Line: p.peekToken.Line, Column: p.peekToken.Column + 1}
+		p.pendingTokens = append([]token.Token{assign}, p.pendingTokens...)
+		p.peekToken = token.Token{Type: token.GT, Literal: ">", Line: p.peekToken.Line, Column: p.peekToken.Column}
+	}
 }
 
 func (p *Parser) parseFunctionType() ast.NoxyType {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.6.0"
+const Version = "v0.7.0"

--- a/internal/vm/builtins_codes_test.go
+++ b/internal/vm/builtins_codes_test.go
@@ -99,7 +99,11 @@ test_report(codes(b"raw"))`
 	machine.DefineNative("test_report", func([]value.Value) value.Value {
 		return value.NewNull()
 	})
-	err := interpretVMSource(t, machine, source)
+	// Task 12 (§8): `use strings select *` now predeclares `codes` with its
+	// declared type instead of erasing it to nil, so the mismatch is caught
+	// at compile time instead of at runtime — same message, earlier stage.
+	// interpretOrCompileErr accepts either.
+	err := interpretOrCompileErr(t, machine, source)
 	if err == nil {
 		t.Fatal("codes(bytes) returned with no error; want a raised type error")
 	}

--- a/internal/vm/builtins_strings_test.go
+++ b/internal/vm/builtins_strings_test.go
@@ -380,7 +380,14 @@ test_report(is_valid_utf8("text"))`
 		}
 		return value.NewNull()
 	})
-	err := interpretVMSource(t, machine, source)
+	// Task 12 (§8): `use strings select *` now predeclares is_valid_utf8 with
+	// its declared `b: bytes` type instead of erasing it to nil, so this
+	// mismatch is caught at compile time rather than reaching the native at
+	// runtime — same message ("expected bytes, got string"), earlier stage.
+	// interpretOrCompileErr accepts either, since the fix documented above
+	// (requireBytesArgument) is now backed up, not superseded, by a static
+	// check.
+	err := interpretOrCompileErr(t, machine, source)
 	if err == nil {
 		t.Fatalf("is_valid_utf8(\"text\") through use strings select * returned %#v with no error; want a raised type error", captured)
 	}

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -218,6 +218,56 @@ test_report(head_twice(xs, ys))
 	expectInt(t, got, 2, "cascata generico->generico")
 }
 
+// Regressao (C2 da revisao final de branch): um nome de template CAPTURADO
+// por uma closure (upvalue) tem de perder para o binding capturado, nao para
+// o template. Os guards de call site em compileCallExpression checavam so
+// resolveLocal — o upvalue escapava, a chamada era interceptada como
+// generica e o programa devolvia 21 (id<int>(21)) em vez de 42 (dobro(21)),
+// silenciosamente. isShadowedByLocal (locais E upvalues) e a regra que todos
+// os outros hooks do §3/§4 ja usavam.
+func TestGenericTemplateShadowedByUpvalue(t *testing.T) {
+	got := captureVMSource(t, `
+func dobro(x: int) -> int
+    return x * 2
+end
+func id<T>(x: T) -> T
+    return x
+end
+func run() -> int
+    let id: func(int) -> int = dobro
+    let f: func(int) -> int = func(v: int) -> int
+        return id(v)
+    end
+    return f(21)
+end
+test_report(run())
+`)
+	expectInt(t, got, 42, "upvalue sombreia o template generico homonimo")
+}
+
+// Par do teste acima para CONSTRUTOR de struct generico: o mesmo guard
+// (segunda metade do C2) protege `Caixa(...)` quando `Caixa` foi capturado
+// como upvalue por uma closure.
+func TestGenericStructTemplateShadowedByUpvalue(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+func incrementa(x: int) -> int
+    return x + 1
+end
+func run() -> int
+    let Caixa: func(int) -> int = incrementa
+    let f: func(int) -> int = func(v: int) -> int
+        return Caixa(v)
+    end
+    return f(41)
+end
+test_report(run())
+`)
+	expectInt(t, got, 42, "upvalue sombreia o template de struct homonimo")
+}
+
 // §3 target-typing: `let` anotado com um tipo de funcao concreto e o alvo que
 // instancia identity<int> — a genérica vira closure comum sem call site
 // nenhum.

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -306,6 +306,28 @@ test_report(mesmos[2])
 	expectInt(t, got, 3, "unificacao bidirecional")
 }
 
+// I5 da revisao final de branch, E2E: uma generica cujo PARAMETRO e um struct
+// generico (`pega<T>(c: Caixa<T>)`) passada como valor-argumento. O template
+// escreve `Caixa<T>` e o tipo observado no site e `main::Caixa<int>` — sem a
+// ponte de expandInstanceNames na unificacao bidirecional, o programa nao
+// compilava ("esperava main::Caixa<int>, encontrado Caixa<T>").
+func TestBidirectionalArgumentWithGenericStructParam(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+func pega<T>(c: Caixa<T>) -> T
+    return c.valor
+end
+func aplica<A, B>(x: A, fn: func(A) -> B) -> B
+    return fn(x)
+end
+let c: Caixa<int> = Caixa(42)
+test_report(aplica(c, pega))
+`)
+	expectInt(t, got, 42, "struct generico como parametro do argumento-template")
+}
+
 // §3: elemento de array literal (tipo do elemento vem da anotacao do `let`
 // envolvente) e posicao de retorno (tipo de retorno declarado da funcao
 // corrente). A sintaxe de array-de-funcao exige parenteses

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -42,6 +42,23 @@ test_report(soma_rec(xs, 0))
 	expectInt(t, got, 3, "recursao generica")
 }
 
+// Chamada generica de dentro de um corpo NAO-generico: o predeclare nao
+// registra mais o template em globals, entao a interceptacao (via registry) e
+// a unica coisa que faz este programa compilar.
+func TestGenericCalledFromNonGenericBody(t *testing.T) {
+	got := captureVMSource(t, `
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+func run() -> int
+    let xs: int[] = [42]
+    return first(xs)
+end
+test_report(run())
+`)
+	expectInt(t, got, 42, "chamada generica dentro de corpo nao-generico")
+}
+
 func TestGenericCallsGeneric(t *testing.T) {
 	got := captureVMSource(t, `
 func first<T>(arr: T[]) -> T

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -217,3 +217,64 @@ test_report(head_twice(xs, ys))
 `)
 	expectInt(t, got, 2, "cascata generico->generico")
 }
+
+// §3 target-typing: `let` anotado com um tipo de funcao concreto e o alvo que
+// instancia identity<int> — a genérica vira closure comum sem call site
+// nenhum.
+func TestTargetTypingLetAnnotation(t *testing.T) {
+	got := captureVMSource(t, `
+func identity<T>(x: T) -> T
+    return x
+end
+let f: func(int) -> int = identity
+test_report(f(5))
+`)
+	expectInt(t, got, 5, "identity instanciada por anotacao de let")
+}
+
+// §3 unificação bidirecional: aplica(nums, identity) — A=int ancora pelo
+// argumento nao-generico primeiro; o parametro esperado func(A)->B (ja com
+// A=int) unifica contra func(T)->T do template do argumento, propagando
+// T=int => B=int. As duas instancias (aplica<int,int> e identity<int>) nascem
+// do mesmo call site.
+func TestTargetTypingBidirectionalArgument(t *testing.T) {
+	got := captureVMSource(t, `
+func identity<T>(x: T) -> T
+    return x
+end
+func aplica<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+let nums: int[] = [1, 2, 3]
+let mesmos: int[] = aplica(nums, identity)
+test_report(mesmos[2])
+`)
+	expectInt(t, got, 3, "unificacao bidirecional")
+}
+
+// §3: elemento de array literal (tipo do elemento vem da anotacao do `let`
+// envolvente) e posicao de retorno (tipo de retorno declarado da funcao
+// corrente). A sintaxe de array-de-funcao exige parenteses
+// (`(func(int) -> int)[]`) porque `func(int) -> int[]` parseia como "retorna
+// int[]" — precedencia de `[]` documentada em parseType/parseAtomicType.
+func TestTargetTypingArrayElementAndReturn(t *testing.T) {
+	got := captureVMSource(t, `
+func dobro(x: int) -> int
+    return x * 2
+end
+func identity<T>(x: T) -> T
+    return x
+end
+func escolhe() -> func(int) -> int
+    return identity
+end
+let fs: (func(int) -> int)[] = [dobro, identity]
+let g: func(int) -> int = escolhe()
+test_report(fs[1](10) + g(1))
+`)
+	expectInt(t, got, 11, "array de funcoes e return position")
+}

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -153,6 +153,23 @@ test_report(topo(p))
 	expectInt(t, got, 42, "Pilha<int> empilhada e lida por funcoes genericas")
 }
 
+// Instancia pedida SO dentro de um corpo de funcao: a declaracao sintetica e
+// prependada no topo do programa, entao o construtor ja e um global definido
+// quando a funcao roda.
+func TestGenericStructInstanceFromFunctionBody(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+func cria() -> int
+    let local: Caixa<string> = Caixa("abc")
+    return length(local.valor)
+end
+test_report(cria())
+`)
+	expectInt(t, got, 3, "instancia criada dentro de corpo nao-generico")
+}
+
 // Instancia como elemento de array e valor de map: as anotacoes compostas
 // preservam a estrutura externa e a runtime type info do container e completa.
 func TestGenericStructInsideContainers(t *testing.T) {

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -59,6 +59,132 @@ test_report(run())
 	expectInt(t, got, 42, "chamada generica dentro de corpo nao-generico")
 }
 
+// §4 terceira familia de hooks: struct generico instanciado por construtor
+// posicional; a instancia e um struct comum no pass 2 (member access, mutacao
+// de campo, validacao CoW por identidade nominal do nome qualificado).
+func TestGenericStructConstructorAndAccess(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let c: Caixa<int> = Caixa(41)
+c.valor = c.valor + 1
+test_report(c.valor)
+`)
+	expectInt(t, got, 42, "Caixa<int> construida e mutada")
+}
+
+func TestGenericStructAnnotationOnlyPositions(t *testing.T) {
+	// §11: instanciacao por anotacao pura — sem call site de construtor
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let vazias: Caixa<int>[] = []
+let semInit: Caixa<int>
+func conta(cs: Caixa<int>[]) -> int
+    return length(cs)
+end
+test_report(conta(vazias))
+`)
+	expectInt(t, got, 0, "anotacoes puras instanciam o struct")
+}
+
+func TestGenericStructSelfReference(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node<T>
+    value: T,
+    next: ref Node<T>
+end
+let n2: Node<int> = Node(2, null)
+let n1: Node<int> = Node(1, ref n2)
+test_report(n1.next.value)
+`)
+	expectInt(t, got, 2, "lista ligada generica")
+}
+
+func TestNestedGenericStruct(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let dupla: Caixa<Caixa<int>> = Caixa(Caixa(9))
+test_report(dupla.valor.valor)
+`)
+	expectInt(t, got, 9, "Caixa<Caixa<int>>")
+}
+
+// §10: a instancia e um tipo nominal comum, entao a semantica de valor (CoW) e
+// a validacao de tipo em runtime valem para ela sem nenhuma mudanca de VM — a
+// copia nao alcanca o original.
+func TestGenericStructValueSemantics(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let a: Caixa<int> = Caixa(1)
+let b: Caixa<int> = a
+b.valor = 99
+test_report(a.valor)
+`)
+	expectInt(t, got, 1, "mutacao da copia nao alcanca o original")
+}
+
+// §11: Stack<T> manipulada por funcoes genericas. Duas coisas de uma vez: o
+// construtor sem ancora nos argumentos (`Pilha([])`, resolvido pelo hint da
+// anotacao do `let`) e a unificacao de `Pilha<T>` — a anotacao do template —
+// contra o tipo concreto `main::Pilha<int>` do argumento.
+func TestGenericStructWithGenericFunctions(t *testing.T) {
+	got := captureVMSource(t, `
+struct Pilha<T>
+    itens: T[]
+end
+func empilha<T>(p: ref Pilha<T>, v: T)
+    append(p.itens, v)
+end
+func topo<T>(p: Pilha<T>) -> T
+    return p.itens[length(p.itens) - 1]
+end
+let p: Pilha<int> = Pilha([])
+empilha(ref p, 7)
+empilha(ref p, 42)
+test_report(topo(p))
+`)
+	expectInt(t, got, 42, "Pilha<int> empilhada e lida por funcoes genericas")
+}
+
+// Instancia como elemento de array e valor de map: as anotacoes compostas
+// preservam a estrutura externa e a runtime type info do container e completa.
+func TestGenericStructInsideContainers(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let cs: Caixa<int>[] = [Caixa(1), Caixa(2)]
+let m: map[string, Caixa<int>] = {"a": Caixa(39)}
+test_report(cs[1].valor + m["a"].valor)
+`)
+	expectInt(t, got, 41, "instancia dentro de array e de map")
+}
+
+// R5: a variavel de for-each ganha o tipo do elemento da colecao quando ele e
+// estaticamente conhecido — sem isso a variavel entra com tipo nil e nenhuma
+// chamada generica ancorada nela consegue inferir T.
+func TestGenericCallAnchoredOnLoopVariable(t *testing.T) {
+	got := captureVMSource(t, `
+func identity<T>(x: T) -> T
+    return x
+end
+let nums: int[] = [10, 20, 12]
+let total: int = 0
+for v in nums do
+    total = total + identity(v)
+end
+test_report(total)
+`)
+	expectInt(t, got, 42, "T=int inferido da variavel do for-each")
+}
+
 func TestGenericCallsGeneric(t *testing.T) {
 	got := captureVMSource(t, `
 func first<T>(arr: T[]) -> T

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -1,0 +1,59 @@
+package vm
+
+// E2E de genericos por monomorfizacao (spec §4/§5): o programa inteiro passa
+// pelo two-pass do compilador e roda na VM sem qualquer mudanca de runtime.
+
+import "testing"
+
+func TestGenericFunctionEndToEnd(t *testing.T) {
+	got := captureVMSource(t, `
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+let nums: int[] = [7, 8]
+test_report(first(nums))
+`)
+	expectInt(t, got, 7, "first<int> deve devolver 7")
+}
+
+func TestGenericTwoInstantiations(t *testing.T) {
+	got := captureVMSource(t, `
+func size<T>(arr: T[]) -> int
+    return length(arr)
+end
+let nums: int[] = [1, 2, 3]
+let names: string[] = ["a"]
+test_report(size(nums) + size(names))
+`)
+	expectInt(t, got, 4, "size<int> + size<string>")
+}
+
+func TestGenericRecursion(t *testing.T) {
+	got := captureVMSource(t, `
+func soma_rec<T>(arr: T[], i: int) -> int
+    if i >= length(arr) then
+        return 0
+    end
+    return 1 + soma_rec(arr, i + 1)
+end
+let xs: string[] = ["a", "b", "c"]
+test_report(soma_rec(xs, 0))
+`)
+	expectInt(t, got, 3, "recursao generica")
+}
+
+func TestGenericCallsGeneric(t *testing.T) {
+	got := captureVMSource(t, `
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+func head_twice<T>(a: T[], b: T[]) -> T
+    let x: T = first(a)
+    return first(b)
+end
+let xs: int[] = [1]
+let ys: int[] = [2]
+test_report(head_twice(xs, ys))
+`)
+	expectInt(t, got, 2, "cascata generico->generico")
+}

--- a/internal/vm/generics_interactions_test.go
+++ b/internal/vm/generics_interactions_test.go
@@ -1,0 +1,117 @@
+package vm
+
+// Task 15 (spec §10/§11): interações de runtime E2E entre generics e as
+// demais features de linguagem — lambda, defer, spawn/task, when/case,
+// json, f-string e semântica de valor (CoW). Instâncias monomorfizadas são
+// código comum no pass 2: nenhuma dessas features precisa saber que um tipo
+// ou uma chamada veio de um template genérico.
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestLambdaInsideGenericBody(t *testing.T) {
+	got := captureVMSource(t, `
+func aplica_dobro<T>(x: T, f: func(T) -> T) -> T
+    return f(x)
+end
+let quadruplo: int = aplica_dobro(2, func(n: int) -> int
+    return n * 4
+end)
+test_report(quadruplo)
+`)
+	expectInt(t, got, 8, "lambda como argumento de generica")
+}
+
+// §11: defer registra a chamada no frame corrente (aqui, o script) e a
+// executa no fim do frame — o alvo é uma instância monomorfizada
+// (soma_caixa<int>) chamada com um struct genérico instanciado (Caixa<int>).
+func TestDeferWithInstantiatedGeneric(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+func soma_caixa<T>(c: Caixa<T>) -> T
+    return c.valor + c.valor
+end
+let c: Caixa<int> = Caixa(21)
+defer test_report(soma_caixa(c))
+`)
+	expectInt(t, got, 42, "defer chamando instancia generica")
+}
+
+// §11: spawn_task roda o worker em outra goroutine; o corpo do worker
+// constrói um Caixa<int> e chama uma função genérica instanciada sobre ele.
+// task_await sincroniza e devolve o envelope {status, value, error} comum a
+// qualquer task — nada disso muda por o valor ter vindo de generics.
+func TestSpawnWithInstantiatedGeneric(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+func triplica<T>(c: Caixa<T>) -> T
+    return c.valor + c.valor + c.valor
+end
+func worker() -> int
+    let c: Caixa<int> = Caixa(14)
+    return triplica(c)
+end
+let task: any = spawn_task(worker)
+let result: any = task_await(task)
+test_report(result["value"])
+`)
+	expectInt(t, got, 42, "spawn_task executando instancia generica")
+}
+
+// when/case é o select de canais da linguagem (cada `case` precisa ser
+// chan_recv/chan_send); aqui o valor que atravessa o canal é o campo de um
+// struct genérico instanciado, provando que Caixa<int>.valor é um int comum
+// tanto para chan_send quanto para o binding do case.
+func TestWhenOverGenericStruct(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let c: Caixa<int> = Caixa(7)
+let ch: any = make_chan(1)
+chan_send(ch, c.valor)
+when
+    case recebido = chan_recv(ch) then
+        test_report(recebido * 6)
+    default
+        test_report(-1)
+end
+`)
+	expectInt(t, got, 42, "when/case sobre campo de struct generico")
+}
+
+// f-string interpolando um campo de struct genérico e json_dumps serializando
+// a instância inteira — ambos tratam Caixa<int> como um struct nominal comum.
+func TestJSONAndFStringWithGenericStruct(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let c: Caixa<int> = Caixa(42)
+let mensagem: string = f"valor={c.valor}"
+let doc: string = json_dumps(c)
+test_report(mensagem == "valor=42" && doc == "{\"valor\":42}")
+`)
+	assertBuiltinValue(t, got, value.NewBool(true))
+}
+
+// §13: semantica de valor vale para structs genericos
+func TestCoWValueSemanticsWithGenericStruct(t *testing.T) {
+	got := captureVMSource(t, `
+struct Caixa<T>
+    valor: T
+end
+let a: Caixa<int> = Caixa(1)
+let b: Caixa<int> = a
+b.valor = 99
+test_report(a.valor)
+`)
+	expectInt(t, got, 1, "atribuicao de struct generico e copia (CoW)")
+}

--- a/internal/vm/generics_interactions_test.go
+++ b/internal/vm/generics_interactions_test.go
@@ -66,9 +66,13 @@ test_report(result["value"])
 }
 
 // when/case é o select de canais da linguagem (cada `case` precisa ser
-// chan_recv/chan_send); aqui o valor que atravessa o canal é o campo de um
-// struct genérico instanciado, provando que Caixa<int>.valor é um int comum
-// tanto para chan_send quanto para o binding do case.
+// chan_recv/chan_send). Aqui é a INSTÂNCIA Caixa<int> inteira que atravessa o
+// canal (não só o campo) — o binding do case (`bound`) tem tipo dinâmico
+// (nil) no compilador e vive só no escopo do case, então ele é copiado para
+// `recebida`, uma variável já declarada FORA do when, antes do `.valor` ser
+// lido depois do bloco. Isso prova que o valor monomorfizado sobrevive
+// intacto ao round-trip pelo canal, ao rebind de case e à passagem de escopo
+// — não apenas que um int qualquer chega do outro lado.
 func TestWhenOverGenericStruct(t *testing.T) {
 	got := captureVMSource(t, `
 struct Caixa<T>
@@ -76,15 +80,17 @@ struct Caixa<T>
 end
 let c: Caixa<int> = Caixa(7)
 let ch: any = make_chan(1)
-chan_send(ch, c.valor)
+chan_send(ch, c)
+let recebida: Caixa<int>
 when
-    case recebido = chan_recv(ch) then
-        test_report(recebido * 6)
+    case bound = chan_recv(ch) then
+        recebida = bound
     default
-        test_report(-1)
+        recebida = Caixa(-1)
 end
+test_report(recebida.valor * 6)
 `)
-	expectInt(t, got, 42, "when/case sobre campo de struct generico")
+	expectInt(t, got, 42, "when/case sobre struct generico inteiro (nao so o campo)")
 }
 
 // f-string interpolando um campo de struct genérico e json_dumps serializando

--- a/internal/vm/generics_modules_e2e_test.go
+++ b/internal/vm/generics_modules_e2e_test.go
@@ -1,0 +1,194 @@
+package vm
+
+// E2E cross-modulo de genericos (spec §8): templates importados, predeclare
+// tipado de imports, validacao de escopo de definicao e o erro de namespace.
+// Padrao de setup copiado de module_exports_test.go:21 (t.TempDir() +
+// os.WriteFile + compiler com RootPath apontando para o TempDir).
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/compiler"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+	"noxy-vm/internal/value"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// write grava source em root/name — helper compartilhado pelos testes deste
+// arquivo para montar modulos .nx num TempDir.
+func write(t *testing.T, root, name, source string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureVMSourceAtRoot compila e roda source com o RootPath do VM apontando
+// para root (para que `use <modulo>` resolva os arquivos escritos por
+// write), devolvendo o ultimo valor passado a test_report. Espelha
+// captureVMSource (vm_test_helpers_test.go), so com RootPath configurado —
+// mesmo padrao de compiler.NewWithStateAndRoot(...) que
+// module_exports_test.go:150 (compileModuleProgram) usa.
+func captureVMSourceAtRoot(t *testing.T, root, source string) value.Value {
+	t.Helper()
+	machine := NewWithConfig(VMConfig{RootPath: root})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	code := compileVMSourceAtRoot(t, root, source)
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	return captured
+}
+
+// compileVMSourceAtRoot compila source (sem rodar) com moduleRoot=root.
+func compileVMSourceAtRoot(t *testing.T, root, source string) *chunk.Chunk {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"), root).Compile(program)
+	if err != nil {
+		t.Fatalf("compiler error: %v", err)
+	}
+	return code
+}
+
+// compileErrAtRoot compila source com moduleRoot=root e devolve o erro (nil
+// se compilou com sucesso) — para os testes negativos deste arquivo, que so
+// querem inspecionar a mensagem de erro sem rodar a VM.
+func compileErrAtRoot(t *testing.T, root, source string) error {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	_, _, err := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filepath.Join(root, "main.nx"), root).Compile(program)
+	return err
+}
+
+func TestGenericCrossModuleSelectStar(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func primeiro<T>(arr: T[]) -> T
+    return arr[0]
+end
+`)
+	got := captureVMSourceAtRoot(t, root, `
+use colecoes select *
+let nums: int[] = [42]
+test_report(primeiro(nums))
+`)
+	expectInt(t, got, 42, "template importado por select *")
+}
+
+func TestGenericCrossModuleSelectiveWithDependency(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func ajuda(x: int) -> int
+    return x + 1
+end
+func processa<T>(arr: T[]) -> int
+    return ajuda(length(arr))
+end
+`)
+	// sem a dependencia: erro acionavel
+	err := compileErrAtRoot(t, root, "use colecoes select processa\nlet ns: int[] = [1]\nprocessa(ns)")
+	if err == nil || !strings.Contains(err.Error(), "adicione ao select") {
+		t.Fatalf("esperava erro de dependencia, veio %v", err)
+	}
+	// com a dependencia: funciona
+	got := captureVMSourceAtRoot(t, root, `
+use colecoes select processa, ajuda
+let ns: int[] = [1, 2]
+test_report(processa(ns))
+`)
+	expectInt(t, got, 3, "dependencia importada junto")
+}
+
+func TestGenericTemplateViaNamespaceIsError(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", "func primeiro<T>(arr: T[]) -> T\n    return arr[0]\nend\n")
+	err := compileErrAtRoot(t, root, "use colecoes\nlet ns: int[] = [1]\ncolecoes.primeiro(ns)")
+	if err == nil || !strings.Contains(err.Error(), "não é acessível via namespace") {
+		t.Fatalf("esperava erro de namespace, veio %v", err)
+	}
+}
+
+func TestImportedDataInference(t *testing.T) {
+	// §8: predeclare tipado — inferir T a partir de um global importado
+	root := t.TempDir()
+	write(t, root, "dados.nx", "let numeros: int[] = [5, 6]\n")
+	got := captureVMSourceAtRoot(t, root, `
+use dados select numeros
+func primeiro<T>(arr: T[]) -> T
+    return arr[0]
+end
+test_report(primeiro(numeros))
+`)
+	expectInt(t, got, 5, "inferencia sobre dado importado tipado")
+}
+
+func TestModuleUsingOwnTemplatesInternally(t *testing.T) {
+	// §5: compileAndRunModule tambem precisa do two-pass
+	root := t.TempDir()
+	write(t, root, "interno.nx", `
+func id<T>(x: T) -> T
+    return x
+end
+let resultado: int = id(11)
+`)
+	got := captureVMSourceAtRoot(t, root, "use interno select resultado\ntest_report(resultado)")
+	expectInt(t, got, 11, "modulo monomorfiza os proprios templates")
+}
+
+// TestHomonymousTemplatesDedupIsSafe prova a metade R8 do §8: dois modulos
+// com templates homonimos ("marca<T>") importados via select* nunca fazem
+// suas INSTANCIAS colidirem, mesmo que o registry (mapa FLAT por nome) so
+// consiga apontar para UM template por vez sob o nome "marca".
+//
+// r1 e chamado logo apos `use a select *` — nesse momento so o template de
+// "a" esta registrado sob "marca", entao marca(0) instancia e executa
+// a::marca<int> (corpo "return 1"), memoizado no two-pass do IMPORTADOR.
+// `use b select *` entao SOBRESCREVE a entrada de NOME do registry — mesmo
+// comportamento de "ultimo import vence" que select* ja tem hoje para
+// globals comuns (nao e uma regressao nova desta task). r2, chamado depois,
+// resolve "marca" contra o template de "b" e instancia b::marca<int> (corpo
+// "return 2") — um simbolo QUALIFICADO DIFERENTE de a::marca<int>, nunca o
+// mesmo global reescrito.
+//
+// A asserção concreta (r1==1 E r2==2, combinados num unico valor para caber
+// no captureVMSourceAtRoot, que so retem o ultimo test_report) prova as duas
+// metades de R8 ao mesmo tempo: a resolução por NOME de fato troca (r2 usa o
+// template de "b", não voltou a chamar o de "a" por engano) e a instância
+// JÁ CRIADA de a::marca<int> continua intacta e correta (r1 permanece 1
+// mesmo depois do registry ser sobrescrito por "b" — se as duas
+// instâncias colidissem no mesmo global qualificado, r1 teria virado 2
+// silenciosamente).
+func TestHomonymousTemplatesDedupIsSafe(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.nx", "func marca<T>(x: T) -> int\n    return 1\nend\n")
+	write(t, root, "b.nx", "func marca<T>(x: T) -> int\n    return 2\nend\n")
+	got := captureVMSourceAtRoot(t, root, `
+use a select *
+let r1: int = marca(0)
+use b select *
+let r2: int = marca(0)
+test_report(r1 * 10 + r2)
+`)
+	expectInt(t, got, 12, "a::marca<int> e b::marca<int> nunca colidem (R8)")
+}

--- a/internal/vm/generics_modules_e2e_test.go
+++ b/internal/vm/generics_modules_e2e_test.go
@@ -192,3 +192,64 @@ test_report(r1 * 10 + r2)
 `)
 	expectInt(t, got, 12, "a::marca<int> e b::marca<int> nunca colidem (R8)")
 }
+
+// TestTemplateDependencyValidationChecksModuleIdentity cobre o achado da
+// revisao pos-Task-12: validateImportedTemplateScope tratava uma dependencia
+// que e ELA MESMA um template generico como satisfeita assim que QUALQUER
+// template com aquele nome BARE existisse em algum lugar do registry
+// (mapa flat por nome, R8) — sem checar se o template registrado vem do
+// MESMO modulo que processa<T> precisa. Cenario concreto: "colecoes" declara
+// processa<T> chamando ajuda<U> (mesmo modulo); um modulo NAO RELACIONADO
+// "outro" tambem exporta um generico homonimo "ajuda". Importar so
+// `processa` de colecoes e SEPARADAMENTE `ajuda` de outro fazia a validacao
+// passar (achava "outro"::ajuda no registry) e o corpo clonado de processa
+// chamaria "outro"::ajuda em silencio — a classe exata de bug que o §8
+// existe pra prevenir. Corrigido comparando o Module do template achado no
+// registry contra moduleQualifier(tpl.Module) antes de aceitar a
+// dependencia como satisfeita.
+func TestTemplateDependencyValidationChecksModuleIdentity(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func ajuda<U>(x: U) -> int
+    return 100
+end
+func processa<T>(arr: T[]) -> int
+    return ajuda(arr[0])
+end
+`)
+	write(t, root, "outro.nx", `
+func ajuda<U>(x: U) -> int
+    return 999
+end
+`)
+
+	t.Run("ajuda do modulo errado nao satisfaz a dependencia", func(t *testing.T) {
+		// processa precisa do 'ajuda' de colecoes; so o de "outro" foi
+		// importado — a validacao tem de recusar, nao aceitar o homonimo
+		// errado silenciosamente.
+		err := compileErrAtRoot(t, root, `
+use colecoes select processa
+use outro select ajuda
+let ns: int[] = [1]
+processa(ns)
+`)
+		if err == nil || !strings.Contains(err.Error(), "adicione ao select") {
+			t.Fatalf("esperava erro de dependencia (modulo errado), veio %v", err)
+		}
+	})
+
+	t.Run("ajuda do modulo certo satisfaz e e a que roda", func(t *testing.T) {
+		// "outro" importado ANTES: registry.Funcs["ajuda"] fica sobrescrito
+		// por colecoes (ultimo import vence, mesma semantica de select* já
+		// provada em TestHomonymousTemplatesDedupIsSafe) — processa's corpo
+		// e a propria validacao tem de enxergar o 'ajuda' de colecoes (valor
+		// de retorno 100), nunca o de "outro" (999).
+		got := captureVMSourceAtRoot(t, root, `
+use outro select ajuda
+use colecoes select processa, ajuda
+let ns: int[] = [1]
+test_report(processa(ns))
+`)
+		expectInt(t, got, 100, "processa deve chamar ajuda de colecoes, nao de outro")
+	})
+}

--- a/internal/vm/generics_modules_e2e_test.go
+++ b/internal/vm/generics_modules_e2e_test.go
@@ -253,3 +253,120 @@ test_report(processa(ns))
 		expectInt(t, got, 100, "processa deve chamar ajuda de colecoes, nao de outro")
 	})
 }
+
+// I1 da revisao final de branch: `use` DENTRO de corpo de funcao (forma legal
+// da linguagem — ver TestRuntimeFunctionBodyOnlyWildcardDoesNotInvalidateModule
+// em module_exports_test.go) que traga um template generico registrava o
+// template no meio da compilacao, DEPOIS da decisao hasGenerics()/two-pass
+// (que so varre `use` de TOPO). A chamada seguinte batia no guard defensivo
+// do pass 2 com "bug do compilador de genéricos" e uma linha deslocada.
+// Agora e um erro acionavel, com a saida obvia. Suporte de verdade a `use`
+// aninhado de template esta fora de escopo.
+func TestNestedUseImportingTemplateIsActionableError(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", "func ident<T>(x: T) -> T\n    return x\nend\n")
+
+	cases := []struct {
+		name    string
+		program string
+	}{
+		{
+			name:    "select nominal",
+			program: "func run() -> int\n    use colecoes select ident\n    return ident(41)\nend\nrun()",
+		},
+		{
+			name:    "select *",
+			program: "func run() -> int\n    use colecoes select *\n    return ident(41)\nend\nrun()",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := compileErrAtRoot(t, root, tt.program)
+			if err == nil {
+				t.Fatal("esperava erro para template importado em corpo de funcao")
+			}
+			want := "template genérico importado dentro de corpo de função não é suportado — mova o 'use' para o top level"
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("erro = %v, quer conter %q", err, want)
+			}
+			// A linha e a do `use`, nao a do call site nem a linha 1 do
+			// guard defensivo antigo.
+			if !strings.HasPrefix(err.Error(), "[line 2]") {
+				t.Fatalf("erro = %v, quer prefixo [line 2] (a linha do `use`)", err)
+			}
+		})
+	}
+}
+
+// I1, contra-prova: `use` aninhado de modulo SEM template continua legal — a
+// checagem nova nao pode transformar o caso suportado em erro.
+func TestNestedUseWithoutTemplateStillCompiles(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "comum.nx", "func dobro(x: int) -> int\n    return x * 2\nend\n")
+	got := captureVMSourceAtRoot(t, root, `
+func run() -> int
+    use comum select dobro
+    return dobro(21)
+end
+test_report(run())
+`)
+	expectInt(t, got, 42, "use aninhado sem generico continua valido")
+}
+
+// I3, primeira linha sem cobertura do catalogo §9: "conflito de shadowing".
+// O corpo do template importado referencia 'base', que existe NOS DOIS lados
+// com tipos DIFERENTES — sem o gate, o 'base' do importador seria capturado
+// em silencio no lugar do binding do modulo definidor.
+func TestImportedTemplateShadowingConflictIsError(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+let base: int = 10
+func processa<T>(arr: T[]) -> int
+    return base + length(arr)
+end
+`)
+	err := compileErrAtRoot(t, root, `
+use colecoes select processa
+let base: string = "outro"
+let ns: int[] = [1]
+processa(ns)
+`)
+	if err == nil {
+		t.Fatal("esperava erro de shadowing entre importador e modulo definidor")
+	}
+	for _, fragment := range []string{"conflito de shadowing", "'base'", "no importador", "'colecoes'"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("erro = %v, quer conter %q", err, fragment)
+		}
+	}
+}
+
+// I3, segunda linha sem cobertura do catalogo §9: "referencia 'X', não
+// declarado no módulo 'Y'". O nome livre do corpo do template NAO existe no
+// modulo definidor mas resolve no importador — o unico caso onde a
+// heuristica "ausente dos dois lados = builtin" nao vale, porque ha risco
+// real de captura por homonimo.
+func TestImportedTemplateReferencesUndeclaredNameIsError(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "colecoes.nx", `
+func processa<T>(arr: T[]) -> int
+    externo()
+    return length(arr)
+end
+`)
+	err := compileErrAtRoot(t, root, `
+use colecoes select processa
+func externo() -> void
+end
+let ns: int[] = [1]
+processa(ns)
+`)
+	if err == nil {
+		t.Fatal("esperava erro de nome nao declarado no modulo definidor")
+	}
+	for _, fragment := range []string{"referencia 'externo'", "não declarado no módulo 'colecoes'"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("erro = %v, quer conter %q", err, fragment)
+		}
+	}
+}

--- a/internal/vm/vm_test_helpers_test.go
+++ b/internal/vm/vm_test_helpers_test.go
@@ -29,6 +29,30 @@ func interpretVMSource(t *testing.T, machine *VM, source string) error {
 	return machine.Interpret(compileVMSource(t, source))
 }
 
+// interpretOrCompileErr compiles and (if compilation succeeds) interprets
+// source, returning whichever error surfaces first — compile-time or
+// runtime — instead of treating a compile failure as a test-infra fatal
+// (unlike interpretVMSource/compileVMSource). Task 12 (§8) gave imports
+// their declared types instead of erasing them to nil, so some type
+// mismatches that could only be caught at runtime before (through a real
+// `use m select *` call site) are now caught earlier, at compile time, with
+// the same message. Use this for a test that only cares THAT a mismatch is
+// reported, not at which stage.
+func interpretOrCompileErr(t *testing.T, machine *VM, source string) error {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	code, _, err := compiler.New().Compile(program)
+	if err != nil {
+		return err
+	}
+	return machine.Interpret(code)
+}
+
 func captureVMSource(t *testing.T, source string) value.Value {
 	t.Helper()
 	machine := New()

--- a/noxy.mod
+++ b/noxy.mod
@@ -1,6 +1,6 @@
 module noxy
 
-noxy v0.6.0
+noxy v0.7.0
 
 require github.com/estevaofon/quicksort v0.1.0
 require github.com/estevaofon/noxy_dynamodb v0.1.0

--- a/noxy_examples/collections.nx
+++ b/noxy_examples/collections.nx
@@ -1,0 +1,40 @@
+// collections: o modulo que a assimetria com builtins impedia de existir.
+// map/filter/reduce/contains_val genericos, escritos em Noxy puro — a mesma
+// classe de abstracao que antes so existia como builtin (append/length/contains).
+// Nota: `map` e palavra reservada da linguagem (tipo `map[K,V]`), entao a
+// funcao de transformacao chama-se `map_arr` — filter/reduce/contains_val nao
+// colidem com nenhuma keyword.
+func map_arr<A, B>(arr: A[], fn: func(A) -> B) -> B[]
+    let out: B[] = []
+    for item in arr do
+        append(out, fn(item))
+    end
+    return out
+end
+
+func filter<T>(arr: T[], keep: func(T) -> bool) -> T[]
+    let out: T[] = []
+    for item in arr do
+        if keep(item) then
+            append(out, item)
+        end
+    end
+    return out
+end
+
+func reduce<T, R>(arr: T[], init: R, fn: func(R, T) -> R) -> R
+    let acc: R = init
+    for item in arr do
+        acc = fn(acc, item)
+    end
+    return acc
+end
+
+func contains_val<T>(arr: T[], alvo: T) -> bool
+    for item in arr do
+        if item == alvo then
+            return true
+        end
+    end
+    return false
+end

--- a/noxy_examples/mergesort_with_slice.nx
+++ b/noxy_examples/mergesort_with_slice.nx
@@ -6,8 +6,17 @@ func merge_sort(arr: int[]) -> int[]
     end
 
     let mid: int = length(arr) / 2
-    let left: int[] = merge_sort(slice(arr, 0, mid))
-    let right: int[] = merge_sort(slice(arr, mid, length(arr)))
+    // `slice` (array_utils) e declarada `any` (curry dinamico) — com o
+    // predeclare tipado de imports (spec §8) seu retorno estatico tambem e
+    // `any`, e passar isso direto para um parametro `int[]` falha a checagem
+    // estrita de argumento (areStrictTypesCompatible rejeita `any` -> tipo
+    // concreto). Um `let` intermediario com anotacao concreta usa a checagem
+    // permissiva de `let` (areTypesCompatible aceita `any` e emite guarda em
+    // runtime), equivalente a um cast checado.
+    let left_slice: int[] = slice(arr, 0, mid)
+    let right_slice: int[] = slice(arr, mid, length(arr))
+    let left: int[] = merge_sort(left_slice)
+    let right: int[] = merge_sort(right_slice)
 
     return merge(left, right)
 end

--- a/noxy_examples/test_generics_basics.nx
+++ b/noxy_examples/test_generics_basics.nx
@@ -1,0 +1,134 @@
+// test_generics_basics.nx — dogfood de structs+funcoes genericos (spec §11):
+// Stack<T> manipulada por funcoes livres (push/pop via ref), Node<T> lista
+// ligada com auto-referencia, e Caixa<Caixa<int>> provando aninhamento de
+// instanciacao (Caixa<int> precisa existir antes de Caixa<Caixa<int>> poder
+// ser resolvida).
+use sys select *
+
+let passed: int = 0
+let failed: int = 0
+
+func check(name: string, condition: bool) -> void
+    if condition then
+        passed = passed + 1
+        print("PASS: " + name)
+    else
+        failed = failed + 1
+        print("FAIL: " + name)
+    end
+end
+
+print("=== GENERICS BASICS TESTS ===")
+
+// --- Stack<T> com push/pop via funcoes genericas ---
+struct Stack<T>
+    items: T[]
+end
+
+func push<T>(s: ref Stack<T>, item: T)
+    append(s.items, item)
+end
+
+// Chamado `pop_stack` (nao `pop`) para nao sombrear o builtin `pop` — uma
+// funcao generica com o mesmo nome do builtin faria `pop(s.items)` abaixo
+// resolver para ELA MESMA em vez do builtin, gerando recursao mal tipada.
+func pop_stack<T>(s: ref Stack<T>) -> T
+    return pop(s.items)
+end
+
+func peek<T>(s: Stack<T>) -> T
+    return s.items[length(s.items) - 1]
+end
+
+func is_empty<T>(s: Stack<T>) -> bool
+    return length(s.items) == 0
+end
+
+// Stack<int>
+let ints: Stack<int> = Stack([])
+check("stack int comeca vazia", is_empty(ints))
+push(ref ints, 10)
+push(ref ints, 20)
+push(ref ints, 30)
+check("stack int tem 3 itens", length(ints.items) == 3)
+check("stack int topo", peek(ints) == 30)
+let popped_int: int = pop_stack(ref ints)
+check("stack int pop devolve topo", popped_int == 30)
+check("stack int apos pop tem 2 itens", length(ints.items) == 2)
+check("stack int novo topo", peek(ints) == 20)
+
+// Stack<string>
+let strs: Stack<string> = Stack([])
+check("stack string comeca vazia", is_empty(strs))
+push(ref strs, "a")
+push(ref strs, "b")
+push(ref strs, "c")
+check("stack string tem 3 itens", length(strs.items) == 3)
+let popped_str: string = pop_stack(ref strs)
+check("stack string pop devolve topo", popped_str == "c")
+check("stack string apos pop tem 2 itens", length(strs.items) == 2)
+check("stack string novo topo", peek(strs) == "b")
+
+// --- Node<T> lista ligada (auto-referencia via ref) ---
+struct Node<T>
+    value: T,
+    next: ref Node<T>
+end
+
+// Node<int>: 1 -> 2 -> 3
+let n3: Node<int> = Node(3, null)
+let n2: Node<int> = Node(2, ref n3)
+let n1: Node<int> = Node(1, ref n2)
+check("lista int n1.value", n1.value == 1)
+check("lista int n1.next.value", n1.next.value == 2)
+check("lista int n1.next.next.value", n1.next.next.value == 3)
+
+func sum_list<T>(head: ref Node<T>) -> T
+    let total: T = head.value
+    let cur: ref Node<T> = head.next
+    while cur != null do
+        total = total + cur.value
+        cur = cur.next
+    end
+    return total
+end
+
+check("sum_list percorre lista int", sum_list(ref n1) == 6)
+
+// Node<string>: "x" -> "y"
+let s2: Node<string> = Node("y", null)
+let s1: Node<string> = Node("x", ref s2)
+check("lista string s1.value", s1.value == "x")
+check("lista string s1.next.value", s1.next.value == "y")
+check("lista string s1.next.next e null", s1.next.next == null)
+
+// --- Caixa<Caixa<int>>: aninhamento de instanciacao ---
+struct Caixa<T>
+    valor: T
+end
+
+let simples: Caixa<int> = Caixa(9)
+check("Caixa<int> simples", simples.valor == 9)
+
+let dupla: Caixa<Caixa<int>> = Caixa(Caixa(9))
+check("Caixa<Caixa<int>> aninhada", dupla.valor.valor == 9)
+
+dupla.valor.valor = dupla.valor.valor + 1
+check("Caixa<Caixa<int>> mutacao do campo interno", dupla.valor.valor == 10)
+
+// Semantica de valor (CoW) tambem vale para o struct aninhado.
+let outra: Caixa<Caixa<int>> = dupla
+outra.valor.valor = 100
+check("Caixa<Caixa<int>> copia nao alcanca original (CoW)", dupla.valor.valor == 10)
+
+print("")
+print("=== RESULTS ===")
+print("Passed: " + to_str(passed))
+print("Failed: " + to_str(failed))
+
+if failed > 0 then
+    print("SOME GENERICS BASICS TESTS FAILED")
+    sys_exit(1)
+end
+
+print("ALL GENERICS BASICS TESTS PASSED")

--- a/noxy_examples/test_generics_collections.nx
+++ b/noxy_examples/test_generics_collections.nx
@@ -1,0 +1,105 @@
+// test_generics_collections.nx — dogfood de collections.nx (spec §11): map_arr
+// /filter/reduce/contains_val genericos exercitados com int E string, incluindo
+// A != B (map_arr) e T != R (reduce), provando que a monomorfizacao cobre
+// combinacoes de tipos distintas na mesma tupla de chamadas.
+use collections select *
+use sys select *
+
+let passed: int = 0
+let failed: int = 0
+
+func check(name: string, condition: bool) -> void
+    if condition then
+        passed = passed + 1
+        print("PASS: " + name)
+    else
+        failed = failed + 1
+        print("FAIL: " + name)
+    end
+end
+
+// --- Helpers de int ---
+func double_int(x: int) -> int
+    return x * 2
+end
+
+func is_even(x: int) -> bool
+    return x % 2 == 0
+end
+
+func add_int(acc: int, x: int) -> int
+    return acc + x
+end
+
+func int_to_label(x: int) -> string
+    return "n" + to_str(x)
+end
+
+// --- Helpers de string ---
+func shout(s: string) -> string
+    return s + "!"
+end
+
+func is_long(s: string) -> bool
+    return strlen(s) > 3
+end
+
+func concat_str(acc: string, x: string) -> string
+    return acc + x
+end
+
+func sum_len(acc: int, s: string) -> int
+    return acc + strlen(s)
+end
+
+print("=== GENERICS COLLECTIONS TESTS ===")
+
+// --- int[] ---
+let nums: int[] = [1, 2, 3, 4, 5]
+
+let doubled: int[] = map_arr(nums, double_int)
+check("map_arr int->int", doubled == [2, 4, 6, 8, 10])
+
+let evens: int[] = filter(nums, is_even)
+check("filter int", evens == [2, 4])
+
+let total: int = reduce(nums, 0, add_int)
+check("reduce int->int", total == 15)
+
+check("contains_val int hit", contains_val(nums, 3))
+check("contains_val int miss", !contains_val(nums, 99))
+
+// A != B: map_arr de int[] para string[]
+let labels: string[] = map_arr(nums, int_to_label)
+check("map_arr int->string (A!=B)", labels == ["n1", "n2", "n3", "n4", "n5"])
+
+// --- string[] ---
+let words: string[] = ["ana", "bob", "charlie", "dan"]
+
+let shouted: string[] = map_arr(words, shout)
+check("map_arr string->string", shouted == ["ana!", "bob!", "charlie!", "dan!"])
+
+let long_words: string[] = filter(words, is_long)
+check("filter string", long_words == ["charlie"])
+
+let joined: string = reduce(words, "", concat_str)
+check("reduce string->string", joined == "anabobcharliedan")
+
+check("contains_val string hit", contains_val(words, "bob"))
+check("contains_val string miss", !contains_val(words, "zzz"))
+
+// T != R: reduce de string[] para int (soma de comprimentos)
+let lengths_sum: int = reduce(words, 0, sum_len)
+check("reduce string->int (T!=R)", lengths_sum == 16)
+
+print("")
+print("=== RESULTS ===")
+print("Passed: " + to_str(passed))
+print("Failed: " + to_str(failed))
+
+if failed > 0 then
+    print("SOME GENERICS COLLECTIONS TESTS FAILED")
+    sys_exit(1)
+end
+
+print("ALL GENERICS COLLECTIONS TESTS PASSED")

--- a/noxy_examples/test_generics_result.nx
+++ b/noxy_examples/test_generics_result.nx
@@ -1,0 +1,105 @@
+// test_generics_result.nx — tratamento de erros com Result<T> generico.
+// Antes dos genericos, cada biblioteca inventava o proprio par de structs
+// (PutResult, LookupResult, ...) porque um Result reutilizavel cairia em
+// `any` e perderia a checagem de tipos. Com monomorfizacao, UM struct
+// Result<T> serve para todo tipo, com erro de compilacao se os tipos nao
+// baterem — o padrao que o NoxyDB pode adotar no lugar dos structs ad-hoc.
+use sys select *
+
+let passed: int = 0
+let failed: int = 0
+
+func check(name: string, condition: bool) -> void
+    if condition then
+        passed = passed + 1
+        print("PASS: " + name)
+    else
+        failed = failed + 1
+        print("FAIL: " + name)
+    end
+end
+
+// --- O tipo: um Result para todos ---
+
+struct Result<T>
+    ok: bool,
+    valor: T,
+    erro: string
+end
+
+func sucesso<T>(valor: T) -> Result<T>
+    return Result(true, valor, "")
+end
+
+func falha<T>(msg: string) -> Result<T>
+    // T so aparece no retorno: quem chama resolve T pela anotacao do let
+    // (target-typing). O campo valor recebe o zero do tipo instanciado.
+    let vazio: T
+    return Result(false, vazio, msg)
+end
+
+// valor_ou: o "unwrap_or" — extrai o valor ou devolve um padrao.
+func valor_ou<T>(r: Result<T>, padrao: T) -> T
+    if r.ok then
+        return r.valor
+    end
+    return padrao
+end
+
+// --- Funcoes que falham de verdade ---
+
+// Nao-generica devolvendo Result<int>: o caso comum de API concreta.
+func divide_seguro(a: int, b: int) -> Result<int>
+    if b == 0 then
+        let r: Result<int> = falha("divisao por zero")
+        return r
+    end
+    return sucesso(a / b)
+end
+
+// Generica devolvendo Result<T>: um acessor seguro que funciona para
+// qualquer array — impossivel de escrever antes sem cair em `any`.
+func primeiro_seguro<T>(arr: T[]) -> Result<T>
+    if length(arr) == 0 then
+        let r: Result<T> = falha("array vazio")
+        return r
+    end
+    return sucesso(arr[0])
+end
+
+// --- Caminho feliz e caminho de erro, int ---
+
+let ok_div: Result<int> = divide_seguro(10, 2)
+check("divide_seguro(10,2) e ok", ok_div.ok)
+check("divide_seguro(10,2) valor 5", ok_div.valor == 5)
+check("divide_seguro(10,2) sem erro", ok_div.erro == "")
+
+let err_div: Result<int> = divide_seguro(1, 0)
+check("divide_seguro(1,0) nao e ok", err_div.ok == false)
+check("divide_seguro(1,0) descreve o erro", err_div.erro == "divisao por zero")
+
+// --- O mesmo Result para outro tipo, sem duplicar nada ---
+
+let nomes: string[] = ["ana", "bia"]
+let ok_nome: Result<string> = primeiro_seguro(nomes)
+check("primeiro_seguro em string[] e ok", ok_nome.ok)
+check("primeiro_seguro devolve ana", ok_nome.valor == "ana")
+
+let vazio_int: int[] = []
+let err_prim: Result<int> = primeiro_seguro(vazio_int)
+check("primeiro_seguro em [] falha", err_prim.ok == false)
+check("primeiro_seguro em [] explica", err_prim.erro == "array vazio")
+
+// --- Composicao: valor_ou encadeado direto na chamada ---
+
+check("valor_ou no caminho feliz", valor_ou(divide_seguro(20, 4), -1) == 5)
+check("valor_ou no caminho de erro", valor_ou(divide_seguro(20, 0), -1) == -1)
+check("valor_ou com string", valor_ou(primeiro_seguro(nomes), "ninguem") == "ana")
+
+// --- Resumo ---
+
+print("")
+print(f"passed: {passed}, failed: {failed}")
+if failed > 0 then
+    sys_exit(1)
+end


### PR DESCRIPTION
## Summary
- Genéricos por monomorfização: funções e structs genéricos (`func f<T>`, `struct Stack<T>`) com instanciação 100% por inferência (sem sintaxe explícita em expressão) e target-typing em posições de valor (let anotado, argumento, retorno, elemento de array, campo)
- Custo zero em runtime provado por três vias: bytecode da instância byte-idêntico ao escrito à mão (incl. tabela de constantes), `OP_ADD_INT` disparando dentro de corpo genérico, e bench `generic_vs_hand` em razão 0.977 (gate ≤1.05)
- Arquitetura two-pass no compilador (pass 1 descobre/instancia/reescreve AST; pass 2 compila pelo caminho normal) — **zero mudanças em arquivos não-teste de `internal/vm/`**
- Cross-módulo: templates importados com identidade qualificada por módulo definidor (`colecoes::map<int,string>`), validação de escopo de definição em duas partes, imports com **tipos declarados** (antes: tipo apagado `nil`) e erro dedicado para acesso via namespace
- Catálogo completo de erros (§9 da spec) com cadeia de instanciação (`em soma<Ponto> (instanciado na linha N)`), mensagem dedicada para inferência só-com-null e atribuição por argumento em conflitos
- REPL passa a persistir structs e templates entre linhas (conserta de carona bug pré-existente de structs no REPL)
- Perf colateral do fix de review: cache de `loadModuleDeclarations` — `use http select *` caiu de ~1.45s para ~96ms (15× mais rápido que o develop atual); suite do compiler de 48s → 0.9s
- Dogfood: módulo `collections` (map_arr/filter/reduce/contains_val) escrito em Noxy — a abstração que a assimetria com builtins impedia

## Components
- `internal/ast/` — nós `GenericType`/`TypeParamType`, campos `TypeParams`, cloner profundo com guard de cobertura por reflexão
- `internal/parser/` — parâmetros de tipo `<T,U>`, `GenericType` em posição de tipo, split de `>>`/`>=` em listas de argumentos de tipo
- `internal/compiler/` — `generics.go`, `generics_unify.go`, `generics_substitute.go`, `generics_structs.go`, `generics_target.go`: registry de templates, unificação (3 superfícies), substituição, two-pass, target-typing, cross-módulo, teto de instanciação (64), cache de módulos
- `cmd/noxy/` — persistência de sessão do REPL (globals + structs + registry)
- `internal/vm/*_test.go` — E2E de genéricos (básicos, módulos, interações com lambda/defer/spawn/when/json/CoW); nenhum arquivo de produção da VM tocado
- `benchmarks/` — `bench_generic_vs_hand.nx`, `startup_generics.nx`, sondas de startup com `use`, seção nova no RESULTS.md
- `noxy_examples/` — `collections.nx`, `test_generics_basics.nx`, `test_generics_collections.nx` (corpus 167/167)
- `docs/` — seção Generics na NOXY_LANGUAGE_SPEC.md (+ doc do `when`/select que faltava), CHANGELOG 0.7.0, README

## Breaking / mudanças de comportamento (documentadas no CHANGELOG)
- Imports tipados podem revelar erros de tipo latentes em código cross-módulo dinâmico (1 exemplo do corpus corrigido assim: `mergesort_with_slice.nx`)
- Operadores aritméticos sobre structs viram erro de compile-time (antes: crash de runtime — nenhum programa válido quebra)
- Variável de `for ... in` agora recebe o tipo estático do elemento da coleção quando conhecido
- `print` de instância genérica mostra o nome qualificado (`<main::Caixa<int> instance>`) — comportamento v1 documentado

## Related Issues
- N/A (sem card Jira — projeto pessoal; spec e ledger de execução em `docs/superpowers/specs/2026-08-18-generics-design.md`)

## Test Plan
- [x] Suite Go completa verde (`go test ./... -count=1`; vm 38.6s)
- [x] `go test ./internal/vm -race -count=1` verde
- [x] `go vet ./...` limpo
- [x] Corpus de exemplos 167/167 (`run_all_tests_concurrent.nx`)
- [x] Teste de igualdade de bytecode (Code + Constants) + prova de `OP_ADD_INT` em corpo genérico
- [x] Benchmarks com gates: generic_vs_hand 0.977 ✅; regressão develop×generics dentro do ruído ✅; startup_generics +1.9ms ✅; sondas de `use` pós-cache ✅
- [x] 2 revisões independentes da spec + review por task + review final de branch inteira (2 críticos achados e corrigidos: cache de módulos, shadowing por upvalue)
- [ ] Smoke manual do REPL interativo no Windows (persistência entre linhas foi testada via stdin piped)
- [ ] Validação em carga real (NoxyDB) antes do release 0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
