### PR TITLE
feat/issue-44 - Target typing em return, erro em literal int fora da faixa e builtin type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
   do template: ele vazava para a primeira chamada genérica aninhada nos
   argumentos, aceitando programa que deveria ser erro de inferência
   (pré-existente no caminho do `let`; o guard endurece `let` e `return`).
+- `zeros(n)` com tamanho negativo panicava no lado Go (`makeslice: len out
+  of range`), imprimia stack trace do interpretador e o processo saía com
+  código 0. Agora é erro de runtime do noxy ("zeros size must be
+  non-negative"), com linha do script e capturável por `call_result` — e um
+  panic que ainda alcance o recover do topo passa a terminar o processo com
+  código 1, nunca mais como sucesso.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [0.7.3] - 2026-08-19
+
+### Added — `type`, target typing em `return` (issue #44)
+
+- Novo nativo global `type(v: any) -> string` devolve o nome do tipo em
+  runtime (`"int"`, `"map"`, `"Caixa<int>"`, `"ref"`, ...). Uso principal:
+  inspecionar `any` nas fronteiras dinâmicas (envelopes de
+  `call_result`/`task_await`, JSON, payloads de canal). A tabela de nomes é
+  única e compartilhada com o verbo `%T` do `fmt` — e com isso o `%T` mudou
+  em dois pontos: instância de struct genérico imprime o nome de exibição
+  (`Caixa<int>`; antes vazava a identidade interna `main::Caixa<int>`,
+  inclusive nos argumentos aninhados) e ref/channel/waitgroup deixam de
+  imprimir `"unknown"`.
+- Target typing em posição de `return`: a anotação de retorno da função
+  envolvente ancora o `T` que só aparece no retorno do template chamado
+  (`return vazia()` numa função `-> int[]`), simétrico à âncora do `let`
+  anotado. Argumentos continuam sendo a âncora primária; construtor de
+  struct genérico também é coberto (`return Stack([])` com `-> Stack<int>`).
+
+### Fixed (BREAKING) — literal int fora da faixa é erro de compilação
+
+- Literal inteiro fora da faixa de int64 (decimal, hex ou binário) era
+  saturado silenciosamente para o máximo — `9223372036854775808` compilava
+  valendo `...807` — e agora é `SyntaxError` com posição. O menos unário
+  diretamente sobre um literal funde o sinal no literal, então o mínimo do
+  tipo (`-9223372036854775808`) passou a ser escrevível e exato (antes
+  valia `-...807`, um off-by-one silencioso). O tamanho em anotação de
+  array (`int[N]`) passa pela mesma validação (antes um `N` estourado
+  virava silenciosamente array sem tamanho).
+- O hint de target typing não é mais armado quando um local sombreia o nome
+  do template: ele vazava para a primeira chamada genérica aninhada nos
+  argumentos, aceitando programa que deveria ser erro de inferência
+  (pré-existente no caminho do `let`; o guard endurece `let` e `return`).
+
+### Docs
+
+- Spec: `strings.char_code`/`from_char_code`/`codes` documentados — o
+  `ord`/`chr` pedido na issue #44 já existia, a lacuna era de documentação.
+  Regra de faixa de literais inteiros em §2.1, âncora de `return` em §6.2,
+  tabela de nomes de `type()`/`%T` em §10, e correção da afirmação falsa de
+  que não havia escape `\u` (o lexer implementa `\u{...}` e `\uXXXX`).
+
 ## [0.7.2] - 2026-08-19
 
 ### Added — `call_result`: fronteira síncrona de erro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.3] - 2026-08-19
+## [0.8.0] - 2026-08-19
 
 ### Added — `type`, target typing em `return` (issue #44)
 

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -28,6 +28,11 @@ func main() {
 		if r := recover(); r != nil {
 			fmt.Println("Recovered from panic:", r)
 			debug.PrintStack()
+			// Um panic que chegou ate aqui e falha, nunca sucesso: sem este
+			// exit, scripts/CI viam codigo 0 de um programa que explodiu no
+			// meio. Este defer e o primeiro registrado em main, logo roda por
+			// ultimo — os demais defers ja executaram quando o Exit dispara.
+			os.Exit(1)
 		}
 	}()
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1466,6 +1466,7 @@ use is inspecting `any` values at dynamic boundaries (`call_result` and
 | array | `"array"` |
 | map | `"map"` |
 | struct instance | the nominal name — `"Pessoa"`, `"Caixa<int>"` (no module qualifier) |
+| struct definition (the constructor as a value) | `"struct"` |
 | function, closure, or native | `"function"` |
 | `ref` | `"ref"` |
 | task handle | `"task"` |
@@ -1603,8 +1604,9 @@ func is_ascii_digit(ch: string) -> bool
 end
 ```
 
-There is no `\u` escape in string literals; build a character from its code
-point with `from_char_code(code)`.
+String literals also accept `\u{...}` and `\uXXXX` escapes for writing a
+character by its code point; `from_char_code(code)` is the runtime
+equivalent for a code point computed at runtime.
 
 ### Indexação de strings
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -687,7 +687,30 @@ print(peek(ints)) // 20
 
 This works because every `let` in Noxy already requires a type annotation —
 the language already forces the caller to write the information inference
-needs. `Stack<int>` and `Stack<string>` are distinct nominal struct types;
+needs.
+
+The declared return type of the enclosing function is the same kind of
+anchor: a generic call in `return` position unifies its return type against
+the annotation, exactly as an annotated `let` does. Arguments remain the
+primary anchor; the annotation only resolves what the arguments leave open:
+
+```noxy
+func vazia<T>() -> T[]
+    let xs: T[] = []
+    return xs
+end
+
+func prepara() -> int[]
+    return vazia() // T = int, from the enclosing function's return type
+end
+
+func nova() -> Stack<int>
+    return Stack([]) // the constructor argument ([]) is empty; the
+                      // return annotation supplies T = int
+end
+```
+
+`Stack<int>` and `Stack<string>` are distinct nominal struct types;
 using one where the other is expected is a compile-time type error, the same
 as any other struct mismatch.
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -92,6 +92,18 @@ x = "text"       // ✗ ERROR - cannot assign string to int variable
 | `void` | Absence of value (function return only) | - |
 | `bytes` | Raw byte sequence | `b"Data"`, `hex_decode("FF")` |
 
+An `int` literal must fit in the signed 64-bit range
+`-9223372036854775808 … 9223372036854775807`. A literal outside that range —
+decimal, hexadecimal (`0x…`) or binary (`0b…`) — is a compile-time error,
+never a silently saturated value. Unary minus applied directly to an integer
+literal is part of the literal, so the minimum of the type is writable as
+`-9223372036854775808`:
+
+```noxy
+let min: int = -9223372036854775808 // ok — exact
+let bad: int = 9223372036854775808  // ERROR: integer literal out of int64 range
+```
+
 ### 2.2 Composite Types
 
 #### Value Semantics (Copy-on-Write)

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1441,6 +1441,7 @@ sem converter. Não existe `is_float`.
   - `%v`: Any value (Default representation)
   - `%t`: Boolean
   - `%q`: Quoted string/bytes
+  - `%T`: Runtime type name of the value (same table as `type(v)` below)
 
 ```noxy
 let msg: string = fmt("Value: %d, Hex: %x", 255, 255)
@@ -1451,6 +1452,39 @@ let data: bytes = b"Hello"
 let hex: string = hex_encode(data)  // "48656c6c6f"
 let back: bytes = hex_decode(hex)   // b"Hello"
 ```
+
+### Type inspection
+
+`type(v: any) -> string` returns the runtime type name of a value. Its main
+use is inspecting `any` values at dynamic boundaries (`call_result` and
+`task_await` envelopes, JSON, channel payloads). The names:
+
+| Value | `type(v)` |
+|-------|-----------|
+| `int`, `float`, `bool`, `string`, `bytes` | `"int"`, `"float"`, `"bool"`, `"string"`, `"bytes"` |
+| `null` | `"null"` |
+| array | `"array"` |
+| map | `"map"` |
+| struct instance | the nominal name — `"Pessoa"`, `"Caixa<int>"` (no module qualifier) |
+| function, closure, or native | `"function"` |
+| `ref` | `"ref"` |
+| task handle | `"task"` |
+| channel / waitgroup | `"channel"` / `"waitgroup"` |
+
+```noxy
+struct Caixa<T>
+    valor: T
+end
+
+print(type(1))          // int
+print(type(Caixa(1)))   // Caixa<int>
+print(type(null))       // null
+```
+
+`type` reports the runtime representation, not the static annotation: a
+`call_result` envelope reports `"map"` (its physical shape at the dynamic
+boundary), and any value bound to `any` reports what it actually is. The
+`%T` verb of `fmt` uses the same table.
 
 ### Concurrency and Supervised Tasks
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1578,6 +1578,34 @@ strings.substring("Hello", -3, -1)  // "ll"   (-3 → 2, -1 → 4)
 strings.substring("aé🙂z", 1, 3)   // "é🙂"  (rune-based, not byte-based)
 ```
 
+#### Code points: `char_code`, `from_char_code`, `codes`
+
+`char_code(s) -> int` returns the Unicode code point of a single-character
+string (the `ord` of other languages); a string whose rune count is not
+exactly 1 is a runtime error. `from_char_code(code) -> string` is its
+inverse (`chr`). `codes(s) -> int[]` decodes the whole string once and
+returns every code point — prefer it when scanning a string character by
+character: `char_at` rebuilds the rune slice on each call, so a `char_at`
+loop is quadratic in the string's length.
+
+```noxy
+use strings select *
+
+char_code("A")            // 65
+char_code("é")            // 233
+from_char_code(233)       // "é"
+codes("já")               // [106, 225]
+
+// range comparison — no digit-table tricks needed
+func is_ascii_digit(ch: string) -> bool
+    let code: int = char_code(ch)
+    return code >= 48 && code <= 57
+end
+```
+
+There is no `\u` escape in string literals; build a character from its code
+point with `from_char_code(code)`.
+
 ### Indexação de strings
 
 Uma `string` é indexada por **caractere** (code point Unicode), não por byte.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1843,7 +1843,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			return nil, nil, err
 		}
 
+		// Target-typing do §7 em posicao de return: a anotacao de retorno da
+		// funcao envolvente e ancora para o T que so aparece no retorno do
+		// template chamado (`return vazia()`), simetrica a ancora do `let`
+		// anotado — mesma disciplina de armar/limpar do LetStmt acima.
+		c.setGenericReturnHint(expected, n.ReturnValue)
+		c.setArrayElementHint(expected, n.ReturnValue)
 		_, actual, err := c.Compile(n.ReturnValue)
+		c.genericReturnHint = nil
+		c.arrayElementHint = nil
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -716,6 +716,14 @@ func (c *Compiler) setGenericReturnHint(target ast.NoxyType, valueExpr ast.Expre
 	if !isFunctionTemplate && !isStructTemplate {
 		return
 	}
+	// Mesma regra de sombreamento da interceptacao de call site: um local ou
+	// upvalue com o nome do template vence, a chamada compila pelo caminho
+	// normal e NAO consome o hint — que entao vazaria para a primeira chamada
+	// generica aninhada nos argumentos, ancorando o T dela por uma anotacao
+	// que nao e do site dela.
+	if c.isShadowedByLocal(callee.Value) {
+		return
+	}
 	c.genericReturnHint = target
 }
 

--- a/internal/compiler/generics_target_test.go
+++ b/internal/compiler/generics_target_test.go
@@ -110,6 +110,61 @@ func TestBindTypeParamConflictIsStructured(t *testing.T) {
 	}
 }
 
