### PR TITLE
feat/call-result - Fronteira sincrona de erro call_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.2] - 2026-08-19
 
 ### Added — `call_result`: fronteira síncrona de erro
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [Unreleased]
+
+### Added — `call_result`: fronteira síncrona de erro
+
+- Novo nativo global `call_result(fn, ...args)` converte uma falha de runtime
+  que desenrola de `fn` em valor: envelope `{ok, value, failure}` com
+  `failure = {kind, message, stack, causes}` — o mesmo vocabulário da
+  fronteira de task, estendido com as falhas de defer agregadas (`causes`,
+  ordem LIFO, localização de registro no stack). Misuse (não-callable,
+  aridade/modos/campos errados onde há metadata) levanta síncrono no
+  chamador. Panics de Go viram `kind="panic"`; fatais do runtime Go seguem
+  fatais. Sem rollback: mutações via `ref`/globais/upvalues permanecem.
+- Novo módulo stdlib `errors` com os shapes `Failure` e `CallResult`
+  (fisicamente o envelope é um map na fronteira dinâmica, como `IntResult`).
+- O validador de tipo em runtime passou a aceitar, na fronteira dinâmica, um
+  map estruturalmente compatível onde um struct é esperado (todo campo do
+  schema precisa existir no map com tipo recursivamente compatível) — sem
+  isso `let r: CallResult = call_result(...)` não tiparia: `CallResult`
+  aninha `failure: Failure`, que por sua vez tem `causes: Failure[]`, campo
+  composto que o precedente `IntResult` nunca tinha e por isso nunca
+  exercitou esse caminho do validador.
+- Gêmeos `_result` agora são escrevíveis em noxy puro (ver
+  `noxy_examples/result_pattern.nx`).
+
+### Changed
+
+- `to_int`/`to_float`: o sufixo "; use to_int_result to handle failure" saiu
+  da mensagem de erro (agora limpa e capturável) e virou `hint:` impresso
+  apenas na saída fatal do topo.
+
+### Deprecated
+
+- Módulo `result` (`use result`): substituído pela convenção `_result` +
+  módulo `errors`. Remoção na próxima release.
+
 ## [0.7.1] - 2026-08-19
 
 ### Fixed (BREAKING) — Igualdade estrita de ref: `==`/`!=` nunca dereferencia implicitamente

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -269,6 +270,10 @@ func startREPL(showDisasm bool) {
 		// VM.Interpret resets stack but keeps globals (which we want).
 		if err := machine.Interpret(chunk); err != nil {
 			fmt.Printf("Runtime error: %s\n", err)
+			var advised *vm.AdvisedError
+			if errors.As(err, &advised) {
+				fmt.Printf("hint: %s\n", advised.Advice)
+			}
 		}
 
 		inputBuffer = "" // Reset buffer after execution
@@ -336,6 +341,10 @@ func runWithConfig(filename string, input string, rootPath string, showDisasm bo
 	machine := vm.NewWithConfig(vm.VMConfig{RootPath: rootPath})
 	if err := machine.Interpret(chunk); err != nil {
 		fmt.Printf("Runtime error: %s\n", err)
+		var advised *vm.AdvisedError
+		if errors.As(err, &advised) {
+			fmt.Printf("hint: %s\n", advised.Advice)
+		}
 		return 1
 	}
 	return 0

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1055,35 +1055,97 @@ else
 end
 ```
 
-**Callable and validation.** `fn` may be any callable value: a typed Noxy
-function or closure, a function value held as an exact or bare `func`, a
-struct constructor, or a native. (A native reaches the boundary as `any` or
-in argument position; the compiler does not admit `let f: func = to_int`.)
-Passing a non-callable is a synchronous runtime error in the caller.
-Arguments are evaluated in the caller's frame, before the boundary exists; an
-error during argument evaluation is not captured. Where the callee exposes
-parameter metadata — typed Noxy functions and closures, struct constructors,
-signed natives — arity and parameter-mode mismatches are synchronous runtime
-errors in the caller. The timing mirrors `spawn_task`'s synchronous
+**Signature.**
+
+```noxy
+call_result(fn, ...args)   // -> CallResult
+```
+
+`fn` is the callable to invoke — always the first argument. `...args` are
+zero or more arguments of any Noxy type (scalars, strings, bytes, arrays,
+maps, struct instances, `null`, explicit `ref`s), forwarded to `fn` exactly
+as a direct call would forward them.
+
+**Accepted callables.** Every category of callable value the language has is
+a valid `fn`. What varies is only *when* a misuse (wrong arity, wrong
+argument type, wrong parameter mode) is reported:
+
+| `fn` | Example | Misuse is reported… |
+|---|---|---|
+| Typed Noxy function | `call_result(dobro, 21)` | synchronously, in the caller |
+| Closure / function literal | `call_result(func() -> int … end)` | synchronously, in the caller |
+| Function value (exact or bare `func`) | `let f: func(int) -> int = dobro` then `call_result(f, 21)` | synchronously, in the caller |
+| Struct constructor | `call_result(Ponto, 3, 4)` | synchronously (field count and field types) |
+| Signed native | `call_result(to_int, entrada)` | synchronously, in the caller |
+| Legacy unsigned native | — | during invocation; the failure is **captured** |
+
+Passing a non-callable is a synchronous runtime error in the caller
+(`call_result expects a callable, got <type>`). A misuse reported
+synchronously raises in the caller like any other runtime error — it is
+never wrapped in an envelope, because a wrong call site is a bug in the
+program, not data. Only legacy natives without parameter metadata cannot be
+pre-validated: their misuse surfaces inside the invocation and is captured,
+indistinguishable from a failure of the callee's own body. (A native
+reaches the boundary as `any` or in argument position; the compiler does not
+admit `let f: func = to_int`.) The timing mirrors `spawn_task`'s synchronous
 validation; the domain is wider — `spawn_task` accepts only Noxy functions
 and closures, while `call_result` also accepts constructors and natives.
-Callees without metadata (legacy untyped natives) validate during invocation,
-so those failures are captured and are indistinguishable from failures of the
-callee's own body. *Compatibility note:* giving a legacy native a signature
-in a later release moves its misuse failures from captured to synchronous —
-an observable change that rides the signing, and one more reason to sign
-natives eagerly.
+*Compatibility note:* giving a legacy native a signature in a later release
+moves its misuse failures from captured to synchronous — an observable
+change that rides the signing, and one more reason to sign natives eagerly.
 
 For a struct constructor, a completed call yields the constructed instance as
 `value`, under the constructor semantics the defer section already gives that
 callee category.
 
-**Argument semantics are unchanged.** Arguments follow §4.3 exactly as in a
-direct call: composite values are independent copy-on-write values, explicit
-`ref` arguments keep reference identity. `call_result` adds no isolation — it
-is the same call, wearing a boundary.
+```noxy
+use errors select *
 
-**Envelope.** `call_result` returns a `CallResult` (module `errors`):
+struct Ponto
+    x: int
+    y: int
+end
+
+func deposita(saldo: ref int, valor: int)
+    *saldo = *saldo + valor
+end
+
+let c: CallResult = call_result(Ponto, 3, 4)      // constructor: value is the instance
+let p: any = c.value                               // p.x == 3, p.y == 4
+
+let saldo: int = 100
+call_result(deposita, ref saldo, 30)               // explicit ref keeps identity: saldo == 130
+```
+
+**Arguments.** Arguments are evaluated in the caller's frame, before the
+boundary exists; an error raised while *evaluating* an argument expression is
+not captured. Passing follows §4.3 exactly as in a direct call: composite
+values are independent copy-on-write values in the callee, and `ref`
+arguments keep reference identity. Because `call_result` is a dynamic
+boundary, a reference must be written explicitly as `ref value` (§4.2) —
+`call_result(deposita, saldo, 30)` passes a plain copy and never manufactures
+a reference. Where the callee exposes parameter metadata, the number of
+`...args` must match its arity, and each argument must satisfy the declared
+parameter type and mode — checked synchronously, per the table above.
+`call_result` adds no isolation — it is the same call, wearing a boundary.
+
+**Envelope.** `call_result` always returns a `CallResult` (module `errors`);
+it never raises for anything that happens *inside* `fn`:
+
+| Field | Type | `fn` completes | Failure captured |
+|---|---|---|---|
+| `ok` | `bool` | `true` | `false` |
+| `value` | `any` | `fn`'s return value; `null` for `void` | `null` |
+| `failure` | `Failure` | `null` | the primary failure |
+
+| `Failure` field | Type | Content |
+|---|---|---|
+| `kind` | `string` | `"runtime"` (Noxy runtime error) or `"panic"` (recovered Go panic) |
+| `message` | `string` | the error message, clean of usage advice |
+| `stack` | `string` | Noxy stack at the failure point for `"runtime"`; Go stack for `"panic"` |
+| `causes` | `Failure[]` | deferred failures aggregated during the unwinding, LIFO; empty otherwise |
+
+In detail:
 
 - `fn` completes: `ok = true`, `value` is its return value (`null` for a
   `void` return), `failure = null`. A composite `value` preserves the identity

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1123,7 +1123,16 @@ precedent: `fmt("%T", r)` reports `map`, and the envelope does not compare
 equal to a hand-constructed `CallResult(...)` instance. Promoting the
 envelopes (this one and `task_await`'s) to genuine struct instances is a
 single future change, gated on natives being able to construct
-stdlib-declared structs.
+stdlib-declared structs. The annotation is nonetheless honored, and by a
+general rule rather than a special case for this envelope: wherever a struct
+shape is expected at a dynamic-boundary annotation or marker, the runtime
+type validator admits any structurally matching map — every field the struct
+declares present, each recursively compatible with the declared field type —
+without nominal checking, and without stamping the map as that struct. The
+admission stops at nominal gates: task-argument validation (`spawn_task`) and
+every other check that requires a real struct instance still reject a map, so
+a `CallResult` envelope passed as a typed task argument fails today;
+unifying the two matchers is tracked as follow-up.
 
 **What the boundary does not change.**
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -603,6 +603,17 @@ struct Node
 end
 ```
 
+A struct may also reference itself through an **array field without `ref`**:
+value semantics without `ref` cannot form a cycle, so no `ref` is needed to
+keep construction well-founded.
+
+```noxy
+struct Failure
+    kind: string
+    causes: Failure[]
+end
+```
+
 ---
 
 ## 6. Generics
@@ -1001,6 +1012,173 @@ Those suppressed errors cannot participate in defer aggregation; only runtime
 errors observable from the deferred call are aggregated. Likewise, the
 ordinary result from `io.close_result(...)` is discarded when deferred.
 
+### Errors: raise for bugs, results for data
+
+Noxy has two failure channels, and they are not interchangeable.
+
+A **runtime error** means the program is wrong: an impossible conversion of a
+value the program itself produced, an out-of-range index, a violated native
+contract. It unwinds call frames, runs deferred calls along the way, and —
+unobserved — terminates the script with a diagnostic.
+
+A **result struct** means the input was allowed to be bad: untrusted text,
+user input, wire data. Failure is an expected outcome, so it is data — an
+`ok` flag the caller must branch on. Because Noxy functions return a single
+value, the result struct occupies the place of Go's `value, err` pair.
+
+API design rule: an operation whose failure indicates a caller bug raises; an
+operation whose failure is an expected outcome of untrusted data returns a
+result struct. When both kinds of caller exist, provide the raising form and a
+`_result` twin: `to_int` / `to_int_result`, `io.close` / `io.close_result`.
+
+Two boundaries convert the first channel into the second, and they are the
+only two: the supervised-task boundary (`spawn_task` / `task_await`), and the
+synchronous `call_result` described next. Advisory hints such as "use
+to_int_result to handle failure" belong to the top-level fatal diagnostic
+output, not to the raised message itself — a captured `Failure.message`
+carries the error, not usage advice.
+
+### The error boundary: `call_result`
+
+`call_result(fn, ...args)` invokes a callable and converts a runtime failure
+that unwinds out of it into a value:
+
+```noxy
+use errors select *
+
+let r: CallResult = call_result(to_int, entrada)
+if r.ok then
+    let n: int = to_int(r.value)   // narrowing only: r.value is already int
+    print(n)
+else
+    print("entrada inválida: " + r.failure.message)
+end
+```
+
+**Callable and validation.** `fn` may be any callable value: a typed Noxy
+function or closure, a function value held as an exact or bare `func`, a
+struct constructor, or a native. (A native reaches the boundary as `any` or
+in argument position; the compiler does not admit `let f: func = to_int`.)
+Passing a non-callable is a synchronous runtime error in the caller.
+Arguments are evaluated in the caller's frame, before the boundary exists; an
+error during argument evaluation is not captured. Where the callee exposes
+parameter metadata — typed Noxy functions and closures, struct constructors,
+signed natives — arity and parameter-mode mismatches are synchronous runtime
+errors in the caller. The timing mirrors `spawn_task`'s synchronous
+validation; the domain is wider — `spawn_task` accepts only Noxy functions
+and closures, while `call_result` also accepts constructors and natives.
+Callees without metadata (legacy untyped natives) validate during invocation,
+so those failures are captured and are indistinguishable from failures of the
+callee's own body. *Compatibility note:* giving a legacy native a signature
+in a later release moves its misuse failures from captured to synchronous —
+an observable change that rides the signing, and one more reason to sign
+natives eagerly.
+
+For a struct constructor, a completed call yields the constructed instance as
+`value`, under the constructor semantics the defer section already gives that
+callee category.
+
+**Argument semantics are unchanged.** Arguments follow §4.3 exactly as in a
+direct call: composite values are independent copy-on-write values, explicit
+`ref` arguments keep reference identity. `call_result` adds no isolation — it
+is the same call, wearing a boundary.
+
+**Envelope.** `call_result` returns a `CallResult` (module `errors`):
+
+- `fn` completes: `ok = true`, `value` is its return value (`null` for a
+  `void` return), `failure = null`. A composite `value` preserves the identity
+  an ordinary call would give it.
+- A runtime failure unwinds out of `fn`: deferred calls registered by `fn` and
+  its nested frames run under the normal unwinding rules, the unwinding stops
+  at the `call_result` frame, and the envelope is `ok = false`,
+  `value = null`, with `failure` describing the primary error.
+- `failure.kind` is `"runtime"` for a Noxy runtime error (with a Noxy stack
+  captured at the failure point) or `"panic"` for a recovered Go panic (with a
+  Go stack) — the same vocabulary as the task boundary. A `"runtime"` stack
+  covers the frames from the failure point down to, and excluding, the
+  `call_result` frame itself.
+- `failure.causes` holds deferred failures observed during that unwinding, in
+  LIFO execution order, each a `Failure` whose own `causes` nest further, per
+  the defer section's aggregation rules. It is empty when no deferred call
+  failed. Each cause's `stack` is captured at that deferred failure point and
+  carries the deferred call's registration location as its outermost frame —
+  the envelope form of the defer section's promise that each deferred failure
+  is collected "with its registration location".
+- Cleanup as first failure: if `fn` returns successfully but one of its
+  deferred calls raises, the boundary reports `ok = false` and the computed
+  return value is discarded, mirroring "converts an otherwise successful
+  return into a runtime error" in the defer section. The first deferred
+  failure is the primary `failure`; deferred failures observed after it
+  aggregate under the primary's `causes` in LIFO order, each nesting its own
+  `causes` further.
+
+**Representation.** `call_result` is a native, and natives return values
+across the dynamic boundary (§4.2). Like every result envelope a native
+produces today (`convert_to_int_result` and its `IntResult`), the envelope is
+physically a map whose fields match the declared shapes; the `errors` module
+declarations exist so Noxy code can annotate (`let r: CallResult = ...`) and
+so the field names are a compile-checkable contract at typed use sites. The
+consequences are observable and identical to the existing `IntResult`
+precedent: `fmt("%T", r)` reports `map`, and the envelope does not compare
+equal to a hand-constructed `CallResult(...)` instance. Promoting the
+envelopes (this one and `task_await`'s) to genuine struct instances is a
+single future change, gated on natives being able to construct
+stdlib-declared structs.
+
+**What the boundary does not change.**
+
+- The caller's own deferred calls and frames are unaffected; after
+  `call_result` returns, execution continues normally.
+- Boundaries nest: a failure is captured by the nearest enclosing
+  `call_result` frame.
+- Detached routines started by `fn` via `spawn` keep running after capture,
+  per the `spawn` contract.
+- `call_result` is an ordinary call and is legal anywhere a call is,
+  including module initialization; frame rules follow the defer section
+  unchanged.
+- **Through native frames.** A failure raised in Noxy code that a native
+  invoked (a callback, an HTTP handler) propagates through the intervening
+  native frame to the nearest boundary; the native observes the failure
+  through its existing error path and releases its resources before
+  propagation continues. A callback-invoking native must forward Noxy
+  failures, never swallow them.
+- **No rollback.** Mutations `fn` performed before failing — through `ref`
+  arguments, globals, closure upvalues, or native resources — remain. Noxy's
+  copy-on-write value semantics can suggest that everything is isolated; the
+  boundary is control flow, not a transaction. The risky shape has a name:
+  a callable that mutates `ref` arguments, globals, or upvalues can leave a
+  broken invariant behind when captured mid-flight — prefer value-in/value-out
+  callables under a boundary, and treat mutating ones as candidates for
+  explicit coordination, exactly as across the task boundary.
+- **Panic coverage.** Go panics are recovered in the executing routine only,
+  not in independent goroutines started by native code — the same coverage
+  rule as supervised tasks. Exhaustion of the VM's Noxy frame limit is an
+  ordinary runtime error and is capturable (`kind = "runtime"`): by the time
+  the boundary observes it, unwinding has already freed frames. Conditions
+  the Go runtime treats as unrecoverable (fatal errors such as concurrent map
+  writes, Go stack exhaustion, out of memory) remain process-fatal; no
+  boundary observes them. The recover covers the invocation of `fn` itself;
+  a Go panic raised outside it (argument preparation, envelope construction)
+  remains process-fatal like any other unrecovered panic.
+
+**Intended idiom.** `call_result` exists to build named `_result` twins, not
+to decorate call sites. The inline form over a closure is legal:
+
+```noxy
+let r: CallResult = call_result(func() -> int
+    return to_int(campo) * fator
+end)
+```
+
+but the idiom is wrap-and-name: a `_result` function with a typed result
+struct is a contract; an inline boundary is a site the reader must decode. The
+boundary's design leans on auditability — `call_result` is one grep away from
+every place errors become data — and on the envelope being deliberately
+untyped (`value: any`), so a named twin that narrows the value is always the
+more comfortable form. Discarding the envelope — `call_result(f, x)` as a
+bare statement — swallows every failure `f` can produce and is almost
+certainly a bug; a compile-time diagnostic for it is tracked as follow-up.
+
 ### When / Channel Select
 
 `when` evaluates a set of channel operations and runs the body of the first
@@ -1107,8 +1285,8 @@ print(f"Hello, {name}!")
 
 ### Conversões numéricas
 
-`to_int` e `to_float` **levantam erro de runtime** quando a conversão é
-impossível. Use-os quando uma falha seria um bug do programa.
+A regra geral levantar-vs-`_result` está em *Errors: raise for bugs, results
+for data*.
 
 ```noxy
 to_int(5.9)      // 5, truncamento em direção a zero
@@ -1117,9 +1295,6 @@ to_int("5.5")    // erro: uma string decimal não é um inteiro
 to_int("abc")    // erro
 to_int(true)     // erro: bool não é número em Noxy
 ```
-
-Para entrada não confiável, use a forma `_result`, do módulo `convert`, que
-nunca levanta:
 
 ```noxy
 use convert select *
@@ -1131,10 +1306,6 @@ else
     print("PORT inválida: " + porta.error)
 end
 ```
-
-Essa é a mesma convenção de `io.close` / `io.close_result`. Como funções Noxy
-têm retorno único, o struct de resultado ocupa o lugar do par `value, err` do
-Go.
 
 Validar antes de converter não é uma alternativa correta: `is_digit` aceita
 `"9999999999999999999"`, que estoura `int64`, e não há como checar o intervalo
@@ -1239,6 +1410,7 @@ Noxy comes with a comprehensive standard library. Available modules include:
 | `crypto` | Cryptographic functions (hashing, UUID) |
 | `sqlite` | SQLite database support |
 | `rand` | Random number generation |
+| `errors` | Error boundary envelope shapes (Failure, CallResult) |
 
 ### Strings
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1712,6 +1712,6 @@ register, roll back, poison, or close the resource again.
     - **Reference Parameters**: A parameter declared with `ref` shares the caller's slot — the only sharing mechanism.
 
 ---
-*Version: 0.7.1*
+*Version: 0.7.2*
 *Language: Noxy*
 *Implementation: Stack VM (Go)*

--- a/docs/superpowers/plans/2026-08-19-call-result.md
+++ b/docs/superpowers/plans/2026-08-19-call-result.md
@@ -1,0 +1,1161 @@
+# call_result Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `call_result(fn, ...args)` synchronous error boundary: a global native that invokes any callable and converts a runtime failure that unwinds out of it into a `CallResult` envelope, per the approved design.
+
+**Architecture:** One new native (`call_result`) built on the VM's existing reentrant invocation machinery (`prepareDeferredCall`/`prepareTaskCall` for synchronous validation, `callPreparedValue` + `vm.run(minFrameCount, &result)` for execution, `UnwindError`/`DeferredError` for failure structure). The envelope is physically a **map** at the dynamic boundary (the `IntResult` precedent), with `stdlib/errors.nx` declaring the `Failure`/`CallResult` shapes for typed annotation. The advisory suffix in `to_int`/`to_float` moves out of the raised message into the fatal diagnostic via a new `AdvisedError` wrapper.
+
+**Tech Stack:** Go (VM in `internal/vm`), Noxy stdlib modules (embedded via `internal/stdlib/embed.go`), Go tests driven by Noxy source strings.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-call-result-design.md` — the plan argues from it; executors read both. The normative language-spec text to merge lives in that file's §2.
+
+## Global Constraints
+
+- Branch: `feat/call-result`, based on `develop` (project convention: PRs target `develop`).
+- The envelope is a **map** built with `value.NewMapWithData` — never a real struct instance. Mirror `taskOutcomeEnvelope` (`internal/vm/builtins_tasks.go:155-174`) for construction and RC behavior.
+- Envelope fields are exactly `ok`, `value`, `failure`; failure fields exactly `kind`, `message`, `stack`, `causes`. `failure` is Noxy `null` when ok; `value` is Noxy `null` on failure and for void returns.
+- `kind` is `"runtime"` or `"panic"` — same vocabulary as the task boundary (`builtins_tasks.go:128-148`).
+- Misuse (non-callable, arity/mode/constructor-field mismatch where metadata exists) is a **synchronous error returned by the native** — never captured in the envelope.
+- `task_await`'s envelope is **not** touched in this change.
+- `internal/stdlib/result.nx` stays functional this release (deprecation comment only).
+- All existing tests must keep passing (`go test ./...` on Windows). Two test files will need updates when the builtin list grows / messages change: `internal/vm/builtins_registry_test.go`, `internal/vm/builtins_convert_test.go` — updating their expectations is in-scope, weakening them is not.
+- Commit style: conventional commits with scope, PT description (match `git log` style, e.g. `feat(vm): ...`).
+
+## Pre-verified facts (do not re-derive)
+
+- `prepareDeferredCall` (`internal/vm/defer.go:15-71`) validates closures (arity + parameter modes, retains args), signed natives (signature arity + modes, eager-copies args), unsigned natives (no validation), struct constructors (field count + `validateStructConstructorArguments`). It **rejects** a bare `*value.ObjFunction` (non-closure); `prepareTaskCall` (`internal/vm/task_execution.go:22-36`) shows the normalization: wrap an `ObjFunction` with `UpvalueCount == 0` into an `ObjClosure`.
+- `invokePreparedCall` (`internal/vm/defer.go:142-187`) is the synchronous same-VM invocation pattern: save `base := vm.stackTop`, push callee+args, `callPreparedValue`, then if `vm.frameCount > ownerFrameCount` run `vm.run(ownerFrameCount+1, nil)`; a Go `defer` zeroes the temp stack slots, restores `stackTop`, and releases retained closure args. On error, `vm.run`'s own deferred handler (`internal/vm/executor.go:52-59`) has already unwound to `minFrameCount-1`, running Noxy defers and aggregating `DeferredError`s into `*UnwindError`.
+- `vm.run(minFrameCount, terminalResult)` stores the returning function's value through `terminalResult` when the frame count drops below `minFrameCount` (`executor.go:1200-1218`, `OP_RETURN`); `executePreparedTaskCall` (`task_execution.go:110`) is the precedent for capturing it.
+- For native and constructor callees, `callPreparedValue` pushes the result on the VM stack without creating a frame (`internal/vm/calls.go:78-112`); read it with `vm.peek(0)` when `vm.frameCount == ownerFrameCount`.
+- Frame exhaustion is an ordinary runtime error `"stack overflow"` (`calls.go:121-122`, `FramesMax = 64` in `vm.go:12`) — capturable by design.
+- `UnwindError{Primary, Deferred []DeferredError}`; `DeferredError{Registration SourceLocation, Cause error}`; `RuntimeError{Location, Message, Cause, Stack}`; `deepestRuntimeStack(err)` extracts the Noxy stack (`internal/vm/runtime_errors.go`). Cleanup-first failure arrives as `UnwindError{Primary: nil, Deferred: [...]}` (`unwind.go:110-119` + `finalizeCurrentFrame`).
+- Native errors are wrapped by `callNative` as `RuntimeError{Message: "native 'X' failed", Cause: err}` (`calls.go:104-112`).
+- Fatal runtime print sites: `cmd/noxy/main.go:271` and `:338` (`fmt.Printf("Runtime error: %s\n", err)`).
+- stdlib modules are embedded by `//go:embed *.nx` (`internal/stdlib/embed.go`) and resolved by filename in `loadModule` (`internal/vm/modules.go:101`) — dropping `errors.nx` into `internal/stdlib/` is the whole registration.
+- **Audit result (design §7, callback-native audit):** grep shows the only callers of the invocation machinery are defer unwinding, tasks, and the call opcodes themselves — no native invokes a Noxy callback synchronously today (the HTTP server is pure Noxy). The audit deliverable is the grep evidence recorded in the spec text plus the defer/nested-frame propagation tests below; there is nothing to fix.
+- Test harness: `interpretVMSource(t, machine, src) error`, `captureVMSource(t, src) value.Value` (uses a `test_report` native), `machine := New()` (`internal/vm/vm_test_helpers_test.go`). Stdlib imports work in tests via the embedded FS.
+
+---
+
+### Task 1: `errors.nx` stdlib module (Failure / CallResult shapes)
+
+**Files:**
+- Create: `internal/stdlib/errors.nx`
+- Test: `internal/vm/builtins_call_result_test.go` (new file, first test in it)
+
+**Interfaces:**
+- Produces: Noxy module `errors` exporting `struct Failure { kind: string, message: string, stack: string, causes: Failure[] }` and `struct CallResult { ok: bool, value: any, failure: Failure }`. Later tasks' Noxy test sources annotate with these.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/vm/builtins_call_result_test.go
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestErrorsModuleShapes(t *testing.T) {
+	source := `
+use errors select *
+
+let f: Failure = Failure("runtime", "boom", "st", [])
+let nested: Failure = Failure("runtime", "outer", "st", [f])
+let r: CallResult = CallResult(true, 42, null)
+test_report(nested.causes[0].message + "|" + to_str(r.ok) + "|" + to_str(r.value))
+`
+	reported := captureVMSource(t, source)
+	text, ok := reported.Obj.(string)
+	if !ok || text != "boom|true|42" {
+		t.Fatalf("unexpected report: %#v", reported)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/vm/ -run TestErrorsModuleShapes -count=1`
+Expected: FAIL — module `errors` not found (import error).
+
+- [ ] **Step 3: Write the module**
+
+```noxy
+// stdlib/errors.nx - Formas do envelope da fronteira sincrona de erro.
+//
+// call_result e um nativo global; estes structs dao nome e contrato de campos
+// ao envelope que ele devolve. Fisicamente o envelope e um MAP na fronteira
+// dinamica (mesmo precedente de IntResult em convert.nx): fmt("%T") reporta
+// "map" e ele nao compara igual a um CallResult construido a mao. A anotacao
+// tipada (`let r: CallResult = ...`) vale pelo contrato de campos.
+
+struct Failure
+    kind: string       // "runtime" | "panic"
+    message: string
+    stack: string
+    causes: Failure[]  // falhas de defer agregadas no unwinding, ordem LIFO
+end
+
+struct CallResult
+    ok: bool
+    value: any         // retorno de fn; null para void e em falha
+    failure: Failure   // null quando ok
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/vm/ -run TestErrorsModuleShapes -count=1`
+Expected: PASS. (This also locks in the §5 self-reference-through-array fact: `causes: Failure[]` compiles and nests.)
+
+- [ ] **Step 5: Check stdlib hygiene test still passes**
+
+Run: `go test ./internal/vm/ -run TestStdlib -count=1` (then the full package if unsure which test enumerates modules: `go test ./internal/vm/ -count=1`). If a hygiene/registry test enumerates stdlib modules, add `errors` to its expected list — do not weaken the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/stdlib/errors.nx internal/vm/builtins_call_result_test.go
+git commit -m "feat(stdlib): modulo errors com as formas Failure e CallResult da fronteira call_result"
+```
+
+---
+
+### Task 2: `AdvisedError` — advisory suffix out of the capturable message
+
+**Files:**
+- Modify: `internal/vm/runtime_errors.go` (append type at end)
+- Modify: `internal/vm/builtins_convert.go:133-153` (`to_int`, `to_float`)
+- Modify: `cmd/noxy/main.go:271` and `:338`
+- Test: `internal/vm/builtins_convert_test.go` (update message assertions), new test in same file
+
+**Interfaces:**
+- Produces: exported `vm.AdvisedError{Err error, Advice string}` with `Error()` returning only `Err.Error()` and `Unwrap()` returning `Err`. Task 5's failure envelope gets clean messages for free (nothing renders `Advice` except the fatal printer).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// append to internal/vm/builtins_convert_test.go
+func TestToIntAdvisedError(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `to_int("abc")`)
+	if err == nil {
+		t.Fatal("expected runtime error")
+	}
+	if strings.Contains(err.Error(), "use to_int_result") {
+		t.Fatalf("advisory suffix leaked into capturable message: %v", err)
+	}
+	var advised *AdvisedError
+	if !errors.As(err, &advised) || advised.Advice != "use to_int_result to handle failure" {
+		t.Fatalf("advice not carried structurally: %v", err)
+	}
+}
+```
+
+(Add `"errors"` and `"strings"` to the test file's imports if absent.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/vm/ -run TestToIntAdvisedError -count=1`
+Expected: FAIL — suffix present in message / `AdvisedError` undefined.
+
+- [ ] **Step 3: Implement**
+
+Append to `internal/vm/runtime_errors.go`:
+
+```go
+// AdvisedError separa o conselho de uso da mensagem de erro capturável: o
+// texto do erro fica limpo (Failure.message, task failure map), e só a saída
+// fatal do topo (cmd/noxy) imprime o Advice.
+type AdvisedError struct {
+	Err    error
+	Advice string
+}
+
+func (err *AdvisedError) Error() string { return err.Err.Error() }
+func (err *AdvisedError) Unwrap() error { return err.Err }
+```
+
+In `internal/vm/builtins_convert.go`, replace the two raising returns:
+
+```go
+// to_int (line ~139):
+return value.NewNull(), &AdvisedError{
+	Err:    fmt.Errorf("to_int: %w", convertErr),
+	Advice: "use to_int_result to handle failure",
+}
+// to_float (line ~150):
+return value.NewNull(), &AdvisedError{
+	Err:    fmt.Errorf("to_float: %w", convertErr),
+	Advice: "use to_float_result to handle failure",
+}
+```
+
+In `cmd/noxy/main.go` (both sites, lines 271 and 338), after the existing print:
+
+```go
+fmt.Printf("Runtime error: %s\n", err)
+var advised *vm.AdvisedError
+if errors.As(err, &advised) {
+	fmt.Printf("hint: %s\n", advised.Advice)
+}
+```
+
+(Add `"errors"` to main.go imports.)
+
+- [ ] **Step 4: Fix stale assertions**
+
+Run: `go test ./... -count=1` and `Grep "use to_int_result to handle failure"` across the repo. Update any test asserting the old inline suffix (expected: `internal/vm/builtins_convert_test.go`; possibly `native_signatures_test.go` messages). Keep asserting the *clean* message (`to_int: cannot convert ...`).
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `go test ./internal/vm/ -count=1` then `go build ./...`
+Expected: PASS, builds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/vm/runtime_errors.go internal/vm/builtins_convert.go cmd/noxy/main.go internal/vm/builtins_convert_test.go
+git commit -m "refactor(vm): sufixo de conselho de to_int/to_float sai da mensagem capturavel via AdvisedError; hint impresso so no fatal"
+```
+
+---
+
+### Task 3: Boundary preparation — synchronous misuse validation
+
+**Files:**
+- Create: `internal/vm/builtins_call_result.go`
+- Modify: `internal/vm/builtins.go` (or wherever `defineTaskBuiltins()` is wired — grep `defineTaskBuiltins()`; add `defineCallResultBuiltins()` beside it)
+- Test: `internal/vm/builtins_call_result_test.go`
+
+**Interfaces:**
+- Consumes: `prepareDeferredCall`, `prepareTaskCall`'s ObjFunction normalization pattern, `nativeVM(context)`.
+- Produces: `(vm *VM) prepareBoundaryCall(callee value.Value, args []value.Value) (PreparedCall, error)`; native `call_result` registered globally (envelope construction stubbed until Task 4 — for this task the native may return `value.NewNull(), nil` after successful preparation, releasing retained args via `releasePreparedArguments` to stay RC-clean).
+- Produces for later tasks: `(vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error)` — signature fixed here, body completed in Tasks 4–7.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
+	cases := []struct {
+		name, source, wantErr string
+	}{
+		{"non-callable", `call_result(42)`, "call_result expects a callable"},
+		{"closure arity", `
+func soma(a: int, b: int) -> int
+    return a + b
+end
+call_result(soma, 1)`, "expected 2 arguments but got 1"},
+		{"constructor arity", `
+struct P
+    x: int
+end
+call_result(P, 1, 2)`, "expected 1 arguments for struct P"},
+		{"no arguments at all", `call_result()`, "call_result expects a callable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			machine := New()
+			err := interpretVMSource(t, machine, tc.source)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want synchronous error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/vm/ -run TestCallResultMisuse -count=1`
+Expected: FAIL — `call_result` undefined ("undefined global variable 'call_result'" or similar).
+
+- [ ] **Step 3: Implement preparation + registration**
+
+```go
+// internal/vm/builtins_call_result.go
+package vm
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/value"
+)
+
+func (vm *VM) defineCallResultBuiltins() {
+	vm.DefineContextualNative("call_result", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 1 {
+			return value.NewNull(), fmt.Errorf("call_result expects a callable")
+		}
+		return machine.runCallBoundary(args[0], args[1:])
+	})
+}
+
+// prepareBoundaryCall valida sincronamente no chamador (design: misuse nunca
+// e capturado). Normaliza ObjFunction sem upvalues para closure — mesmo
+// ajuste de prepareTaskCall — e delega o resto a prepareDeferredCall, que ja
+// valida closure (aridade+modos), native assinado (assinatura+modos, copia
+// ansiosa) e construtor de struct (campos+tipos).
+func (vm *VM) prepareBoundaryCall(callee value.Value, args []value.Value) (PreparedCall, error) {
+	if callee.Type == value.VAL_FUNCTION {
+		if fn, ok := callee.Obj.(*value.ObjFunction); ok && fn != nil && fn.UpvalueCount == 0 {
+			callee = value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjClosure{
+				Function:    fn,
+				Upvalues:    []*value.ObjUpvalue{},
+				Environment: fn.Environment,
+			}}
+		}
+	}
+	registration := SourceLocation{File: "?"}
+	if frame := vm.currentFrame; frame != nil && frame.Closure != nil && frame.Closure.Function != nil {
+		if c, ok := frame.Closure.Function.Chunk.(*chunk.Chunk); ok {
+			registration = sourceLocation(c, frame.IP)
+		}
+	}
+	prepared, err := vm.prepareDeferredCall(callee, args, registration)
+	if err != nil {
+		if callee.Type != value.VAL_FUNCTION && callee.Type != value.VAL_NATIVE {
+			if _, isStruct := callee.Obj.(*value.ObjStruct); callee.Type != value.VAL_OBJ || !isStruct {
+				return PreparedCall{}, fmt.Errorf("call_result expects a callable, got %s", runtimeValueMode(callee))
+			}
+		}
+		return PreparedCall{}, err
+	}
+	return prepared, nil
+}
+
+// runCallBoundary: corpo completado nas Tasks 4-7. Nesta task, apenas valida
+// e devolve null, desfazendo a retencao de preparacao para nao vazar RC.
+func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error) {
+	prepared, err := vm.prepareBoundaryCall(callee, args)
+	if err != nil {
+		return value.NewNull(), err
+	}
+	if closure, ok := prepared.Callee.Obj.(*value.ObjClosure); ok && prepared.Callee.Type == value.VAL_FUNCTION {
+		vm.releasePreparedArguments(prepared.Arguments, closure.Function.Params)
+	}
+	return value.NewNull(), nil
+}
+```
+
+Notes for the implementer:
+- Add `"noxy-vm/internal/chunk"` to imports.
+- The non-callable message: `prepareDeferredCall` returns `"can only call functions and classes"` for non-callables; the wrapper above rewrites it to `"call_result expects a callable, got <mode>"` so the misuse test asserts our name. Keep `prepareDeferredCall`'s own messages for arity/mode/constructor errors (the tests above assert their existing texts).
+- Register: grep for the function that calls `defineTaskBuiltins()` (expected `internal/vm/builtins.go`); add `vm.defineCallResultBuiltins()` in the same list.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/vm/ -run TestCallResultMisuse -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Reconcile the builtin registry test**
+
+Run: `go test ./internal/vm/ -run 'TestBuiltin|TestNativeSignatures|Registry' -count=1`. If `builtins_registry_test.go` (or `native_signatures_test.go`) asserts the complete builtin list, add `call_result` following the pattern used by `spawn_task`/`task_await` entries (contextual, variadic, no signature). Then `go test ./internal/vm/ -count=1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/vm/builtins_call_result.go internal/vm/builtins.go internal/vm/builtins_call_result_test.go internal/vm/builtins_registry_test.go
+git commit -m "feat(vm): call_result — registro do nativo e validacao sincrona de misuse no chamador"
+```
+
+---
+
+### Task 4: Happy path — invocation and ok envelope
+
+**Files:**
+- Modify: `internal/vm/builtins_call_result.go`
+- Test: `internal/vm/builtins_call_result_test.go`
+
+**Interfaces:**
+- Consumes: `callPreparedValue`, `vm.run`, `invokePreparedCall`'s cleanup pattern (`defer.go:142-187`).
+- Produces: `(vm *VM) invokeBoundaryCall(prepared PreparedCall) (value.Value, error)` — result or raw Go error (not yet enveloped); `callResultOkEnvelope(result value.Value) value.Value`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestCallResultOkPaths(t *testing.T) {
+	source := `
+use errors select *
+
+func dobro(x: int) -> int
+    return x * 2
+end
+
+func nada()
+end
+
+struct P
+    x: int
+end
+
+let a: CallResult = call_result(dobro, 21)
+let b: CallResult = call_result(to_int, "5")
+let c: CallResult = call_result(P, 7)
+let d: CallResult = call_result(nada)
+let inst: any = c.value
+test_report(to_str(a.ok) + "|" + to_str(a.value) + "|" + to_str(b.value) + "|" + to_str(inst.x) + "|" + to_str(d.ok) + "|" + to_str(d.value == null) + "|" + to_str(a.failure == null))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if text != "true|42|5|7|true|true|true" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+}
+
+func TestCallResultEnvelopeIsMap(t *testing.T) {
+	source := `
+let r: any = call_result(to_int, "5")
+test_report(fmt("%T", r))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "map" {
+		t.Fatalf("envelope should be a map at the dynamic boundary, got %q", text)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/vm/ -run 'TestCallResultOk|TestCallResultEnvelope' -count=1`
+Expected: FAIL — envelope is null (stub) so field access errors / report mismatches.
+
+- [ ] **Step 3: Implement invocation + ok envelope**
+
+Replace the Task 3 stub of `runCallBoundary` and add:
+
+```go
+func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error) {
+	prepared, err := vm.prepareBoundaryCall(callee, args)
+	if err != nil {
+		return value.NewNull(), err
+	}
+	result, callErr := vm.invokeBoundaryCall(prepared)
+	if callErr != nil {
+		return callResultFailureEnvelope(callErr), nil // Task 5
+	}
+	return callResultOkEnvelope(result), nil
+}
+
+// invokeBoundaryCall espelha invokePreparedCall (defer.go) com duas
+// diferencas: captura o resultado (terminalResult para closures; topo da
+// pilha para native/construtor) e nao descarta o valor no cleanup — o
+// envelope o carrega. O release da retencao de closure e identico.
+func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err error) {
+	base := vm.stackTop
+	if base < 0 || base >= len(vm.stack) || len(call.Arguments) > len(vm.stack)-base-1 {
+		return value.NewNull(), vm.runtimeErrorAtCurrentFrame("stack overflow while invoking call_result")
+	}
+	result = value.NewNull()
+	temporaryTop := base
+	defer func() {
+		cleanupTop := vm.stackTop
+		if temporaryTop > cleanupTop {
+			cleanupTop = temporaryTop
+		}
+		for i := base; i < cleanupTop; i++ {
+			vm.stack[i] = value.Value{}
+		}
+		vm.stackTop = base
+		if call.Callee.Type == value.VAL_FUNCTION {
+			if closure, ok := call.Callee.Obj.(*value.ObjClosure); ok && closure != nil && closure.Function != nil {
+				vm.releasePreparedArguments(call.Arguments, closure.Function.Params)
+			}
+		}
+	}()
+
+	ownerFrameCount := vm.frameCount
+	vm.push(call.Callee)
+	for _, argument := range call.Arguments {
+		vm.push(argument)
+	}
+	temporaryTop = vm.stackTop
+
+	ok, err := vm.callPreparedValue(call.Callee, len(call.Arguments), nil, 0)
+	if !ok {
+		return value.NewNull(), err
+	}
+	if vm.frameCount > ownerFrameCount {
+		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
+			return value.NewNull(), runErr
+		}
+		return result, nil
+	}
+	// native/construtor: sem frame novo; resultado no topo da pilha.
+	return vm.peek(0), nil
+}
+
+func callResultOkEnvelope(result value.Value) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(true),
+		"value":   result,
+		"failure": value.NewNull(),
+	})
+}
+
+// placeholder ate a Task 5 (mantem o pacote compilando):
+func callResultFailureEnvelope(err error) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": value.NewNull(),
+	})
+}
+```
+
+**RC verification note (mandatory, not optional):** the ok `value` travels from a finished frame into the envelope exactly as in `startSupervisedTask` → `taskOutcomeEnvelope` (`builtins_tasks.go:136-173`), which adds no extra retain. If `TestCallResultValueSemantics` (Task 7) crashes or corrupts, add `value.Retain(result)` before the cleanup runs and a matching comment — decide by test evidence, mirroring the task path first.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/vm/ -run 'TestCallResult' -count=1`, then the whole package `go test ./internal/vm/ -count=1` (defer/RC suites must stay green).
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/vm/builtins_call_result.go internal/vm/builtins_call_result_test.go
+git commit -m "feat(vm): call_result — invocacao sincrona com captura de resultado e envelope ok"
+```
+
+---
+
+### Task 5: Failure capture — runtime errors into the envelope
+
+**Files:**
+- Modify: `internal/vm/builtins_call_result.go` (real `callResultFailureEnvelope`)
+- Test: `internal/vm/builtins_call_result_test.go`
+
+**Interfaces:**
+- Consumes: `UnwindError`, `DeferredError`, `RuntimeError`, `deepestRuntimeStack`.
+- Produces: `callResultFailureEnvelope(err error) value.Value` and `failureMap(err error) value.Value` (recursive; used by Task 6's assertions).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestCallResultCapturesRuntimeError(t *testing.T) {
+	source := `
+use errors select *
+
+func quebra(texto: string) -> int
+    return to_int(texto)
+end
+
+let r: CallResult = call_result(quebra, "abc")
+let depois: int = 40 + 2
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message + "|" + to_str(length(r.failure.causes)) + "|" + to_str(r.value == null) + "|" + to_str(depois))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.Split(text, "|")
+	if len(parts) != 6 || parts[0] != "false" || parts[1] != "runtime" || parts[3] != "0" || parts[4] != "true" || parts[5] != "42" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+	if !strings.Contains(parts[2], "cannot convert") || strings.Contains(parts[2], "use to_int_result") {
+		t.Fatalf("message wrong or advisory suffix leaked: %q", parts[2])
+	}
+}
+
+func TestCallResultFailureStackExcludesBoundary(t *testing.T) {
+	source := `
+func fundo() -> int
+    return to_int("x")
+end
+func meio() -> int
+    return fundo()
+end
+let r: any = call_result(meio)
+test_report(r.failure.stack)
+`
+	reported := captureVMSource(t, source)
+	stack, _ := reported.Obj.(string)
+	if !strings.Contains(stack, "in fundo") || !strings.Contains(stack, "in meio") {
+		t.Fatalf("stack missing inner frames: %q", stack)
+	}
+	if strings.Contains(stack, "call_result") {
+		t.Fatalf("stack must stop before the boundary frame: %q", stack)
+	}
+}
+
+func TestCallResultCapturesStackOverflow(t *testing.T) {
+	source := `
+func infinita() -> int
+    return infinita()
+end
+let r: any = call_result(infinita)
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message)
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if !strings.HasPrefix(text, "false|runtime|") || !strings.Contains(text, "stack overflow") {
+		t.Fatalf("frame exhaustion should be captured: %q", text)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/vm/ -run 'TestCallResultCaptures|TestCallResultFailureStack' -count=1`
+Expected: FAIL — `r.failure` is null (placeholder), field access on null errors out.
+
+- [ ] **Step 3: Implement the failure envelope**
+
+Replace the placeholder:
+
+```go
+func callResultFailureEnvelope(err error) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": failureMap(err),
+	})
+}
+
+// failureMap converte a arvore de erro do unwinding no shape Failure.
+// UnwindError com Primary vira a falha primaria com cada DeferredError em
+// causes (ordem LIFO ja garantida por finalizeCurrentFrame); cleanup-first
+// (Primary nil) promove a PRIMEIRA falha diferida a primaria e agrega as
+// demais sob as causes dela (design §2, "Cleanup as first failure").
+func failureMap(err error) value.Value {
+	if unwind, ok := err.(*UnwindError); ok {
+		if unwind.Primary != nil {
+			return failureMapWithCauses(unwind.Primary, unwind.Deferred)
+		}
+		if len(unwind.Deferred) > 0 {
+			primary := deferredFailureMap(&unwind.Deferred[0], unwind.Deferred[1:])
+			return primary
+		}
+	}
+	if deferred, ok := err.(*DeferredError); ok {
+		return deferredFailureMap(deferred, nil)
+	}
+	return failureMapWithCauses(err, nil)
+}
+
+func failureMapWithCauses(primary error, deferred []DeferredError) value.Value {
+	causes := make([]value.Value, 0, len(deferred))
+	for index := range deferred {
+		causes = append(causes, deferredFailureMap(&deferred[index], nil))
+	}
+	message := ""
+	if primary != nil {
+		message = primary.Error()
+	}
+	return value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString(message),
+		"stack":   value.NewString(deepestRuntimeStack(primary)),
+		"causes":  value.NewArray(causes),
+	})
+}
+
+// deferredFailureMap constroi a Failure de uma falha diferida: a causa vira a
+// falha (aninhando as proprias causes dela recursivamente via failureMap) e a
+// localizacao de REGISTRO do defer entra como frame mais externo do stack —
+// forma-envelope da promessa da spec de defer ("with its registration
+// location"). siblings sao falhas diferidas posteriores promovidas para as
+// causes desta (apenas no caso cleanup-first).
+func deferredFailureMap(deferred *DeferredError, siblings []DeferredError) value.Value {
+	failure := failureMap(deferred.Cause)
+	mapping := failure.Obj.(*value.ObjMap)
+
+	stackValue, _ := mapping.Get("stack")
+	stack, _ := stackValue.Obj.(string)
+	registrationFrame := fmt.Sprintf("[%s] defer registration", deferred.Registration)
+	if stack == "" {
+		stack = registrationFrame
+	} else {
+		stack = stack + "\n" + registrationFrame
+	}
+	mapping.Set("stack", value.NewString(stack))
+
+	if len(siblings) > 0 {
+		causes := make([]value.Value, 0, len(siblings))
+		for index := range siblings {
+			causes = append(causes, deferredFailureMap(&siblings[index], nil))
+		}
+		mapping.Set("causes", value.NewArray(causes))
+	}
+	return failure
+}
+```
+
+Stack extent: `deepestRuntimeStack` returns the stack captured at the failure point by `runtimeErrorCause`, whose `captureNoxyStack` walks only Noxy frames — the boundary is inside a native call, so the `call_result` native itself never appears as a frame; the test locks this in.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/vm/ -run 'TestCallResult' -count=1` then `go test ./internal/vm/ -count=1`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/vm/builtins_call_result.go internal/vm/builtins_call_result_test.go
+git commit -m "feat(vm): call_result — captura de erro de runtime no envelope Failure com stack e kind"
+```
+
+---
+
+### Task 6: Defer aggregation — causes, registration location, cleanup-first
+
+**Files:**
+- Test only: `internal/vm/builtins_call_result_test.go` (the Task 5 code already implements the shape; this task proves it against the defer machinery and fixes what the tests reveal)
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestCallResultAggregatesDeferFailures(t *testing.T) {
+	source := `
+func limpeza_ruim()
+    to_int("defer-quebrado")
+end
+
+func corpo() -> int
+    defer limpeza_ruim()
+    return to_int("primario")
+end
+
+let r: any = call_result(corpo)
+let causa: any = r.failure.causes[0]
+test_report(to_str(length(r.failure.causes)) + "|" + causa.kind + "|" + causa.message + "|" + causa.stack)
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.SplitN(text, "|", 4)
+	if len(parts) != 4 || parts[0] != "1" || parts[1] != "runtime" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+	if !strings.Contains(parts[2], "defer-quebrado") {
+		t.Fatalf("cause message should carry the deferred failure: %q", parts[2])
+	}
+	if !strings.Contains(parts[3], "defer registration") {
+		t.Fatalf("cause stack must carry the registration location as outermost frame: %q", parts[3])
+	}
+}
+
+func TestCallResultCleanupFirstFailure(t *testing.T) {
+	source := `
+func limpeza_ruim()
+    to_int("so-o-defer-quebra")
+end
+
+func corpo() -> int
+    defer limpeza_ruim()
+    return 42
+end
+
+let r: any = call_result(corpo)
+test_report(to_str(r.ok) + "|" + to_str(r.value == null) + "|" + r.failure.message + "|" + to_str(length(r.failure.causes)))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.SplitN(text, "|", 4)
+	if len(parts) != 4 || parts[0] != "false" || parts[1] != "true" || parts[3] != "0" {
+		t.Fatalf("cleanup-first must discard the computed value and promote the deferred failure: %q", text)
+	}
+	if !strings.Contains(parts[2], "so-o-defer-quebra") {
+		t.Fatalf("primary failure should be the deferred one: %q", parts[2])
+	}
+}
+
+func TestCallResultCallerDefersUnaffected(t *testing.T) {
+	source := `
+let trilha: string[] = []
+
+func marca(rotulo: string)
+    append(trilha, rotulo)
+end
+
+func corpo() -> int
+    return to_int("x")
+end
+
+func chamador() -> string
+    defer marca("caller-defer")
+    let r: any = call_result(corpo)
+    append(trilha, "depois-da-captura")
+    return to_str(r.ok)
+end
+
+let ok_text: string = chamador()
+test_report(ok_text + "|" + trilha[0] + "|" + trilha[1])
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if text != "false|depois-da-captura|caller-defer" {
+		t.Fatalf("caller frame must be unaffected by the capture: %q", text)
+	}
+}
+```
+
+Note: if `append(trilha, ...)` on a global from inside functions trips CoW/global semantics, switch the trail to `ref` parameters — the assertion (execution continues; caller defer runs after) is what matters, adapt the vehicle.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/vm/ -run 'TestCallResultAggregates|TestCallResultCleanup|TestCallResultCallerDefers' -count=1`
+Expected: likely PASS from Task 5's implementation; any FAIL here is a real bug in the aggregation mapping — fix `failureMap`/`deferredFailureMap` (not the tests) until green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/vm/builtins_call_result_test.go internal/vm/builtins_call_result.go
+git commit -m "test(vm): call_result — agregacao de falhas de defer, cleanup-first e isolamento do frame chamador"
+```
+
+---
+
+### Task 7: Panic recovery, nesting, no-rollback, value semantics
+
+**Files:**
+- Modify: `internal/vm/builtins_call_result.go`
+- Test: `internal/vm/builtins_call_result_test.go`
+
+**Interfaces:**
+- Produces: `(vm *VM) hardUnwindTo(target int)` — frame release without running Noxy defers, for the panic path only.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestCallResultCapturesGoPanic(t *testing.T) {
+	machine := New()
+	machine.DefineNative("explode", func(args []value.Value) value.Value {
+		panic("boom-nativo")
+	})
+	source := `
+func corpo() -> int
+    explode()
+    return 1
+end
+let r: any = call_result(corpo)
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message)
+`
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	text, _ := captured.Obj.(string)
+	if !strings.HasPrefix(text, "false|panic|") || !strings.Contains(text, "boom-nativo") {
+		t.Fatalf("panic must be captured as kind=panic: %q", text)
+	}
+}
+
+func TestCallResultNestedBoundaries(t *testing.T) {
+	source := `
+func interna() -> int
+    return to_int("x")
+end
+func externa() -> string
+    let r: any = call_result(interna)
+    return "interna-capturou:" + to_str(r.ok)
+end
+let fora: any = call_result(externa)
+test_report(to_str(fora.ok) + "|" + fora.value)
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "true|interna-capturou:false" {
+		t.Fatalf("nearest boundary must capture: %q", text)
+	}
+}
+
+func TestCallResultNoRollback(t *testing.T) {
+	source := `
+func muta_e_quebra(alvo: ref int) -> int
+    *alvo = 99
+    return to_int("x")
+end
+let caixa: int = 1
+let r: any = call_result(muta_e_quebra, ref caixa)
+test_report(to_str(r.ok) + "|" + to_str(caixa))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "false|99" {
+		t.Fatalf("mutations before the failure must remain (no rollback): %q", text)
+	}
+}
+
+func TestCallResultValueSemantics(t *testing.T) {
+	source := `
+func faz_array() -> int[]
+    return [1, 2, 3]
+end
+let r: any = call_result(faz_array)
+let copia: int[] = r.value
+copia[0] = 100
+let original: any = r.value
+test_report(to_str(original[0]) + "|" + to_str(copia[0]) + "|" + to_str(length(original)))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "1|100|3" {
+		t.Fatalf("composite value must obey CoW semantics without corruption: %q", text)
+	}
+}
+```
+
+(`ref` syntax check: `*alvo = 99` per spec §2; if the compiler wants a different deref-store spelling, match the spec — the assertion is `caixa == 99` after capture.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/vm/ -run 'TestCallResultCapturesGoPanic|TestCallResultNested|TestCallResultNoRollback|TestCallResultValueSemantics' -count=1`
+Expected: the panic test FAILS (panic propagates out and kills the test / gets caught by Go test harness). The other three may already pass — keep them; they are regression armor.
+
+- [ ] **Step 3: Implement panic recovery**
+
+Add to `invokeBoundaryCall`, wrapping the invocation region — replace the section from `ownerFrameCount := vm.frameCount` to the end with:
+
+```go
+	ownerFrameCount := vm.frameCount
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			vm.hardUnwindTo(ownerFrameCount)
+			result = value.NewNull()
+			err = &boundaryPanicError{payload: fmt.Sprint(recovered), stack: string(debug.Stack())}
+		}
+	}()
+	vm.push(call.Callee)
+	for _, argument := range call.Arguments {
+		vm.push(argument)
+	}
+	temporaryTop = vm.stackTop
+
+	ok, err := vm.callPreparedValue(call.Callee, len(call.Arguments), nil, 0)
+	if !ok {
+		return value.NewNull(), err
+	}
+	if vm.frameCount > ownerFrameCount {
+		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
+			return value.NewNull(), runErr
+		}
+		return result, nil
+	}
+	return vm.peek(0), nil
+```
+
+**Ordering constraint:** Go defers run LIFO — this recover defer must be registered AFTER the Task 4 cleanup defer, so on panic the recover body runs FIRST (restoring frames via `hardUnwindTo`), then the cleanup defer restores the stack window. Keep the two defers in that order in the final function body (cleanup registered first, recover registered second).
+
+Add the helper and the panic error type:
+
+```go
+// boundaryPanicError transporta um panico de Go recuperado na fronteira; o
+// envelope o converte em Failure{kind: "panic"}. Nunca escapa da fronteira.
+type boundaryPanicError struct {
+	payload string
+	stack   string
+}
+
+func (err *boundaryPanicError) Error() string { return err.payload }
+
+// hardUnwindTo libera os frames acima de target sem executar defers Noxy —
+// depois de um panico de Go o estado desses frames e suspeito; espelha a
+// fronteira de task, que tambem nao roda defers no caminho de panico (o VM
+// filho e abandonado). Truncar Deferred antes de finalizar reusa o funil
+// unico de release (Owned/upvalues) sem rodar codigo Noxy.
+func (vm *VM) hardUnwindTo(target int) {
+	for vm.frameCount > target {
+		if frame := vm.currentFrame; frame != nil {
+			frame.Deferred = frame.Deferred[:0]
+		}
+		vm.finalizeCurrentFrame(frameOutcome{Err: errBoundaryPanic})
+	}
+}
+
+var errBoundaryPanic = fmt.Errorf("call_result: unwinding after Go panic")
+```
+
+(Add `"runtime/debug"` to imports.) In `failureMap`, handle the panic error first:
+
+```go
+	if panicErr, ok := err.(*boundaryPanicError); ok {
+		return value.NewMapWithData(map[string]value.Value{
+			"kind":    value.NewString("panic"),
+			"message": value.NewString(panicErr.payload),
+			"stack":   value.NewString(panicErr.stack),
+			"causes":  value.NewArray([]value.Value{}),
+		})
+	}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/vm/ -run 'TestCallResult' -count=1`, then the full package with race: `go test ./internal/vm/ -count=1 -race` (concurrency suites exercise the shared machinery).
+Expected: PASS. If `TestCallResultValueSemantics` fails with corruption/double-release, apply the Task 4 RC note (retain the result before cleanup) and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/vm/builtins_call_result.go internal/vm/builtins_call_result_test.go
+git commit -m "feat(vm): call_result — recuperacao de panico Go como kind=panic, fronteiras aninhadas e sem rollback"
+```
+
+---
+
+### Task 8: `result.nx` deprecation + example migration
+
+**Files:**
+- Modify: `internal/stdlib/result.nx` (deprecation header only)
+- Rewrite: `noxy_examples/result_pattern.nx`
+
+- [ ] **Step 1: Deprecation header**
+
+Prepend to `internal/stdlib/result.nx` (keep everything else intact):
+
+```noxy
+// DEPRECATED desde 0.8.0: use a convencao `_result` (structs proprios com
+// ok/value/error) construida sobre `call_result`, e o modulo `errors`
+// (Failure/CallResult). Este modulo sera removido na release seguinte.
+// Motivo: terceiro vocabulario de erro; ver
+// docs/superpowers/specs/2026-08-19-call-result-design.md §4.
+```
+
+- [ ] **Step 2: Migrate the example**
+
+Rewrite `noxy_examples/result_pattern.nx` as the canonical wrap-and-name `_result` twin (this is the design doc's intended idiom demo). Read the current file first to keep any narrative comments that still apply, then replace its mechanism:
+
+```noxy
+// result_pattern.nx — o idioma _result construido em noxy puro com call_result.
+//
+// Antes: modulo `result` (deprecado). Agora: um gemeo `_result` nomeado, com
+// struct de resultado tipado, embrulhando uma primitiva que levanta.
+
+use errors select *
+
+struct DivResult
+    ok: bool
+    value: int
+    error: string
+end
+
+func divide(a: int, b: int) -> int
+    return a / b   // levanta "division by zero" quando b == 0
+end
+
+func divide_result(a: int, b: int) -> DivResult
+    let r: CallResult = call_result(divide, a, b)
+    if r.ok then
+        let quociente: int = to_int(r.value)
+        return DivResult(true, quociente, "")
+    end
+    return DivResult(false, 0, r.failure.message)
+end
+
+let boa: DivResult = divide_result(10, 2)
+let ruim: DivResult = divide_result(1, 0)
+
+if boa.ok then
+    print("10 / 2 = " + to_str(boa.value))
+end
+if !ruim.ok then
+    print("1 / 0 falhou: " + ruim.error)
+end
+```
+
+- [ ] **Step 3: Run the example and the examples suite**
+
+Run: `go run ./cmd/noxy noxy_examples/result_pattern.nx`
+Expected output lines: `10 / 2 = 5` and `1 / 0 falhou: ...division by zero...`.
+Then run the examples runner used by CI (locate it: `Glob noxy_examples/*test*` / check how `language_semantics_test2.nx` is executed — there is a runner with exclusions per project memory). Run it; all examples green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/stdlib/result.nx noxy_examples/result_pattern.nx
+git commit -m "refactor(stdlib): deprecia o modulo result e migra result_pattern.nx para o idioma _result sobre call_result"
+```
+
+---
+
+### Task 9: Spec merge + CHANGELOG
+
+**Files:**
+- Modify: `docs/NOXY_LANGUAGE_SPEC.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Merge the normative sections**
+
+From `docs/superpowers/specs/2026-08-19-call-result-design.md` §2, copy the two sections between the `---` markers ("Errors: raise for bugs, results for data" and "The error boundary: `call_result`") into `docs/NOXY_LANGUAGE_SPEC.md`, inserted after the "Defer and deterministic cleanup" section (before "When / Channel Select", currently line ~1004). Adjustments while merging:
+- In the conversions section (~lines 1108-1141), keep the `to_int`/`to_int_result` examples but replace the philosophy paragraphs with one line referencing the new section ("A regra geral levantar-vs-`_result` está em *Errors: raise for bugs, results for data*.").
+- Drop design-doc-only phrasing ("this design", "see §N of this document"); the spec text must stand alone.
+
+- [ ] **Step 2: §5 and §12 updates**
+
+- §5 (struct self-reference): add one sentence + example that a struct may reference itself through an **array field without `ref`** (`causes: Failure[]`), noting value semantics cannot form cycles; keep the existing `ref` self-reference text.
+- §12 (Standard Library table): add row `| errors | Error boundary envelope shapes (Failure, CallResult) |`. Mark the `result` module row (if listed) as deprecated; if not listed, add nothing for it.
+
+- [ ] **Step 3: CHANGELOG entry**
+
+Add at top of `CHANGELOG.md`, following the existing format (compare the 0.7.1 entry):
+
+```markdown
+## [Unreleased]
+
+### Added — `call_result`: fronteira síncrona de erro
+
+- Novo nativo global `call_result(fn, ...args)` converte uma falha de runtime
+  que desenrola de `fn` em valor: envelope `{ok, value, failure}` com
+  `failure = {kind, message, stack, causes}` — o mesmo vocabulário da
+  fronteira de task, estendido com as falhas de defer agregadas (`causes`,
+  ordem LIFO, localização de registro no stack). Misuse (não-callable,
+  aridade/modos/campos errados onde há metadata) levanta síncrono no
+  chamador. Panics de Go viram `kind="panic"`; fatais do runtime Go seguem
+  fatais. Sem rollback: mutações via `ref`/globais/upvalues permanecem.
+- Novo módulo stdlib `errors` com os shapes `Failure` e `CallResult`
+  (fisicamente o envelope é um map na fronteira dinâmica, como `IntResult`).
+- Gêmeos `_result` agora são escrevíveis em noxy puro (ver
+  `noxy_examples/result_pattern.nx`).
+
+### Changed
+
+- `to_int`/`to_float`: o sufixo "; use to_int_result to handle failure" saiu
+  da mensagem de erro (agora limpa e capturável) e virou `hint:` impresso
+  apenas na saída fatal do topo.
+
+### Deprecated
+
+- Módulo `result` (`use result`): substituído pela convenção `_result` +
+  módulo `errors`. Remoção na próxima release.
+```
+
+- [ ] **Step 4: Verify docs coherence**
+
+Grep the spec for `call_result` — the merged text must not reference undefined anchors. Run `go test ./... -count=1` once more (spec edits can't break tests; this is the cheap full-suite checkpoint).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/NOXY_LANGUAGE_SPEC.md CHANGELOG.md
+git commit -m "docs(spec): call_result — filosofia levantar-vs-result e fronteira sincrona de erro; §5 autorreferencia via array; §12 modulo errors; CHANGELOG"
+```
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `go test ./... -count=1` and `go vet ./...` and `go build ./...`
+Expected: all green.
+
+- [ ] **Step 2: End-to-end smoke on the real binary**
+
+Run: `go run ./cmd/noxy noxy_examples/result_pattern.nx` (expected output per Task 8).
+Write a throwaway smoke script in the scratchpad (NOT in the repo) exercising: ok path, captured runtime error, misuse raising, fatal `hint:` line (`to_int("abc")` at top level must print `Runtime error: ...` then `hint: use to_int_result to handle failure`). Run and eyeball.
+
+- [ ] **Step 3: Examples runner**
+
+Run the project's noxy_examples runner (as found in Task 8); all green.
+
+- [ ] **Step 4: Self-review the diff**
+
+Run: `git diff develop --stat` and review each file against the design doc §2 checklist: envelope fields, misuse-synchronous, defer edge cases, panic coverage, representation (map), no `task_await` changes, `result.nx` still functional.

--- a/docs/superpowers/specs/2026-08-19-call-result-design.md
+++ b/docs/superpowers/specs/2026-08-19-call-result-design.md
@@ -215,7 +215,12 @@ precedent: `fmt("%T", r)` reports `map`, and the envelope does not compare
 equal to a hand-constructed `CallResult(...)` instance. Promoting the
 envelopes (this one and `task_await`'s) to genuine struct instances is a
 single future change, gated on natives being able to construct
-stdlib-declared structs — see "Relation to the task boundary".
+stdlib-declared structs — see "Relation to the task boundary". The typed
+annotation (`let r: CallResult = ...`) is honored by the runtime type
+validator accepting a structurally matching map wherever a struct shape is
+expected at the dynamic boundary; the `IntResult` precedent never exercised
+this path because it has no composite field, and the `call_result`
+implementation extended the validator accordingly.
 
 **What the boundary does not change.**
 
@@ -249,7 +254,9 @@ stdlib-declared structs — see "Relation to the task boundary".
   the boundary observes it, unwinding has already freed frames. Conditions
   the Go runtime treats as unrecoverable (fatal errors such as concurrent map
   writes, Go stack exhaustion, out of memory) remain process-fatal; no
-  boundary observes them.
+  boundary observes them. The recover covers the invocation of `fn` itself;
+  a Go panic raised outside it (argument preparation, envelope construction)
+  remains process-fatal like any other unrecovered panic.
 
 **Intended idiom.** `call_result` exists to build named `_result` twins, not
 to decorate call sites. The inline form over a closure is legal:

--- a/docs/superpowers/specs/2026-08-19-call-result-design.md
+++ b/docs/superpowers/specs/2026-08-19-call-result-design.md
@@ -1,0 +1,367 @@
+# `call_result` — Synchronous Error Boundary Design
+
+## Goal and Scope
+
+Noxy has a deliberate two-channel error philosophy: raising is for program
+bugs, `_result` structs are for untrusted data (`NOXY_LANGUAGE_SPEC.md`,
+conversions section). The philosophy is sound, but the language does not close
+over it: every `_result` twin in existence is born in Go
+(`internal/vm/builtins_convert.go`), because no Noxy code can observe a runtime
+error and survive. The evidence is `noxy_examples/int_to_result_noxy.nx`, where
+reimplementing `to_int_result` in pure Noxy required ~55 lines reimplementing
+`strconv.ParseInt` by hand — not because the parse is interesting, but because
+`to_int` raises and nothing can catch.
+
+The language already believes in catching errors at boundaries: a runtime
+error inside a supervised task does not kill the parent, and `task_await`
+reports it as a structured value. That boundary is asynchronous and costs a
+child VM. This design adds the synchronous, per-call form of the same
+boundary.
+
+**Goal:** user code can build its own `_result` twins; the stdlib's twins
+become expressible (not necessarily implemented) in pure Noxy.
+
+**Non-goals:**
+
+- `try`/`catch`/`rescue` syntax. A block construct invites using the bug
+  channel as the data channel. If an expression form is ever added, it must
+  compile down to this boundary, not compete with it.
+- A generically typed `Result<T>` envelope in v1. The decisive fact:
+  `call_result` is a native, and monomorphization (§6) reaches only Noxy code
+  — no generic signature can bind it. Supporting facts, verified against the
+  binary: `null` does not satisfy primitive contracts (§4.2), so a
+  `Result<int>` error case has no constructible `value`; `any` is not a valid
+  instantiation target (§6.5); and the enclosing function's declared return
+  type does not anchor a generic call in a `return` statement (`return
+  vazia()` inside `func f() -> Caixa<int>` fails to infer `T` — a `let`
+  annotation does anchor, which cannot help a native). `value: any` is the
+  documented dynamic floor for callables whose result is not statically known
+  (§4.2), and it is the cheap-to-deprecate choice if sum types ever arrive.
+- Migrating the existing native twins (`to_int_result`, `to_float_result`) as
+  part of this change. See "Migration and performance policy".
+
+**Design history.** A first draft carried `error: string` and was revised
+after independent review: the string collided with the task boundary's
+existing failure shape (`kind`, `message`, `stack`) and with the defer
+section's requirement that deferred failures remain "nested, structured causes
+rather than being flattened into one message". A second independent review of
+the revised spec confirmed those resolutions and demanded: a decision on the
+envelope's physical representation, a position on `stdlib/result.nx`, the
+`spawn_task` analogy corrected, and destinations for the defer registration
+location and the constructor/frame-overflow edge cases — all incorporated
+below. A comparison with Rust's `catch_unwind` contributed the discarded-
+envelope diagnostic, the native-frame traversal rule, and the unwind-safety
+guidance.
+
+## 1. The mechanism
+
+One global native and two stdlib struct shapes:
+
+```noxy
+// stdlib/errors.nx
+struct Failure
+    kind: string       // "runtime" | "panic"
+    message: string
+    stack: string
+    causes: Failure[]  // deferred failures aggregated during unwinding, LIFO
+end
+
+struct CallResult
+    ok: bool
+    value: any         // fn's return value; null for void and on failure
+    failure: Failure   // null when ok
+end
+```
+
+```noxy
+call_result(fn, ...args)   // global native, like spawn_task
+```
+
+`call_result` invokes `fn` with `args` in the current routine, synchronously,
+on the current frame stack. If the call completes, the envelope carries its
+value. If a runtime failure unwinds out of it, the unwinding stops at the
+`call_result` frame and the envelope carries a `Failure`.
+
+The name closes the existing convention — `io.close`/`io.close_result`,
+`to_int`/`to_int_result`, `call`/`call_result` — and the envelope reuses the
+failure vocabulary the task boundary already defined. `call_result` is not a
+second error idiom; it is the factory for the first one (and §4 retires the
+accidental third one).
+
+## 2. Normative spec section
+
+The text below is written to merge into `NOXY_LANGUAGE_SPEC.md`. Placement:
+the philosophy subsection replaces/absorbs the "raising vs `_result`" passage
+currently embedded in the conversions section (which then references it); the
+boundary subsection goes immediately after "Defer and deterministic cleanup",
+which it depends on.
+
+Merge checklist for the same spec change: register the `errors` module in §12
+(Standard Library); update §5 to sanction struct self-reference through an
+array field without `ref` (`causes: Failure[]` — verified against the current
+binary: it compiles, constructs, and nests; value semantics without `ref`
+cannot form cycles).
+
+---
+
+### Errors: raise for bugs, results for data
+
+Noxy has two failure channels, and they are not interchangeable.
+
+A **runtime error** means the program is wrong: an impossible conversion of a
+value the program itself produced, an out-of-range index, a violated native
+contract. It unwinds call frames, runs deferred calls along the way, and —
+unobserved — terminates the script with a diagnostic.
+
+A **result struct** means the input was allowed to be bad: untrusted text,
+user input, wire data. Failure is an expected outcome, so it is data — an
+`ok` flag the caller must branch on. Because Noxy functions return a single
+value, the result struct occupies the place of Go's `value, err` pair.
+
+API design rule: an operation whose failure indicates a caller bug raises; an
+operation whose failure is an expected outcome of untrusted data returns a
+result struct. When both kinds of caller exist, provide the raising form and a
+`_result` twin: `to_int` / `to_int_result`, `io.close` / `io.close_result`.
+
+Two boundaries convert the first channel into the second, and they are the
+only two: the supervised-task boundary (`spawn_task` / `task_await`), and the
+synchronous `call_result` described next. Advisory hints such as "use
+to_int_result to handle failure" belong to the top-level fatal diagnostic
+output, not to the raised message itself — a captured `Failure.message`
+carries the error, not usage advice.
+
+### The error boundary: `call_result`
+
+`call_result(fn, ...args)` invokes a callable and converts a runtime failure
+that unwinds out of it into a value:
+
+```noxy
+use errors select *
+
+let r: CallResult = call_result(to_int, entrada)
+if r.ok then
+    let n: int = to_int(r.value)   // narrowing only: r.value is already int
+    print(n)
+else
+    print("entrada inválida: " + r.failure.message)
+end
+```
+
+**Callable and validation.** `fn` may be any callable value: a typed Noxy
+function or closure, a function value held as an exact or bare `func`, a
+struct constructor, or a native. (A native reaches the boundary as `any` or
+in argument position; the compiler does not admit `let f: func = to_int`.)
+Passing a non-callable is a synchronous runtime error in the caller.
+Arguments are evaluated in the caller's frame, before the boundary exists; an
+error during argument evaluation is not captured. Where the callee exposes
+parameter metadata — typed Noxy functions and closures, struct constructors,
+signed natives — arity and parameter-mode mismatches are synchronous runtime
+errors in the caller. The timing mirrors `spawn_task`'s synchronous
+validation; the domain is wider — `spawn_task` accepts only Noxy functions
+and closures, while `call_result` also accepts constructors and natives.
+Callees without metadata (legacy untyped natives) validate during invocation,
+so those failures are captured and are indistinguishable from failures of the
+callee's own body. *Compatibility note:* giving a legacy native a signature
+in a later release moves its misuse failures from captured to synchronous —
+an observable change that rides the signing, and one more reason to sign
+natives eagerly.
+
+For a struct constructor, a completed call yields the constructed instance as
+`value`, under the constructor semantics the defer section already gives that
+callee category.
+
+**Argument semantics are unchanged.** Arguments follow §4.3 exactly as in a
+direct call: composite values are independent copy-on-write values, explicit
+`ref` arguments keep reference identity. `call_result` adds no isolation — it
+is the same call, wearing a boundary.
+
+**Envelope.** `call_result` returns a `CallResult` (module `errors`):
+
+- `fn` completes: `ok = true`, `value` is its return value (`null` for a
+  `void` return), `failure = null`. A composite `value` preserves the identity
+  an ordinary call would give it.
+- A runtime failure unwinds out of `fn`: deferred calls registered by `fn` and
+  its nested frames run under the normal unwinding rules, the unwinding stops
+  at the `call_result` frame, and the envelope is `ok = false`,
+  `value = null`, with `failure` describing the primary error.
+- `failure.kind` is `"runtime"` for a Noxy runtime error (with a Noxy stack
+  captured at the failure point) or `"panic"` for a recovered Go panic (with a
+  Go stack) — the same vocabulary as the task boundary. A `"runtime"` stack
+  covers the frames from the failure point down to, and excluding, the
+  `call_result` frame itself.
+- `failure.causes` holds deferred failures observed during that unwinding, in
+  LIFO execution order, each a `Failure` whose own `causes` nest further, per
+  the defer section's aggregation rules. It is empty when no deferred call
+  failed. Each cause's `stack` is captured at that deferred failure point and
+  carries the deferred call's registration location as its outermost frame —
+  the envelope form of the defer section's promise that each deferred failure
+  is collected "with its registration location".
+- Cleanup as first failure: if `fn` returns successfully but one of its
+  deferred calls raises, the boundary reports `ok = false` and the computed
+  return value is discarded, mirroring "converts an otherwise successful
+  return into a runtime error" in the defer section. The first deferred
+  failure is the primary `failure`; deferred failures observed after it
+  aggregate under the primary's `causes` in LIFO order, each nesting its own
+  `causes` further.
+
+**Representation.** `call_result` is a native, and natives return values
+across the dynamic boundary (§4.2). Like every result envelope a native
+produces today (`convert_to_int_result` and its `IntResult`), the envelope is
+physically a map whose fields match the declared shapes; the `errors` module
+declarations exist so Noxy code can annotate (`let r: CallResult = ...`) and
+so the field names are a compile-checkable contract at typed use sites. The
+consequences are observable and identical to the existing `IntResult`
+precedent: `fmt("%T", r)` reports `map`, and the envelope does not compare
+equal to a hand-constructed `CallResult(...)` instance. Promoting the
+envelopes (this one and `task_await`'s) to genuine struct instances is a
+single future change, gated on natives being able to construct
+stdlib-declared structs — see "Relation to the task boundary".
+
+**What the boundary does not change.**
+
+- The caller's own deferred calls and frames are unaffected; after
+  `call_result` returns, execution continues normally.
+- Boundaries nest: a failure is captured by the nearest enclosing
+  `call_result` frame.
+- Detached routines started by `fn` via `spawn` keep running after capture,
+  per the `spawn` contract.
+- `call_result` is an ordinary call and is legal anywhere a call is,
+  including module initialization; frame rules follow the defer section
+  unchanged.
+- **Through native frames.** A failure raised in Noxy code that a native
+  invoked (a callback, an HTTP handler) propagates through the intervening
+  native frame to the nearest boundary; the native observes the failure
+  through its existing error path and releases its resources before
+  propagation continues. A callback-invoking native must forward Noxy
+  failures, never swallow them.
+- **No rollback.** Mutations `fn` performed before failing — through `ref`
+  arguments, globals, closure upvalues, or native resources — remain. Noxy's
+  copy-on-write value semantics can suggest that everything is isolated; the
+  boundary is control flow, not a transaction. The risky shape has a name:
+  a callable that mutates `ref` arguments, globals, or upvalues can leave a
+  broken invariant behind when captured mid-flight — prefer value-in/value-out
+  callables under a boundary, and treat mutating ones as candidates for
+  explicit coordination, exactly as across the task boundary.
+- **Panic coverage.** Go panics are recovered in the executing routine only,
+  not in independent goroutines started by native code — the same coverage
+  rule as supervised tasks. Exhaustion of the VM's Noxy frame limit is an
+  ordinary runtime error and is capturable (`kind = "runtime"`): by the time
+  the boundary observes it, unwinding has already freed frames. Conditions
+  the Go runtime treats as unrecoverable (fatal errors such as concurrent map
+  writes, Go stack exhaustion, out of memory) remain process-fatal; no
+  boundary observes them.
+
+**Intended idiom.** `call_result` exists to build named `_result` twins, not
+to decorate call sites. The inline form over a closure is legal:
+
+```noxy
+let r: CallResult = call_result(func() -> int
+    return to_int(campo) * fator
+end)
+```
+
+but the idiom is wrap-and-name: a `_result` function with a typed result
+struct is a contract; an inline boundary is a site the reader must decode. The
+boundary's design leans on auditability — `call_result` is one grep away from
+every place errors become data — and on the envelope being deliberately
+untyped (`value: any`), so a named twin that narrows the value is always the
+more comfortable form. Discarding the envelope — `call_result(f, x)` as a
+bare statement — swallows every failure `f` can produce and is almost
+certainly a bug; a compile-time diagnostic for it is tracked as follow-up.
+
+---
+
+## 3. Relation to the task boundary
+
+`task_await`'s `"error"` envelope carries a failure map with string fields
+`kind`, `message`, and `stack`. `Failure` is that shape, promoted to a named
+declaration and extended with `causes`. Direction, not part of this change:
+`task_await` adopts the same shape (`causes` is additive on the existing map;
+the map-to-struct promotion is the breaking part and rides a major version).
+The honest obstacle to full unification is machinery, not intent: the task
+envelope is built by the VM in Go, and constructing a genuine
+stdlib-declared struct from native code is capability the VM does not have
+today — the same gate recorded under "Representation". Until then the two
+boundaries share vocabulary and semantics, not a nominal type.
+
+The differences that remain are real and intended: `call_result` is
+synchronous, runs on the current frame stack with no child VM, provides no
+timeout, and returns exactly once — there is no completion replay.
+
+## 4. The `result` module is absorbed
+
+`internal/stdlib/result.nx` predates this design: `Result{value: any,
+err: Error{code, msg}}` with `Ok`/`Err`/`is_ok`/`is_err`/`unwrap`, whose own
+comment concedes "we don't have panic/unwrap safely". It is a third failure
+vocabulary — after the `_result` structs and the task failure map — with a
+single consumer in the tree, `noxy_examples/result_pattern.nx`.
+
+This design retires it: `Failure` supersedes `Error` (kind/stack/causes are
+strictly richer than code/msg), and the `_result` convention supersedes
+`Result`. The module is marked deprecated in the release that ships
+`call_result` and removed in the following one; the example migrates to a
+named `_result` twin over `call_result` in the same change. Without this,
+`call_result`'s claim of not being a second error idiom would be false — it
+would be the third.
+
+## 5. Migration and performance policy
+
+- **The immediate value is user-side capability.** New `_result` twins —
+  stdlib and user — can be written in Noxy against raising primitives.
+- **Hot native twins stay native until a benchmark approves.** Rewriting
+  `to_int_result` over `call_result` turns 1 native frame into ~4 frames plus
+  an envelope allocation, in functions that live inside parse loops, in a
+  project whose current performance front is per-call validation cost.
+  `convert.nx` may migrate as a proof of concept only if the numbers hold.
+- **Raised-message cleanup.** `to_int`'s raised message currently embeds the
+  advisory suffix "; use to_int_result to handle failure"
+  (`builtins_convert.go`). The suffix moves to the fatal diagnostic output;
+  the capturable message stays clean. This is a small observable change to
+  fatal output wording and lands with the builtin.
+
+## 6. Alternatives and precedent
+
+- **Closure-only form** (`call_result(fn)` with no varargs) is Rust's choice
+  for `std::panic::catch_unwind`, and Rust could afford it: its
+  monomorphization reaches the standard library, so the closure types the
+  success side. Noxy gets no such benefit (the boundary is a native), the
+  varargs form is a strict superset (a zero-arg closure still works), and
+  `spawn_task(function, ...arguments)` already fixed the convention. Varargs
+  stands.
+- **Rust parallels that support the shape as designed.** The most statically
+  typed of the three languages also left its boundary payload dynamic
+  (`Box<dyn Any>`); its documentation confines the boundary to boundaries
+  ("catch_unwind is not recommended for general error handling") — the
+  wrap-and-name idiom; `UnwindSafe` is the type-system form of the no-rollback
+  guidance (and even Rust could do no better than a bypassable marker);
+  `JoinHandle::join` returning the panic payload is `task_await`; aborts stay
+  fatal there as Go-fatal stays fatal here.
+- **`rescue`/`or` expression syntax**: out of scope; if ever added, it
+  compiles down to this boundary rather than competing with it.
+- **Error as plain string**: rejected in review round one — it collided with
+  the task boundary's structured shape and the defer section's structured
+  aggregation, and a string propagated into every `_result` signature would be
+  the one irreversible choice in this design.
+
+## 7. Open questions and follow-ups
+
+- **`errors` module name.** `CallResult` and `Failure` need a home;
+  `stdlib/errors.nx` is proposed. The native `call_result` is global (like
+  `spawn_task`), so the import is only needed to *annotate* — dynamic access
+  (`let r: any = call_result(f)`) works without it, which keeps casual use
+  cheap and typed use explicit.
+- **Discarded-envelope diagnostic.** `call_result(...)` in statement position
+  with the envelope discarded is the empty-catch antipattern; a compile-time
+  diagnostic (precedent: Rust's `#[must_use]`) is future work — the compiler
+  knows the native's name.
+- **Callback-native audit.** The "through native frames" rule requires every
+  callback-invoking native to forward Noxy failures; implementation must
+  audit the existing ones (HTTP server handlers foremost) and add a
+  regression test per category.
+- **Typed variant later.** If sum types or native-reaching generics arrive, a
+  typed boundary (`Ok(T) | Err(Failure)`) can coexist; `CallResult` is an
+  ordinary shape and deprecates cheaply. Nothing in this design leaks a poor
+  error type into user signatures — `Failure` is already the rich form.
+- **`fmt("%T", ...)` / `type_of`.** Building twins over `any` inputs needs
+  runtime type dispatch; today that is the undocumented `%T` verb. The
+  companion proposal (a documented `type_of` builtin) is tracked separately.

--- a/docs/superpowers/specs/2026-08-19-call-result-design.md
+++ b/docs/superpowers/specs/2026-08-19-call-result-design.md
@@ -216,11 +216,18 @@ equal to a hand-constructed `CallResult(...)` instance. Promoting the
 envelopes (this one and `task_await`'s) to genuine struct instances is a
 single future change, gated on natives being able to construct
 stdlib-declared structs — see "Relation to the task boundary". The typed
-annotation (`let r: CallResult = ...`) is honored by the runtime type
-validator accepting a structurally matching map wherever a struct shape is
-expected at the dynamic boundary; the `IntResult` precedent never exercised
-this path because it has no composite field, and the `call_result`
-implementation extended the validator accordingly.
+annotation (`let r: CallResult = ...`) is honored by a general rule rather
+than a special case for this envelope: wherever a struct shape is expected at
+a dynamic-boundary annotation or marker, the runtime type validator admits any
+structurally matching map — every field the struct declares present, each
+recursively compatible with the declared field type — without nominal
+checking, and without stamping the map as that struct. The `IntResult`
+precedent never exercised this path because it has no composite field, and the
+`call_result` implementation extended the validator accordingly. The admission
+stops at nominal gates: task-argument validation (`spawn_task`) and every
+other check that requires a real struct instance still reject a map, so a
+`CallResult` envelope passed as a typed task argument fails today; unifying
+the two matchers is tracked as follow-up.
 
 **What the boundary does not change.**
 
@@ -361,6 +368,14 @@ would be the third.
   with the envelope discarded is the empty-catch antipattern; a compile-time
   diagnostic (precedent: Rust's `#[must_use]`) is future work — the compiler
   knows the native's name.
+- **Matcher unification.** Two type matchers disagree about the envelope: the
+  runtime type validator admits any structurally matching map where a struct
+  shape is expected, while task-argument validation (`spawn_task`) and the
+  other nominal gates demand a real struct instance — so `let r: CallResult =
+  call_result(f)` is accepted and `spawn_task(g, r)` with a `CallResult`
+  parameter is not. Unifying them is follow-up work; promoting the envelopes
+  to genuine struct instances would dissolve the split instead, which makes
+  the two items worth sequencing together.
 - **Callback-native audit.** The "through native frames" rule requires every
   callback-invoking native to forward Noxy failures; implementation must
   audit the existing ones (HTTP server handlers foremost) and add a

--- a/internal/stdlib/errors.nx
+++ b/internal/stdlib/errors.nx
@@ -1,10 +1,14 @@
-// stdlib/errors.nx - Formas do envelope da fronteira sincrona de erro.
+// errors.nx - Formas do envelope da fronteira sincrona de erro.
 //
 // call_result e um nativo global; estes structs dao nome e contrato de campos
 // ao envelope que ele devolve. Fisicamente o envelope e um MAP na fronteira
 // dinamica (mesmo precedente de IntResult em convert.nx): fmt("%T") reporta
 // "map" e ele nao compara igual a um CallResult construido a mao. A anotacao
 // tipada (`let r: CallResult = ...`) vale pelo contrato de campos.
+//
+// Referencia completa (callables aceitos, semantica dos argumentos, misuse
+// sincrono vs falha capturada, agregacao de defer, cobertura de panico):
+// docs/NOXY_LANGUAGE_SPEC.md, secao "The error boundary: call_result".
 
 struct Failure
     kind: string       // "runtime" | "panic"

--- a/internal/stdlib/errors.nx
+++ b/internal/stdlib/errors.nx
@@ -1,0 +1,20 @@
+// stdlib/errors.nx - Formas do envelope da fronteira sincrona de erro.
+//
+// call_result e um nativo global; estes structs dao nome e contrato de campos
+// ao envelope que ele devolve. Fisicamente o envelope e um MAP na fronteira
+// dinamica (mesmo precedente de IntResult em convert.nx): fmt("%T") reporta
+// "map" e ele nao compara igual a um CallResult construido a mao. A anotacao
+// tipada (`let r: CallResult = ...`) vale pelo contrato de campos.
+
+struct Failure
+    kind: string       // "runtime" | "panic"
+    message: string
+    stack: string
+    causes: Failure[]  // falhas de defer agregadas no unwinding, ordem LIFO
+end
+
+struct CallResult
+    ok: bool
+    value: any         // retorno de fn; null para void e em falha
+    failure: Failure   // null quando ok
+end

--- a/internal/stdlib/result.nx
+++ b/internal/stdlib/result.nx
@@ -1,3 +1,9 @@
+// DEPRECATED desde 0.8.0: use a convencao `_result` (structs proprios com
+// ok/value/error) construida sobre `call_result`, e o modulo `errors`
+// (Failure/CallResult). Este modulo sera removido na release seguinte.
+// Motivo: terceiro vocabulario de erro; ver
+// docs/superpowers/specs/2026-08-19-call-result-design.md §4.
+
 // result.nx - Standard Result and Error Pattern for Noxy
 
 struct Error

--- a/internal/stdlib/result.nx
+++ b/internal/stdlib/result.nx
@@ -1,4 +1,4 @@
-// DEPRECATED desde 0.8.0: use a convencao `_result` (structs proprios com
+// DEPRECATED desde 0.7.2: use a convencao `_result` (structs proprios com
 // ok/value/error) construida sobre `call_result`, e o modulo `errors`
 // (Failure/CallResult). Este modulo sera removido na release seguinte.
 // Motivo: terceiro vocabulario de erro; ver

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.7.1"
+const Version = "v0.7.2"

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"noxy-vm/internal/chunk"
 	"noxy-vm/internal/value"
@@ -96,6 +97,19 @@ func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err err
 	}()
 
 	ownerFrameCount := vm.frameCount
+	// Registrado DEPOIS do defer de cleanup acima: defers do Go rodam LIFO,
+	// entao num panico este corpo roda PRIMEIRO (hardUnwindTo restaura os
+	// frames acima da fronteira) e SO ENTAO o cleanup acima roda (restaura a
+	// janela da pilha e solta os argumentos preparados). Se a ordem fosse
+	// invertida o cleanup rodaria sobre frames que o unwind ainda nao
+	// desfez — vm.stackTop e vm.frameCount ficariam inconsistentes.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			vm.hardUnwindTo(ownerFrameCount)
+			result = value.NewNull()
+			err = &boundaryPanicError{payload: fmt.Sprint(recovered), stack: string(debug.Stack())}
+		}
+	}()
 	vm.push(call.Callee)
 	for _, argument := range call.Arguments {
 		vm.push(argument)
@@ -110,11 +124,52 @@ func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err err
 		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
 			return value.NewNull(), runErr
 		}
+		// RC: o envelope ok (callResultOkEnvelope) guarda `result` no campo
+		// "value" via NewMapWithData, que — ao contrario de OP_MAP/OP_ARRAY —
+		// NAO retem os valores que recebe. Sem este retain, uma composta
+		// devolvida sem dono previo (Owners=0, caso comum de um retorno
+		// fresco) apareceria com Owners=1 apos o PRIMEIRO `let` no lado Noxy
+		// que capturar r.value; IsShared ficaria falso e uma mutacao nesse
+		// primeiro binding aconteceria in-place, vazando para qualquer outra
+		// leitura de r.value (mesmo objeto, guardado por referencia no mapa)
+		// — corrupcao comprovada por TestCallResultValueSemantics antes deste
+		// retain ("100|100|3" em vez de "1|100|3"). O retain aqui da ao
+		// envelope o mesmo dono-duravel que OP_MAP teria registrado se este
+		// valor tivesse sido escrito por bytecode Noxy comum.
+		value.Retain(result)
 		return result, nil
 	}
-	// native/construtor: sem frame novo; resultado no topo da pilha.
-	return vm.peek(0), nil
+	// native/construtor: sem frame novo; resultado no topo da pilha. Mesmo
+	// retain do ramo acima, mesma justificativa.
+	result = vm.peek(0)
+	value.Retain(result)
+	return result, nil
 }
