### PR TITLE
ci/run-examples-in-actions - Roda os exemplos (run_all_tests_concurrent.nx) no GitHub Actions

### DIFF
--- a/.github/workflows/network-deadlines.yml
+++ b/.github/workflows/network-deadlines.yml
@@ -27,6 +27,27 @@ jobs:
       - run: go test -race ./internal/vm -run 'Test.*(Network|Net|Socket|Listener|Deadline|Timeout|Poll|Wake|WSA|PendingRead|PendingWrite|PendingAccept|BlockedWrite)' -count=1 -timeout=180s
       - run: go test ./internal/... -count=1
 
+  examples:
+    name: Noxy examples (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      # run_all_tests_concurrent.nx runs every noxy_examples/*.nx (minus the
+      # interactive/server demos in its exclusion list) through argv[0] — the
+      # interpreter `go run` just built — with 8 workers, and exits 1 if any
+      # example fails. It lists the directory via `ls`/`dir` by OS, so it must
+      # run from the repository root.
+      - run: go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx
+
   cross-build:
     name: Production cross-build (${{ matrix.goos }}/${{ matrix.goarch }})
     strategy:


### PR DESCRIPTION
## Summary
- Novo job **`examples`** ("Noxy examples (os)") no workflow de testes (`.github/workflows/network-deadlines.yml`), na mesma matriz `ubuntu-latest` + `windows-latest` do job de `go test`, com `fail-fast: false` e `timeout-minutes: 20`.
- Executa `go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx` (forma de pacote em vez de `cmd/noxy/main.go` — equivalente hoje, só há `main.go`, e continua funcionando se o pacote ganhar outros arquivos).
- O runner já é CI-friendly sem mudanças: usa `argv()[0]` (= `os.Args[0]`, o binário temporário que o `go run` compilou) para executar cada exemplo, lista `noxy_examples/` via `ls`/`dir` conforme o SO, pula as demos interativas/servidores da sua lista de exclusão, usa 8 workers e faz `exit(1)` se qualquer exemplo falhar — o step fica vermelho. Os dois exemplos HTTP fora da lista de exclusão (`debug_http.nx`, `test_http_server.nx`) falam só com `127.0.0.1`, sem rede externa.

## Components
- `.github/workflows/network-deadlines.yml` — job `examples` (checkout, setup-go com cache por `go.sum`, step `go run`), inserido entre `network-semantics` e `cross-build`

## Test Plan
- [x] Local (Windows, Git Bash): `go run cmd/noxy/main.go noxy_examples/run_all_tests_concurrent.nx` → `Total: 171 / Passou: 171 / Falhou: 0`, 11,4 s de runner (16,7 s com compilação), exit 0
- [x] YAML parseia; jobs na ordem `network-semantics`, `examples`, `cross-build`
- [x] Check `Noxy examples (ubuntu-latest)` verde neste PR — job em 49 s, log: `Encontrados 171 / Passou: 171 / Falhou: 0`, runner em 1,4 s ([run](https://github.com/estevaofon/noxy/actions/runs/32335434715/job/96323989436))
- [x] Check `Noxy examples (windows-latest)` verde neste PR — job em 1m02s, log: `Encontrados 171 / Passou: 171 / Falhou: 0`, runner em 3,6 s ([run](https://github.com/estevaofon/noxy/actions/runs/32335434715/job/96323989526))
- [x] Required check no `develop`: decidido que não precisa — o ruleset `protect-branches` segue só com proibição de delete/force-push (admin tem bypass, então a regra seria só informativa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