+// Issue #44 (1): a anotacao de retorno da funcao envolvente e ancora de
+// target-typing para chamada generica em posicao de `return` — simetrica a
+// ancora do `let` anotado (§6.2). Cobre T que so aparece no retorno do
+// template, tanto funcao quanto construtor de struct generico.
+func TestReturnPositionAnchorsGenericCall(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "funcao com T so no retorno",
+			src: `func vazia<T>() -> T[]
+    let xs: T[] = []
+    return xs
+end
+func faz() -> int[]
+    return vazia()
+end`,
+		},
+		{
+			name: "construtor generico sem ancora nos argumentos",
+			src: `struct Pilha<T>
+    itens: T[]
+end
+func nova() -> Pilha<int>
+    return Pilha([])
+end`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := New().Compile(parse(tt.src)); err != nil {
+				t.Fatalf("retorno anotado deveria ancorar o tipo, veio %v", err)
+			}
+		})
+	}
+}
+
+// Issue #44 (1), caso de erro: quando a anotacao de retorno NAO casa com o
+// retorno do template, a falha e a mesma do caminho do `let` ("retorno de
+// 'f': ..."), nao a generica "não foi possível inferir T".
+func TestReturnPositionHintMismatchIsError(t *testing.T) {
+	src := `func vazia<T>() -> T[]
+    let xs: T[] = []
+    return xs
+end
+func faz() -> int
+    return vazia()
+end`
+	_, _, err := New().Compile(parse(src))
+	if err == nil || !strings.Contains(err.Error(), "retorno de 'vazia'") {
+		t.Fatalf("mismatch de retorno deveria unificar e falhar com atribuicao, veio %v", err)
+	}
+}
+
 // I5 (2b): erro vindo da passada BIDIRECIONAL carrega a atribuicao por
 // argumento — antes o unico contexto era o indice do argumento-template, sem
 // nenhum caminho para a mensagem "(argumento N) e (argumento M)" do §9.