+
+// boundaryPanicError transporta um panico de Go recuperado na fronteira; o
+// envelope o converte em Failure{kind: "panic"}. Nunca escapa da fronteira.
+type boundaryPanicError struct {
+	payload string
+	stack   string
+}
+
+func (err *boundaryPanicError) Error() string { return err.payload }
+
+// hardUnwindTo libera os frames acima de target sem executar defers Noxy —
+// depois de um panico de Go o estado desses frames e suspeito; espelha a
+// fronteira de task, que tambem nao roda defers no caminho de panico (o VM
+// filho e abandonado). Truncar Deferred antes de finalizar reusa o funil
+// unico de release (Owned/upvalues) sem rodar codigo Noxy.
+func (vm *VM) hardUnwindTo(target int) {
+	for vm.frameCount > target {
+		if frame := vm.currentFrame; frame != nil {
+			frame.Deferred = frame.Deferred[:0]
+		}
+		vm.finalizeCurrentFrame(frameOutcome{Err: errBoundaryPanic})
+	}
+}
+
+var errBoundaryPanic = fmt.Errorf("call_result: unwinding after Go panic")
 
 func callResultOkEnvelope(result value.Value) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
@@ -138,6 +193,14 @@ func callResultFailureEnvelope(err error) value.Value {
 // (Primary nil) promove a PRIMEIRA falha diferida a primaria e agrega as
 // demais sob as causes dela (design §2, "Cleanup as first failure").
 func failureMap(err error) value.Value {
+	if panicErr, ok := err.(*boundaryPanicError); ok {
+		return value.NewMapWithData(map[string]value.Value{
+			"kind":    value.NewString("panic"),
+			"message": value.NewString(panicErr.payload),
+			"stack":   value.NewString(panicErr.stack),
+			"causes":  value.NewArray([]value.Value{}),
+		})
+	}
 	if unwind, ok := err.(*UnwindError); ok {
 		if unwind.Primary != nil {
 			return failureMapWithCauses(unwind.Primary, unwind.Deferred)

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -124,11 +124,81 @@ func callResultOkEnvelope(result value.Value) value.Value {
 	})
 }
 
-// placeholder ate a Task 5 (mantem o pacote compilando):
 func callResultFailureEnvelope(err error) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
 		"ok":      value.NewBool(false),
 		"value":   value.NewNull(),
-		"failure": value.NewNull(),
+		"failure": failureMap(err),
 	})
