### PR TITLE
fix/string-ordering-and-ref-assign-hint - Igualdade estrita de ref, ordenação de strings e hints de deref (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@
   Migração: código que dependia de `ref == ref` como comparação de valor deve
   dereferenciar explicitamente um dos lados (`*ra == *rb`) ou comparar contra
   o valor (`ra == b`). Spec atualizada em §2.2 (regra 7) e §2.3, que agora
-  registra `==`/`!=` entre dois refs como a única exceção ao auto-deref.
+  registra `==`/`!=` entre dois refs como exceção ao auto-deref (ao lado da
+  segunda exceção, explicitada nesta mesma release — ver "Hint de deref na
+  atribuição" abaixo).
 
 ### Added
 
@@ -50,6 +52,47 @@
   comportamento observável e o arquivo sai com código 1 quando alguma falha,
   reportando todas de uma vez. Entra automaticamente no
   `run_all_tests_concurrent.nx`.
+
+- **Ordenação lexicográfica de strings**: `<`, `>`, `<=`, `>=` agora aceitam
+  duas strings, comparando byte a byte — dentro do invariante UTF-8, isso é
+  idêntico à ordem por code point, como em Python. Antes, `"abc" < "abd"`
+  compilava e estourava em **runtime** com `operands must be numbers`, embora
+  a spec listasse os operadores de comparação sem restringi-los a números.
+  Misturar string com número, ou ordenar `bytes`, continua erro de runtime —
+  agora com a mensagem `operands must be numbers or strings`; `bytes` seguem
+  deliberadamente fora da ordenação (a ponte explícita é `to_str`). `ref
+  string` participa pelo valor apontado (auto-deref de expressão, já emitido
+  pelo compilador). Spec atualizada em §8 (Comparison) e §12 (comparação
+  byte-exata). Testes: `internal/vm/string_ordering_test.go` e o grupo
+  "ordenacao de strings" da suíte de semântica.
+
+- `noxy_examples/language_semantics_test2.nx`: parte 2 da suíte de semântica
+  (129 asserções em 12 grupos — conversões numéricas, structs de resultado do
+  `convert`, `fmt`, as três formas de import, stdlib `strings` por code
+  point, ordenação de strings, `bytes` por octeto, arrays fixos e containers
+  aninhados, listas ligadas com `ref Node`/`GNode<T>`, `ref` avançado
+  (entrada de map, forwarding, escape de frame, closures compartilhando
+  slot, `defer` com `ref`), `when`/`case` e a fronteira `any`). Mesmo
+  contrato da parte 1: cada asserção afirma comportamento observável e o
+  arquivo sai com código 1 em falha. Entra automaticamente no
+  `run_all_tests_concurrent.nx`.
+
+### Changed
+
+- **Hint de deref na atribuição `x = r`**: atribuir um `ref T` a um alvo que
+  espera `T` (variável local, global ou capturada, índice de array, valor de
+  map, campo de struct) continua erro de compilação — atribuição não faz
+  auto-deref, agora explicitado na spec (§2.3, exceção 2, com linha nova na
+  tabela de Type-Based Assignment) — mas a mensagem passa a apontar o
+  conserto: `hint: use '*r' to read the referenced value`, espelhando o hint
+  já existente da direção inversa (`r = 50` → `use '*r = ...' to update the
+  referenced value`). O hint só aparece quando o deref de fato consertaria o
+  programa. A spec também corrige o exemplo `*r = ref z` de "Strict Type
+  Safety", que documentava um erro que a implementação nunca emitiu: no alvo
+  `*r =` o `*` já desfez a ambiguidade update/rebind, então um RHS `ref` é
+  lido como em qualquer expressão (`*r = s` equivale a `*r = *s`) —
+  comportamento agora fixado em teste na suíte de semântica. Testes:
+  `internal/compiler/assign_deref_hint_test.go`.
 
 ## [0.7.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.1] - 2026-08-19
+
+### Fixed (BREAKING) — Igualdade estrita de ref: `==`/`!=` nunca dereferencia implicitamente
+
+- **O caso misto `ref` vs valor virou erro de compilação com hint.** Completa
+  a regra iniciada pela correção de identidade abaixo: em `==`/`!=` um
+  operando `ref` nunca é dereferenciado implicitamente. O `=` já recusava
+  conversão implícita de ref nas duas direções pelo mesmo motivo — o
+  significado deve ser evidente na sintaxe, nunca decidido por tipos que não
+  aparecem no código. Antes, `x == y` perguntava identidade ou valor
+  dependendo dos tipos estáticos dos dois lados; agora cada pergunta tem sua
+  sintaxe:
+
+  ```noxy
+  ra == rb     // identidade de slot
+  ra == null   // o próprio ref é nulo?
+  *ra == 1     // valor apontado, explícito
+  ra == 1      // ERRO: cannot compare ref int with int: a ref is never
+               //       implicitly dereferenced in '=='
+               //   hint: use '*ra' to compare the referenced value
+  ```
+
+- **A ambiguidade do null foi resolvida de graça pela mesma regra**: um ref
+  VÁLIDO apontando para um slot que contém `null` não é mais "igual a null"
+  — `r == null` pergunta sobre o próprio ref e `*r == null` sobre o valor
+  apontado, duas perguntas que o deref implícito tornava indistinguíveis. O
+  padrão comum `no.proximo != null` continua funcionando idêntico (o
+  terminador é um ref nulo de verdade).
+
+- Em runtime, `OP_EQUAL` deixou de resolver o caso misto: na fronteira
+  dinâmica (ex.: campo `ref` lido via membro de `any`), ref vs valor é
+  simplesmente diferente (`false`), e ref vs ref segue por identidade.
+
+- Migração: comparações mistas quebram **em compilação**, com o hint
+  apontando o conserto (`*r`). Código que usava `r == null` para perguntar
+  "o slot apontado está vazio?" (padrão fill-null-slot) migra para
+  `*r == null` — no repositório, isso alcançou exatamente 4 dos 170
+  exemplos (`bst.nx`, `binary_tree.nx`, `linked_list.nx`,
+  `test_explicit_deref.nx`), migrados nesta release; travessias com
+  `cur != null`/`no.proximo != null` não mudam. Spec atualizada: §2.2
+  (regra 7) e §2.3 (exceção 1 reescrita, com o par
+  `r == null`/`*r == null`). Testes:
+  `internal/compiler/ref_equality_strict_test.go`,
+  `internal/vm/ref_equality_strict_runtime_test.go` e as suítes de
+  semântica em `noxy_examples/`.
 
 ### Fixed (BREAKING) — `==`/`!=` entre dois `ref` compara identidade
 
@@ -25,14 +69,12 @@
   ra == rb    // antes: true   agora: false  (slots distintos)
   ```
 
-  O caso **misto** é deliberadamente preservado: um `ref` comparado contra um
-  não-`ref` continua fazendo auto-deref e lendo o valor apontado, agora
-  resolvido em runtime por `OP_EQUAL` (que enxerga os dois operandos de uma
-  vez, ao contrário do compilador, que ainda não conhece o tipo do lado
-  direito quando o deref do esquerdo precisaria ser emitido). Isso mantém
-  intactos `no.proximo != null`, `res.err != null` e `contador == 10` — os
-  169 exemplos de `noxy_examples/` passam sem alteração, incluindo listas
-  encadeadas, BST e grafos.
+  O caso **misto** (ref contra não-ref) chegou a ser preservado com
+  auto-deref em runtime, mas ainda nesta release a regra foi completada e
+  ele passou a ser rejeitado em compilação — ver "Igualdade estrita de ref"
+  abaixo, que descreve a semântica final: `no.proximo != null` continua
+  intacto (nulidade do próprio ref), e `contador == 10` migra para
+  `*contador == 10`.
 
   Migração: código que dependia de `ref == ref` como comparação de valor deve
   dereferenciar explicitamente um dos lados (`*ra == *rb`) ou comparar contra
@@ -67,7 +109,7 @@
   "ordenacao de strings" da suíte de semântica.
 
 - `noxy_examples/language_semantics_test2.nx`: parte 2 da suíte de semântica
-  (129 asserções em 12 grupos — conversões numéricas, structs de resultado do
+  (131 asserções em 12 grupos — conversões numéricas, structs de resultado do
   `convert`, `fmt`, as três formas de import, stdlib `strings` por code
   point, ordenação de strings, `bytes` por octeto, arrays fixos e containers
   aninhados, listas ligadas com `ref Node`/`GNode<T>`, `ref` avançado

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -236,7 +236,10 @@ print(r)             // Prints 10
 ```
 This applies to both Local Variables and Struct Fields.
 
-**The one exception: `==` and `!=` between two references.** Auto-dereference
+Auto-dereference has exactly **two exceptions**, described below: `==`/`!=`
+between two references, and the right-hand side of a plain assignment.
+
+**Exception 1: `==` and `!=` between two references.** Auto-dereference
 answers "what value is there?", which is the wrong question when *both* sides
 are references — there the question is about identity. So when both operands
 are statically `ref T`, the comparison is by **slot identity** (§2.2, rule 7)
@@ -261,6 +264,33 @@ node.next != null   // unchanged: the usual null test on a `ref` field
 `addr(ref x)` remains available when you want that identity as a printable
 value rather than a comparison.
 
+**Exception 2: the right-hand side of a plain assignment.** Assignment is
+where *update* and *rebind* are told apart by the static types of both sides
+(see the summary table below), so around `=` no reference conversion is
+implicit — in either direction. Assigning a `ref T` to a target that expects
+a plain `T` (a variable, an array/map entry, or a struct field) is a
+compile-time error with a hint, not an implicit read:
+
+```noxy
+let x: int = 10
+let r: ref int = ref x
+let n: int = 0
+
+n = r    // ERROR: type mismatch in assignment to 'n': expected int, got ref int
+         //   hint: use '*r' to read the referenced value
+n = *r   // OK: explicit dereference reads 10
+```
+
+The explicit-update form is different: in `*r = value` the `*` already names
+the target unambiguously, so a reference RHS keeps the ordinary expression
+rule and is read. With `s: ref int`, `*r = s` writes the value `s` points to
+(equivalent to `*r = *s`).
+
+Note that `let` initialization is *not* an assignment in this sense: a `let`
+creates a fresh slot, so there is nothing to rebind and no ambiguity —
+`let n: int = r` auto-dereferences, like any other expression position
+(including exact call arguments; see §4.2).
+
 #### 2. Writing (Update vs Rebind)
 The distinction between modifying the *value* and modifying the *pointer* is made explicit by syntax:
 
@@ -280,10 +310,17 @@ r = ref z    // REBIND: 'r' now points to 'z' (does not affect 'x')
 ```
 
 #### 3. Strict Type Safety
-The compiler enforces these rules to prevent ambiguity:
+The compiler enforces these rules to prevent ambiguity, and each rejection
+points at the intended fix:
 ```noxy
-r = 50       // ERROR: Cannot assign 'int' to 'ref int'. Did you mean '*r = 50'?
-*r = ref z   // ERROR: Cannot assign 'ref int' to 'int'.
+let n: int = 0
+r = 50       // ERROR: cannot assign int to ref int
+             //   hint: use '*r = ...' to update the referenced value
+n = r        // ERROR: type mismatch in assignment to 'n': expected int, got ref int
+             //   hint: use '*r' to read the referenced value
+n = *r       // OK: explicit dereference
+*r = ref z   // OK: '*' names the target unambiguously, so the reference RHS
+             // is read — writes z's value through r (same as '*r = z')
 ```
 
 #### 4. Reference Patterns
@@ -366,6 +403,7 @@ sensor.target = ref humidity  // Now watching humidity
 | `ref T` | `T` | `*r = val` | **UPDATE** – writes into memory |
 | `ref T` | `ref T` | `r = ref x`| **REBIND** – changes pointer |
 | `T` | `T` | `x = val` | Standard assignment |
+| `T` | `ref T` | `x = *r` | **READ** – explicit dereference required; plain `x = r` is a compile error (§2.3, exception 2) |
 
 #### Memory Safety (Captured Variables)
 Noxy ensures memory safety when using `ref`.
@@ -1014,6 +1052,14 @@ by `when`/`case` exactly like any other value.
 ### Comparison
 `>`, `<`, `>=`, `<=`, `==`, `!=`
 
+Ordering (`>`, `<`, `>=`, `<=`) is defined for **numbers** (with the usual
+int/float promotion) and for **strings**. String ordering is lexicographic
+and byte-exact — for valid UTF-8, which every Noxy string is by invariant,
+this is identical to code-point order, mirroring Python. Ordering any other
+operand pair, including `bytes`, is a runtime error (`operands must be
+numbers or strings`); bridge bytes through `to_str` first. Equality
+(`==`, `!=`) is structural for every type (§2.2, rule 7).
+
 ### Logical
 - `&&` (AND)
 - `||` (OR)
@@ -1274,7 +1320,9 @@ do carregamento de módulos e ainda não é validado (registrado como trabalho
 futuro no CHANGELOG).
 
 Noxy não aplica normalização Unicode (NFC/NFD). Comparação é byte-exata, como
-em Python.
+em Python — tanto a igualdade quanto a ordenação (`<`, `>`, `<=`, `>=`), que
+ordena strings lexicograficamente por byte; dentro do invariante UTF-8 isso
+é idêntico à ordem por code point.
 
 ### Network sockets
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -114,8 +114,9 @@ Arrays, maps, and structs are composite **values**. Every binding without
 7. **`==`/`!=` on composites is structural** (recursive by content). `ref`
    values compare by slot identity and are not dereferenced — both as fields
    nested inside a composite and as the two operands of a direct comparison.
-   A `ref` compared against a *non*-`ref` (a plain value, `null`) is the one
-   shape that still auto-dereferences; see §2.3.
+   A `ref` compared against `null` asks whether the reference *itself* is
+   null, and a `ref` compared against a plain value is a compile-time error:
+   the read must be explicit (`*r == value`); see §2.3.
 8. Closures capture *variables* (slots); captured-variable aliasing is
    unchanged and orthogonal to value semantics.
 
@@ -237,14 +238,21 @@ print(r)             // Prints 10
 This applies to both Local Variables and Struct Fields.
 
 Auto-dereference has exactly **two exceptions**, described below: `==`/`!=`
-between two references, and the right-hand side of a plain assignment.
+with a reference operand, and the right-hand side of a plain assignment.
 
-**Exception 1: `==` and `!=` between two references.** Auto-dereference
-answers "what value is there?", which is the wrong question when *both* sides
-are references — there the question is about identity. So when both operands
-are statically `ref T`, the comparison is by **slot identity** (§2.2, rule 7)
-and neither side is dereferenced. Every other shape keeps auto-dereference,
-including a reference compared against a plain value or against `null`:
+**Exception 1: `==` and `!=` with a reference operand.** Auto-dereference
+answers "what value is there?", which is the wrong question for equality on
+references — there the questions are about *identity* and *nullity*. In
+`==`/`!=` a reference operand is **never** implicitly dereferenced:
+
+- **two references** compare by **slot identity** (§2.2, rule 7);
+- a reference compared against **`null`** asks whether the reference
+  *itself* is null — which keeps `node.next != null` working, and makes a
+  valid reference to a slot that *contains* null distinguishable from a
+  null reference (`r == null` asks about the ref, `*r == null` about the
+  pointed value — two questions that implicit dereference used to conflate);
+- a reference compared against a **plain value** is a compile-time error
+  with a hint — write the read explicitly, as in assignment.
 
 ```noxy
 let a: int = 1
@@ -255,10 +263,13 @@ let ra2: ref int = ref a
 
 ra == ra2   // true  — same slot
 ra == rb    // false — different slots, even though both hold 1
-ra == 1     // true  — mixed: auto-deref reads the pointed value
-ra == null  // false — mixed: the reference is valid
+*ra == 1    // true  — explicit dereference reads the pointed value
+ra == 1     // ERROR: cannot compare ref int with int: a ref is never
+            //        implicitly dereferenced in '=='
+            //   hint: use '*ra' to compare the referenced value
+ra == null  // false — the reference itself is valid
 
-node.next != null   // unchanged: the usual null test on a `ref` field
+node.next != null   // unchanged: asks whether the `ref` field is null
 ```
 
 `addr(ref x)` remains available when you want that identity as a printable
@@ -1458,6 +1469,6 @@ register, roll back, poison, or close the resource again.
     - **Reference Parameters**: A parameter declared with `ref` shares the caller's slot — the only sharing mechanism.
 
 ---
-*Version: 0.4.0*
+*Version: 0.7.1*
 *Language: Noxy*
 *Implementation: Stack VM (Go)*

--- a/internal/compiler/assign_deref_hint_test.go
+++ b/internal/compiler/assign_deref_hint_test.go
@@ -1,0 +1,111 @@
+package compiler
+
+// Atribuicao NAO faz auto-deref (spec §2.3, tabela de Type-Based
+// Assignment): `x = r` com x: T e r: ref T e a terceira combinacao invalida,
+// irma das duas ja documentadas (`r = 50`, que tem hint proprio via
+// referenceAssignmentTypeError, e `*r = <nao-T>`). Ate aqui ela caia no
+// mismatch generico "expected int, got ref int" sem apontar o conserto.
+// Estes testes fixam o hint novo — "use '*r' to read the referenced value" —
+// em cada shape de alvo de atribuicao, e que ele NAO aparece quando o deref
+// nao consertaria o programa.
+
+import (
+	"strings"
+	"testing"
+)
+
+const derefReadHintText = "to read the referenced value"
+
+func requireDerefReadHint(t *testing.T, src string, wantHint string) {
+	t.Helper()
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("atribuicao de ref a alvo de valor deveria falhar")
+	}
+	if !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("erro deveria continuar sendo type mismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantHint) {
+		t.Fatalf("erro sem o hint %q: %v", wantHint, err)
+	}
+}
+
+func TestLocalAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `func f()
+    let x: int = 10
+    let r: ref int = ref x
+    let a: int = 0
+    a = r
+end`, "hint: use '*r' "+derefReadHintText)
+}
+
+func TestGlobalAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `let x: int = 10
+let r: ref int = ref x
+let g: int = 0
+g = r`, "hint: use '*r' "+derefReadHintText)
+}
+
+func TestUpvalueAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `func outer()
+    let n: int = 0
+    let base: int = 9
+    let r: ref int = ref base
+    let f: func() -> int = func() -> int
+        n = r
+        return n
+    end
+    f()
+end`, "hint: use '*r' "+derefReadHintText)
+}
+
+func TestArrayElementAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `let base: int = 10
+let r: ref int = ref base
+let arr: int[] = [1]
+arr[0] = r`, "hint: use '*r' "+derefReadHintText)
+}
+
+func TestMapEntryAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `let base: int = 10
+let r: ref int = ref base
+let m: map[string, int] = {"k": 1}
+m["k"] = r`, "hint: use '*r' "+derefReadHintText)
+}
+
+func TestFieldAssignmentFromRefSuggestsDeref(t *testing.T) {
+	requireDerefReadHint(t, `struct P
+    x: int
+end
+let base: int = 10
+let r: ref int = ref base
+let p: P = P(0)
+p.x = r`, "hint: use '*r' "+derefReadHintText)
+}
+
+// RHS que nao e identificador simples ainda ganha hint, na forma generica.
+func TestNonIdentifierRefRhsGetsGenericDerefHint(t *testing.T) {
+	requireDerefReadHint(t, `func cria() -> ref int
+    let n: int = 42
+    return ref n
+end
+let a: int = 0
+a = cria()`, "hint: use '*' "+derefReadHintText)
+}
+
+// Quando o deref NAO consertaria (tipos incompativeis mesmo apos deref),
+// o mismatch continua sem hint — sugerir '*' seria orientacao errada.
+func TestMismatchedRefRhsDoesNotSuggestDeref(t *testing.T) {
+	_, _, err := New().Compile(parse(`func f()
+    let x: int = 10
+    let r: ref int = ref x
+    let s: string = ""
+    s = r
+end`))
+	if err == nil {
+		t.Fatal("atribuir ref int a string deveria falhar")
+	}
+	if strings.Contains(err.Error(), derefReadHintText) {
+		t.Fatalf("hint de deref nao deveria aparecer quando deref nao conserta: %v", err)
+	}
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -491,7 +491,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				} else {
 					// Standard Value Assignment (int = int)
 					if !c.areTypesCompatible(localType, valType) {
-						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s", c.currentLine, ident.Value, localType.String(), valType.String())
+						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s%s", c.currentLine, ident.Value, localType.String(), valType.String(), c.derefReadHint(localType, valType, n.Value))
 					}
 					if err := c.emitRuntimeValueType(localType); err != nil {
 						return nil, nil, err
@@ -516,8 +516,8 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				}
 				if !c.areTypesCompatible(upvalueType, valType) {
 					return nil, nil, fmt.Errorf(
-						"[line %d] type mismatch in assignment to '%s': expected %s, got %s",
-						c.currentLine, ident.Value, noxyTypeName(upvalueType), noxyTypeName(valType),
+						"[line %d] type mismatch in assignment to '%s': expected %s, got %s%s",
+						c.currentLine, ident.Value, noxyTypeName(upvalueType), noxyTypeName(valType), c.derefReadHint(upvalueType, valType, n.Value),
 					)
 				}
 				if err := c.emitRuntimeValueType(upvalueType); err != nil {
@@ -560,7 +560,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 					// Standard Global Assignment
 					if !c.areTypesCompatible(globalType, valType) {
-						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s", c.currentLine, ident.Value, globalType.String(), valType.String())
+						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s%s", c.currentLine, ident.Value, globalType.String(), valType.String(), c.derefReadHint(globalType, valType, n.Value))
 					}
 					if err := c.emitRuntimeValueType(globalType); err != nil {
 						return nil, nil, err
@@ -626,7 +626,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					return nil, nil, referenceAssignmentTypeError(c.currentLine, assignmentTargetName(indexExp), arrType.ElementType, valType)
 				}
 				if !c.areTypesCompatible(arrType.ElementType, valType) {
-					return nil, nil, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s", c.currentLine, arrType.ElementType.String(), valType.String())
+					return nil, nil, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s%s", c.currentLine, arrType.ElementType.String(), valType.String(), c.derefReadHint(arrType.ElementType, valType, n.Value))
 				}
 			} else if mapType, ok := leftType.(*ast.MapType); ok {
 				assignedType = mapType.ValueType
@@ -639,7 +639,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					return nil, nil, referenceAssignmentTypeError(c.currentLine, assignmentTargetName(indexExp), mapType.ValueType, valType)
 				}
 				if !c.areTypesCompatible(mapType.ValueType, valType) {
-					return nil, nil, fmt.Errorf("[line %d] type mismatch in map value: expected %s, got %s", c.currentLine, mapType.ValueType.String(), valType.String())
+					return nil, nil, fmt.Errorf("[line %d] type mismatch in map value: expected %s, got %s%s", c.currentLine, mapType.ValueType.String(), valType.String(), c.derefReadHint(mapType.ValueType, valType, n.Value))
 				}
 			} else {
 				if leftType != nil && leftType.String() != "any" {
@@ -722,7 +722,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				} else {
 					// Standard Field
 					if !c.areTypesCompatible(fieldType, valType) {
-						return nil, nil, fmt.Errorf("[line %d] type mismatch in field assignment: expected %s, got %s", c.currentLine, fieldType.String(), valType.String())
+						return nil, nil, fmt.Errorf("[line %d] type mismatch in field assignment: expected %s, got %s%s", c.currentLine, fieldType.String(), valType.String(), c.derefReadHint(fieldType, valType, n.Value))
 					}
 				}
 				if err := c.emitRuntimeValueType(fieldType); err != nil {
@@ -2694,6 +2694,28 @@ func referenceAssignmentTypeError(line int, name string, expected, actual ast.No
 		"[line %d] cannot assign %s to %s\n  hint: use '*%s = ...' to update the referenced value",
 		line, noxyTypeName(actual), noxyTypeName(expected), name,
 	)
+}
+
+// derefReadHint e o espelho de referenceAssignmentTypeError para a direcao
+// inversa: RHS `ref T` num alvo que espera `T`. Atribuicao nao faz
+// auto-deref (spec §2.3, Type-Based Assignment) — a leitura pede '*'
+// explicito. Devolve "" quando o deref nao consertaria o programa, para o
+// mismatch generico nao sugerir orientacao errada.
+func (c *Compiler) derefReadHint(expected, actual ast.NoxyType, rhs ast.Expression) string {
+	refVal, isRef := actual.(*ast.RefType)
+	if !isRef || expected == nil {
+		return ""
+	}
+	if _, expectedIsRef := expected.(*ast.RefType); expectedIsRef {
+		return ""
+	}
+	if !c.areTypesCompatible(expected, refVal.ElementType) {
+		return ""
+	}
+	if ident, ok := rhs.(*ast.Identifier); ok {
+		return fmt.Sprintf("\n  hint: use '*%s' to read the referenced value", ident.Value)
+	}
+	return "\n  hint: use '*' to read the referenced value"
 }
 
 func isReferenceType(t ast.NoxyType) bool {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1040,14 +1040,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return c.currentChunk, &ast.PrimitiveType{Name: "bool"}, nil
 		}
 
-		// `==`/`!=` sao a UNICA excecao ao auto-deref de operandos (spec
-		// §2.3): dois refs precisam chegar inteiros ate OP_EQUAL para
-		// comparar IDENTIDADE DE SLOT (§2.2.7), e nao o valor apontado.
-		// O caso misto (`ref T` contra `T`, contra `null`) continua lendo o
-		// valor apontado, mas resolvido em runtime por OP_EQUAL, que enxerga
-		// os dois operandos de uma vez — aqui o tipo do lado direito ainda
-		// nao e conhecido quando o deref do esquerdo teria de ser emitido.
-		// Todos os demais operadores seguem dereferenciando neste ponto.
+		// Em `==`/`!=` um operando ref NUNCA e dereferenciado
+		// implicitamente (spec §2.3, excecao 1): dois refs chegam inteiros
+		// ate OP_EQUAL para comparar IDENTIDADE DE SLOT (§2.2.7), ref vs
+		// null pergunta sobre o PROPRIO ref, e o caso misto estatico
+		// ref vs valor e rejeitado logo abaixo (rejectMixedRefComparison)
+		// com hint para o deref explicito. Todos os demais operadores
+		// seguem dereferenciando neste ponto.
 		identityComparison := n.Operator == "==" || n.Operator == "!="
 
 		_, leftType, err := c.Compile(n.Left)
@@ -1074,6 +1073,18 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			c.emitByte(byte(chunk.OP_DEREF))
 			if ref, ok := rightType.(*ast.RefType); ok {
 				rightType = ref.ElementType
+			}
+		}
+
+		// Igualdade estrita de ref: no caso MISTO (um lado estaticamente
+		// `ref T`, o outro um valor conhecido nao-ref) `==`/`!=` nao le o
+		// valor implicitamente — o deref e por conta do programador, como
+		// no `=`. null (pergunta sobre o proprio ref), `any` e tipos
+		// desconhecidos (fronteira dinamica, que pode carregar um ref em
+		// runtime) passam; dois refs comparam identidade em runtime.
+		if identityComparison {
+			if err := c.rejectMixedRefComparison(n, leftType, rightType); err != nil {
+				return nil, nil, err
 			}
 		}
 
@@ -2716,6 +2727,35 @@ func (c *Compiler) derefReadHint(expected, actual ast.NoxyType, rhs ast.Expressi
 		return fmt.Sprintf("\n  hint: use '*%s' to read the referenced value", ident.Value)
 	}
 	return "\n  hint: use '*' to read the referenced value"
+}
+
+// rejectMixedRefComparison aplica a regra "em `==`/`!=` um ref nunca e
+// dereferenciado implicitamente" ao caso misto estatico: exatamente um dos
+// lados e `ref T` e o outro e um valor de tipo conhecido. Ref vs null
+// pergunta sobre o proprio ref, e `any`/tipo desconhecido e fronteira
+// dinamica (pode carregar um ref em runtime, comparacao de identidade
+// legitima) — ambos passam. O erro aponta o deref explicito.
+func (c *Compiler) rejectMixedRefComparison(n *ast.InfixExpression, leftType, rightType ast.NoxyType) error {
+	leftRef := isReferenceType(leftType)
+	rightRef := isReferenceType(rightType)
+	if leftRef == rightRef {
+		return nil
+	}
+	refType, other, refExpr := leftType, rightType, n.Left
+	if rightRef {
+		refType, other, refExpr = rightType, leftType, n.Right
+	}
+	if other == nil || isNullType(other) || other.String() == "any" {
+		return nil
+	}
+	hint := "\n  hint: use '*' to compare the referenced value"
+	if ident, ok := refExpr.(*ast.Identifier); ok {
+		hint = fmt.Sprintf("\n  hint: use '*%s' to compare the referenced value", ident.Value)
+	}
+	return fmt.Errorf(
+		"[line %d] cannot compare %s with %s: a ref is never implicitly dereferenced in '%s'%s",
+		c.currentLine, noxyTypeName(refType), noxyTypeName(other), n.Operator, hint,
+	)
 }
 
 func isReferenceType(t ast.NoxyType) bool {

--- a/internal/compiler/ref_equality_strict_test.go
+++ b/internal/compiler/ref_equality_strict_test.go
@@ -1,0 +1,99 @@
+package compiler
+
+// Igualdade estrita de ref (v0.7.1): em `==`/`!=` um operando `ref` NUNCA e
+// dereferenciado implicitamente. Dois refs comparam identidade de slot (ja
+// vigente desde o fix de 0.7.x), ref vs null pergunta se o REF e nulo, e o
+// caso misto ref vs valor — que antes fazia auto-deref silencioso — vira
+// erro de compilacao com hint apontando o deref explicito. Fecha a
+// assimetria com o `=`, que ja recusa conversao implicita de ref nas duas
+// direcoes.
+
+import (
+	"strings"
+	"testing"
+)
+
+const compareHintText = "to compare the referenced value"
+
+func requireStrictCompareError(t *testing.T, src, wantHint string) {
+	t.Helper()
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatal("comparacao mista ref vs valor deveria falhar na compilacao")
+	}
+	if !strings.Contains(err.Error(), "never implicitly dereferenced") {
+		t.Fatalf("erro sem a explicacao da regra: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantHint) {
+		t.Fatalf("erro sem o hint %q: %v", wantHint, err)
+	}
+}
+
+func requireStrictCompareOK(t *testing.T, src string) {
+	t.Helper()
+	if _, _, err := New().Compile(parse(src)); err != nil {
+		t.Fatalf("deveria compilar: %v", err)
+	}
+}
+
+func TestMixedRefEqualityIsCompileError(t *testing.T) {
+	requireStrictCompareError(t, `let x: int = 1
+let ra: ref int = ref x
+let r: bool = ra == 1
+print(r)`, "hint: use '*ra' "+compareHintText)
+}
+
+func TestMixedRefEqualityErrorsWithRefOnRight(t *testing.T) {
+	requireStrictCompareError(t, `let x: int = 1
+let ra: ref int = ref x
+let r: bool = 1 == ra
+print(r)`, "hint: use '*ra' "+compareHintText)
+}
+
+func TestMixedRefInequalityIsCompileError(t *testing.T) {
+	requireStrictCompareError(t, `let x: int = 1
+let ra: ref int = ref x
+let r: bool = ra != 6
+print(r)`, "hint: use '*ra' "+compareHintText)
+}
+
+func TestMixedRefFieldEqualityGetsGenericHint(t *testing.T) {
+	requireStrictCompareError(t, `struct Obs
+    alvo: ref int
+end
+let t: int = 20
+let o: Obs = Obs(ref t)
+let r: bool = o.alvo == 20
+print(r)`, "hint: use '*' "+compareHintText)
+}
+
+func TestRefAgainstNullStillCompiles(t *testing.T) {
+	requireStrictCompareOK(t, `let x: int = 1
+let ra: ref int = ref x
+print(ra == null)
+print(null != ra)`)
+}
+
+func TestRefAgainstRefStillCompiles(t *testing.T) {
+	requireStrictCompareOK(t, `let x: int = 1
+let y: int = 1
+let ra: ref int = ref x
+let rb: ref int = ref y
+print(ra == rb)`)
+}
+
+func TestExplicitDerefComparisonCompiles(t *testing.T) {
+	requireStrictCompareOK(t, `let x: int = 1
+let ra: ref int = ref x
+print(*ra == 1)
+print(*ra != 6)`)
+}
+
+// `any` e fronteira dinamica: o lado nao-ref pode conter um ref em runtime
+// (comparacao de identidade legitima), entao a checagem estatica nao rejeita.
+func TestRefAgainstAnyStillCompiles(t *testing.T) {
+	requireStrictCompareOK(t, `let x: int = 1
+let ra: ref int = ref x
+let a: any = ra
+print(a == ra)`)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.7.0"
+const Version = "v0.7.1"

--- a/internal/vm/cow_equality_test.go
+++ b/internal/vm/cow_equality_test.go
@@ -152,18 +152,22 @@ main()
 	}
 }
 
-// TestRefEqualityAutoDerefsAgainstNonRef guarda o outro lado da regra: um ref
-// comparado com algo que NAO e ref continua lendo o valor apontado (spec
-// §2.3). Sem isso, `no.proximo != null` e `contador == 10` quebrariam.
-func TestRefEqualityAutoDerefsAgainstNonRef(t *testing.T) {
+// TestRefEqualityNeverImplicitlyDereferences guarda o outro lado da regra
+// (v0.7.1): em `==`/`!=` um ref NUNCA e dereferenciado implicitamente. O
+// caso misto estatico ref vs valor e erro de compilacao (coberto em
+// internal/compiler/ref_equality_strict_test.go); a comparacao de valor se
+// escreve com deref explicito, e ref vs null pergunta sobre o PROPRIO ref
+// — o que mantem `no.proximo != null` funcionando por nulidade do ref, nao
+// por leitura do valor.
+func TestRefEqualityNeverImplicitlyDereferences(t *testing.T) {
 	cases := []struct {
 		name string
 		expr string
 		want bool
 	}{
-		{"ref contra valor igual", "ra == 1", true},
-		{"ref contra valor diferente", "ra == 2", false},
-		{"valor a esquerda", "1 == ra", true},
+		{"deref explicito contra valor igual", "*ra == 1", true},
+		{"deref explicito contra valor diferente", "*ra == 2", false},
+		{"deref explicito a direita", "1 == *ra", true},
 		{"ref valido nao é null", "ra == null", false},
 		{"ref nulo é null", "nulo == null", true},
 	}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1020,27 +1020,15 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_EQUAL:
 			b := vm.pop()
 			a := vm.pop()
-			// Auto-deref ASSIMETRICO. Comparar um `ref T` com algo que nao e
-			// ref (um `T`, um `null`) le o valor apontado, como qualquer
-			// outro uso de ref numa expressao (spec §2.3) — e o que mantem
-			// `no.proximo != null` e `contador == 10` funcionando.
-			// Dois refs, porem, NAO sao dereferenciados: valuesEqual compara
-			// identidade de slot (§2.2.7), a semantica de ponteiro. O
-			// compilador nao emite OP_DEREF para `==`/`!=` justamente para
-			// que os dois casos possam ser distinguidos aqui.
-			if a.Type == value.VAL_REF && b.Type != value.VAL_REF {
-				resolved, err := vm.resolveReferenceValue(a)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				a = resolved
-			} else if b.Type == value.VAL_REF && a.Type != value.VAL_REF {
-				resolved, err := vm.resolveReferenceValue(b)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				b = resolved
-			}
+			// Em `==`/`!=` um ref NUNCA e dereferenciado implicitamente
+			// (spec §2.3, excecao 1): dois refs comparam identidade de slot
+			// (§2.2.7), um ref nulo E o proprio VAL_NULL (entao `r == null`
+			// pergunta sobre o ref, nao sobre o valor apontado — o que
+			// mantem `no.proximo != null` funcionando e torna distinguivel
+			// o ref valido para um slot que contem null), e ref vs valor e
+			// simplesmente diferente. O caso misto estatico e rejeitado
+			// pelo compilador com hint para `*r`; aqui so chega via
+			// fronteira dinamica (`any`), onde a resposta honesta e false.
 			vm.push(value.NewBool(valuesEqual(a, b)))
 		case chunk.OP_EQUAL_INT:
 			b := vm.pop()

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -965,7 +965,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_GREATER:
 			b := vm.pop()
 			a := vm.pop()
-			// Only supporting int/float comparison for now
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
 				vm.push(value.NewBool(a.AsInt > b.AsInt))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
@@ -974,8 +973,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				vm.push(value.NewBool(float64(a.AsInt) > b.AsFloat))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
 				vm.push(value.NewBool(a.AsFloat > float64(b.AsInt)))
+			} else if strA, strB, ok := stringOperands(a, b); ok {
+				// Ordenacao lexicografica byte a byte — para UTF-8 valido
+				// (invariante de toda string Noxy) coincide com a ordem por
+				// code point, e casa com a igualdade byte-exata da spec.
+				// bytes ficam de fora: a ponte explicita e to_str.
+				vm.push(value.NewBool(strA > strB))
 			} else {
-				return vm.runtimeError(c, ip, "operands must be numbers")
+				return vm.runtimeError(c, ip, "operands must be numbers or strings")
 			}
 		case chunk.OP_GREATER_INT:
 			b := vm.pop()
@@ -996,8 +1001,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				vm.push(value.NewBool(float64(a.AsInt) < b.AsFloat))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
 				vm.push(value.NewBool(a.AsFloat < float64(b.AsInt)))
+			} else if strA, strB, ok := stringOperands(a, b); ok {
+				// Mesma ordenacao lexicografica de OP_GREATER; `>=`/`<=`
+				// compilam como NOT(OP_LESS)/NOT(OP_GREATER) e herdam isto.
+				vm.push(value.NewBool(strA < strB))
 			} else {
-				return vm.runtimeError(c, ip, "operands must be numbers")
+				return vm.runtimeError(c, ip, "operands must be numbers or strings")
 			}
 		case chunk.OP_LESS_INT:
 			// Inline pop/pop/push

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -119,7 +119,7 @@ struct Node
     next: ref Node
 end
 func fill(node: ref Node) -> void
-    if node == null then
+    if *node == null then
         *node = Node(42, null)
     end
 end

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -638,7 +638,7 @@ end
 let target: Vertex = Vertex(1)
 let ok: bool = json_loads("null", target)
 if ok then
-    if target == null then test_report(1) else test_report(998) end
+    if *target == null then test_report(1) else test_report(998) end
 else
     test_report(999)
 end`,
@@ -2561,7 +2561,7 @@ func TestContextualReferenceCallsCanFillNullIndexSlots(t *testing.T) {
 			name: "array index",
 			source: `
 func fill(target: ref int) -> void
-    if target == null then
+    if *target == null then
         *target = 42
     end
 end
@@ -2573,7 +2573,7 @@ test_report(stored[0])`,
 			name: "map index",
 			source: `
 func fill(target: ref int) -> void
-    if target == null then
+    if *target == null then
         *target = 42
     end
 end

--- a/internal/vm/ref_equality_strict_runtime_test.go
+++ b/internal/vm/ref_equality_strict_runtime_test.go
@@ -1,0 +1,107 @@
+package vm
+
+// Runtime da igualdade estrita de ref (v0.7.1): OP_EQUAL deixa de resolver
+// o caso misto VAL_REF vs nao-ref. Um ref comparado com null pergunta se o
+// PROPRIO ref e nulo (antes, o deref implicito tornava `rv == null` true
+// para um ref VALIDO apontando para um slot que contem null — a pergunta
+// "ref nulo?" e "valor apontado nulo?" eram indistinguiveis). Na fronteira
+// dinamica (`any`), um ref comparado com um valor e simplesmente diferente
+// — nunca dereferenciado.
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func requireBoolResults(t *testing.T, src string, want []bool) {
+	t.Helper()
+	got := captureVMSource(t, src)
+	arr, ok := got.Obj.(*value.ObjArray)
+	if !ok {
+		t.Fatalf("esperava array de bools, veio %v", got)
+	}
+	if len(arr.Elements) != len(want) {
+		t.Fatalf("esperava %d resultados, vieram %d", len(want), len(arr.Elements))
+	}
+	for i, expected := range want {
+		if arr.Elements[i].AsBool != expected {
+			t.Errorf("caso %d: esperava %v, veio %v", i, expected, arr.Elements[i].AsBool)
+		}
+	}
+}
+
+// O caso-armadilha do null, agora com as duas perguntas expressaveis.
+func TestRefNullComparisonAsksAboutTheRefItself(t *testing.T) {
+	requireBoolResults(t, `
+struct Ponto
+    x: int
+end
+let vazio: Ponto = null
+let rv: ref Ponto = ref vazio
+let nulo: ref Ponto = null
+test_report([
+    rv == null,
+    rv != null,
+    *rv == null,
+    nulo == null,
+    nulo != null
+])`, []bool{false, true, true, true, false})
+}
+
+// Travessia classica continua identica: o terminador e um ref nulo.
+func TestLinkedListTraversalUnchanged(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    value: int,
+    next: ref Node
+end
+let n2: Node = Node(2, null)
+let n1: Node = Node(1, ref n2)
+let soma: int = 0
+let cur: ref Node = ref n1
+while cur != null do
+    soma = soma + cur.value
+    cur = cur.next
+end
+test_report(soma)`)
+	if got.AsInt != 3 {
+		t.Fatalf("travessia deveria somar 3, veio %d", got.AsInt)
+	}
+}
+
+// Na fronteira dinamica, ref vs valor e diferente (sem deref); ref vs ref
+// segue comparando identidade de slot. Nota sobre o canal: um ref cru nao
+// entra numa VARIAVEL `any` (`let a: any = ref r` guarda copia deref'ada, e
+// parametro `any` rejeita ref em runtime) — o caminho real e o acesso
+// dinamico a membro, que devolve o campo `ref` sem deref.
+func TestAnyBoundaryDoesNotDereference(t *testing.T) {
+	requireBoolResults(t, `
+struct Obs
+    alvo: ref int
+end
+let t: int = 20
+let o: Obs = Obs(ref t)
+let d: any = o
+let d2: any = o
+test_report([
+    d.alvo == 20,
+    d.alvo != 20,
+    d.alvo == null,
+    d.alvo == d2.alvo
+])`, []bool{false, true, false, true})
+}
+
+// O caminho explicito compara valores normalmente.
+func TestExplicitDerefComparesValues(t *testing.T) {
+	requireBoolResults(t, `
+let x: int = 5
+let y: int = 5
+let ra: ref int = ref x
+let rb: ref int = ref y
+test_report([
+    *ra == 5,
+    *ra == *rb,
+    ra == rb
+])`, []bool{true, true, false})
+}

--- a/internal/vm/string_ordering.go
+++ b/internal/vm/string_ordering.go
@@ -1,0 +1,20 @@
+package vm
+
+import "noxy-vm/internal/value"
+
+// stringOperands reconhece o par (string, string) para os opcodes de
+// ordenacao OP_GREATER/OP_LESS. Segue o mesmo criterio do branch de strings
+// de OP_ADD: ambos VAL_OBJ carregando Go string. bytes (VAL_BYTES) ficam
+// deliberadamente de fora — ordena-los exige a ponte explicita to_str,
+// como no resto da stdlib.
+func stringOperands(a, b value.Value) (string, string, bool) {
+	if a.Type != value.VAL_OBJ || b.Type != value.VAL_OBJ {
+		return "", "", false
+	}
+	strA, okA := a.Obj.(string)
+	strB, okB := b.Obj.(string)
+	if !okA || !okB {
+		return "", "", false
+	}
+	return strA, strB, true
+}

--- a/internal/vm/string_ordering_test.go
+++ b/internal/vm/string_ordering_test.go
@@ -1,0 +1,92 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// A spec (§1.3/§8) lista `>`, `<`, `>=`, `<=` como operadores de comparacao
+// sem restringi-los a numeros, e define comparacao de strings como byte-exata
+// (sem normalizacao Unicode, como Python). Ate aqui o executor so aceitava
+// numeros em OP_GREATER/OP_LESS, entao `"a" < "b"` compilava e estourava em
+// RUNTIME com "operands must be numbers". Estes testes fixam a semantica
+// correta: ordenacao lexicografica byte a byte — que, para UTF-8 valido
+// (invariante de toda string Noxy), coincide com a ordem por code point.
+func TestStringOrderingIsLexicographic(t *testing.T) {
+	got := captureVMSource(t, `
+test_report([
+    "abc" < "abd",
+    "b" > "a",
+    "a" <= "a",
+    "abc" >= "abc",
+    "ab" < "b",
+    "Z" < "a",
+    "e" < "é",
+    "a" > "b",
+    "b" <= "a"
+])`)
+	arr, ok := got.Obj.(*value.ObjArray)
+	if !ok {
+		t.Fatalf("esperava array de bools, veio %v", got)
+	}
+	want := []bool{true, true, true, true, true, true, true, false, false}
+	if len(arr.Elements) != len(want) {
+		t.Fatalf("esperava %d resultados, vieram %d", len(want), len(arr.Elements))
+	}
+	for i, expected := range want {
+		if arr.Elements[i].AsBool != expected {
+			t.Errorf("comparacao %d: esperava %v, veio %v", i, expected, arr.Elements[i].AsBool)
+		}
+	}
+}
+
+// O compilador ja dereferencia operandos ref de `<`/`>` (compiler.go, bloco
+// identityComparison); com strings suportadas no executor, `ref string`
+// ordena pelo valor apontado.
+func TestStringOrderingDereferencesRefOperands(t *testing.T) {
+	got := captureVMSource(t, `
+let s: string = "a"
+let r: ref string = ref s
+test_report(r < "b")`)
+	if !got.AsBool {
+		t.Fatal("ref string < string deveria comparar o valor apontado")
+	}
+}
+
+// A fronteira dinamica tambem ordena: operandos `any` que carregam strings
+// em runtime usam o mesmo caminho generico de OP_LESS.
+func TestStringOrderingThroughAnyBoundary(t *testing.T) {
+	got := captureVMSource(t, `
+let a: any = "abc"
+test_report(a < "abd")`)
+	if !got.AsBool {
+		t.Fatal("any carregando string deveria ordenar lexicograficamente")
+	}
+}
+
+// Misturar string com numero continua erro de runtime — agora com mensagem
+// que reconhece os dois domínios validos.
+func TestStringOrderingMixedOperandsStillError(t *testing.T) {
+	err := interpretVMSource(t, New(), `
+let a: any = "a"
+let r: bool = a < 1
+print(r)`)
+	if err == nil || !strings.Contains(err.Error(), "operands must be numbers or strings") {
+		t.Fatalf("esperava erro de operandos mistos, veio %v", err)
+	}
+}
+
+// bytes seguem FORA da ordenacao (so strings ganharam suporte): a ponte
+// explicita e to_str, como em toda a stdlib.
+func TestBytesOrderingRemainsUnsupported(t *testing.T) {
+	err := interpretVMSource(t, New(), `
+let a: any = b"a"
+let b: any = b"b"
+let r: bool = a < b
+print(r)`)
+	if err == nil || !strings.Contains(err.Error(), "operands must be numbers or strings") {
+		t.Fatalf("esperava erro para ordenacao de bytes, veio %v", err)
+	}
+}

--- a/noxy_examples/binary_tree.nx
+++ b/noxy_examples/binary_tree.nx
@@ -98,7 +98,7 @@ root.left.right = Node(5, null, null)
 // 4   5 
 
 func pre_order(node: ref Node, array: ref DynamicArray) -> void
-  if node != null then
+  if *node != null then
     adicionar_elemento(array, node.data)
     pre_order(node.left, array)
     pre_order(node.right, array)

--- a/noxy_examples/bst.nx
+++ b/noxy_examples/bst.nx
@@ -28,7 +28,7 @@ end
 
 // Busca um valor na árvore
 func search(node: ref TreeNode, valor: int) -> bool
-    if node == null then
+    if *node == null then
         return false
     end
     if node.valor == valor then
@@ -43,7 +43,7 @@ end
 
 // Travessia In-Order (esquerda, raiz, direita) - imprime em ordem crescente
 func inorder(node: ref TreeNode)
-    if node == null then
+    if *node == null then
         return
     end
     inorder(node.esquerda)
@@ -53,7 +53,7 @@ end
 
 // Encontra o valor mínimo da árvore
 func find_min(node: ref TreeNode) -> int
-    if node == null then
+    if *node == null then
         return -1
     end
     let current: ref TreeNode = node
@@ -65,7 +65,7 @@ end
 
 // Encontra o valor máximo da árvore
 func find_max(node: ref TreeNode) -> int
-    if node == null then
+    if *node == null then
         return -1
     end
     let current: ref TreeNode = node
@@ -77,7 +77,7 @@ end
 
 // Conta o número de nós na árvore
 func count_nodes(node: ref TreeNode) -> int
-    if node == null then
+    if *node == null then
         return 0
     end
     return 1 + count_nodes(node.esquerda) + count_nodes(node.direita)
@@ -85,7 +85,7 @@ end
 
 // Calcula a altura da árvore
 func height(node: ref TreeNode) -> int
-    if node == null then
+    if *node == null then
         return 0
     end
     let left_height: int = height(node.esquerda)

--- a/noxy_examples/language_semantics_test.nx
+++ b/noxy_examples/language_semantics_test.nx
@@ -362,13 +362,15 @@ func test_igualdade()
     y = 5
     check(rx != ry, "identidade nao muda quando os valores voltam a coincidir")
 
-    // Ja o caso MISTO -- ref contra nao-ref -- continua lendo o valor
-    // apontado, como qualquer outro uso de ref numa expressao.
-    check(rx == 5, "ref contra valor faz auto-deref")
-    check(5 == rx, "auto-deref tambem com o ref a direita")
-    check(rx != 6, "auto-deref no caso negativo")
+    // O caso MISTO -- ref contra nao-ref -- e erro de COMPILACAO com hint
+    // ('rx == 5' nao compila): em '=='/'!=' um ref nunca e dereferenciado
+    // implicitamente, como o '=' ja recusava conversao implicita de ref.
+    // A comparacao de valor pede o deref explicito.
+    check(*rx == 5, "deref explicito compara o valor apontado")
+    check(5 == *rx, "deref explicito com o valor a esquerda")
+    check(*rx != 6, "deref explicito no caso negativo")
 
-    // E o teste de nulidade pergunta sobre o proprio ref.
+    // E o teste de nulidade pergunta sobre o PROPRIO ref, sem deref.
     let nulo: ref int = null
     check(nulo == null, "ref nulo é null")
     check(rx != null, "ref valido nao é null")

--- a/noxy_examples/language_semantics_test2.nx
+++ b/noxy_examples/language_semantics_test2.nx
@@ -382,6 +382,15 @@ func test_listas_ligadas()
     p = Ponto(1, 2)
     check(p != null, "instancia real nao e null")
     check_int(p.x, 1, "campos acessiveis apos sair do null")
+
+    // Igualdade estrita de ref: '== null' pergunta sobre o PROPRIO ref.
+    // Um ref VALIDO para um slot que contem null nao e null; a pergunta
+    // sobre o valor apontado e '*r == null'. As duas perguntas, antes
+    // indistinguiveis, agora tem cada uma sua sintaxe.
+    let vaga: Ponto = null
+    let rv: ref Ponto = ref vaga
+    check(rv != null, "ref valido para slot com null nao e null")
+    check(*rv == null, "'*r == null' pergunta sobre o valor apontado")
 end
 
 // ------------------------------------------------------------

--- a/noxy_examples/language_semantics_test2.nx
+++ b/noxy_examples/language_semantics_test2.nx
@@ -1,0 +1,566 @@
+// ============================================================
+// Testes unitarios de SEMANTICA da linguagem Noxy -- parte 2
+// ============================================================
+//
+// Continuacao de language_semantics_test.nx, com o mesmo contrato:
+// cada bloco afirma um comportamento OBSERVAVEL e falha (exit 1)
+// quando a semantica muda -- mesmo que o programa continue executando.
+//
+// Cobertura desta parte: conversoes e formatacao (to_*, fmt), as tres
+// formas de import, stdlib strings (unidade = code point), ordenacao
+// lexicografica de strings, bytes como octetos, structs de resultado do
+// modulo convert, arrays fixos e containers aninhados, structs
+// auto-referenciadas (listas ligadas), ref avancado (map entry,
+// forwarding, escape de frame, closures que compartilham slot, defer com
+// ref), when/case e a fronteira 'any'.
+//
+// Referencia: docs/NOXY_LANGUAGE_SPEC.md
+//
+// Uso: noxy noxy_examples/language_semantics_test2.nx
+
+use sys select exit
+
+// As tres formas de import sao, elas mesmas, semantica sob teste:
+// namespace, alias e selecao apontam para as MESMAS funcoes.
+use strings
+use strings as st
+use strings select to_upper, is_valid_utf8
+use convert select *
+
+// ------------------------------------------------------------
+// Harness minimo (identico ao da parte 1)
+// ------------------------------------------------------------
+
+let total: int = 0
+let failures: int = 0
+let grupo: string = ""
+
+func begin(nome: string)
+    grupo = nome
+end
+
+func check(condicao: bool, nome: string)
+    total = total + 1
+    if condicao then
+        return
+    end
+    failures = failures + 1
+    print("  [FAIL] " + grupo + " :: " + nome)
+end
+
+func check_int(obtido: int, esperado: int, nome: string)
+    check(obtido == esperado, nome + " (esperado " + to_str(esperado) + ", obtido " + to_str(obtido) + ")")
+end
+
+func check_str(obtido: string, esperado: string, nome: string)
+    check(obtido == esperado, nome + " (esperado '" + esperado + "', obtido '" + obtido + "')")
+end
+
+// ------------------------------------------------------------
+// Tipos de apoio
+// ------------------------------------------------------------
+
+struct Ponto
+    x: int,
+    y: int
+end
+
+struct Node
+    value: int,
+    next: ref Node
+end
+
+struct GNode<T>
+    value: T,
+    next: ref GNode<T>
+end
+
+struct Caixa<T>
+    valor: T
+end
+
+// ------------------------------------------------------------
+// 1. Conversoes numericas e floats
+// ------------------------------------------------------------
+
+func test_conversoes()
+    begin("conversoes")
+
+    // to_int/to_float aceitam strings quando a conversao e exata.
+    check_int(to_int("7"), 7, "to_int de string decimal")
+    check(to_float("5.5") == 5.5, "to_float de string com fracao")
+    check(to_float(5) == 5.0, "to_float de int")
+
+    // to_str de float usa formato fixo de 6 casas (igual a %f).
+    check_str(to_str(3.14), "3.140000", "to_str de float tem 6 casas")
+    check_str(to_str(1.0), "1.000000", "to_str de float inteiro mantem as casas")
+    check_str(to_str(42), "42", "to_str de int nao ganha casas")
+    check_str(to_str(true), "true", "to_str de bool")
+
+    // Floats seguem IEEE 754: fracoes decimais nao-representaveis
+    // acumulam erro; fracoes binarias exatas comparam exatas.
+    check(0.1 + 0.2 != 0.3, "0.1+0.2 difere de 0.3 (IEEE 754)")
+    check(0.5 + 0.25 == 0.75, "fracoes binarias exatas comparam exatas")
+
+    // Comparacao mista int/float promove, igual a aritmetica.
+    check(1 < 1.5, "int < float compara por valor numerico")
+    check(3 <= 3.0, "int <= float na igualdade numerica")
+    check(2.5 >= 2.5, "float >= float reflexivo")
+end
+
+// ------------------------------------------------------------
+// 2. Modulo convert: falha como dado, nao como erro
+// ------------------------------------------------------------
+
+func test_convert_result()
+    begin("convert result")
+
+    // A forma _result nunca levanta: sucesso e falha viram campos.
+    let ok_int: IntResult = to_int_result("42")
+    check(ok_int.ok, "to_int_result aceita inteiro decimal")
+    check_int(ok_int.value, 42, "value carrega o convertido")
+
+    // "5.5" e um float valido mas NAO um int: to_int_result recusa
+    // em vez de truncar silenciosamente.
+    let nao_int: IntResult = to_int_result("5.5")
+    check(!nao_int.ok, "to_int_result recusa string decimal fracionaria")
+    check(nao_int.error != "", "a falha vem descrita no campo error")
+
+    let ok_float: FloatResult = to_float_result("2.5")
+    check(ok_float.ok, "to_float_result aceita fracao")
+    check(ok_float.value == 2.5, "value carrega o float exato")
+
+    let nao_float: FloatResult = to_float_result("abc")
+    check(!nao_float.ok, "to_float_result recusa texto nao numerico")
+end
+
+// ------------------------------------------------------------
+// 3. fmt: formatacao estilo printf
+// ------------------------------------------------------------
+
+func test_fmt()
+    begin("fmt")
+
+    check_str(fmt("%d", 255), "255", "%d base 10")
+    check_str(fmt("%x", 255), "ff", "%x hex minusculo")
+    check_str(fmt("%X", 255), "FF", "%X hex maiusculo")
+    check_str(fmt("%b", 5), "101", "%b binario")
+    check_str(fmt("%f", 3.5), "3.500000", "%f usa 6 casas por padrao")
+    check_str(fmt("%.2f", 3.14159), "3.14", "%.Nf trunca a precisao pedida")
+    check_str(fmt("%e", 12345.678), "1.234568e+04", "%e notacao cientifica")
+    check_str(fmt("%t", true), "true", "%t bool")
+    check_str(fmt("%q", "hi"), "\"hi\"", "%q string entre aspas")
+    check_str(fmt("%s", "str"), "str", "%s string crua")
+    check_str(fmt("%v", [1, 2]), "[1, 2]", "%v representacao padrao de array")
+
+    // Varios verbos consomem os argumentos em ordem.
+    check_str(fmt("Value: %d, Hex: %x", 255, 255), "Value: 255, Hex: ff", "verbos em sequencia")
+end
+
+// ------------------------------------------------------------
+// 4. Formas de import: namespace, alias e selecao
+// ------------------------------------------------------------
+
+func test_import_forms()
+    begin("imports")
+
+    check_str(strings.to_lower("ABC"), "abc", "forma namespace: modulo.funcao")
+    check_str(st.reverse("abc"), "cba", "forma alias: 'use m as a'")
+    check_str(to_upper("abc"), "ABC", "forma seletiva importa direto no escopo")
+
+    // As tres formas resolvem para a MESMA funcao do modulo.
+    check_str(st.to_upper("ab"), to_upper("ab"), "alias e selecao coincidem")
+    check_str(strings.to_upper("ab"), to_upper("ab"), "namespace e selecao coincidem")
+end
+
+// ------------------------------------------------------------
+// 5. stdlib strings: a unidade e o code point
+// ------------------------------------------------------------
+
+func test_strings_stdlib()
+    begin("strings stdlib")
+
+    // substring: indices por rune, negativos contam do fim (estilo
+    // Python) e ambos os lados sao clampados a [0, len].
+    check_str(strings.substring("Hello", 1, 4), "ell", "substring basico")
+    check_str(strings.substring("Hello", 3, 100), "lo", "end e clampado ao tamanho")
+    check_str(strings.substring("Hello", -2, 5), "lo", "start negativo conta do fim")
+    check_str(strings.substring("Hello", 0, -1), "Hell", "end negativo conta do fim")
+    check_str(strings.substring("Hello", 3, 1), "", "start >= end resulta vazio")
+    check_str(strings.substring("aé🙂z", 1, 3), "é🙂", "indices por rune, nao por byte")
+
+    // Busca tambem responde em runes.
+    check_int(strings.index_of("banana", "na"), 2, "index_of devolve indice por rune")
+    check_int(strings.index_of("banana", "zz"), -1, "index_of sem match e -1")
+    check_int(strings.count("banana", "na"), 2, "count conta ocorrencias")
+    check_str(strings.char_at("café", 3), "é", "char_at devolve o code point")
+
+    // Transformacoes.
+    check_str(strings.repeat("ab", 3), "ababab", "repeat")
+    check_str(strings.pad_left("7", 3, "0"), "007", "pad_left preenche ate o total")
+    check_str(strings.trim("  oi  "), "oi", "trim remove espacos das pontas")
+    check_str(strings.replace("aaa", "a", "b"), "bbb", "replace troca todas")
+    check_str(strings.replace_first("aaa", "a", "b"), "baa", "replace_first troca so a primeira")
+    check_str(strings.reverse("abc"), "cba", "reverse")
+
+    // split devolve um struct de resultado, nao um array cru.
+    let sp: strings.SplitResult = strings.split("a,b,c", ",")
+    check_int(sp.count, 3, "split conta as partes")
+    check_str(sp.parts[0], "a", "primeira parte")
+    check_str(sp.parts[2], "c", "ultima parte")
+    check_str(strings.join_count(sp.parts, "-", sp.count), "a-b-c", "join_count inverte o split")
+
+    // Ponte caractere <-> codigo.
+    check_int(strings.char_code("A"), 65, "char_code")
+    check_str(strings.from_char_code(66), "B", "from_char_code")
+    let cs: int[] = strings.codes("hi")
+    check_int(cs[0], 104, "codes devolve os code points")
+    check_int(cs[1], 105, "codes segundo elemento")
+
+    // Predicados.
+    check(strings.starts_with("noxy", "no"), "starts_with")
+    check(strings.ends_with("noxy", "xy"), "ends_with")
+    check(strings.contains("noxy", "ox"), "contains de substring")
+    check(strings.is_digit("123"), "is_digit")
+    check(strings.is_alpha("abc"), "is_alpha")
+
+    // O builtin slice tambem opera em strings, por rune.
+    check_str(slice("hello", 1, 3), "el", "slice de string por rune")
+    check(slice([1, 2, 3, 4], 1, 3) == [2, 3], "slice de array devolve subarray")
+
+    // Escapes classicos valem um caractere cada.
+    check_int(length("a\nb"), 3, "\\n e um caractere")
+    check_int(length("a\tb"), 3, "\\t e um caractere")
+end
+
+// ------------------------------------------------------------
+// 5b. Ordenacao de strings: lexicografica, byte-exata
+// ------------------------------------------------------------
+
+func test_ordenacao_strings()
+    begin("ordenacao de strings")
+
+    // <, >, <=, >= ordenam strings lexicograficamente byte a byte --
+    // dentro do invariante UTF-8 isso e identico a ordem por code point.
+    check("abc" < "abd", "ordem lexicografica basica")
+    check("b" > "a", "> e o espelho de <")
+    check("a" <= "a", "<= e reflexivo")
+    check("abc" >= "abc", ">= e reflexivo")
+    check(!("a" > "b"), "caso negativo de >")
+
+    // Prefixo vem antes da palavra completa.
+    check("ab" < "b", "prefixo ordena antes")
+
+    // A ordem e byte-exata, nao 'alfabetica': maiusculas (0x5A) vem
+    // antes de minusculas (0x61), e acentos depois do ascii.
+    check("Z" < "a", "maiuscula antes de minuscula (byte order)")
+    check("e" < "é", "ascii antes de acentuado (code point order)")
+
+    // ref string ordena pelo valor apontado (auto-deref de expressao).
+    let s: string = "a"
+    let rs: ref string = ref s
+    check(rs < "b", "ref string participa da ordenacao pelo valor")
+end
+
+// ------------------------------------------------------------
+// 6. bytes: o espelho da string, indexado por octeto
+// ------------------------------------------------------------
+
+func test_bytes()
+    begin("bytes")
+
+    let b: bytes = b"Hi"
+
+    // Elemento de bytes e o proprio octeto, como int.
+    check_int(b[0], 72, "b[0] devolve o octeto como int")
+    check_int(b[1], 105, "b[1] segundo octeto")
+
+    // slice e concatenacao operam em octetos.
+    check_int(length(slice(b, 0, 1)), 1, "slice de bytes por octeto")
+    check_str(hex_encode(slice(b, 0, 1)), "48", "slice preserva o conteudo")
+    check_str(hex_encode(b"a" + b"b"), "6162", "+ concatena bytes")
+
+    // to_bytes/to_str sao a ponte explicita entre os dois tipos.
+    check(to_bytes("Hi") == b, "to_bytes de string ascii")
+    check_str(to_str(b), "Hi", "to_str de bytes validos")
+    check_str(to_str(to_bytes("café")), "café", "round-trip preserva unicode")
+
+    // O invariante UTF-8 e checado na fronteira, via is_valid_utf8.
+    check(is_valid_utf8(to_bytes("ok")), "bytes vindos de string sao UTF-8")
+    check(!is_valid_utf8(hex_decode("FF")), "0xFF sozinho nao e UTF-8")
+end
+
+// ------------------------------------------------------------
+// 7. Arrays fixos, containers aninhados e igualdade
+// ------------------------------------------------------------
+
+func test_containers()
+    begin("containers")
+
+    // Array dinamico declarado sem inicializador comeca vazio.
+    let vazia: int[]
+    check_int(length(vazia), 0, "declaracao sem inicializador comeca vazia")
+
+    // Array fixo participa da mesma semantica de valor...
+    let fx: int[3] = [1, 2, 3]
+    let cp: int[3] = fx
+    cp[0] = 9
+    check_int(fx[0], 1, "copia de array fixo nao vaza (CoW)")
+    check_int(cp[0], 9, "a copia e independente")
+
+    // ...e da mesma igualdade estrutural, inclusive contra dinamico.
+    let dyn: int[] = [1, 2, 3]
+    check(fx == dyn, "fixo e dinamico comparam por conteudo")
+
+    // for-in tambem itera arrays fixos.
+    let soma: int = 0
+    for v in fx do
+        soma = soma + v
+    end
+    check_int(soma, 6, "for-in sobre array fixo")
+
+    // Escrita atraves de indices encadeados alcanca o nivel interno.
+    let a2: int[][] = [[1, 2], [3, 4]]
+    a2[0][1] = 9
+    check_int(a2[0][1], 9, "escrita em array aninhado")
+    check_int(a2[1][0], 3, "o vizinho nao e afetado")
+
+    let m2: map[string, map[string, int]] = {"a": {"b": 1, "c": 2}}
+    m2["a"]["b"] = 5
+    check_int(m2["a"]["b"], 5, "escrita em map aninhado")
+    check_int(m2["a"]["c"], 2, "a chave vizinha nao e afetada")
+
+    // Chave de map nao precisa ser string.
+    let mi: map[int, string] = {1: "um", 2: "dois"}
+    check_str(mi[1] + mi[2], "umdois", "map com chave int")
+    let ks: int[] = keys(mi)
+    check_int(length(ks), 2, "keys de map[int] devolve int[]")
+    check(contains(ks, 1) && contains(ks, 2), "todas as chaves aparecem")
+
+    // Struct generica compara por conteudo como qualquer struct.
+    check(Caixa(1) == Caixa(1), "structs genericas iguais por conteudo")
+    check(Caixa(1) != Caixa(2), "structs genericas diferentes por conteudo")
+end
+
+// ------------------------------------------------------------
+// 8. Structs auto-referenciadas e null em contratos
+// ------------------------------------------------------------
+
+func test_listas_ligadas()
+    begin("listas ligadas")
+
+    // 'ref Node' dentro do proprio Node permite encadear valores;
+    // null e o terminador natural.
+    let n3: Node = Node(3, null)
+    let n2: Node = Node(2, ref n3)
+    let n1: Node = Node(1, ref n2)
+
+    // Encadeamento de acesso faz auto-deref em cada salto.
+    check_int(n1.next.value, 2, "n1.next.value atravessa o ref")
+    check_int(n1.next.next.value, 3, "dois saltos de ref")
+
+    // Percurso classico: rebind do cursor ate o null terminador.
+    let soma: int = 0
+    let cur: ref Node = ref n1
+    while cur != null do
+        soma = soma + cur.value
+        cur = cur.next
+    end
+    check_int(soma, 6, "percurso visita todos os nos e termina no null")
+
+    // A versao generica se comporta igual.
+    let g2: GNode<string> = GNode("b", null)
+    let g1: GNode<string> = GNode("a", ref g2)
+    check_str(g1.next.value, "b", "GNode<T> auto-referenciada")
+    check(g2.next == null, "terminador null no campo ref generico")
+
+    // null satisfaz contrato de struct: a variavel existe sem valor...
+    let p: Ponto = null
+    check(p == null, "variavel de struct aceita null")
+
+    // ...e volta ao normal ao receber uma instancia real.
+    p = Ponto(1, 2)
+    check(p != null, "instancia real nao e null")
+    check_int(p.x, 1, "campos acessiveis apos sair do null")
+end
+
+// ------------------------------------------------------------
+// 9. ref avancado
+// ------------------------------------------------------------
+
+let registro: int = 0
+
+func grava(v: ref int)
+    // Atribuir 'registro = v' direto e erro de compilacao (int vs ref int,
+    // com hint sugerindo '*v'): atribuicao nao faz auto-deref -- spec
+    // §2.3, excecao 2. O deref explicito e a forma canonica.
+    registro = *v
+end
+
+func frame_defer_ref()
+    let n: int = 1
+    defer grava(ref n)
+    n = 9
+end
+
+func cria_ref() -> ref int
+    let local: int = 42
+    return ref local
+end
+
+func par_de_closures() -> (func() -> int)[]
+    let n: int = 0
+    let incrementa: func() -> int = func() -> int
+        n = n + 1
+        return n
+    end
+    let le: func() -> int = func() -> int
+        return n
+    end
+    return [incrementa, le]
+end
+
+func test_ref_avancado()
+    begin("ref avancado")
+
+    // Entrada de map tambem e um slot referenciavel.
+    let m: map[string, int] = {"k": 1}
+    let r: ref int = ref m["k"]
+    *r = 5
+    check_int(m["k"], 5, "ref para entrada de map escreve no map")
+
+    // 'ref' sobre um ref FORWARDA a referencia existente (nao existe
+    // ref ref T): o resultado e o mesmo slot.
+    let x: int = 1
+    let rx: ref int = ref x
+    let fwd: ref int = ref rx
+    check(fwd == rx, "forwarding preserva a identidade do slot")
+    *fwd = 2
+    check_int(x, 2, "escrever via forward alcanca o original")
+
+    // '*' tambem funciona em posicao de leitura, como forma explicita.
+    check_int(*rx, 2, "'*r' le o valor apontado")
+
+    // No alvo '*r =' o RHS ref e lido (o '*' ja desfez a ambiguidade
+    // update/rebind): '*ra = ro' equivale a '*ra = *ro'.
+    let alvo: int = 1
+    let origem: int = 5
+    let ra: ref int = ref alvo
+    let ro: ref int = ref origem
+    *ra = ro
+    check_int(alvo, 5, "'*r = outro_ref' escreve o valor apontado pelo RHS")
+    check_int(origem, 5, "o RHS so e lido, nao alterado")
+
+    // ref para local sobrevive ao frame que o criou (promocao a heap).
+    let esc: ref int = cria_ref()
+    check_int(esc, 42, "ref devolvido le o valor da local promovida")
+    *esc = 99
+    check_int(esc, 99, "o slot promovido continua gravavel")
+
+    // Duas closures sobre a MESMA variavel compartilham o slot.
+    let fs: (func() -> int)[] = par_de_closures()
+    check_int(fs[0](), 1, "primeira mutacao via closure A")
+    check_int(fs[0](), 2, "segunda mutacao via closure A")
+    check_int(fs[1](), 2, "closure B enxerga o estado da closure A")
+
+    // defer com parametro ref RETEM a referencia: a chamada adiada
+    // le o valor final, nao o do registro do defer.
+    registro = 0
+    frame_defer_ref()
+    check_int(registro, 9, "defer com ref observa mutacoes posteriores")
+end
+
+// ------------------------------------------------------------
+// 10. when/case sobre canais
+// ------------------------------------------------------------
+
+func test_when()
+    begin("when/case")
+
+    // Canal com valor pronto: o case de recv vence e faz o bind.
+    let ch: any = make_chan(1)
+    chan_send(ch, 42)
+    let got: int = -1
+    when
+        case v = chan_recv(ch) then
+            got = to_int(v)
+        default
+            got = -2
+    end
+    check_int(got, 42, "case recv com bind entrega o valor")
+
+    // Canal vazio + default: o when nao bloqueia.
+    let vazio: any = make_chan(1)
+    let ramo: string = ""
+    when
+        case chan_recv(vazio) then
+            ramo = "recv"
+        default
+            ramo = "default"
+    end
+    check_str(ramo, "default", "default roda quando nenhum case esta pronto")
+
+    // case de send fica pronto quando o buffer tem espaco, e o valor
+    // realmente entra no canal.
+    let livre: any = make_chan(1)
+    let enviou: bool = false
+    when
+        case chan_send(livre, 7) then
+            enviou = true
+        default
+            enviou = false
+    end
+    check(enviou, "case send pronto com buffer livre")
+    check_int(to_int(chan_recv(livre)), 7, "o valor enviado pelo case chegou")
+end
+
+// ------------------------------------------------------------
+// 11. any: a fronteira dinamica
+// ------------------------------------------------------------
+
+func test_any()
+    begin("any")
+
+    // Uma variavel 'any' e a excecao a estabilidade de tipos: aceita
+    // valores de tipos diferentes ao longo da vida.
+    let a: any = 5
+    check_int(to_int(a) + 1, 6, "any carregando int")
+    a = "texto"
+    check_str(to_str(a), "texto", "o mesmo any carregando string")
+    a = [1, 2]
+    check_int(length(a), 2, "o mesmo any carregando array")
+end
+
+// ------------------------------------------------------------
+// Runner
+// ------------------------------------------------------------
+
+func main()
+    print("=== NOXY :: TESTES DE SEMANTICA DA LINGUAGEM (PARTE 2) ===")
+
+    test_conversoes()
+    test_convert_result()
+    test_fmt()
+    test_import_forms()
+    test_strings_stdlib()
+    test_ordenacao_strings()
+    test_bytes()
+    test_containers()
+    test_listas_ligadas()
+    test_ref_avancado()
+    test_when()
+    test_any()
+
+    print("")
+    print("Asercoes: " + to_str(total))
+    print("Passaram: " + to_str(total - failures))
+    print("Falharam: " + to_str(failures))
+
+    if failures > 0 then
+        print("=== FALHOU ===")
+        exit(1)
+    end
+    print("=== OK ===")
+end
+
+main()

--- a/noxy_examples/linked_list.nx
+++ b/noxy_examples/linked_list.nx
@@ -4,7 +4,9 @@ struct Node
 end
 
 func _append(node: ref Node, valor: int)
-    if node == null then
+    // '*node == null' pergunta se o SLOT apontado esta vazio (padrao
+    // fill-null-slot); 'node == null' perguntaria sobre o proprio ref.
+    if *node == null then
         *node = Node(valor, null)
     else
         _append(node.proximo, valor)

--- a/noxy_examples/test_explicit_deref.nx
+++ b/noxy_examples/test_explicit_deref.nx
@@ -15,8 +15,8 @@ func verify_syntax(r: ref int)
     *r = 100
     print(f"Updated value via *r: {*r}") // *r in expression is valid (though r works too)
     
-    // 2. Read (r works as value)
-    if r == 100 then
+    // 2. Read via explicit deref ('==' never auto-derefs a ref operand)
+    if *r == 100 then
         print("PASS: Update worked")
     else
         print(f"FAIL: Expected 100, got {r}")


### PR DESCRIPTION
Release **v0.7.1** — três mudanças na mesma área (clareza sintática de `ref` e comparações), sendo uma **BREAKING**.

## Summary
- **BREAKING — Igualdade estrita de ref**: em `==`/`!=` um operando `ref` **nunca** é dereferenciado implicitamente. Dois refs comparam identidade de slot (regra já vigente), `r == null` pergunta se o **próprio ref** é nulo, e o caso misto `ref` vs valor vira **erro de compilação** com `hint: use '*r' to compare the referenced value`. Fecha a assimetria com o `=` (que já recusava conversão implícita de ref) e elimina a comparação cujo significado dependia de tipos invisíveis no código.
- **A ambiguidade do null foi resolvida pela mesma regra**: um ref válido apontando para um slot que contém `null` não é mais "igual a null" — `r == null` (sobre o ref) e `*r == null` (sobre o valor apontado) são agora duas perguntas distintas e expressáveis. Travessias com `no.proximo != null` continuam idênticas.
- `<`, `>`, `<=`, `>=` agora ordenam strings lexicograficamente, byte a byte (idêntico à ordem por code point no invariante UTF-8, como Python). Antes, `"abc" < "abd"` compilava e estourava em runtime com `operands must be numbers`, contradizendo a spec. Mistos e `bytes` continuam erro de runtime com a mensagem nova `operands must be numbers or strings`.
- Atribuir `ref T` a alvo que espera `T` (6 shapes: local, global, upvalue, índice de array, valor de map, campo de struct) continua erro — atribuição não faz auto-deref — mas agora com `hint: use '*r' to read the referenced value`, espelho do hint existente de `r = 50`.
- Spec explicita as **duas exceções** ao auto-deref (§2.3: `==`/`!=` com operando ref, e o RHS de atribuição), corrige o exemplo `*r = ref z` (documentado como ERROR, mas a implementação lê o RHS — comportamento agora fixado em teste) e ganha a linha `T = ref T` na tabela de Type-Based Assignment.
- Nova suíte `noxy_examples/language_semantics_test2.nx` (131 asserções em 12 grupos), parte 2 dos testes de semântica, incluindo ordenação de strings e os pins da armadilha do null resolvida.

## Components
- `internal/compiler/compiler.go` — `rejectMixedRefComparison` (erro estático do caso misto; null/`any`/tipo desconhecido passam) e `derefReadHint` nos seis sites de atribuição
- `internal/vm/executor.go` — `OP_EQUAL` deixa de resolver o caso misto em runtime; branches de string em `OP_GREATER`/`OP_LESS` (`>=`/`<=` herdam via `NOT`)
- `internal/vm/string_ordering.go` — helper `stringOperands` (`bytes` deliberadamente fora; ponte é `to_str`)
- `internal/compiler/ref_equality_strict_test.go` + `internal/vm/ref_equality_strict_runtime_test.go` — regra nova (erro+hint por shape, armadilha do null, fronteira dinâmica via membro de `any`, travessia inalterada)
- `internal/compiler/assign_deref_hint_test.go` + `internal/vm/string_ordering_test.go` — hints de atribuição e ordenação lexicográfica
- `internal/vm/{cow_equality,function_types,native_signatures}_test.go` — testes de caracterização migrados (fill-null-slot → `*node == null`)
- `docs/NOXY_LANGUAGE_SPEC.md` — §2.2 regra 7, §2.3 (exceções 1 e 2, Strict Type Safety, tabela), §8, §12; footer 0.7.1
- `noxy_examples/` — suítes de semântica partes 1 (134 asserções) e 2 (131); migração de `bst.nx`, `binary_tree.nx`, `linked_list.nx`, `test_explicit_deref.nx` (únicos 4 de 170 afetados)
- `CHANGELOG.md` + `internal/version/version.go` — release v0.7.1

## Test Plan
- [x] TDD: testes novos escritos primeiro e vistos falhar (RED) antes de cada implementação
- [x] `go test ./...` completo passando
- [x] Suítes de semântica: parte 1 (134) e parte 2 (131) com exit 0
- [x] `run_all_tests_concurrent.nx`: 170/170 exemplos passando após a migração dos 4 afetados
- [x] E2E via CLI: erro+hint do caso misto, armadilha do null (`rv == null` → false, `*rv == null` → true), ordenação de strings, hints de atribuição, `noxy --version` → v0.7.1
- [ ] Review humano da redação nova do spec (§2.2/§2.3/§8/§12) e da entrada BREAKING no CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
