### PR TITLE
docs/readme-version-badge - Badge de versão no topo do README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Docs
+
+- README ganha badge de versão no topo (`noxy | 0.9.0`, shields.io estático,
+  linkando para este CHANGELOG). Estático de propósito: as tags git (v1.x) e
+  a release do GitHub (v0.1.0) não acompanham `internal/version/version.go`,
+  então um badge dinâmico mostraria o número errado — bumpar o badge junto
+  com `version.go` a cada release.
+
 ## [0.9.0] - 2026-08-20
 
 ### Changed (BREAKING) — redeclarar `let` no mesmo escopo é erro de compilação

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Noxy VM 🚀
 
+[![noxy 0.9.0](https://img.shields.io/badge/noxy-0.9.0-blue)](CHANGELOG.md)
+
 A complete bytecode virtual machine for the **Noxy** programming language, written in Go. [Official Website.](https://noxylang.com/)
 
 For a complete guide, consult the [NOXY_LANGUAGE_SPEC.md](docs/NOXY_LANGUAGE_SPEC.md).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.7.0
+Noxy REPL v0.9.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Noxy VM 🚀
-
 [![noxy 0.9.0](https://img.shields.io/badge/noxy-0.9.0-blue)](CHANGELOG.md)
+
+# Noxy VM 🚀
 
 A complete bytecode virtual machine for the **Noxy** programming language, written in Go. [Official Website.](https://noxylang.com/)
 


### PR DESCRIPTION
## Summary
- README ganha um badge de versão na **primeira linha, acima do título**: `noxy | 0.9.0` (shields.io, azul), clicável para o `CHANGELOG.md`.
- Badge **estático** de propósito: as tags git (`v1.x`) e a release do GitHub (`v0.1.0`) não acompanham `internal/version/version.go` (`v0.9.0`), então `shields.io/github/v/release|tag` mostraria o número errado. Custo: bumpar o badge junto com `version.go` a cada release — se um dia tags/releases forem realinhadas, dá para trocar por `https://img.shields.io/github/v/release/estevaofon/noxy` e ele passa a se atualizar sozinho.
- Exemplo do REPL interativo no README atualizado: o banner mostrava `Noxy REPL v0.7.0`, agora `Noxy REPL v0.9.0` — idêntico ao que `cmd/noxy/main.go` imprime (`Noxy REPL %s` + `Type 'exit' to quit.`).
- CHANGELOG ganha seção `[Unreleased]` / `### Docs` registrando a mudança e o motivo de ser estático.

## Components
- `README.md` — linha 1: `[![noxy 0.9.0](https://img.shields.io/badge/noxy-0.9.0-blue)](CHANGELOG.md)`, seguida de linha em branco e do `# Noxy VM 🚀`
- `README.md` — seção "Interactive REPL": banner do exemplo `v0.7.0` → `v0.9.0`
- `CHANGELOG.md` — nova seção `[Unreleased]` → `### Docs`

## Test Plan
- [x] URL do badge responde `200 image/svg+xml` no shields.io
- [x] Line endings do README preservados (LF, igual ao HEAD)
- [x] Visual conferido no GitHub (posição, cor, link) — movido para acima do título após o primeiro review
- [x] Banner do exemplo do REPL conferido contra `startREPL` em `cmd/noxy/main.go` (mesmas duas linhas, versão vinda de `version.Version`)
- [ ] Decidir se vale manter o badge estático ou realinhar tags/releases com `version.go` para usar um dinâmico

🤖 Generated with [Claude Code](https://claude.com/claude-code)