+}
+
+// failureMap converte a arvore de erro do unwinding no shape Failure.
+// UnwindError com Primary vira a falha primaria com cada DeferredError em
+// causes (ordem LIFO ja garantida por finalizeCurrentFrame); cleanup-first
+// (Primary nil) promove a PRIMEIRA falha diferida a primaria e agrega as
+// demais sob as causes dela (design §2, "Cleanup as first failure").
+func failureMap(err error) value.Value {
+	if unwind, ok := err.(*UnwindError); ok {
+		if unwind.Primary != nil {
+			return failureMapWithCauses(unwind.Primary, unwind.Deferred)
+		}
+		if len(unwind.Deferred) > 0 {
+			primary := deferredFailureMap(&unwind.Deferred[0], unwind.Deferred[1:])
+			return primary
+		}
+	}
+	if deferred, ok := err.(*DeferredError); ok {
+		return deferredFailureMap(deferred, nil)
+	}
+	if deferred, ok := err.(DeferredError); ok {
+		return deferredFailureMap(&deferred, nil)
+	}
+	return failureMapWithCauses(err, nil)
+}
+
+func failureMapWithCauses(primary error, deferred []DeferredError) value.Value {
+	causes := make([]value.Value, 0, len(deferred))
+	for index := range deferred {
+		causes = append(causes, deferredFailureMap(&deferred[index], nil))
+	}
+	message := ""
+	if primary != nil {
+		message = primary.Error()
+	}
+	return value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString(message),
+		"stack":   value.NewString(deepestRuntimeStack(primary)),
+		"causes":  value.NewArray(causes),
+	})
+}
+
+// deferredFailureMap constroi a Failure de uma falha diferida: a causa vira a
+// falha (aninhando as proprias causes dela recursivamente via failureMap) e a
+// localizacao de REGISTRO do defer entra como frame mais externo do stack —
+// forma-envelope da promessa da spec de defer ("with its registration
+// location"). siblings sao falhas diferidas posteriores promovidas para as
+// causes desta (apenas no caso cleanup-first).
+func deferredFailureMap(deferred *DeferredError, siblings []DeferredError) value.Value {
+	failure := failureMap(deferred.Cause)
+	mapping := failure.Obj.(*value.ObjMap)
+
+	stackValue, _ := mapping.Get("stack")
+	stack, _ := stackValue.Obj.(string)
+	registrationFrame := fmt.Sprintf("[%s] defer registration", deferred.Registration)
+	if stack == "" {
+		stack = registrationFrame
+	} else {
+		stack = stack + "\n" + registrationFrame
+	}
+	mapping.Set("stack", value.NewString(stack))
+
+	if len(siblings) > 0 {
+		causes := make([]value.Value, 0, len(siblings))
+		for index := range siblings {
+			causes = append(causes, deferredFailureMap(&siblings[index], nil))
+		}
+		mapping.Set("causes", value.NewArray(causes))
+	}
+	return failure
 }

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -1,0 +1,67 @@
+package vm
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+func (vm *VM) defineCallResultBuiltins() {
+	vm.DefineContextualNative("call_result", func(context value.NativeContext, args []value.Value) (value.Value, error) {
+		machine, err := nativeVM(context)
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if len(args) < 1 {
+			return value.NewNull(), fmt.Errorf("call_result expects a callable")
+		}
+		return machine.runCallBoundary(args[0], args[1:])
+	})
+}
+
+// prepareBoundaryCall valida sincronamente no chamador (design: misuse nunca
+// e capturado). Normaliza ObjFunction sem upvalues para closure — mesmo
+// ajuste de prepareTaskCall — e delega o resto a prepareDeferredCall, que ja
+// valida closure (aridade+modos), native assinado (assinatura+modos, copia
+// ansiosa) e construtor de struct (campos+tipos).
+func (vm *VM) prepareBoundaryCall(callee value.Value, args []value.Value) (PreparedCall, error) {
+	if callee.Type == value.VAL_FUNCTION {
+		if fn, ok := callee.Obj.(*value.ObjFunction); ok && fn != nil && fn.UpvalueCount == 0 {
+			callee = value.Value{Type: value.VAL_FUNCTION, Obj: &value.ObjClosure{
+				Function:    fn,
+				Upvalues:    []*value.ObjUpvalue{},
+				Environment: fn.Environment,
+			}}
+		}
+	}
+	registration := SourceLocation{File: "?"}
+	if frame := vm.currentFrame; frame != nil && frame.Closure != nil && frame.Closure.Function != nil {
+		if c, ok := frame.Closure.Function.Chunk.(*chunk.Chunk); ok {
+			registration = sourceLocation(c, frame.IP)
+		}
+	}
+	prepared, err := vm.prepareDeferredCall(callee, args, registration)
+	if err != nil {
+		if callee.Type != value.VAL_FUNCTION && callee.Type != value.VAL_NATIVE {
+			if _, isStruct := callee.Obj.(*value.ObjStruct); callee.Type != value.VAL_OBJ || !isStruct {
+				return PreparedCall{}, fmt.Errorf("call_result expects a callable, got %s", runtimeValueMode(callee))
+			}
+		}
+		return PreparedCall{}, err
+	}
+	return prepared, nil
+}
+
+// runCallBoundary: corpo completado nas Tasks 4-7. Nesta task, apenas valida
+// e devolve null, desfazendo a retencao de preparacao para nao vazar RC.
+func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error) {
+	prepared, err := vm.prepareBoundaryCall(callee, args)
+	if err != nil {
+		return value.NewNull(), err
+	}
+	if closure, ok := prepared.Callee.Obj.(*value.ObjClosure); ok && prepared.Callee.Type == value.VAL_FUNCTION {
+		vm.releasePreparedArguments(prepared.Arguments, closure.Function.Params)
+	}
+	return value.NewNull(), nil
+}

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -160,9 +160,34 @@ func (err *boundaryPanicError) Error() string { return err.payload }
 // fronteira de task, que tambem nao roda defers no caminho de panico (o VM
 // filho e abandonado). Truncar Deferred antes de finalizar reusa o funil
 // unico de release (Owned/upvalues) sem rodar codigo Noxy.