--- a/internal/compiler/generics_target_test.go
+++ b/internal/compiler/generics_target_test.go
@@ -148,6 +148,39 @@ end`,
 	}
 }
 
+// O hint so pode ser armado quando o call site realmente e o template: um
+// local que sombreia o nome do template compila pelo caminho normal, e um
+// hint armado vazaria para a PRIMEIRA chamada generica aninhada nos
+// argumentos (ancorando o T de 'outro' pela anotacao de um site que nao e
+// dele — target typing em posicao de argumento, que nao existe). Mesma regra
+// de sombreamento da interceptacao de call site (isShadowedByLocal).
+func TestShadowedTemplateNameDoesNotArmHint(t *testing.T) {
+	for _, tt := range []struct{ name, body string }{
+		{"let anotado", "let y: int[] = tpl(outro())\n    return y"},
+		{"posicao de return", "return tpl(outro())"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			src := `func tpl<T>(xs: T[]) -> T[]
+    return xs
+end
+func outro<T>() -> T[]
+    let xs: T[] = []
+    return xs
+end
+func usa() -> int[]
+    let tpl: func(int[]) -> int[] = func(xs: int[]) -> int[]
+        return xs
+    end
+    ` + tt.body + `
+end`
+			_, _, err := New().Compile(parse(src))
+			if err == nil || !strings.Contains(err.Error(), "não foi possível inferir") {
+				t.Fatalf("outro() aninhado sem ancora propria deveria falhar, veio %v", err)
+			}
+		})
+	}
+}
+
 // Issue #44 (1), caso de erro: quando a anotacao de retorno NAO casa com o
 // retorno do template, a falha e a mesma do caminho do `let` ("retorno de
 // 'f': ..."), nao a generica "não foi possível inferir T".

--- a/internal/parser/int_literal_test.go
+++ b/internal/parser/int_literal_test.go
@@ -1,0 +1,85 @@
+package parser
+
+// Issue #44 (3): literal inteiro fora da faixa de int64 e erro de parse, nao
+// saturacao silenciosa (strconv.ParseInt devolve o valor saturado JUNTO com
+// ErrRange, e o erro era descartado). O menos unario diretamente sobre um
+// literal inteiro funde o sinal no proprio literal: a faixa de int64 e
+// assimetrica e o minimo (-9223372036854775808) so e representavel assim —
+// sem a fusao, a parte positiva estoura antes de o menos ser aplicado.
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+)
+
+func TestIntLiteralOutOfRangeIsError(t *testing.T) {
+	for _, source := range []string{
+		"let x: int = 9223372036854775808",
+		"let x: int = 99999999999999999999999999",
+		"let x: int = 0xFFFFFFFFFFFFFFFF",
+		"let x: int = -9223372036854775809",
+	} {
+		p := New(lexer.New(source))
+		_ = p.ParseProgram()
+		if len(p.Errors()) == 0 || !strings.Contains(strings.Join(p.Errors(), "\n"), "out of int64 range") {
+			t.Fatalf("source=%q errors=%v, quer erro de faixa", source, p.Errors())
+		}
+	}
+}
+
+func TestMinInt64LiteralIsExact(t *testing.T) {
+	p := New(lexer.New("let x: int = -9223372036854775808"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	let := program.Statements[0].(*ast.LetStmt)
+	lit, ok := let.Value.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("valor=%#v, quer IntegerLiteral com sinal fundido", let.Value)
+	}
+	if lit.Value != math.MinInt64 {
+		t.Fatalf("valor=%d, quer %d", lit.Value, int64(math.MinInt64))
+	}
+	if lit.String() != "-9223372036854775808" {
+		t.Fatalf("String()=%q deve refletir o literal com sinal", lit.String())
+	}
+}
+
+func TestNegativeLiteralFoldKeepsMaxIntNegatable(t *testing.T) {
+	p := New(lexer.New("let x: int = -9223372036854775807"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	let := program.Statements[0].(*ast.LetStmt)
+	lit, ok := let.Value.(*ast.IntegerLiteral)
+	if !ok || lit.Value != -math.MaxInt64 {
+		t.Fatalf("valor=%#v, quer IntegerLiteral(-9223372036854775807)", let.Value)
+	}
+}
+
+func TestUnaryMinusOnNonLiteralStaysPrefix(t *testing.T) {
+	p := New(lexer.New("let x: int = -y"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	let := program.Statements[0].(*ast.LetStmt)
+	if _, ok := let.Value.(*ast.PrefixExpression); !ok {
+		t.Fatalf("valor=%#v, menos unario sobre identificador segue PrefixExpression", let.Value)
+	}
+}
+
+func TestInfixMinusUnaffectedByFold(t *testing.T) {
+	p := New(lexer.New("let x: int = 1 - 5"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	let := program.Statements[0].(*ast.LetStmt)
+	infix, ok := let.Value.(*ast.InfixExpression)
+	if !ok || infix.Operator != "-" {
+		t.Fatalf("valor=%#v, quer InfixExpression de subtracao", let.Value)
+	}
+	right, ok := infix.Right.(*ast.IntegerLiteral)
+	if !ok || right.Value != 5 {
+		t.Fatalf("lado direito=%#v, quer IntegerLiteral(5)", infix.Right)
+	}
+}

--- a/internal/parser/int_literal_test.go
+++ b/internal/parser/int_literal_test.go
@@ -59,6 +59,28 @@ func TestNegativeLiteralFoldKeepsMaxIntNegatable(t *testing.T) {
 	}
 }
 
+// O tamanho em anotacao de array (`int[N]`) passa pela mesma validacao de
+// faixa dos literais de expressao — antes usava Sscanf com erro descartado e
+// um N que estourasse virava silenciosamente 0 (array sem tamanho).
+func TestArraySizeAnnotationOutOfRangeIsError(t *testing.T) {
+	p := New(lexer.New("let xs: int[99999999999999999999] = [1, 2]"))
+	_ = p.ParseProgram()
+	if len(p.Errors()) == 0 || !strings.Contains(strings.Join(p.Errors(), "\n"), "out of int64 range") {
+		t.Fatalf("errors=%v, quer erro de faixa no tamanho do array", p.Errors())
+	}
+}
+
+func TestArraySizeAnnotationInRangeIsKept(t *testing.T) {
+	p := New(lexer.New("let xs: int[3] = [1, 2, 3]"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	let := program.Statements[0].(*ast.LetStmt)
+	arr, ok := let.Type.(*ast.ArrayType)
+	if !ok || arr.Size != 3 {
+		t.Fatalf("tipo=%#v, quer ArrayType com Size 3", let.Type)
+	}
+}
+
 func TestUnaryMinusOnNonLiteralStaysPrefix(t *testing.T) {
 	p := New(lexer.New("let x: int = -y"))
 	program := p.ParseProgram()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"noxy-vm/internal/ast"
 	"noxy-vm/internal/lexer"
@@ -898,9 +899,24 @@ func (p *Parser) parseIdentifier() ast.Expression {
 }
 
 func (p *Parser) parseIntegerLiteral() ast.Expression {
-	lit := &ast.IntegerLiteral{Token: p.curToken}
+	return p.newIntegerLiteral(p.curToken)
+}
 
-	value, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+// newIntegerLiteral converte o texto do token em int64. ParseInt devolve o
+// valor SATURADO junto com ErrRange, entao descartar o erro faria literais
+// fora da faixa compilarem silenciosamente com outro valor.
+func (p *Parser) newIntegerLiteral(tok token.Token) ast.Expression {
+	lit := &ast.IntegerLiteral{Token: tok}
+	value, err := strconv.ParseInt(tok.Literal, 0, 64)
+	if err != nil {
+		reason := "invalid integer literal"
+		if errors.Is(err, strconv.ErrRange) {
+			reason = "integer literal out of int64 range"
+		}
+		p.errors = append(p.errors, fmt.Sprintf(
+			"[%d:%d] SyntaxError: %s: %s", tok.Line, tok.Column, reason, tok.Literal))
+		return lit
+	}
 	lit.Value = value
 	return lit
 }
@@ -1042,6 +1058,19 @@ func (p *Parser) parseFString() ast.Expression {
 }
 
 func (p *Parser) parsePrefixExpression() ast.Expression {
+	// Menos unario diretamente sobre um literal inteiro funde o sinal no
+	// literal: a faixa de int64 e assimetrica, entao o minimo
+	// (-9223372036854775808) so e representavel com o sinal incorporado —
+	// negar o literal positivo estouraria antes de o menos ser aplicado.
+	if p.curToken.Type == token.MINUS && p.peekToken.Type == token.INT {
+		minus := p.curToken
+		p.nextToken()
+		tok := p.curToken
+		tok.Literal = "-" + tok.Literal
+		tok.Line = minus.Line
+		tok.Column = minus.Column
+		return p.newIntegerLiteral(tok)
+	}
 	expression := &ast.PrefixExpression{
 		Token:    p.curToken,
 		Operator: p.curToken.Literal,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -597,7 +597,12 @@ func (p *Parser) parseType() ast.NoxyType {
 		if !p.peekTokenIs(token.RBRACKET) {
 			p.nextToken()                     // Eat the size token
 			if p.curToken.Type == token.INT { // Verify token type name
-				fmt.Sscanf(p.curToken.Literal, "%d", &size)
+				// Mesma validacao de faixa dos literais de expressao: antes
+				// (Sscanf com erro descartado) um N que estourasse virava
+				// silenciosamente um array sem tamanho.
+				if lit, ok := p.newIntegerLiteral(p.curToken).(*ast.IntegerLiteral); ok {
+					size = int(lit.Value)
+				}
 			}
 		}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.7.3"
+const Version = "v0.8.0"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.7.2"
+const Version = "v0.7.3"

--- a/internal/vm/builtins_core.go
+++ b/internal/vm/builtins_core.go
@@ -192,6 +192,15 @@ func (vm *VM) defineCoreBuiltins() {
 	// Verb: [a-zA-Z%]
 	fmtVerbRe := regexp.MustCompile(`%([-+ #0]*)(?:(\d+|\*)?)(?:\.(\d+|\*))?([a-zA-Z%])`)
 
+	// Inspecao de tipo em runtime (issue #44): devolve o nome da tabela de
+	// runtimeTypeName — a mesma que o verbo %T do fmt usa.
+	vm.DefineContextualNative("type", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
+		if len(args) != 1 {
+			return value.NewNull(), fmt.Errorf("type: expects exactly 1 argument, got %d", len(args))
+		}
+		return value.NewString(runtimeTypeName(args[0])), nil
+	})
+
 	vm.DefineNative("fmt", func(args []value.Value) value.Value {
 		if len(args) < 1 {
 			return value.NewString("")
@@ -275,42 +284,7 @@ func (vm *VM) defineCoreBuiltins() {
 				if verb == 'T' {
 					// Replace %T with %s and supply type name string
 					newFormatBuilder.WriteString("%s")
-
-					typeName := "unknown"
-					switch val.Type {
-					case value.VAL_INT:
-						typeName = "int"
-					case value.VAL_FLOAT:
-						typeName = "float"
-					case value.VAL_BOOL:
-						typeName = "bool"
-					case value.VAL_NULL:
-						typeName = "null"
-					case value.VAL_BYTES:
-						typeName = "bytes"
-					case value.VAL_FUNCTION:
-						typeName = "function"
-					case value.VAL_NATIVE:
-						typeName = "function"
-					case value.VAL_TASK:
-						typeName = "task"
-					case value.VAL_OBJ:
-						// Determine specific object type
-						if _, ok := val.Obj.(*value.ObjArray); ok {
-							typeName = "array"
-						} else if _, ok := val.Obj.(*value.ObjMap); ok {
-							typeName = "map"
-						} else if inst, ok := val.Obj.(*value.ObjInstance); ok {
-							typeName = inst.Struct.Name
-						} else if _, ok := val.Obj.(*value.ObjStruct); ok {
-							typeName = "struct" // Class definition
-						} else if _, ok := val.Obj.(string); ok {
-							typeName = "string"
-						} else {
-							typeName = fmt.Sprintf("%T", val.Obj)
-						}
-					}
-					newArgs = append(newArgs, typeName)
+					newArgs = append(newArgs, runtimeTypeName(val))
 				} else {
 					// Keep original verb sequence (including flags/width/prec)
 					newFormatBuilder.WriteString(formatStr[start:end])

--- a/internal/vm/builtins_registry_test.go
+++ b/internal/vm/builtins_registry_test.go
@@ -44,7 +44,7 @@ func TestBuiltinRegistrySnapshot(t *testing.T) {
 		"time_month_name", "time_now", "time_now_datetime", "time_now_ms",
 		"time_parse", "time_parse_date", "time_sleep", "time_to_timestamp",
 		"time_weekday_name", "to_bytes", "to_float", "to_int", "to_str",
-		"wg_add", "wg_done", "wg_wait",
+		"type", "wg_add", "wg_done", "wg_wait",
 	}
 
 	globals := machine.shared.Root.LocalSnapshot()

--- a/internal/vm/builtins_type_test.go
+++ b/internal/vm/builtins_type_test.go
@@ -44,10 +44,30 @@ func TestTypeBuiltinNames(t *testing.T) {
 	}
 }
 
-func TestTypeBuiltinTaskHandle(t *testing.T) {
+func TestTypeBuiltinRuntimeHandles(t *testing.T) {
 	machine := New()
-	got := callBuiltin(t, machine, "type", value.NewTask())
-	expectReportedString(t, got, "task", "type(task)")
+	tests := []struct {
+		name string
+		arg  value.Value
+		want string
+	}{
+		{"task", value.NewTask(), "task"},
+		{"channel", value.NewChannel(1), "channel"},
+		{"waitgroup", value.NewWaitGroup(), "waitgroup"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := callBuiltin(t, machine, "type", tt.arg)
+			expectReportedString(t, got, tt.want, "type()")
+		})
+	}
+}
+
+// O construtor como valor (a DEFINICAO do struct, nao uma instancia) reporta
+// "struct" — herdado do %T antigo e agora documentado na tabela do spec.
+func TestTypeBuiltinStructDefinition(t *testing.T) {
+	got := captureVMSource(t, "struct Pessoa\n    nome: string\nend\ntest_report(type(Pessoa))")
+	expectReportedString(t, got, "struct", "type(Pessoa)")
 }
 
 func TestTypeBuiltinArityIsExactlyOne(t *testing.T) {

--- a/internal/vm/builtins_type_test.go
+++ b/internal/vm/builtins_type_test.go
@@ -1,0 +1,69 @@
+package vm
+
+// Issue #44 (4): builtin `type(v: any) -> string` — inspecao de tipo em
+// runtime. A tabela de nomes e a MESMA do verbo %T do fmt (fonte unica), com
+// duas correcoes sobre o comportamento antigo do %T: instancia de struct
+// generico usa o nome de exibicao (sem qualificador de modulo) e ref deixa
+// de ser "unknown".
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func expectReportedString(t *testing.T, got value.Value, want string, msg string) {
+	t.Helper()
+	text, ok := got.Obj.(string)
+	if got.Type != value.VAL_OBJ || !ok || text != want {
+		t.Fatalf("%s: esperado %q, veio %s (%v)", msg, want, got.String(), got.Type)
+	}
+}
+
+func TestTypeBuiltinNames(t *testing.T) {
+	tests := []struct{ name, src, want string }{
+		{"int", `test_report(type(1))`, "int"},
+		{"float", `test_report(type(1.5))`, "float"},
+		{"bool", `test_report(type(true))`, "bool"},
+		{"null", `test_report(type(null))`, "null"},
+		{"string", `test_report(type("x"))`, "string"},
+		{"bytes", `test_report(type(b"x"))`, "bytes"},
+		{"array", `test_report(type([1, 2]))`, "array"},
+		{"map", "let m: map[string, int] = {\"a\": 1}\ntest_report(type(m))", "map"},
+		{"funcao nativa", `test_report(type(print))`, "function"},
+		{"funcao declarada", "func f() -> int\n    return 1\nend\ntest_report(type(f))", "function"},
+		{"struct nominal", "struct Pessoa\n    nome: string\nend\ntest_report(type(Pessoa(\"Ana\")))", "Pessoa"},
+		{"struct generico", "struct Caixa<T>\n    valor: T\nend\nlet c: Caixa<int> = Caixa(1)\ntest_report(type(c))", "Caixa<int>"},
+		{"generico aninhado", "struct Caixa<T>\n    valor: T\nend\nlet dupla: Caixa<Caixa<int>> = Caixa(Caixa(9))\ntest_report(type(dupla))", "Caixa<Caixa<int>>"},
+		{"ref", "struct Pessoa\n    nome: string\nend\nlet p: Pessoa = Pessoa(\"Ana\")\ntest_report(type(ref p))", "ref"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectReportedString(t, captureVMSource(t, tt.src), tt.want, "type()")
+		})
+	}
+}
+
+func TestTypeBuiltinTaskHandle(t *testing.T) {
+	machine := New()
+	got := callBuiltin(t, machine, "type", value.NewTask())
+	expectReportedString(t, got, "task", "type(task)")
+}
+
+func TestTypeBuiltinArityIsExactlyOne(t *testing.T) {
+	machine := New()
+	native := requireBuiltin(t, machine, "type")
+	for _, args := range [][]value.Value{nil, {value.NewInt(1), value.NewInt(2)}} {
+		if _, err := native.Invoke(machine, args); err == nil {
+			t.Fatalf("type com %d argumentos deveria falhar", len(args))
+		}
+	}
+}
+
+// O %T do fmt compartilha a tabela de nomes do type(): instancia de struct
+// generico imprime o nome de exibicao, nao a identidade interna com
+// qualificador de modulo (antes: "main::Caixa<int>").
+func TestFmtTypeVerbUsesDisplayName(t *testing.T) {
+	got := captureVMSource(t, "struct Caixa<T>\n    valor: T\nend\ntest_report(fmt(\"%T\", Caixa(1)))")
+	expectReportedString(t, got, "Caixa<int>", "fmt %T")
+}

--- a/internal/vm/cow_natives.go
+++ b/internal/vm/cow_natives.go
@@ -21,7 +21,7 @@ var readonlyNatives = map[string]bool{
 	"to_int":      true,
 	"to_float":    true,
 	"fmt":         true,
-	"typeof":      true,
+	"type":        true, // só lê o valor e devolve string nova
 	"chan_recv":   true, // recebe o canal; o payload foi retido no send
 	"test_report": true, // harness de teste: apenas observa
 	"has_key":     true, // só consulta o mapa; devolve bool novo

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -957,6 +957,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return vm.runtimeError(c, ip, "zeros size must be integer")
 			}
 			count := int(countVal.AsInt)
+			if count < 0 {
+				// Sem o guard, make() panica no lado Go (makeslice: len out
+				// of range) e o panic atravessa a VM — fora do alcance de
+				// call_result e sem linha do script.
+				return vm.runtimeError(c, ip, "zeros size must be non-negative, got %d", count)
+			}
 			elements := make([]value.Value, count)
 			for i := 0; i < count; i++ {
 				elements[i] = value.NewInt(0)

--- a/internal/vm/generics_e2e_test.go
+++ b/internal/vm/generics_e2e_test.go
@@ -42,6 +42,25 @@ test_report(soma_rec(xs, 0))
 	expectInt(t, got, 3, "recursao generica")
 }
 
+// Issue #44 (1): target-typing em posicao de return — a anotacao de retorno
+// da funcao envolvente ancora o T que so aparece no retorno do template, e o
+// valor flui correto em runtime.
+func TestGenericReturnPositionEndToEnd(t *testing.T) {
+	got := captureVMSource(t, `
+func vazia<T>() -> T[]
+    let xs: T[] = []
+    return xs
+end
+func prepara() -> int[]
+    return vazia()
+end
+let r: int[] = prepara()
+append(r, 41)
+test_report(r[0] + length(r))
+`)
+	expectInt(t, got, 42, "vazia<int> via anotacao de retorno")
+}
+
 // Chamada generica de dentro de um corpo NAO-generico: o predeclare nao
 // registra mais o template em globals, entao a interceptacao (via registry) e
 // a unica coisa que faz este programa compilar.

--- a/internal/vm/runtime_type_name.go
+++ b/internal/vm/runtime_type_name.go
@@ -1,0 +1,61 @@
+package vm
+
+import (
+	"fmt"
+	"regexp"
+
+	"noxy-vm/internal/value"
+)
+
+// moduleQualifierPattern casa cada qualificador de modulo (`main::`,
+// `strings::`, caminhos de pacote) dentro de um nome de instancia, inclusive
+// nos argumentos aninhados (`main::Caixa<main::Caixa<int>>`). O qualificador
+// e identidade interna da monomorfizacao e nao interessa ao usuario.
+var moduleQualifierPattern = regexp.MustCompile(`[^<>,\s]+::`)
+
+func displayStructName(name string) string {
+	return moduleQualifierPattern.ReplaceAllString(name, "")
+}
+
+// runtimeTypeName e a fonte unica dos nomes de tipo em runtime, compartilhada
+// pelo builtin `type` e pelo verbo %T do fmt.
+func runtimeTypeName(val value.Value) string {
+	switch val.Type {
+	case value.VAL_INT:
+		return "int"
+	case value.VAL_FLOAT:
+		return "float"
+	case value.VAL_BOOL:
+		return "bool"
+	case value.VAL_NULL:
+		return "null"
+	case value.VAL_BYTES:
+		return "bytes"
+	case value.VAL_FUNCTION, value.VAL_NATIVE:
+		return "function"
+	case value.VAL_TASK:
+		return "task"
+	case value.VAL_CHANNEL:
+		return "channel"
+	case value.VAL_WAITGROUP:
+		return "waitgroup"
+	case value.VAL_REF:
+		return "ref"
+	case value.VAL_OBJ:
+		switch obj := val.Obj.(type) {
+		case string:
+			return "string"
+		case *value.ObjArray:
+			return "array"
+		case *value.ObjMap:
+			return "map"
+		case *value.ObjInstance:
+			return displayStructName(obj.Struct.Name)
+		case *value.ObjStruct:
+			return "struct" // definicao (o construtor como valor), nao instancia
+		default:
+			return fmt.Sprintf("%T", val.Obj)
+		}
+	}
+	return "unknown"
+}

--- a/internal/vm/zeros_test.go
+++ b/internal/vm/zeros_test.go
@@ -1,0 +1,23 @@
+package vm
+
+// zeros(n) com tamanho negativo era panic de Go (makeslice: len out of
+// range) atravessando a VM inteira ate o recover do main — deve ser erro de
+// runtime do noxy, com linha do script e capturavel.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZerosNegativeSizeIsRuntimeError(t *testing.T) {
+	machine := New()
+	err := interpretVMSource(t, machine, "let n: int = 0 - 5\nlet xs: int[] = zeros(n)")
+	if err == nil || !strings.Contains(err.Error(), "zeros size must be non-negative") {
+		t.Fatalf("tamanho negativo deveria ser erro de runtime do noxy, veio %v", err)
+	}
+}
+
+func TestZerosZeroSizeIsEmptyArray(t *testing.T) {
+	got := captureVMSource(t, "let xs: int[] = zeros(0)\ntest_report(length(xs))")
+	expectInt(t, got, 0, "zeros(0)")
+}


### PR DESCRIPTION
## Summary
- Target typing em posição de `return`: a anotação de retorno da função envolvente ancora o `T` que só aparece no retorno do template chamado (`return vazia()` numa função `-> int[]`), simétrico à âncora do `let` anotado; cobre função genérica e construtor de struct genérico (`return Stack([])`)
- Literal int fora da faixa de int64 (decimal, hex ou binário) vira `SyntaxError` com posição em vez de saturar silenciosamente; o menos unário diretamente sobre literal funde o sinal no literal, tornando o mínimo do tipo (`-9223372036854775808`) escrevível e exato (antes valia `-...807`, off-by-one); tamanho em anotação `int[N]` passa pela mesma validação
- Novo builtin `type(v: any) -> string` para inspeção de tipo em runtime, com tabela única de nomes compartilhada com o verbo `%T` do `fmt` — que de quebra corrige dois pontos do `%T`: instância de struct genérico usa nome de exibição (`Caixa<int>` em vez de `main::Caixa<int>`, inclusive aninhado) e `ref`/`channel`/`waitgroup` deixam de imprimir `"unknown"`
- Ponto 2 da issue (`ord`/`chr`) resolvido como documentação: `strings.char_code`, `from_char_code` e `codes` já existiam — a lacuna era o spec
- Fix de review: o hint de target typing não é mais armado quando um local sombreia o nome do template (vazava para a primeira chamada genérica aninhada nos argumentos; pré-existente no caminho do `let`, o guard endurece os dois)
- Fix de review (pré-existente): `zeros(n)` negativo panicava no lado Go, imprimia stack do interpretador e o processo saía com código 0 — agora é erro de runtime do noxy com linha do script, e panic que alcance o recover do topo termina com código 1
- Bump `v0.8.0` + CHANGELOG datado

## Components
- `internal/compiler/compiler.go`, `internal/compiler/generics.go` — âncora de return (`genericReturnHint`/`arrayElementHint` no `ReturnStmt`, mesma disciplina do `LetStmt`) e guard `isShadowedByLocal` no armador do hint
- `internal/parser/parser.go` — `newIntegerLiteral` (validação de faixa única), fold do menos unário em `parsePrefixExpression`, tamanho de array via mesma validação
- `internal/vm/runtime_type_name.go` (novo), `internal/vm/builtins_core.go`, `internal/vm/cow_natives.go` — nativo `type`, `runtimeTypeName` como fonte única, `%T` reescrito sobre ela
- `internal/vm/executor.go`, `cmd/noxy/main.go` — validação de tamanho no `OP_ZEROS`; `os.Exit(1)` no recover do topo
- `docs/NOXY_LANGUAGE_SPEC.md` — §2.1 (faixa de literais), §6.2 (âncora de return), §10 (tabela `type()`/`%T`), code points no módulo strings, correção da afirmação falsa sobre `\u`
- Testes — `internal/compiler/generics_target_test.go`, `internal/vm/generics_e2e_test.go`, `internal/parser/int_literal_test.go`, `internal/vm/builtins_type_test.go`, `internal/vm/zeros_test.go`, snapshot do registry
- `CHANGELOG.md`, `internal/version/version.go` — v0.8.0

## Related Issues
- Closes #44

## Test Plan
- [x] TDD por item (RED verificado antes de cada implementação)
- [x] `go build ./...`, `go vet ./...` e `go test ./... -count=1` verdes nos 8 pacotes
- [x] Repros da issue validados no binário (`return vazia()`, mínimo int64 exato, overflow → SyntaxError, `char_code`/faixa de dígitos)
- [x] Code review de branch: os 2 Importants corrigidos com teste de regressão (shadow-leak, spec do `\u`)
- [x] `zeros(-5)`: erro de runtime noxy com linha do script e exit 1 (antes: panic Go + exit 0); exit code verificado manualmente antes/depois nos dois estágios do fix
- [x] Validação manual no REPL / dogfooding NoxyDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