+//
+// Nao rodar os PreparedCall pendentes NAO significa que a captura deles pode
+// ser esquecida: prepareDeferredCall ja reteve (retainPreparedArguments,
+// defer.go:35/101-110) cada argumento composto nao-ref no REGISTRO do defer —
+// o unico lugar que desfaz isso hoje e o cleanup de invokePreparedCall
+// (defer.go:165-169), que so roda se a chamada for de fato invocada. Pular a
+// invocacao sem soltar essa retencao vaza um dono por argumento composto de
+// cada defer pendente nos frames abandonados: o valor fica IsShared para
+// sempre (clona a cada mutacao) e, pior, um ref vivo que ainda aponte para o
+// slot original diverge do clone. Por isso cada PreparedCall e liberado aqui
+// (mesma condicao de invokePreparedCall — so VAL_FUNCTION reteve na captura;
+// native usou copia ansiosa, construtor nao reteve nada) antes do slice ser
+// truncado; cada entrada tambem e zerada (nao so descartada por indice) para
+// nao prender o PreparedCall antigo no array de suporte reusado — o mesmo
+// padrao de vazamento que os comentarios de unwind.go documentam para
+// frame.Owned.
 func (vm *VM) hardUnwindTo(target int) {
 	for vm.frameCount > target {
 		if frame := vm.currentFrame; frame != nil {
+			for i := range frame.Deferred {
+				call := frame.Deferred[i]
+				if call.Callee.Type == value.VAL_FUNCTION {
+					if closure, ok := call.Callee.Obj.(*value.ObjClosure); ok && closure != nil && closure.Function != nil {
+						vm.releasePreparedArguments(call.Arguments, closure.Function.Params)
+					}
+				}
+				frame.Deferred[i] = PreparedCall{}
+			}
 			frame.Deferred = frame.Deferred[:0]
 		}
 		vm.finalizeCurrentFrame(frameOutcome{Err: errBoundaryPanic})

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -53,15 +53,82 @@ func (vm *VM) prepareBoundaryCall(callee value.Value, args []value.Value) (Prepa
 	return prepared, nil
 }
 
-// runCallBoundary: corpo completado nas Tasks 4-7. Nesta task, apenas valida
-// e devolve null, desfazendo a retencao de preparacao para nao vazar RC.
+// runCallBoundary: corpo completado nas Tasks 4-7. Nesta task, invoca a
+// chamada preparada e envelopa o resultado no caminho ok; o mapeamento de
+// falha real chega na Task 5 (placeholder abaixo mantem o pacote compilando).
 func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error) {
 	prepared, err := vm.prepareBoundaryCall(callee, args)
 	if err != nil {
 		return value.NewNull(), err
 	}
-	if closure, ok := prepared.Callee.Obj.(*value.ObjClosure); ok && prepared.Callee.Type == value.VAL_FUNCTION {
-		vm.releasePreparedArguments(prepared.Arguments, closure.Function.Params)
+	result, callErr := vm.invokeBoundaryCall(prepared)
+	if callErr != nil {
+		return callResultFailureEnvelope(callErr), nil // Task 5
 	}
-	return value.NewNull(), nil
+	return callResultOkEnvelope(result), nil
+}
+
+// invokeBoundaryCall espelha invokePreparedCall (defer.go) com duas
+// diferencas: captura o resultado (terminalResult para closures; topo da
+// pilha para native/construtor) e nao descarta o valor no cleanup — o
+// envelope o carrega. O release da retencao de closure e identico.
+func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err error) {
+	base := vm.stackTop
+	if base < 0 || base >= len(vm.stack) || len(call.Arguments) > len(vm.stack)-base-1 {
+		return value.NewNull(), vm.runtimeErrorAtCurrentFrame("stack overflow while invoking call_result")
+	}
+	result = value.NewNull()
+	temporaryTop := base
+	defer func() {
+		cleanupTop := vm.stackTop
+		if temporaryTop > cleanupTop {
+			cleanupTop = temporaryTop
+		}
+		for i := base; i < cleanupTop; i++ {
+			vm.stack[i] = value.Value{}
+		}
+		vm.stackTop = base
+		if call.Callee.Type == value.VAL_FUNCTION {
+			if closure, ok := call.Callee.Obj.(*value.ObjClosure); ok && closure != nil && closure.Function != nil {
+				vm.releasePreparedArguments(call.Arguments, closure.Function.Params)
+			}
+		}
+	}()
+
+	ownerFrameCount := vm.frameCount
+	vm.push(call.Callee)
+	for _, argument := range call.Arguments {
+		vm.push(argument)
+	}
+	temporaryTop = vm.stackTop
+
+	ok, err := vm.callPreparedValue(call.Callee, len(call.Arguments), nil, 0)
+	if !ok {
+		return value.NewNull(), err
+	}
+	if vm.frameCount > ownerFrameCount {
+		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
+			return value.NewNull(), runErr
+		}
+		return result, nil
+	}
+	// native/construtor: sem frame novo; resultado no topo da pilha.
+	return vm.peek(0), nil
+}
+
+func callResultOkEnvelope(result value.Value) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(true),
+		"value":   result,
+		"failure": value.NewNull(),
+	})
+}
+
+// placeholder ate a Task 5 (mantem o pacote compilando):
+func callResultFailureEnvelope(err error) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": value.NewNull(),
+	})
 }

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -97,6 +97,20 @@ func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err err
 	}()
 
 	ownerFrameCount := vm.frameCount
+	// A spec promete que Failure.stack cobre "the frames from the failure
+	// point down to, and excluding, the call_result frame itself". Quem sabe
+	// onde fica esse corte e a fronteira, nao captureNoxyStack: enquanto a
+	// chamada capturada roda, o piso vale ownerFrameCount e todo stack
+	// capturado la dentro (inclusive os das falhas diferidas montadas durante
+	// o unwind) para no primeiro frame acima do chamador. Piso por indice, e
+	// nao pos-processamento do texto: captureNoxyStack pula frames sem
+	// Closure/Function, entao "corte as N ultimas linhas" nao teria
+	// correspondencia confiavel com N frames de chamador. Salvo/restaurado
+	// para nao vazar para o chamador (e para aninhar fronteiras); erro fatal
+	// de topo segue com a pilha inteira, piso 0.
+	previousStackFloor := vm.stackCaptureFloor
+	vm.stackCaptureFloor = ownerFrameCount
+	defer func() { vm.stackCaptureFloor = previousStackFloor }()
 	// Registrado DEPOIS do defer de cleanup acima: defers do Go rodam LIFO,
 	// entao num panico este corpo roda PRIMEIRO (hardUnwindTo restaura os
 	// frames acima da fronteira) e SO ENTAO o cleanup acima roda (restaura a

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -54,9 +54,11 @@ func (vm *VM) prepareBoundaryCall(callee value.Value, args []value.Value) (Prepa
 	return prepared, nil
 }
 
-// runCallBoundary: corpo completado nas Tasks 4-7. Nesta task, invoca a
-// chamada preparada e envelopa o resultado no caminho ok; o mapeamento de
-// falha real chega na Task 5 (placeholder abaixo mantem o pacote compilando).
+// runCallBoundary e a fronteira inteira em tres passos: valida (erro de
+// misuse sobe para o chamador — nunca vira envelope), invoca, e envelopa. O
+// invariante que a assinatura carrega: depois de prepareBoundaryCall passar,
+// esta funcao so devolve erro se a propria fronteira estiver quebrada — toda
+// falha do callee vira CallResult{ok: false}.
 func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Value, error) {
 	prepared, err := vm.prepareBoundaryCall(callee, args)
 	if err != nil {
@@ -64,7 +66,7 @@ func (vm *VM) runCallBoundary(callee value.Value, args []value.Value) (value.Val
 	}
 	result, callErr := vm.invokeBoundaryCall(prepared)
 	if callErr != nil {
-		return callResultFailureEnvelope(callErr), nil // Task 5
+		return callResultFailureEnvelope(callErr), nil
 	}
 	return callResultOkEnvelope(result), nil
 }

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -196,6 +196,36 @@ func (vm *VM) hardUnwindTo(target int) {
 
 var errBoundaryPanic = fmt.Errorf("call_result: unwinding after Go panic")
 
+// retainingMap e retainingArray espelham OP_MAP/OP_ARRAY (executor.go,
+// "elemento e dono duravel"): o composto pai vira dono duravel de cada filho
+// composto que guarda. value.NewMapWithData/value.NewArray, ao contrario dos
+// opcodes, NAO retem o que recebem — sem estes funis a arvore de Failure
+// nasceria com Owners=0 nos filhos e o PRIMEIRO `let` do lado Noxy que
+// capturasse r.failure (ou uma entrada de causes) levaria o filho a Owners=1:
+// IsShared falso, mutacao aplicada in-place e o envelope reescrito por baixo
+// (corrupcao comprovada — ver TestCallResultFailureAliasDoesNotMutateEnvelope
+// e TestCallResultCauseAliasDoesNotMutateEnvelope). Com o retain do pai, o
+// mesmo `let` chega a Owners=2 e a mutacao clona, como em qualquer composto
+// escrito por bytecode Noxy comum. Strings e escalares dispensam o funil:
+// ownersOf so rastreia compostos, entao Retain neles e no-op.
+func retainingMap(data map[string]value.Value) value.Value {
+	for _, item := range data {
+		value.Retain(item)
+	}
+	return value.NewMapWithData(data)
+}
+
+func retainingArray(elements []value.Value) value.Value {
+	for _, element := range elements {
+		value.Retain(element)
+	}
+	return value.NewArray(elements)
+}
+
+// callResultOkEnvelope NAO usa retainingMap de proposito: `result` ja foi
+// retido por invokeBoundaryCall (comentario "RC" la), e um segundo retain
+// aqui deixaria o valor eternamente IsShared — clonaria a cada mutacao. Os
+// outros dois campos sao escalares.
 func callResultOkEnvelope(result value.Value) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
 		"ok":      value.NewBool(true),
@@ -205,7 +235,7 @@ func callResultOkEnvelope(result value.Value) value.Value {
 }
 
 func callResultFailureEnvelope(err error) value.Value {
-	return value.NewMapWithData(map[string]value.Value{
+	return retainingMap(map[string]value.Value{
 		"ok":      value.NewBool(false),
 		"value":   value.NewNull(),
 		"failure": failureMap(err),
@@ -219,11 +249,11 @@ func callResultFailureEnvelope(err error) value.Value {
 // demais sob as causes dela (design §2, "Cleanup as first failure").
 func failureMap(err error) value.Value {
 	if panicErr, ok := err.(*boundaryPanicError); ok {
-		return value.NewMapWithData(map[string]value.Value{
+		return retainingMap(map[string]value.Value{
 			"kind":    value.NewString("panic"),
 			"message": value.NewString(panicErr.payload),
 			"stack":   value.NewString(panicErr.stack),
-			"causes":  value.NewArray([]value.Value{}),
+			"causes":  retainingArray([]value.Value{}),
 		})
 	}
 	if unwind, ok := err.(*UnwindError); ok {
@@ -253,11 +283,11 @@ func failureMapWithCauses(primary error, deferred []DeferredError) value.Value {
 	if primary != nil {
 		message = primary.Error()
 	}
-	return value.NewMapWithData(map[string]value.Value{
+	return retainingMap(map[string]value.Value{
 		"kind":    value.NewString("runtime"),
 		"message": value.NewString(message),
 		"stack":   value.NewString(deepestRuntimeStack(primary)),
-		"causes":  value.NewArray(causes),
+		"causes":  retainingArray(causes),
 	})
 }
 
@@ -286,13 +316,30 @@ func deferredFailureMap(deferred *DeferredError, siblings []DeferredError) value
 		// (o Cause dela era um *UnwindError com seu proprio Deferred) —
 		// preserva-las primeiro e so entao anexa os siblings (falhas
 		// diferidas posteriores no mesmo frame, cleanup-first) por cima.
+		previous, hadPrevious := mapping.Get("causes")
 		inner := existingCauses(mapping)
 		causes := make([]value.Value, 0, len(inner)+len(siblings))
+		// RC: os herdados apenas TROCAM de array — o retain que o array
+		// antigo registrou passa a valer pelo novo, entao re-reter aqui seria
+		// um dono a mais que ninguem solta (composto IsShared para sempre,
+		// clonando a cada mutacao).
 		causes = append(causes, inner...)
 		for index := range siblings {
-			causes = append(causes, deferredFailureMap(&siblings[index], nil))
+			sibling := deferredFailureMap(&siblings[index], nil)
+			value.Retain(sibling) // filho novo: o array vira dono duravel
+			causes = append(causes, sibling)
 		}
-		mapping.Set("causes", value.NewArray(causes))
+		// RC: ObjMap.Set NAO solta o valor sobrescrito (bindingStore.set so
+		// escreve) — quem faz retain-novo/release-velho no map-set do Noxy e
+		// o funil de OP_SET_INDEX no executor. Aqui a troca e a mao e segue a
+		// mesma ordem: o array novo ganha `mapping` como dono ANTES do antigo
+		// perder o dele (nunca soltar primeiro; um dec a mais nao tem volta).
+		replacement := value.NewArray(causes)
+		value.Retain(replacement)
+		mapping.Set("causes", replacement)
+		if hadPrevious {
+			value.Release(previous)
+		}
 	}
 	return failure
 }

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -194,11 +194,33 @@ func deferredFailureMap(deferred *DeferredError, siblings []DeferredError) value
 	mapping.Set("stack", value.NewString(stack))
 
 	if len(siblings) > 0 {
-		causes := make([]value.Value, 0, len(siblings))
+		// merge, nao substitui: a falha promovida ja pode ter causes proprias
+		// (o Cause dela era um *UnwindError com seu proprio Deferred) —
+		// preserva-las primeiro e so entao anexa os siblings (falhas
+		// diferidas posteriores no mesmo frame, cleanup-first) por cima.
+		inner := existingCauses(mapping)
+		causes := make([]value.Value, 0, len(inner)+len(siblings))
+		causes = append(causes, inner...)
 		for index := range siblings {
 			causes = append(causes, deferredFailureMap(&siblings[index], nil))
 		}
 		mapping.Set("causes", value.NewArray(causes))
 	}
 	return failure
+}
+
+// existingCauses le o array "causes" ja presente num mapa Failure recem
+// construido por failureMap — sempre presente (failureMapWithCauses e
+// deferredFailureMap ambos o preenchem, mesmo vazio) mas lido com defesa
+// contra shape inesperado.
+func existingCauses(mapping *value.ObjMap) []value.Value {
+	causesValue, ok := mapping.Get("causes")
+	if !ok {
+		return nil
+	}
+	array, ok := causesValue.Obj.(*value.ObjArray)
+	if !ok || array == nil {
+		return nil
+	}
+	return array.Elements
 }

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -88,6 +88,13 @@ test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message + "|" 
 	}
 }
 
+// TestCallResultFailureStackExcludesBoundary pina a promessa da spec ("a
+// 'runtime' stack covers the frames from the failure point down to, and
+// excluding, the call_result frame itself"): a pilha capturada tem os frames
+// ACIMA da fronteira e nenhum do chamador. O chamador ganha nome proprio
+// (`chamador_externo`) justamente para poder afirmar a AUSENCIA dele — antes
+// do piso de captura, r.failure.stack trazia "in chamador_externo" e "in
+// script" junto.
 func TestCallResultFailureStackExcludesBoundary(t *testing.T) {
 	source := `
 func fundo() -> int
@@ -96,16 +103,58 @@ end
 func meio() -> int
     return fundo()
 end
-let r: any = call_result(meio)
-test_report(r.failure.stack)
+func chamador_externo() -> string
+    let r: any = call_result(meio)
+    return r.failure.stack
+end
+test_report(chamador_externo())
 `
 	reported := captureVMSource(t, source)
 	stack, _ := reported.Obj.(string)
 	if !strings.Contains(stack, "in fundo") || !strings.Contains(stack, "in meio") {
 		t.Fatalf("stack missing inner frames: %q", stack)
 	}
+	if strings.Contains(stack, "in chamador_externo") {
+		t.Fatalf("stack must exclude the caller frame that invoked call_result: %q", stack)
+	}
+	if strings.Contains(stack, "in script") {
+		t.Fatalf("stack must exclude the frames below the boundary: %q", stack)
+	}
 	if strings.Contains(stack, "call_result") {
 		t.Fatalf("stack must stop before the boundary frame: %q", stack)
+	}
+}
+
+// TestCallResultStackFloorIsRestoredAfterBoundary garante que o piso de
+// captura e estritamente local a fronteira: uma fronteira que ja retornou nao
+// pode deixar o piso dela para tras. A primeira chamada (bem sucedida) sobe e
+// desce o piso; a segunda tem que enxergar exatamente os frames acima de si
+// mesma — nem menos (piso vazado alto) nem mais (piso vazado baixo traria "in
+// externa"). O caso "sem fronteira nenhuma = pilha inteira" segue coberto por
+// TestRuntimeErrorRemainsTypedThroughImportFailure (task_execution_test.go),
+// que exige "in script" no Stack de um erro fora de qualquer call_result.
+func TestCallResultStackFloorIsRestoredAfterBoundary(t *testing.T) {
+	source := `
+func inofensiva() -> int
+    return 1
+end
+func dentro() -> int
+    return to_int("x")
+end
+func externa() -> string
+    let ignorado: any = call_result(inofensiva)
+    let r: any = call_result(dentro)
+    return r.failure.stack
+end
+test_report(externa())
+`
+	reported := captureVMSource(t, source)
+	stack, _ := reported.Obj.(string)
+	if !strings.Contains(stack, "in dentro") {
+		t.Fatalf("stack missing the failing frame: %q", stack)
+	}
+	if strings.Contains(stack, "in externa") || strings.Contains(stack, "in script") {
+		t.Fatalf("floor must be restored to the outer boundary's own value, not leaked: %q", stack)
 	}
 }
 
@@ -200,7 +249,10 @@ func TestFailureMapMergesInnerCausesWithSiblingsOnPromotion(t *testing.T) {
 // corpo TAMBEM falha durante o unwind, e a falha diferida precisa aparecer em
 // r.failure.causes[0] com kind "runtime", a mensagem original preservada, e o
 // stack carregando "defer registration" como frame mais externo (a
-// localizacao de REGISTRO do defer, nao a de falha).
+// localizacao de REGISTRO do defer, nao a de falha). O chamador tem nome
+// proprio para tambem exigir que o piso de captura da fronteira valha para os
+// stacks das causas — truncados nos frames acima da fronteira — SEM comer a
+// linha sintetica de registro, que e concatenada depois da truncagem.
 func TestCallResultAggregatesDeferFailures(t *testing.T) {
 	source := `
 func limpeza_ruim()
@@ -212,9 +264,13 @@ func corpo() -> int
     return to_int("primario")
 end
 
-let r: any = call_result(corpo)
-let causa: any = r.failure.causes[0]
-test_report(to_str(length(r.failure.causes)) + "|" + causa.kind + "|" + causa.message + "|" + causa.stack)
+func chamador_do_defer() -> string
+    let r: any = call_result(corpo)
+    let causa: any = r.failure.causes[0]
+    return to_str(length(r.failure.causes)) + "|" + causa.kind + "|" + causa.message + "|" + causa.stack
+end
+
+test_report(chamador_do_defer())
 `
 	reported := captureVMSource(t, source)
 	text, _ := reported.Obj.(string)
@@ -227,6 +283,12 @@ test_report(to_str(length(r.failure.causes)) + "|" + causa.kind + "|" + causa.me
 	}
 	if !strings.Contains(parts[3], "defer registration") {
 		t.Fatalf("cause stack must carry the registration location as outermost frame: %q", parts[3])
+	}
+	if !strings.Contains(parts[3], "in limpeza_ruim") || !strings.Contains(parts[3], "in corpo") {
+		t.Fatalf("cause stack must keep the frames above the boundary: %q", parts[3])
+	}
+	if strings.Contains(parts[3], "in chamador_do_defer") || strings.Contains(parts[3], "in script") {
+		t.Fatalf("cause stack must be truncated at the boundary too: %q", parts[3])
 	}
 }
 

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -22,6 +22,46 @@ test_report(nested.causes[0].message + "|" + to_str(r.ok) + "|" + to_str(r.value
 	}
 }
 
+func TestCallResultOkPaths(t *testing.T) {
+	source := `
+use errors select *
+
+func dobro(x: int) -> int
+    return x * 2
+end
+
+func nada()
+end
+
+struct P
+    x: int
+end
+
+let a: CallResult = call_result(dobro, 21)
+let b: CallResult = call_result(to_int, "5")
+let c: CallResult = call_result(P, 7)
+let d: CallResult = call_result(nada)
+let inst: any = c.value
+test_report(to_str(a.ok) + "|" + to_str(a.value) + "|" + to_str(b.value) + "|" + to_str(inst.x) + "|" + to_str(d.ok) + "|" + to_str(d.value == null) + "|" + to_str(a.failure == null))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if text != "true|42|5|7|true|true|true" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+}
+
+func TestCallResultEnvelopeIsMap(t *testing.T) {
+	source := `
+let r: any = call_result(to_int, "5")
+test_report(fmt("%T", r))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "map" {
+		t.Fatalf("envelope should be a map at the dynamic boundary, got %q", text)
+	}
+}
+
 func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
 	cases := []struct {
 		name, source, wantErr string

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -62,6 +62,65 @@ test_report(fmt("%T", r))
 	}
 }
 
+func TestCallResultCapturesRuntimeError(t *testing.T) {
+	source := `
+use errors select *
+
+func quebra(texto: string) -> int
+    return to_int(texto)
+end
+
+let r: CallResult = call_result(quebra, "abc")
+let depois: int = 40 + 2
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message + "|" + to_str(length(r.failure.causes)) + "|" + to_str(r.value == null) + "|" + to_str(depois))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.Split(text, "|")
+	if len(parts) != 6 || parts[0] != "false" || parts[1] != "runtime" || parts[3] != "0" || parts[4] != "true" || parts[5] != "42" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+	if !strings.Contains(parts[2], "cannot convert") || strings.Contains(parts[2], "use to_int_result") {
+		t.Fatalf("message wrong or advisory suffix leaked: %q", parts[2])
+	}
+}
+
+func TestCallResultFailureStackExcludesBoundary(t *testing.T) {
+	source := `
+func fundo() -> int
+    return to_int("x")
+end
+func meio() -> int
+    return fundo()
+end
+let r: any = call_result(meio)
+test_report(r.failure.stack)
+`
+	reported := captureVMSource(t, source)
+	stack, _ := reported.Obj.(string)
+	if !strings.Contains(stack, "in fundo") || !strings.Contains(stack, "in meio") {
+		t.Fatalf("stack missing inner frames: %q", stack)
+	}
+	if strings.Contains(stack, "call_result") {
+		t.Fatalf("stack must stop before the boundary frame: %q", stack)
+	}
+}
+
+func TestCallResultCapturesStackOverflow(t *testing.T) {
+	source := `
+func infinita() -> int
+    return infinita()
+end
+let r: any = call_result(infinita)
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message)
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if !strings.HasPrefix(text, "false|runtime|") || !strings.Contains(text, "stack overflow") {
+		t.Fatalf("frame exhaustion should be captured: %q", text)
+	}
+}
+
 func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
 	cases := []struct {
 		name, source, wantErr string

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -2,8 +2,11 @@
 package vm
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"noxy-vm/internal/value"
 )
 
 func TestErrorsModuleShapes(t *testing.T) {
@@ -118,6 +121,77 @@ test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message)
 	text, _ := reported.Obj.(string)
 	if !strings.HasPrefix(text, "false|runtime|") || !strings.Contains(text, "stack overflow") {
 		t.Fatalf("frame exhaustion should be captured: %q", text)
+	}
+}
+
+// TestFailureMapMergesInnerCausesWithSiblingsOnPromotion cobre um bug real:
+// no caso cleanup-first, deferredFailureMap promove o primeiro DeferredError
+// a falha primaria. Se a Cause desse promovido ja e um *UnwindError com seu
+// proprio Primary+Deferred (i.e. a falha promovida ja tinha causes proprias
+// aninhadas), o merge com os siblings (falhas diferidas posteriores no mesmo
+// frame) precisa PRESERVAR essas causes internas e so anexar os siblings por
+// cima — nunca substituir. Constroi a arvore de erro diretamente em Go (via
+// failureMap) porque replicar "defer cujo Cause e um UnwindError aninhado"
+// de forma confiavel a partir de fonte Noxy exigiria coordenar timing de
+// falhas concorrentes de defer; a arvore de erro e o dado relevante aqui, nao
+// o caminho de execucao que a produz.
+func TestFailureMapMergesInnerCausesWithSiblingsOnPromotion(t *testing.T) {
+	innerSibling := DeferredError{
+		Registration: SourceLocation{File: "inner.nx", Line: 3},
+		Cause:        errors.New("inner sibling failure"),
+	}
+	promoted := DeferredError{
+		Registration: SourceLocation{File: "outer.nx", Line: 5},
+		Cause: &UnwindError{
+			Primary:  errors.New("inner primary failure"),
+			Deferred: []DeferredError{innerSibling},
+		},
+	}
+	outerSibling := DeferredError{
+		Registration: SourceLocation{File: "outer.nx", Line: 9},
+		Cause:        errors.New("outer sibling failure"),
+	}
+	unwind := &UnwindError{
+		Primary:  nil,
+		Deferred: []DeferredError{promoted, outerSibling},
+	}
+
+	result := failureMap(unwind)
+	mapping, ok := result.Obj.(*value.ObjMap)
+	if !ok {
+		t.Fatalf("failureMap did not return a map: %#v", result)
+	}
+	message, _ := mapping.Get("message")
+	if text, _ := message.Obj.(string); text != "inner primary failure" {
+		t.Fatalf("promoted primary should keep the inner UnwindError's message, got %q", text)
+	}
+
+	causesValue, ok := mapping.Get("causes")
+	if !ok {
+		t.Fatalf("promoted failure missing causes key")
+	}
+	array, ok := causesValue.Obj.(*value.ObjArray)
+	if !ok {
+		t.Fatalf("causes is not an array: %#v", causesValue)
+	}
+	if len(array.Elements) != 2 {
+		t.Fatalf("want 2 causes (1 inner + 1 outer sibling), got %d: %#v", len(array.Elements), array.Elements)
+	}
+
+	causeMessage := func(v value.Value) string {
+		m, ok := v.Obj.(*value.ObjMap)
+		if !ok {
+			t.Fatalf("cause is not a map: %#v", v)
+		}
+		msg, _ := m.Get("message")
+		text, _ := msg.Obj.(string)
+		return text
+	}
+	if got := causeMessage(array.Elements[0]); got != "inner sibling failure" {
+		t.Fatalf("first cause should be the promoted failure's own inner cause, got %q", got)
+	}
+	if got := causeMessage(array.Elements[1]); got != "outer sibling failure" {
+		t.Fatalf("second cause should be the outer sibling, got %q", got)
 	}
 }
 

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -384,6 +384,61 @@ test_report(to_str(original[0]) + "|" + to_str(copia[0]) + "|" + to_str(length(o
 	}
 }
 
+// TestCallResultFailureAliasDoesNotMutateEnvelope espelha
+// TestCallResultValueSemantics no ramo de FALHA: a arvore de Failure e
+// construida por Go (NewMapWithData/NewArray), que — ao contrario de
+// OP_MAP/OP_ARRAY — nao retem os filhos compostos. Sem o retain do pai, o
+// mapa `failure` chegava ao Noxy com Owners=0; o primeiro `let f: any =
+// r.failure` o levava a Owners=1, IsShared ficava falso e `f["message"] =
+// ...` mutava IN-PLACE o mesmo objeto guardado no envelope — r.failure.message
+// passava a ler "hacked". Com o envelope como dono duravel, o `let` chega a
+// Owners=2 e a mutacao clona (CoW), deixando o envelope intacto.
+func TestCallResultFailureAliasDoesNotMutateEnvelope(t *testing.T) {
+	source := `
+func quebra(texto: string) -> int
+    return to_int(texto)
+end
+let r: any = call_result(quebra, "abc")
+let f: any = r.failure
+f["message"] = "hacked"
+test_report(to_str(r.failure.message == "hacked") + "|" + to_str(f.message))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.SplitN(text, "|", 2)
+	if len(parts) != 2 || parts[0] != "false" {
+		t.Fatalf("alias mutation must not rewrite the envelope's failure map: %q", text)
+	}
+	if parts[1] != "hacked" {
+		t.Fatalf("the alias itself must carry the mutation (CoW clone): %q", text)
+	}
+}
+
+// TestCallResultCauseAliasDoesNotMutateEnvelope: mesma corrupcao, um nivel
+// mais fundo — o mapa de causa vive dentro do array `causes`, que por sua vez
+// vive dentro do mapa `failure`. Exige que TANTO o array quanto cada mapa de
+// causa tenham dono duravel registrado na construcao.
+func TestCallResultCauseAliasDoesNotMutateEnvelope(t *testing.T) {
+	source := `
+func limpeza_ruim()
+    to_int("defer-quebrado")
+end
+func corpo() -> int
+    defer limpeza_ruim()
+    return to_int("primario")
+end
+let r: any = call_result(corpo)
+let c: any = r.failure.causes[0]
+c["kind"] = "hacked"
+test_report(to_str(r.failure.causes[0].kind == "hacked") + "|" + to_str(c.kind) + "|" + to_str(length(r.failure.causes)))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if text != "false|hacked|1" {
+		t.Fatalf("alias mutation on a cause map must not rewrite the envelope: %q", text)
+	}
+}
+
 // TestCallResultPanicSkipsPendingNoxyDeferAndReleasesCapturedArgs cobre o
 // achado do review em hardUnwindTo (fix loop): um defer Noxy pendente nos
 // frames abandonados pelo panico NAO pode rodar (defer.Deferred truncado sem

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -304,6 +304,86 @@ test_report(ok_text + "|" + trilha[0] + "|" + trilha[1])
 	}
 }
 
+func TestCallResultCapturesGoPanic(t *testing.T) {
+	machine := New()
+	machine.DefineNative("explode", func(args []value.Value) value.Value {
+		panic("boom-nativo")
+	})
+	source := `
+func corpo() -> int
+    explode()
+    return 1
+end
+let r: any = call_result(corpo)
+test_report(to_str(r.ok) + "|" + r.failure.kind + "|" + r.failure.message)
+`
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	text, _ := captured.Obj.(string)
+	if !strings.HasPrefix(text, "false|panic|") || !strings.Contains(text, "boom-nativo") {
+		t.Fatalf("panic must be captured as kind=panic: %q", text)
+	}
+}
+
+func TestCallResultNestedBoundaries(t *testing.T) {
+	source := `
+func interna() -> int
+    return to_int("x")
+end
+func externa() -> string
+    let r: any = call_result(interna)
+    return "interna-capturou:" + to_str(r.ok)
+end
+let fora: any = call_result(externa)
+test_report(to_str(fora.ok) + "|" + fora.value)
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "true|interna-capturou:false" {
+		t.Fatalf("nearest boundary must capture: %q", text)
+	}
+}
+
+func TestCallResultNoRollback(t *testing.T) {
+	source := `
+func muta_e_quebra(alvo: ref int) -> int
+    *alvo = 99
+    return to_int("x")
+end
+let caixa: int = 1
+let r: any = call_result(muta_e_quebra, ref caixa)
+test_report(to_str(r.ok) + "|" + to_str(caixa))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "false|99" {
+		t.Fatalf("mutations before the failure must remain (no rollback): %q", text)
+	}
+}
+
+func TestCallResultValueSemantics(t *testing.T) {
+	source := `
+func faz_array() -> int[]
+    return [1, 2, 3]
+end
+let r: any = call_result(faz_array)
+let copia: int[] = r.value
+copia[0] = 100
+let original: any = r.value
+test_report(to_str(original[0]) + "|" + to_str(copia[0]) + "|" + to_str(length(original)))
+`
+	reported := captureVMSource(t, source)
+	if text, _ := reported.Obj.(string); text != "1|100|3" {
+		t.Fatalf("composite value must obey CoW semantics without corruption: %q", text)
+	}
+}
+
 func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
 	cases := []struct {
 		name, source, wantErr string

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -384,6 +384,89 @@ test_report(to_str(original[0]) + "|" + to_str(copia[0]) + "|" + to_str(length(o
 	}
 }
 
+// TestCallResultPanicSkipsPendingNoxyDeferAndReleasesCapturedArgs cobre o
+// achado do review em hardUnwindTo (fix loop): um defer Noxy pendente nos
+// frames abandonados pelo panico NAO pode rodar (defer.Deferred truncado sem
+// invocacao — mesma promessa do design para task, "VM filho e abandonado"),
+// E o argumento composto que esse defer capturou em prepareDeferredCall
+// (retainPreparedArguments, defer.go:35/101-110) precisa ser liberado mesmo
+// sem invocacao, senao o dono fica vazado (composto permanece IsShared para
+// sempre — clona a cada mutacao, e um ref vivo para o slot original divergia
+// do clone).
+//
+// A asserção de RC usa delta, nao valor absoluto: probe_capture e um native
+// nao assinado e nao listado em readonlyNatives, entao o caminho conservador
+// de callValue (calls.go) ja aplica um retain PERMANENTE (nunca solto) sobre
+// o mapa so por passa-lo como argumento de chamada comum — isso soma ao
+// retain do proprio `let m` local. `baseline` captura Owners(m) LOGO APOS
+// essa chamada (antes do defer ser registrado), refletindo os dois retains
+// que nao tem nada a ver com o defer. Depois do defer, Owners = baseline+1
+// (captura do defer). O panico dispara hardUnwindTo, que SEMPRE libera o
+// binding local `m` (frame.Owned, teardown incondicional de frame) — isso
+// sozinho already devolveria Owners a baseline mesmo SEM soltar a captura do
+// defer, entao um teste que so verificasse "Owners == baseline" nao pegaria
+// o vazamento (e o motivo de precisar do baseline capturado ANTES do
+// registro do defer, nao depois: com o vazamento, o valor final coincide
+// com baseline por acidente). O fix soma mais um release (o da captura do
+// defer): o valor final correto e baseline-1. Sem o fix desta rodada de
+// review (frame.Deferred = frame.Deferred[:0] sem release), o valor final
+// fica em baseline — este teste falha exatamente contra o codigo antigo e
+// passa contra o fix.
+func TestCallResultPanicSkipsPendingNoxyDeferAndReleasesCapturedArgs(t *testing.T) {
+	machine := New()
+	machine.DefineNative("explode", func(args []value.Value) value.Value {
+		panic("boom-com-defer-pendente")
+	})
+	var capturedMap value.Value
+	var baseline int32
+	machine.DefineNative("probe_capture", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			capturedMap = args[0]
+			baseline = value.OwnersCount(args[0])
+		}
+		return value.NewNull()
+	})
+	source := `
+let trilha: string[] = []
+
+func marca(rotulo: string)
+    append(trilha, rotulo)
+end
+
+func cleanup(m: map[string, int])
+    marca("cleanup-nao-deveria-rodar")
+end
+
+func corpo() -> int
+    let m: map[string, int] = {"a": 1}
+    probe_capture(m)
+    defer cleanup(m)
+    explode()
+    return 1
+end
+
+let r: any = call_result(corpo)
+test_report(to_str(r.ok) + "|" + to_str(length(trilha)))
+`
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	text, _ := captured.Obj.(string)
+	if text != "false|0" {
+		t.Fatalf("pending Noxy defer must NOT run on the panic path: %q", text)
+	}
+	if got := value.OwnersCount(capturedMap); got != baseline-1 {
+		t.Fatalf("hardUnwindTo must release the pending defer's captured composite argument: baseline=%d, want %d, got %d", baseline, baseline-1, got)
+	}
+}
+
 func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
 	cases := []struct {
 		name, source, wantErr string

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -195,6 +195,115 @@ func TestFailureMapMergesInnerCausesWithSiblingsOnPromotion(t *testing.T) {
 	}
 }
 
+// TestCallResultAggregatesDeferFailures cobre a agregacao ponta-a-ponta: o
+// corpo falha (to_int com string invalida), o defer de limpeza registrado no
+// corpo TAMBEM falha durante o unwind, e a falha diferida precisa aparecer em
+// r.failure.causes[0] com kind "runtime", a mensagem original preservada, e o
+// stack carregando "defer registration" como frame mais externo (a
+// localizacao de REGISTRO do defer, nao a de falha).
+func TestCallResultAggregatesDeferFailures(t *testing.T) {
+	source := `
+func limpeza_ruim()
+    to_int("defer-quebrado")
+end
+
+func corpo() -> int
+    defer limpeza_ruim()
+    return to_int("primario")
+end
+
+let r: any = call_result(corpo)
+let causa: any = r.failure.causes[0]
+test_report(to_str(length(r.failure.causes)) + "|" + causa.kind + "|" + causa.message + "|" + causa.stack)
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.SplitN(text, "|", 4)
+	if len(parts) != 4 || parts[0] != "1" || parts[1] != "runtime" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+	if !strings.Contains(parts[2], "defer-quebrado") {
+		t.Fatalf("cause message should carry the deferred failure: %q", parts[2])
+	}
+	if !strings.Contains(parts[3], "defer registration") {
+		t.Fatalf("cause stack must carry the registration location as outermost frame: %q", parts[3])
+	}
+}
+
+// TestCallResultCleanupFirstFailure cobre o caso "cleanup as first failure"
+// (design §2): o corpo TERMINA COM SUCESSO (return 42) mas o defer de
+// limpeza falha durante o unwind — cleanup-first promove essa falha diferida
+// a falha PRIMARIA do envelope (ok=false, value=null), descartando o valor
+// computado, com zero causes (nao ha falha primaria original para aninhar
+// sob ela).
+func TestCallResultCleanupFirstFailure(t *testing.T) {
+	source := `
+func limpeza_ruim()
+    to_int("so-o-defer-quebra")
+end
+
+func corpo() -> int
+    defer limpeza_ruim()
+    return 42
+end
+
+let r: any = call_result(corpo)
+test_report(to_str(r.ok) + "|" + to_str(r.value == null) + "|" + r.failure.message + "|" + to_str(length(r.failure.causes)))
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	parts := strings.SplitN(text, "|", 4)
+	if len(parts) != 4 || parts[0] != "false" || parts[1] != "true" || parts[3] != "0" {
+		t.Fatalf("cleanup-first must discard the computed value and promote the deferred failure: %q", text)
+	}
+	if !strings.Contains(parts[2], "so-o-defer-quebra") {
+		t.Fatalf("primary failure should be the deferred one: %q", parts[2])
+	}
+}
+
+// TestCallResultCallerDefersUnaffected cobre isolamento do frame chamador: a
+// captura de falha em call_result(corpo) NAO deve interromper a execucao do
+// chamador nem disparar prematuramente o defer do PROPRIO chamador — a
+// execucao continua apos a captura (append "depois-da-captura" roda) e o
+// defer do chamador so dispara quando a FUNCAO CHAMADORA retorna (append
+// "caller-defer" fica por ultimo). Vehicle sem adaptacao: `trilha` e o global
+// mutado por append de dentro de func e closure exatamente como no brief —
+// verificado a parte (fora do arquivo final de teste) que mutacao de global
+// via append dentro de funcoes chega visivel ao `let` de nivel superior
+// (mesmo padrao de TestGlobalPathMutationStillWorks em
+// value_semantics_test.go, so que via chamada de native com parametro ref
+// em vez de indexacao direta); a ressalva do brief sobre CoW/global nao se
+// materializou aqui, entao a asserção original fica com o vetor de prova
+// mais direto.
+func TestCallResultCallerDefersUnaffected(t *testing.T) {
+	source := `
+let trilha: string[] = []
+
+func marca(rotulo: string)
+    append(trilha, rotulo)
+end
+
+func corpo() -> int
+    return to_int("x")
+end
+
+func chamador() -> string
+    defer marca("caller-defer")
+    let r: any = call_result(corpo)
+    append(trilha, "depois-da-captura")
+    return to_str(r.ok)
+end
+
+let ok_text: string = chamador()
+test_report(ok_text + "|" + trilha[0] + "|" + trilha[1])
+`
+	reported := captureVMSource(t, source)
+	text, _ := reported.Obj.(string)
+	if text != "false|depois-da-captura|caller-defer" {
+		t.Fatalf("caller frame must be unaffected by the capture: %q", text)
+	}
+}
+
 func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
 	cases := []struct {
 		name, source, wantErr string

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -2,6 +2,7 @@
 package vm
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -18,5 +19,33 @@ test_report(nested.causes[0].message + "|" + to_str(r.ok) + "|" + to_str(r.value
 	text, ok := reported.Obj.(string)
 	if !ok || text != "boom|true|42" {
 		t.Fatalf("unexpected report: %#v", reported)
+	}
+}
+
+func TestCallResultMisuseRaisesSynchronously(t *testing.T) {
+	cases := []struct {
+		name, source, wantErr string
+	}{
+		{"non-callable", `call_result(42)`, "call_result expects a callable"},
+		{"closure arity", `
+func soma(a: int, b: int) -> int
+    return a + b
+end
+call_result(soma, 1)`, "expected 2 arguments but got 1"},
+		{"constructor arity", `
+struct P
+    x: int
+end
+call_result(P, 1, 2)`, "expected 1 arguments for struct P"},
+		{"no arguments at all", `call_result()`, "call_result expects a callable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			machine := New()
+			err := interpretVMSource(t, machine, tc.source)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want synchronous error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
 	}
 }

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -1,0 +1,22 @@
+// internal/vm/builtins_call_result_test.go
+package vm
+
+import (
+	"testing"
+)
+
+func TestErrorsModuleShapes(t *testing.T) {
+	source := `
+use errors select *
+
+let f: Failure = Failure("runtime", "boom", "st", [])
+let nested: Failure = Failure("runtime", "outer", "st", [f])
+let r: CallResult = CallResult(true, 42, null)
+test_report(nested.causes[0].message + "|" + to_str(r.ok) + "|" + to_str(r.value))
+`
+	reported := captureVMSource(t, source)
+	text, ok := reported.Obj.(string)
+	if !ok || text != "boom|true|42" {
+		t.Fatalf("unexpected report: %#v", reported)
+	}
+}

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -9,6 +9,7 @@ import (
 
 func (vm *VM) defineConcurrencyBuiltins() {
 	vm.defineTaskBuiltins()
+	vm.defineCallResultBuiltins()
 
 	// Concurrency Primitives
 	vm.DefineContextualNative("spawn", func(context value.NativeContext, args []value.Value) (value.Value, error) {

--- a/internal/vm/builtins_convert.go
+++ b/internal/vm/builtins_convert.go
@@ -136,7 +136,10 @@ func (vm *VM) defineConvertBuiltins() {
 		}
 		converted, convertErr := convertValueToInt(args[0])
 		if convertErr != nil {
-			return value.NewNull(), fmt.Errorf("to_int: %w; use to_int_result to handle failure", convertErr)
+			return value.NewNull(), &AdvisedError{
+				Err:    fmt.Errorf("to_int: %w", convertErr),
+				Advice: "use to_int_result to handle failure",
+			}
 		}
 		return value.NewInt(converted), nil
 	})
@@ -147,7 +150,10 @@ func (vm *VM) defineConvertBuiltins() {
 		}
 		converted, convertErr := convertValueToFloat(args[0])
 		if convertErr != nil {
-			return value.NewNull(), fmt.Errorf("to_float: %w; use to_float_result to handle failure", convertErr)
+			return value.NewNull(), &AdvisedError{
+				Err:    fmt.Errorf("to_float: %w", convertErr),
+				Advice: "use to_float_result to handle failure",
+			}
 		}
 		return value.NewFloat(converted), nil
 	})

--- a/internal/vm/builtins_convert_test.go
+++ b/internal/vm/builtins_convert_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"math"
 	"strings"
 	"testing"
@@ -277,8 +278,8 @@ func TestToIntRaisesOnUnconvertibleInput(t *testing.T) {
 			if !strings.HasPrefix(message, "to_int: ") {
 				t.Fatalf("message = %q, want it to name the function", message)
 			}
-			if !strings.Contains(message, "use to_int_result to handle failure") {
-				t.Fatalf("message = %q, want the recoverable alternative", message)
+			if !strings.Contains(message, "cannot convert") {
+				t.Fatalf("message = %q, want to describe the conversion failure", message)
 			}
 		})
 	}
@@ -319,8 +320,11 @@ func TestToFloatRaisesOnUnconvertibleInput(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			message := requireStrictConversionError(t, machine, "to_float", test.input)
-			if !strings.Contains(message, "use to_float_result to handle failure") {
-				t.Fatalf("message = %q, want the recoverable alternative", message)
+			if !strings.HasPrefix(message, "to_float: ") {
+				t.Fatalf("message = %q, want it to name the function", message)
+			}
+			if !strings.Contains(message, "cannot convert") {
+				t.Fatalf("message = %q, want to describe the conversion failure", message)
 			}
 		})
 	}
@@ -461,5 +465,20 @@ func TestToStrBoundsTheEchoedPayload(t *testing.T) {
 	}
 	if len([]rune(err.Error())) > 200 {
 		t.Fatalf("message is %d characters, want a bounded message", len([]rune(err.Error())))
+	}
+}
+
+func TestToIntAdvisedError(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, `to_int("abc")`)
+	if err == nil {
+		t.Fatal("expected runtime error")
+	}
+	if strings.Contains(err.Error(), "use to_int_result") {
+		t.Fatalf("advisory suffix leaked into capturable message: %v", err)
+	}
+	var advised *AdvisedError
+	if !errors.As(err, &advised) || advised.Advice != "use to_int_result to handle failure" {
+		t.Fatalf("advice not carried structurally: %v", err)
 	}
 }

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -12,7 +12,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 	machine := New()
 	expected := []string{
 		"append", "base62_decode", "base62_encode", "base64_decode",
-		"base64_encode", "chan_close", "chan_is_closed", "chan_recv",
+		"base64_encode", "call_result", "chan_close", "chan_is_closed", "chan_recv",
 		"chan_send", "contains", "convert_to_float_result", "convert_to_int_result",
 		"crypto_aes256_gcm_decrypt",
 		"crypto_aes256_gcm_encrypt", "crypto_pbkdf2_sha256",

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -183,3 +183,14 @@ func renderErrorCause(prefix string, cause error) string {
 func indentError(text, indent string) string {
 	return indent + strings.ReplaceAll(text, "\n", "\n"+indent)
 }
+
+// AdvisedError separa o conselho de uso da mensagem de erro capturável: o
+// texto do erro fica limpo (Failure.message, task failure map), e só a saída
+// fatal do topo (cmd/noxy) imprime o Advice.
+type AdvisedError struct {
+	Err    error
+	Advice string
+}
+
+func (err *AdvisedError) Error() string { return err.Err.Error() }
+func (err *AdvisedError) Unwrap() error { return err.Err }

--- a/internal/vm/runtime_errors.go
+++ b/internal/vm/runtime_errors.go
@@ -101,9 +101,21 @@ func sourceLocation(c *chunk.Chunk, ip int) SourceLocation {
 	return location
 }
 
+// captureNoxyStack renderiza os frames Noxy vivos, do mais recente para o mais
+// antigo. Para em vm.stackCaptureFloor — 0 fora de uma fronteira de
+// call_result, ou seja, pilha completa como sempre; dentro da fronteira, o
+// piso e o frame count do chamador, o que corta exatamente os frames abaixo
+// (e inclusive) do ponto onde call_result foi chamado.
 func (vm *VM) captureNoxyStack(activeChunk *chunk.Chunk, activeIP int) string {
-	frames := make([]string, 0, vm.frameCount)
-	for i := vm.frameCount - 1; i >= 0; i-- {
+	floor := vm.stackCaptureFloor
+	if floor < 0 {
+		floor = 0
+	}
+	if floor > vm.frameCount {
+		floor = vm.frameCount
+	}
+	frames := make([]string, 0, vm.frameCount-floor)
+	for i := vm.frameCount - 1; i >= floor; i-- {
 		frame := &vm.frames[i]
 		if frame.Closure == nil || frame.Closure.Function == nil {
 			continue

--- a/internal/vm/runtime_type_validation.go
+++ b/internal/vm/runtime_type_validation.go
@@ -373,6 +373,31 @@ func (vm *VM) walkRuntimeValueType(actual value.Value, schema *value.RuntimeType
 		}
 		return vm.walkRuntimeValueType(resolved, schema.Element, apply, seen)
 	case value.TYPE_STRUCT:
+		// Fronteira dinâmica de envelope-como-map (call_result / errors.nx,
+		// design doc §Representation): um native sem assinatura devolve um
+		// *value.ObjMap fisicamente — nunca um ObjInstance — e o contrato
+		// tipado (`let r: CallResult = ...`) vale pelo campo, não pelo nome
+		// nominal (errors.nx: "vale pelo contrato de campos"). Aceita aqui
+		// se TODO campo de schema.Fields existe no map com tipo
+		// recursivamente compatível; chaves extras no map são ignoradas.
+		// Deliberadamente NÃO estampa RuntimeType no map (ObjMap.RuntimeType
+		// seguiria intocado) — cada marcação revalida do zero, evitando a
+		// pergunta de CAS "mesmo map validado contra struct diferente
+		// depois". O caminho ObjInstance abaixo (nominal, por Struct.Name)
+		// continua byte-a-byte o de sempre.
+		if mapping, ok := actual.Obj.(*value.ObjMap); ok && actual.Type == value.VAL_OBJ && mapping != nil {
+			if runtimeValueTypeSeen(mapping, schema, seen) {
+				return true
+			}
+			snapshot := mapping.Snapshot()
+			for name, fieldSchema := range schema.Fields {
+				field, exists := snapshot[name]
+				if !exists || !vm.walkRuntimeValueType(field, fieldSchema, apply, seen) {
+					return false
+				}
+			}
+			return true
+		}
 		instance, ok := actual.Obj.(*value.ObjInstance)
 		if actual.Type != value.VAL_OBJ || !ok || instance == nil || instance.Struct == nil || instance.Struct.Name != schema.Name {
 			return false

--- a/internal/vm/runtime_type_validation_test.go
+++ b/internal/vm/runtime_type_validation_test.go
@@ -257,6 +257,43 @@ let r: CallResult = __test_dynamic_envelope_bad()
 	}
 }
 
+// (a) o outro lado do contrato estrutural: a checagem é "todo campo do
+// esquema está presente e compatível", NÃO "os conjuntos de chaves são
+// iguais". Um map com todos os campos de CallResult MAIS uma chave estranha
+// satisfaz a anotação — chaves extras são ignoradas, como o comentário do
+// caso TYPE_STRUCT em walkRuntimeValueType promete. Pinado porque a direção
+// oposta (exigir igualdade de chaves) é uma regressão fácil de introduzir e
+// quebraria qualquer envelope que ganhe um campo novo depois.
+func TestLetStructAnnotationIgnoresExtraMapKeys(t *testing.T) {
+	machine := New()
+	machine.DefineNative("__test_dynamic_envelope_extra", func(args []value.Value) value.Value {
+		return value.NewMapWithData(map[string]value.Value{
+			"ok":      value.NewBool(true),
+			"value":   value.NewInt(42),
+			"failure": value.NewNull(),
+			"extra":   value.NewString("nao declarado em CallResult"),
+		})
+	})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	source := `
+use errors select *
+let r: CallResult = __test_dynamic_envelope_extra()
+test_report(to_str(r.ok) + "|" + to_str(r.value) + "|" + to_str(r.extra))
+`
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("extra keys must not break the struct-typed binding: %v", err)
+	}
+	if text, _ := captured.Obj.(string); text != "true|42|nao declarado em CallResult" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+}
+
 // As três acima só exercitam o campo composto "failure" quando ele é null —
 // walkRuntimeValueType:311-313 aceita VAL_NULL contra TYPE_STRUCT de
 // imediato, então o schema aninhado de Failure (causes: Failure[]

--- a/internal/vm/runtime_type_validation_test.go
+++ b/internal/vm/runtime_type_validation_test.go
@@ -257,6 +257,83 @@ let r: CallResult = __test_dynamic_envelope_bad()
 	}
 }
 
+// As três acima só exercitam o campo composto "failure" quando ele é null —
+// walkRuntimeValueType:311-313 aceita VAL_NULL contra TYPE_STRUCT de
+// imediato, então o schema aninhado de Failure (causes: Failure[]
+// autorreferente incluso) nunca era percorrido pelo ramo novo de map. As três
+// a seguir cobrem exatamente esse caminho: failure populado (profundidade 1),
+// causes com uma entrada Failure-shaped (profundidade >= 2), e um campo
+// aninhado com tipo errado (prova que a rejeição por profundidade funciona).
+
+// (recursão, positivo) failure populado como map (kind/message/stack/causes)
+// satisfaz o schema aninhado de Failure — não passa mais só pelo atalho null.
+func TestMarkerAcceptsMapWithPopulatedNestedFailureMap(t *testing.T) {
+	machine := New()
+	failure := value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString("boom"),
+		"stack":   value.NewString("st"),
+		"causes":  value.NewArray(nil),
+	})
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": failure,
+	})
+	if !machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map com failure populado (map kind/message/stack/causes) deveria satisfazer o schema aninhado de Failure")
+	}
+}
+
+// (recursão, positivo) causes contém uma entrada Failure-shaped (map), então
+// o walk desce por Failure.causes: Failure[] -> elemento Failure -> seus
+// próprios campos: profundidade >= 2, exercitando o schema autorreferente que
+// failureStructSchema() constrói.
+func TestMarkerAcceptsMapWithSelfReferentialCausesEntry(t *testing.T) {
+	machine := New()
+	nestedCause := value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString("inner"),
+		"stack":   value.NewString("st2"),
+		"causes":  value.NewArray(nil),
+	})
+	failure := value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString("outer"),
+		"stack":   value.NewString("st1"),
+		"causes":  value.NewArray([]value.Value{nestedCause}),
+	})
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": failure,
+	})
+	if !machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map cujo failure.causes contém uma entrada Failure-shaped deveria satisfazer o schema autorreferente em profundidade >= 2")
+	}
+}
+
+// (recursão, negativo) failure.kind com tipo errado (int em vez de string) —
+// prova que o walk recursivo realmente rejeita em profundidade, não só na
+// superfície do map raiz.
+func TestMarkerRejectsMapWithWrongNestedFieldType(t *testing.T) {
+	machine := New()
+	failure := value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewInt(1), // errado: schema espera string
+		"message": value.NewString("boom"),
+		"stack":   value.NewString("st"),
+		"causes":  value.NewArray(nil),
+	})
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": failure,
+	})
+	if machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map com failure.kind de tipo errado deveria ser rejeitado pelo walk recursivo em profundidade")
+	}
+}
+
 // (c) uma ObjInstance real de struct com NOME errado continua rejeitada — o
 // caminho nominal para instâncias reais não muda.
 func TestMarkerRejectsRealInstanceOfWrongStructName(t *testing.T) {

--- a/internal/vm/runtime_type_validation_test.go
+++ b/internal/vm/runtime_type_validation_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"strings"
 	"testing"
 
 	"noxy-vm/internal/value"
@@ -123,5 +124,154 @@ func TestMarkerStillWalksUntaggedArray(t *testing.T) {
 	}
 	if array.Obj.(*value.ObjArray).RuntimeType.Load() != nil {
 		t.Fatal("tag foi gravada apesar da validação ter falhado")
+	}
+}
+
+// Fronteira dinâmica de envelope-como-map (call_result / errors.nx): o
+// envelope físico é sempre um *value.ObjMap (design doc §Representation), mas
+// CallResult tem um campo composto aninhado (failure: Failure, cujo próprio
+// causes: Failure[] é array) — diferente de IntResult, que não tem campo
+// composto e por isso nunca dispara marcação em runtime. Isto obriga o caso
+// TYPE_STRUCT de walkRuntimeValueType a aceitar um map estruturalmente
+// compatível (contrato de campos, sem checagem nominal), sem estampar
+// RuntimeType no próprio map — cada marcação revalida do zero.
+
+func failureStructSchema() *value.RuntimeTypeInfo {
+	stringT := &value.RuntimeTypeInfo{Kind: value.TYPE_STRING}
+	schema := &value.RuntimeTypeInfo{Kind: value.TYPE_STRUCT, Name: "Failure"}
+	schema.Fields = map[string]*value.RuntimeTypeInfo{
+		"kind":    stringT,
+		"message": stringT,
+		"stack":   stringT,
+		"causes":  {Kind: value.TYPE_ARRAY, Element: schema},
+	}
+	return schema
+}
+
+func callResultStructSchema() *value.RuntimeTypeInfo {
+	return &value.RuntimeTypeInfo{
+		Kind: value.TYPE_STRUCT,
+		Name: "CallResult",
+		Fields: map[string]*value.RuntimeTypeInfo{
+			"ok":      {Kind: value.TYPE_BOOL},
+			"value":   {Kind: value.TYPE_ANY},
+			"failure": failureStructSchema(),
+		},
+	}
+}
+
+// (a) um map com todo campo do esquema presente e recursivamente compatível
+// satisfaz um contrato de struct com campo composto aninhado.
+func TestMarkerAcceptsStructurallyMatchingMapAtStructBoundary(t *testing.T) {
+	machine := New()
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(true),
+		"value":   value.NewInt(42),
+		"failure": value.NewNull(),
+	})
+	if !machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map com todo campo do esquema presente e compatível deveria satisfazer o contrato de struct")
+	}
+}
+
+// (b) map faltando campo do esquema é rejeitado.
+func TestMarkerRejectsMapMissingStructField(t *testing.T) {
+	machine := New()
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":    value.NewBool(true),
+		"value": value.NewInt(42),
+		// "failure" ausente.
+	})
+	if machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map faltando campo declarado do esquema deveria ser rejeitado")
+	}
+}
+
+// (b) map com campo de tipo errado é rejeitado.
+func TestMarkerRejectsMapWithWrongFieldType(t *testing.T) {
+	machine := New()
+	envelope := value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewString("not a bool"),
+		"value":   value.NewInt(42),
+		"failure": value.NewNull(),
+	})
+	if machine.markRuntimeValueType(envelope, callResultStructSchema()) {
+		t.Fatal("map com campo de tipo incompatível com o esquema deveria ser rejeitado")
+	}
+}
+
+// (a)+(b) fim a fim, com o struct real `CallResult` do módulo `errors` (o
+// mesmo cujo campo `failure: Failure` aninha `causes: Failure[]` e por isso
+// dispara o marcador em runtime — diferente de IntResult). Um native de teste
+// próprio produz o map dinamicamente, sem depender do native call_result: o
+// mecanismo sob teste é genérico, não específico à feature call_result.
+func TestLetStructAnnotationOverDynamicMapEnvelope(t *testing.T) {
+	machine := New()
+	machine.DefineNative("__test_dynamic_envelope_ok", func(args []value.Value) value.Value {
+		return value.NewMapWithData(map[string]value.Value{
+			"ok":      value.NewBool(true),
+			"value":   value.NewInt(42),
+			"failure": value.NewNull(),
+		})
+	})
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) != 0 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	source := `
+use errors select *
+let r: CallResult = __test_dynamic_envelope_ok()
+test_report(to_str(r.ok) + "|" + to_str(r.value))
+`
+	if err := interpretVMSource(t, machine, source); err != nil {
+		t.Fatalf("map matching CallResult's field contract should satisfy the struct-typed let: %v", err)
+	}
+	text, _ := captured.Obj.(string)
+	if text != "true|42" {
+		t.Fatalf("unexpected report: %q", text)
+	}
+}
+
+// (b) fim a fim: um map faltando o campo `failure` do contrato de CallResult
+// é rejeitado com o erro de marcador já existente — o mesmo caminho que hoje
+// rejeita qualquer conflito estrutural.
+func TestLetStructAnnotationRejectsStructurallyMismatchedMap(t *testing.T) {
+	machine := New()
+	machine.DefineNative("__test_dynamic_envelope_bad", func(args []value.Value) value.Value {
+		return value.NewMapWithData(map[string]value.Value{
+			"ok":    value.NewBool(true),
+			"value": value.NewInt(42),
+			// "failure" ausente de propósito.
+		})
+	})
+	source := `
+use errors select *
+let r: CallResult = __test_dynamic_envelope_bad()
+`
+	err := interpretVMSource(t, machine, source)
+	if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
+		t.Fatalf("want the existing marker-rejection error, got: %v", err)
+	}
+}
+
+// (c) uma ObjInstance real de struct com NOME errado continua rejeitada — o
+// caminho nominal para instâncias reais não muda.
+func TestMarkerRejectsRealInstanceOfWrongStructName(t *testing.T) {
+	machine := New()
+	schema := &value.RuntimeTypeInfo{
+		Kind:   value.TYPE_STRUCT,
+		Name:   "CallResult",
+		Fields: map[string]*value.RuntimeTypeInfo{},
+	}
+	otherDefinition := &value.ObjStruct{Name: "SomethingElse", Fields: []string{}}
+	instance := value.Value{
+		Type: value.VAL_OBJ,
+		Obj:  &value.ObjInstance{Struct: otherDefinition, Fields: map[string]value.Value{}},
+	}
+	if machine.markRuntimeValueType(instance, schema) {
+		t.Fatal("uma ObjInstance de struct com nome diferente do esquema deveria continuar rejeitada (caminho nominal intocado)")
 	}
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -67,6 +67,15 @@ type VM struct {
 	frameCount   int
 	currentFrame *CallFrame
 
+	// stackCaptureFloor e o indice do frame mais baixo que captureNoxyStack
+	// pode incluir. Zero (padrao) = pilha inteira, o comportamento historico
+	// de todo erro fatal de topo. So a fronteira de call_result o levanta,
+	// pelo tempo da chamada capturada, para cumprir a promessa da spec de que
+	// Failure.stack vai do ponto de falha ate — excluindo — o frame que
+	// chamou call_result. Por-VM (tasks rodam em VM proprio), salvo e
+	// restaurado pela fronteira, entao fronteiras aninhadas empilham pisos.
+	stackCaptureFloor int
+
 	chunk *chunk.Chunk // Removed, accessed via frame
 	ip    int          // Removed, accessed via frame (or cached)
 

--- a/noxy_examples/int_to_result_noxy.nx
+++ b/noxy_examples/int_to_result_noxy.nx
@@ -1,0 +1,150 @@
+// int_to_result_noxy.nx — experimento: reimplementar to_int_result em noxy PURO.
+//
+// Antes dos generics o stdlib precisava de dois structs duplicados
+// (IntResult e FloatResult). Com generics, um único Result<T> serve
+// para qualquer tipo, monomorfizado em compile time.
+//
+// Peças em noxy puro:
+//   - dispatch de tipo sobre `any` via fmt("%T", v)
+//   - parse manual de string base 10 com deteccao de overflow de int64
+//     (nao da para usar to_int no caminho de falha: ele levanta erro)
+//   - truncamento de float via to_int, mas so depois de validar NaN e faixa
+//
+// No final, cada entrada e comparada com o builtin to_int_result (convert).
+
+use strings select char_at, substring, index_of
+use convert select *
+
+struct Result<T>
+    ok: bool
+    value: T
+    error: string
+end
+
+let DIGITS: string = "0123456789"
+let MIN_INT: int = -9223372036854775807 - 1
+let MIN_DIV10: int = -922337203685477580  // MIN_INT / 10, truncado
+
+// Parse manual de inteiro decimal, mesmo contrato do strconv.ParseInt(s, 10, 64):
+// sinal opcional, so digitos, sem espacos. Acumula NEGATIVO para conseguir
+// representar exatamente MIN_INT (-2^63), que nao tem simetrico positivo.
+func parse_int_text(text: string) -> Result<int>
+    let s: string = text
+    let negative: bool = false
+    if length(s) > 0 then
+        let first: string = char_at(s, 0)
+        if first == "-" || first == "+" then
+            negative = first == "-"
+            s = substring(s, 1, length(s))
+        end
+    end
+    if length(s) == 0 then
+        return Result(false, 0, "cannot convert string '" + text + "' to int")
+    end
+    let acc: int = 0
+    for ch in s do
+        let d: int = index_of(DIGITS, ch)
+        if d < 0 then
+            return Result(false, 0, "cannot convert string '" + text + "' to int")
+        end
+        // proximo passo seria acc*10 - d; estoura int64?
+        if acc < MIN_DIV10 || (acc == MIN_DIV10 && d > 8) then
+            return Result(false, 0, "cannot convert string '" + text + "' to int: out of range")
+        end
+        acc = acc * 10 - d
+    end
+    if !negative then
+        if acc == MIN_INT then
+            return Result(false, 0, "cannot convert string '" + text + "' to int: out of range")
+        end
+        acc = -acc
+    end
+    return Result(true, acc, "")
+end
+
+func int_to_result_noxy(v: any) -> Result<int>
+    let kind: string = fmt("%T", v)
+    if kind == "int" then
+        let n: int = to_int(v)
+        return Result(true, n, "")
+    end
+    if kind == "float" then
+        let f: float = to_float(v)
+        if f != f then
+            return Result(false, 0, "cannot convert float NaN to int")
+        end
+        if f < -9223372036854775808.0 || f >= 9223372036854775808.0 then
+            return Result(false, 0, "cannot convert float " + to_str(v) + " to int: out of range")
+        end
+        // faixa validada: aqui to_int nunca levanta, so trunca em direcao a zero
+        let truncated: int = to_int(f)
+        return Result(true, truncated, "")
+    end
+    if kind == "string" then
+        return parse_int_text(to_str(v))
+    end
+    return Result(false, 0, "cannot convert " + kind + " to int")
+end
+
+// Bonus generics: o MESMO Result<T> serve para float — sem duplicar struct.
+func ok_of<T>(v: T) -> Result<T>
+    return Result(true, v, "")
+end
+
+// ---- teste: compara com o builtin to_int_result em cada entrada ----
+
+func check(input: any) -> bool
+    let mine: Result<int> = int_to_result_noxy(input)
+    let builtin: IntResult = to_int_result(input)
+    let verdict: string = "MATCH"
+    let same: bool = true
+    if mine.ok != builtin.ok || mine.value != builtin.value then
+        verdict = "DIFF!"
+        same = false
+    end
+    print(fmt("%-8s %-22v noxy: ok=%-5t val=%-20v builtin: ok=%-5t val=%-20v %s",
+        fmt("(%T)", input), input, mine.ok, mine.value, builtin.ok, builtin.value, verdict))
+    return same
+end
+
+let tests: any[] = [
+    42,
+    -7,
+    3.99,
+    -3.99,
+    "123",
+    "-123",
+    "+99",
+    "0",
+    "00123",
+    "",
+    "-",
+    "abc",
+    "12.5",
+    " 42",
+    "9223372036854775807",
+    "-9223372036854775808",
+    "9223372036854775808",
+    "-9223372036854775809",
+    9223372036854775808.0,
+    -9223372036854775808.0,
+    true,
+    null,
+    b"12"
+]
+
+let all_ok: bool = true
+for t in tests do
+    if !check(t) then
+        all_ok = false
+    end
+end
+
+let rf: Result<float> = ok_of(2.5)
+print(fmt("Result<float> reutilizado do mesmo struct generico: ok=%t value=%v", rf.ok, rf.value))
+
+if all_ok then
+    print("TODOS OS CASOS BATEM COM O BUILTIN")
+else
+    print("HOUVE DIVERGENCIA — ver linhas DIFF! acima")
+end

--- a/noxy_examples/result_pattern.nx
+++ b/noxy_examples/result_pattern.nx
@@ -1,55 +1,35 @@
-// result_pattern.nx - Demonstrating the Standard Result Pattern
-use result
+// result_pattern.nx — o idioma _result construido em noxy puro com call_result.
+//
+// Antes: modulo `result` (deprecado). Agora: um gemeo `_result` nomeado, com
+// struct de resultado tipado, embrulhando uma primitiva que levanta.
 
-// Simulating a database query
-func get_user_age(user_id: int) -> result.Result
-    if user_id == 1 then
-        return result.Ok(30)
-    elif user_id == 2 then
-        return result.Ok(25)
-    else
-        return result.Err(404, "User not found")
+use errors select *
+
+struct DivResult
+    ok: bool
+    value: int
+    error: string
+end
+
+func divide(a: int, b: int) -> int
+    return a / b   // levanta "division by zero" quando b == 0
+end
+
+func divide_result(a: int, b: int) -> DivResult
+    let r: CallResult = call_result(divide, a, b)
+    if r.ok then
+        let quociente: int = to_int(r.value)
+        return DivResult(true, quociente, "")
     end
+    return DivResult(false, 0, r.failure.message)
 end
 
-// Simulating division
-func safe_div(a: float, b: float) -> result.Result
-    if b == 0.0 then
-        return result.Err(1, "Division by zero")
-    end
-    return result.Ok(a / b)
+let boa: DivResult = divide_result(10, 2)
+let ruim: DivResult = divide_result(1, 0)
+
+if boa.ok then
+    print("10 / 2 = " + to_str(boa.value))
 end
-
-print("=== Testing Result Pattern ===")
-
-// Test Case 1: Success
-let res1: result.Result = get_user_age(1)
-if result.is_ok(res1) then
-    let age: int = to_int(result.unwrap(res1))
-    print(f"User 1 Age: {age}")
+if !ruim.ok then
+    print("1 / 0 falhou: " + ruim.error)
 end
-
-// Test Case 2: Failure
-let res2: result.Result = get_user_age(99)
-if result.is_err(res2) then
-    let err: result.Error = result.unwrap_err(res2)
-    print(f"User 99 Error: {err.msg} (Code: {err.code})")
-end
-
-// Test Case 3: Math with Result
-let val1: result.Result = safe_div(10.0, 2.0)
-let val2: result.Result = safe_div(20.0, 4.0)
-let val3: result.Result = safe_div(20.0, 0.0)
-
-if result.is_ok(val1) && result.is_ok(val2) then
-    let v1: float = to_float(result.unwrap(val1))
-    let v2: float = to_float(result.unwrap(val2))
-    print(f"Calculation: {v1} + {v2} = {v1 + v2}")
-end
-
-if result.is_err(val3) then
-    let err: result.Error = result.unwrap_err(val3)
-    print(f"Error: {err.msg} (Code: {err.code})")
-end
-
-print("=== Tests Completed ===")


### PR DESCRIPTION
## Summary
- Novo nativo global `call_result(fn, ...args)`: fronteira síncrona de erro que converte falha de runtime que desenrola de `fn` em valor — envelope `CallResult{ok, value, failure}` com `Failure{kind, message, stack, causes}` (mesmo vocabulário da fronteira de task, estendido com agregação estruturada de falhas de defer: ordem LIFO, localização de registro no stack, promoção cleanup-first com merge de causes internas)
- Misuse (não-callable, aridade/modos/campos errados onde há metadata) levanta síncrono no chamador, espelhando `spawn_task`; callables aceitos: função/closure noxy, nativo, construtor de struct
- Panics de Go recuperados como `kind="panic"` via `hardUnwindTo` (libera frames sem rodar defers noxy, com contabilidade RC balanceada); fatais do runtime Go seguem fatais
- Validador de tipo em runtime aceita map estruturalmente compatível em contrato de struct na fronteira dinâmica (o que torna `let r: CallResult = call_result(...)` válido); gates nominais (args de `spawn_task`) seguem exigindo instância — limitação documentada, unificação como follow-up
- `Failure.stack` para no frame da fronteira (`stackCaptureFloor`), como a spec promete; árvore de Failure retém filhos compostos (correção de corrupção CoW por alias, com testes de regressão)
- Sufixo de conselho de `to_int`/`to_float` ("use to_int_result...") sai da mensagem capturável (`AdvisedError`) e vira `hint:` impresso só na saída fatal
- Módulo `result` deprecado (remoção na próxima release); gêmeos `_result` agora são escrevíveis em noxy puro

## Components
- `internal/vm/builtins_call_result.go` — nativo, validação de fronteira, invocação com captura de resultado, envelope de falha, recuperação de panic
- `internal/vm/runtime_type_validation.go` — admissão estrutural de map em `TYPE_STRUCT` (caminho nominal de instância intacto)
- `internal/vm/runtime_errors.go` — `AdvisedError`, `stackCaptureFloor` em `captureNoxyStack`
- `internal/vm/builtins_convert.go`, `cmd/noxy/main.go` — mensagens limpas + hint fatal
- `internal/stdlib/errors.nx` — shapes `Failure`/`CallResult`; `internal/stdlib/result.nx` — deprecação
- `noxy_examples/result_pattern.nx` — migrado para o idioma wrap-and-name sobre `call_result`; `noxy_examples/int_to_result_noxy.nx` — experimento que motivou o design
- `docs/NOXY_LANGUAGE_SPEC.md` — seções normativas (filosofia levantar-vs-`_result` + fronteira), §5 autorreferência via array, §12 módulo `errors`; `docs/superpowers/specs|plans/` — design doc (2 rodadas de review independente) e plano; `CHANGELOG.md`

## Test Plan
- [x] `go test ./... -count=1` verde (repo inteiro)
- [x] `go test ./internal/vm/ -count=1 -race` verde
- [x] `go vet ./...` e `go build ./...` limpos
- [x] 20+ testes novos: ok paths (closure/nativo/construtor/void), misuse síncrono, kind/message/stack, stack overflow capturável, agregação de defer + cleanup-first + isolamento do caller, panic Go, fronteiras aninhadas, no-rollback via ref, semântica de valor CoW do envelope (ok e failure), validador estrutural (recursão em schema cíclico, rejeição em profundidade, chaves extras)
- [x] Smoke no binário real: hint fatal, exemplos `result_pattern.nx` e `int_to_result_noxy.nx`
- [ ] Validação manual no fluxo NoxyDB (dogfooding)
- [ ] Follow-ups registrados: retain em `taskOutcomeEnvelope` (mesmo padrão, fronteira de task), unificação do matcher nominal, location em callee nativo direto

🤖 Generated with [Claude Code](https://claude.com/claude-code)
