### PR TITLE
fix/ref-null-forwarding - Campo/índice ref T nulo passado a parâmetro ref T encaminha null; fim do padrão fill-null-slot (BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.9.1] - 2026-08-20
 
 ### Changed (BREAKING) — campo/índice `ref T` nulo passado a parâmetro `ref T` encaminha `null`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+### Changed (BREAKING) — campo/índice `ref T` nulo passado a parâmetro `ref T` encaminha `null`
+
+- Um argumento cujo tipo estático já é `ref T` — campo de struct, elemento
+  de `(ref T)[]`, valor de `map[K, ref T]` — é **encaminhado como está**,
+  inclusive quando contém `null`, exatamente como uma variável `ref T` já
+  era (spec §2.3 regra 2 e §4.2: a conversão contextual existe para
+  expressões de tipo `T`, não `ref T`). Antes, `OP_CONTEXT_REF_PROPERTY` e
+  `OP_CONTEXT_REF_INDEX` fabricavam uma ref para o *slot* quando ele
+  continha `null`: dentro da função `n == null` era `false` para um campo
+  nulo (uma ref válida para um slot que contém null), enquanto o mesmo
+  `a.proximo` lido em `let`/atribuição dava `null`; e um `_append` que
+  recursa por `_append(node.proximo, v)` morria com "contextual property
+  reference base must be an instance" em vez de uma mensagem sobre ref
+  nula. Chave ausente em `map[K, ref T]` encaminha `null`, igual à leitura
+  plana `m[k]`.
+
+- **O padrão fill-null-slot deixa de existir.** `*node == null` /
+  `*node = Node(v, null)` sobre um slot recebido contextualmente preenchia
+  o campo `ref Node` com um `Node` *cru* (`type(no.proximo)` virava
+  `"Node"`, e um `*viz = ...` posterior através dele falhava com "expected
+  reference value, got object"). Agora o `null` chega como ref nula e
+  `*node = ...` é o erro claro `cannot update null reference`. Migração: a
+  função recebe o **pai** e liga pelo campo —
+  `if node.proximo == null then let novo: Node = Node(v, null)`
+  `node.proximo = ref novo` (o nó novo é uma variável porque `ref` exige
+  L-value; o compilador o promove para a heap). No repositório isso
+  alcançou `noxy_examples/linked_list.nx` (migrado) e os testes
+  `TestReferenceFieldArgumentCanFillNullSlot` /
+  `TestContextualReferenceCallsCanFillNullIndexSlots` (reescritos para a
+  semântica nova). Travessias (`cur != null`, `no.proximo != null`) e o
+  `_append` que já ligava pelo campo (`stack.nx`) não mudam.
+
+- Inalterado, e registrado como pendência: um valor referente **cru** num
+  slot `ref T` — alcançável por `json_loads` com payload compatível e por
+  `campo = T` através de uma base `ref`, que o compilador hoje não rejeita
+  (via base valor é erro "cannot assign T to ref T") — segue sendo
+  embrulhado numa ref para o slot ao ser passado adiante, como antes.
+
+- Testes: `internal/vm/ref_null_forwarding_test.go` (campo, campo via base
+  `ref`, índice, chave ausente de map, guarda do caso não-nulo). Spec §4.2
+  ganha o parágrafo sobre encaminhamento de `ref T` (inclusive `null`) com o
+  `append_node` idiomático.
+
 ### Docs
 
 - README ganha badge de versão no topo (`noxy | 0.9.0`, shields.io estático,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,52 @@
 
 - **O padrão fill-null-slot deixa de existir.** `*node == null` /
   `*node = Node(v, null)` sobre um slot recebido contextualmente preenchia
-  o campo `ref Node` com um `Node` *cru* (`type(no.proximo)` virava
-  `"Node"`, e um `*viz = ...` posterior através dele falhava com "expected
-  reference value, got object"). Agora o `null` chega como ref nula e
-  `*node = ...` é o erro claro `cannot update null reference`. Migração: a
-  função recebe o **pai** e liga pelo campo —
+  o campo `ref Node` com um `Node` *cru* (um `let viz: ref Node = no.proximo`
+  seguido de `*viz = ...` falhava com "expected reference value, got
+  object"). Agora o `null` chega como ref nula e `*node = ...` é o erro
+  claro `cannot update null reference`. Migração: a função recebe o **pai**
+  e liga pelo campo —
   `if node.proximo == null then let novo: Node = Node(v, null)`
   `node.proximo = ref novo` (o nó novo é uma variável porque `ref` exige
-  L-value; o compilador o promove para a heap). No repositório isso
-  alcançou `noxy_examples/linked_list.nx` (migrado) e os testes
+  L-value; o compilador o promove para a heap). Para elemento de
+  `(ref T)[]` e valor de `map[K, ref T]` a regra é a mesma: quem preenche é
+  o dono (`lista[0] = ref novo`, `m["k"] = ref novo`); `*param = ...` sobre
+  o `null` encaminhado é `cannot update null reference` tanto para elemento
+  nulo quanto para chave ausente. No repositório isso alcançou
+  `noxy_examples/linked_list.nx` (migrado) e os testes
   `TestReferenceFieldArgumentCanFillNullSlot` /
   `TestContextualReferenceCallsCanFillNullIndexSlots` (reescritos para a
-  semântica nova). Travessias (`cur != null`, `no.proximo != null`) e o
-  `_append` que já ligava pelo campo (`stack.nx`) não mudam.
+  semântica nova). Travessias (`cur != null`, `no.proximo != null`) não
+  mudam; `bst.nx` trocou `*node == null` por `node == null` (a pergunta
+  certa para um parâmetro `ref` que recebe um campo `ref`; `binary_tree.nx`
+  usa campos `Node` por valor, onde o parâmetro é uma ref para o slot e
+  `*node != null` segue sendo a pergunta certa). O `_append` de
+  `stack.nx`, que grava `Node` cru via base `ref` (lacuna da #50), segue
+  funcionando pelo shim descrito abaixo.
+
+- **Vale para toda posição que recebe a referência contextualmente**, não
+  só argumento de função script: `ref a.campo` explícito, argumento de
+  construtor para campo `ref` (`Node(2, a.proximo)`), `return ref n.campo`,
+  `append(lista, a.campo)` em `(ref T)[]` e o alvo de `json_loads`. Em todas,
+  um `ref T` armazenado como `null` chega como `null` — antes chegava como
+  ref para o slot de origem (em `Node(2, a.proximo)`, por exemplo, o nó novo
+  ficava *apontando para o slot* `a.proximo`, um alias acidental).
+
+- **`json_loads` com alvo `ref T` nulo vindo de campo/índice** (ex.:
+  `json_loads(s, h.child)` com `child: ref any` nulo) passa a devolver
+  `false` sem preencher nada — o alvo chega como `null` e não há slot por
+  trás; `OP_MARK_REF_JSON_DYNAMIC` deixa o `null` passar (antes, sem o
+  passthrough, seria erro de runtime). Antes do encaminhamento o slot era
+  preenchido com o payload cru. Para preencher, passe o **dono**
+  (`json_loads(s, h)` com schema do struct) ou pré-aponte o slot; a decisão
+  definitiva sobre slot `ref T` nulo em `json_loads` fica na #50 (Parte 3).
+
+- **Atenção na migração dentro de laços com `break`** (issue #52,
+  pré-existente): `break` não fecha os upvalues dos locais do corpo do laço,
+  então `let novo: Node = ...; campo = ref novo` seguido de `break` deixa a
+  ref apontando para um slot de pilha reaproveitado. Até a #52, prefira a
+  forma recursiva do `_append`, ou deixe o laço terminar pela condição em
+  vez de `break` quando houver `ref` a um local do corpo.
 
 - Inalterado, e registrado como pendência (issue #50): um valor referente
   **cru** num slot `ref T` — alcançável por `json_loads` com payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,13 @@
   semântica nova). Travessias (`cur != null`, `no.proximo != null`) e o
   `_append` que já ligava pelo campo (`stack.nx`) não mudam.
 
-- Inalterado, e registrado como pendência: um valor referente **cru** num
-  slot `ref T` — alcançável por `json_loads` com payload compatível e por
-  `campo = T` através de uma base `ref`, que o compilador hoje não rejeita
-  (via base valor é erro "cannot assign T to ref T") — segue sendo
-  embrulhado numa ref para o slot ao ser passado adiante, como antes.
+- Inalterado, e registrado como pendência (issue #50): um valor referente
+  **cru** num slot `ref T` — alcançável por `json_loads` com payload
+  compatível e por `campo = T` através de uma base `ref`, que o compilador
+  hoje não rejeita (via base valor é erro "cannot assign T to ref T") —
+  segue sendo embrulhado numa ref para o slot ao ser passado adiante, como
+  antes. A #50 fecha a checagem de campo com base `ref`, decide o
+  `json_loads` e remove esse shim.
 
 - Testes: `internal/vm/ref_null_forwarding_test.go` (campo, campo via base
   `ref`, índice, chave ausente de map, guarda do caso não-nulo). Spec §4.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.9.0](https://img.shields.io/badge/noxy-0.9.0-blue)](CHANGELOG.md)
+[![noxy 0.9.1](https://img.shields.io/badge/noxy-0.9.1-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -76,7 +76,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.9.0
+Noxy REPL v0.9.1
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -542,6 +542,26 @@ This contextual conversion is limited to exact script signatures and public
 native contracts known by the compiler. It never applies at a dynamic
 boundary.
 
+An argument whose static type is already `ref T` — a `ref` variable, a struct
+field, an array element, or a map value declared `ref T` — needs no
+conversion: the stored reference is forwarded as is, **including `null`**,
+exactly as a `ref` variable is (§2.3, rule 2). No reference to the containing
+slot is created, so inside the callee `param == null` is true precisely when
+the stored reference was null, and writing through such a parameter is the
+ordinary null-reference error. To fill an empty `ref` field, the callee
+receives the *owner* and rebinds the field:
+
+```noxy
+func append_node(node: ref Node, valor: int)
+    if node.proximo == null then
+        let novo: Node = Node(valor, null)   // a variable: `ref` needs an L-value
+        node.proximo = ref novo              // REBIND of the owner's field
+    else
+        append_node(node.proximo, valor)     // forwards the stored reference
+    end
+end
+```
+
 Bare `func` is the **dynamic callable type**. It guarantees only that the value is callable:
 
 ```noxy

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -191,7 +191,9 @@ end
 Structs are passed by **VALUE**: the callee's instance is independent at any depth (copy-on-write), including nested composite fields. Use `ref` when the function must modify the caller's original instance.
 
 ---
-### 2.3 The `ref` Operator
+### 2.3 References (`ref`)
+
+#### The `ref` Operator
 
 The `ref` operator produces an explicit first-class reference value according
 to the operand's type:
@@ -230,7 +232,7 @@ let forwarded: ref Error = ref r // OK: forwards the existing ref Error
 let r: ref Error = ref Error("msg") // ERROR: Cannot take reference of temporary value
 ```
 
-### 2.3 Reference Semantics (`ref`)
+#### Reference Semantics
 The `ref` keyword creates references to addressable values or explicitly
 forwards existing reference values. Noxy unifies reference usage through
 **"Automatic Dereference"** and **"Type-Based Assignment"**.
@@ -548,8 +550,12 @@ conversion: the stored reference is forwarded as is, **including `null`**,
 exactly as a `ref` variable is (§2.3, rule 2). No reference to the containing
 slot is created, so inside the callee `param == null` is true precisely when
 the stored reference was null, and writing through such a parameter is the
-ordinary null-reference error. To fill an empty `ref` field, the callee
-receives the *owner* and rebinds the field:
+ordinary null-reference error. The same forwarding applies to every position
+that takes a reference contextually — the explicit form `ref a.field`, a
+constructor argument for a `ref` field (`Node(2, a.next)`), `return ref
+n.field`, `append` into a `(ref T)[]`, and the target of `json_loads`. To
+fill an empty `ref` field, the callee receives the *owner* and rebinds the
+field:
 
 ```noxy
 func append_node(node: ref Node, valor: int)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.9.0"
+const Version = "v0.9.1"

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -520,6 +520,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 		case chunk.OP_MARK_REF_JSON_DYNAMIC:
 			refValue := vm.peek(0)
+			// Alvo `ref any` nulo encaminhado (campo/indice): nao ha ref para
+			// marcar; deixa o null passar, como OP_MARK_REF_TARGET_TYPE —
+			// json_loads devolve false para alvo null.
+			if refValue.Type == value.VAL_NULL {
+				continue
+			}
 			ref, ok := refValue.Obj.(*value.ObjRef)
 			if refValue.Type != value.VAL_REF || !ok || ref == nil {
 				return vm.runtimeError(c, ip, "dynamic target marker requires a reference")

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -459,7 +459,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// Valor referente cru num slot `ref T` (hoje alcancavel por
 			// json_loads com payload compativel e por `campo = T` atraves de
 			// base ref) segue embrulhado numa ref para o slot, para continuar
-			// passavel adiante como antes.
+			// passavel adiante como antes. Shim temporario: sai quando a
+			// issue #50 fechar o invariante "slot ref T contem ref ou null".
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -447,10 +447,19 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if !ok {
 				return vm.runtimeError(c, ip, "undefined property '%s'", name)
 			}
-			if stored.Type == value.VAL_REF {
+			// O tipo estatico do campo ja e `ref T`: uma ref existente ou
+			// null e encaminhado como esta (spec §2.3 regra 2, §4.2) — igual
+			// a uma variavel `ref T`. Antes, null virava ref para o SLOT, o
+			// que tornava `n == null` falso para um campo nulo e deixava
+			// `*n = ...` gravar um T cru num slot tipado `ref T`.
+			if stored.Type == value.VAL_REF || stored.Type == value.VAL_NULL {
 				vm.push(stored)
 				continue
 			}
+			// Valor referente cru num slot `ref T` (hoje alcancavel por
+			// json_loads com payload compativel e por `campo = T` atraves de
+			// base ref) segue embrulhado numa ref para o slot, para continuar
+			// passavel adiante como antes.
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
@@ -482,12 +491,20 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				if err != nil {
 					return vm.runtimeError(c, ip, "%s", err)
 				}
-				stored, _ = mapObj.Get(key)
+				var found bool
+				if stored, found = mapObj.Get(key); !found {
+					// Chave ausente le como null, igual a leitura plana
+					// `m[k]` (o zero de value.Value e VAL_BOOL, nao null).
+					stored = value.NewNull()
+				}
 			} else {
 				return vm.runtimeError(c, ip, "contextual index reference base must be an array or map")
 			}
 
-			if stored.Type == value.VAL_REF {
+			// Elemento/valor de tipo estatico `ref T`: ref existente ou null e
+			// encaminhado como esta; valor referente cru segue embrulhado em
+			// ref para o slot (ver OP_CONTEXT_REF_PROPERTY acima).
+			if stored.Type == value.VAL_REF || stored.Type == value.VAL_NULL {
 				vm.push(stored)
 				continue
 			}

--- a/internal/vm/function_types_test.go
+++ b/internal/vm/function_types_test.go
@@ -112,21 +112,51 @@ test_report(answer)`)
 	testExpectedObject(t, 42, got)
 }
 
-func TestReferenceFieldArgumentCanFillNullSlot(t *testing.T) {
+// Spec §2.3 regra 2 / §4.2: um campo `ref Node` nulo passado a parametro
+// `ref Node` e encaminhado como null (`node == null` dentro da funcao). Para
+// preencher o campo, a funcao recebe o PAI e liga `parent.next = ref novo`
+// — o padrao fill-null-slot (`*node == null` / `*node = Node(...)` sobre um
+// slot recebido contextualmente) deixou de existir.
+func TestReferenceFieldArgumentForwardsNullSlot(t *testing.T) {
 	got := runTypedFunctionProgram(t, `
 struct Node
     value: int
     next: ref Node
 end
-func fill(node: ref Node) -> void
-    if *node == null then
-        *node = Node(42, null)
+func is_null(node: ref Node) -> bool
+    return node == null
+end
+func fill(parent: ref Node) -> void
+    if parent.next == null then
+        let novo: Node = Node(42, null)
+        parent.next = ref novo
     end
 end
 let head: Node = Node(1, null)
-fill(head.next)
-test_report(head.next.value)`)
+let was_null: bool = is_null(head.next)
+fill(head)
+if was_null then
+    test_report(head.next.value)
+else
+    test_report(0)
+end`)
 	testExpectedObject(t, 42, got)
+}
+
+func TestWritingThroughForwardedNullFieldIsRuntimeError(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+struct Node
+    value: int
+    next: ref Node
+end
+func fill(node: ref Node) -> void
+    *node = Node(42, null)
+end
+let head: Node = Node(1, null)
+fill(head.next)`)
+	if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
+		t.Fatalf("error=%v", err)
+	}
 }
 
 func TestExplicitReferenceSurvivesBareFunctionCall(t *testing.T) {

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -511,6 +511,27 @@ end`)
 	testExpectedObject(t, 42, got)
 }
 
+// Alvo `ref any` nulo (campo) chega ao json_loads como null encaminhado: o
+// marcador OP_MARK_REF_JSON_DYNAMIC deixa o null passar (como o marcador de
+// tipo-alvo ja fazia) e o json_loads devolve false — nao ha slot por tras
+// para preencher. Antes do encaminhamento, o slot era preenchido com o
+// payload cru; sem o passthrough, era "dynamic target marker requires a
+// reference" em runtime.
+func TestTypedJSONLoadsIntoNullRefAnyFieldReturnsFalse(t *testing.T) {
+	got := runTypedFunctionProgram(t, `
+struct Holder
+    child: ref any
+end
+let h: Holder = Holder(null)
+let ok: bool = json_loads("{\"a\": 1}", h.child)
+if !ok && h.child == null then
+    test_report(42)
+else
+    test_report(0)
+end`)
+	testExpectedObject(t, 42, got)
+}
+
 func TestTypedJSONLoadsAcceptsCompatibleReferenceElementPayloads(t *testing.T) {
 	t.Run("fill null slot with referent value", func(t *testing.T) {
 		got := runTypedFunctionProgram(t, `
@@ -2598,15 +2619,48 @@ end`,
 }
 
 // Escrever atraves do null encaminhado e o erro claro de ref nula — nao ha
-// slot por tras para preencher.
+// slot por tras para preencher. Vale para elemento null de array, valor null
+// de map e chave ausente de map (que le como null); para preencher, o
+// chamador escreve no dono: `stored[0] = ref novo` / `m["k"] = ref novo`.
 func TestWritingThroughForwardedNullIndexSlotIsRuntimeError(t *testing.T) {
-	err := runTypedFunctionProgramError(t, `
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "array element",
+			source: `
 func fill(target: ref int) -> void
     *target = 42
 end
 let stored: (ref int)[] = [null]
-fill(stored[0])`)
-	if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
-		t.Fatalf("error=%v", err)
+fill(stored[0])`,
+		},
+		{
+			name: "map null value",
+			source: `
+func fill(target: ref int) -> void
+    *target = 42
+end
+let stored: map[string, ref int] = {"answer": null}
+fill(stored["answer"])`,
+		},
+		{
+			name: "map missing key",
+			source: `
+func fill(target: ref int) -> void
+    *target = 42
+end
+let stored: map[string, ref int] = {}
+fill(stored["missing"])`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runTypedFunctionProgramError(t, tt.source)
+			if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
+				t.Fatalf("error=%v", err)
+			}
+		})
 	}
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -2552,7 +2552,12 @@ test_report(42)`)
 	testExpectedObject(t, 42, got)
 }
 
-func TestContextualReferenceCallsCanFillNullIndexSlots(t *testing.T) {
+// Spec §2.3 regra 2 / §4.2: um elemento ou valor de tipo estatico `ref T`
+// que contem null e ENCAMINHADO como null — nao vira ref para o slot. Dentro
+// da funcao `target == null` e verdadeiro, igual a uma variavel `ref T` nula.
+// (Antes, o padrao fill-null-slot preenchia o slot `ref int` com um int cru
+// via `*target = 42`.)
+func TestContextualReferenceCallsForwardNullIndexSlots(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
@@ -2560,26 +2565,28 @@ func TestContextualReferenceCallsCanFillNullIndexSlots(t *testing.T) {
 		{
 			name: "array index",
 			source: `
-func fill(target: ref int) -> void
-    if *target == null then
-        *target = 42
-    end
+func eh_nulo(target: ref int) -> bool
+    return target == null
 end
 let stored: (ref int)[] = [null]
-fill(stored[0])
-test_report(stored[0])`,
+if eh_nulo(stored[0]) then
+    test_report(42)
+else
+    test_report(0)
+end`,
 		},
 		{
 			name: "map index",
 			source: `
-func fill(target: ref int) -> void
-    if *target == null then
-        *target = 42
-    end
+func eh_nulo(target: ref int) -> bool
+    return target == null
 end
 let stored: map[string, ref int] = {"answer": null}
-fill(stored["answer"])
-test_report(stored["answer"])`,
+if eh_nulo(stored["answer"]) then
+    test_report(42)
+else
+    test_report(0)
+end`,
 		},
 	}
 
@@ -2587,5 +2594,19 @@ test_report(stored["answer"])`,
 		t.Run(tt.name, func(t *testing.T) {
 			testExpectedObject(t, 42, runTypedFunctionProgram(t, tt.source))
 		})
+	}
+}
+
+// Escrever atraves do null encaminhado e o erro claro de ref nula — nao ha
+// slot por tras para preencher.
+func TestWritingThroughForwardedNullIndexSlotIsRuntimeError(t *testing.T) {
+	err := runTypedFunctionProgramError(t, `
+func fill(target: ref int) -> void
+    *target = 42
+end
+let stored: (ref int)[] = [null]
+fill(stored[0])`)
+	if err == nil || !strings.Contains(err.Error(), "cannot update null reference") {
+		t.Fatalf("error=%v", err)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -854,18 +854,24 @@ func TestChanRecvOnClosedEmptyChannelDoesNotRelease(t *testing.T) {
 // Task 6 (Step 1): spawn e a excecao onde retain e registro no frame.Owned
 // ficam em pontos separados do codigo (o retain acontece no loop de push,
 // sincrono, antes do goroutine ser lancado; o registro no frame manual da
-// thread e o que causa o release quando aquele frame termina). Como o
-// retain+registro sao sincronos (rodam dentro do proprio native "spawn",
-// antes do "go func(){...}()"), medimos logo apos spawn.Invoke retornar —
-// sem precisar sincronizar com a goroutine para a medida "durante".
+// thread e o que causa o release quando aquele frame termina).
+//
+// A medida "durante" precisa acontecer com a thread ainda viva: o worker
+// bloqueia num gate (canal) ate o teste medir, e so entao e liberado. Sem o
+// gate, um worker de corpo vazio terminava e liberava o Owned antes da
+// primeira leitura (1 falha em ~900 execucoes com -cpu 2,4,8; flake visto
+// no Actions windows-latest, PR #51).
 func TestSpawnRetainsArgSynchronouslyAndReleasesWhenThreadFrameEnds(t *testing.T) {
 	machine := New()
 	if err := interpretVMSource(t, machine, `
+let gate: any = make_chan(1)
 func worker(m: map[string, int])
+    chan_recv(gate)
 end`); err != nil {
 		t.Fatal(err)
 	}
 	workerFn, _ := machine.GetGlobal("worker")
+	gate, _ := machine.GetGlobal("gate")
 	m := value.NewMap()
 	before := value.OwnersCount(m)
 
@@ -873,9 +879,14 @@ end`); err != nil {
 	if _, err := spawn.Invoke(machine, []value.Value{workerFn, m}); err != nil {
 		t.Fatal(err)
 	}
+	// Durante: a thread esta bloqueada em chan_recv(gate), entao o Owned
+	// registrado no frame dela ainda nao foi liberado.
 	if got := value.OwnersCount(m); got != before+1 {
 		t.Fatalf("esperado Owners=%d logo apos spawn (retain sincrono no push), veio %d", before+1, got)
 	}
+
+	// Libera a thread: ela sai do chan_recv, o frame termina e solta o Owned.
+	callBuiltin(t, machine, "chan_send", gate, value.NewInt(1))
 
 	deadline := time.Now().Add(statefulBuiltinTimeout)
 	for time.Now().Before(deadline) {

--- a/internal/vm/ref_null_forwarding_test.go
+++ b/internal/vm/ref_null_forwarding_test.go
@@ -1,0 +1,76 @@
+package vm
+
+// Encaminhamento de `ref T` nulo vindo de campo/indice (spec §2.3 regra 2 e
+// §4.2): um argumento cujo tipo estatico ja e `ref T` nao sofre conversao
+// contextual — o valor armazenado e encaminhado como esta, inclusive `null`.
+// Antes, OP_CONTEXT_REF_PROPERTY/OP_CONTEXT_REF_INDEX fabricavam uma ref
+// para o SLOT quando ele continha null, e `n == null` dentro da funcao dava
+// false (ref valida para um slot que contem null). Variavel local ja
+// encaminhava; campo, indice de array e chave de map nao.
+
+import "testing"
+
+const refNullForwardingPrelude = `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+func eh_nulo(n: ref Node) -> bool
+    return n == null
+end
+`
+
+// Campo `ref Node` contendo null passado a parametro `ref Node`.
+func TestNullRefFieldForwardsNullToRefParameter(t *testing.T) {
+	requireBoolResults(t, refNullForwardingPrelude+`
+let a: Node = Node(1, null)
+test_report([eh_nulo(a.proximo)])`, []bool{true})
+}
+
+// O mesmo campo, acessado atraves de uma base que e ela propria `ref Node`
+// (o caso do append recursivo: `_append(node.proximo, v)` com `node: ref`).
+// Antes: "contextual property reference base must be an instance".
+func TestNullRefFieldThroughRefBaseForwardsNull(t *testing.T) {
+	requireBoolResults(t, refNullForwardingPrelude+`
+func via_ref(node: ref Node) -> bool
+    return eh_nulo(node.proximo)
+end
+let a: Node = Node(1, null)
+test_report([via_ref(a)])`, []bool{true})
+}
+
+// Elemento null de `(ref Node)[]`.
+func TestNullRefArrayElementForwardsNullToRefParameter(t *testing.T) {
+	requireBoolResults(t, refNullForwardingPrelude+`
+let arr: (ref Node)[] = [null]
+test_report([eh_nulo(arr[0])])`, []bool{true})
+}
+
+// Chave ausente em `map[string, ref Node]`: a leitura plana `m["x"]` da
+// null, e o encaminhamento tem de dar o mesmo null.
+func TestMissingMapKeyOfRefValueForwardsNullToRefParameter(t *testing.T) {
+	requireBoolResults(t, refNullForwardingPrelude+`
+let m: map[string, ref Node] = {}
+let lido: ref Node = m["x"]
+test_report([lido == null, eh_nulo(m["x"])])`, []bool{true, true})
+}
+
+// Guarda de regressao: campo/indice com ref NAO-nula continua encaminhando
+// a ref existente (identidade preservada: escrever atraves do parametro
+// altera o no original).
+func TestNonNullRefFieldStillForwardsExistingReference(t *testing.T) {
+	requireBoolResults(t, refNullForwardingPrelude+`
+func marca(n: ref Node)
+    n.valor = 99
+end
+let b: Node = Node(2, null)
+let a: Node = Node(1, ref b)
+let arr: (ref Node)[] = [ref b]
+marca(a.proximo)
+let via_campo: bool = b.valor == 99
+b.valor = 2
+marca(arr[0])
+let via_indice: bool = b.valor == 99
+test_report([eh_nulo(a.proximo), eh_nulo(arr[0]), via_campo, via_indice])`,
+		[]bool{false, false, true, true})
+}

--- a/internal/vm/ref_null_forwarding_test.go
+++ b/internal/vm/ref_null_forwarding_test.go
@@ -29,7 +29,10 @@ test_report([eh_nulo(a.proximo)])`, []bool{true})
 
 // O mesmo campo, acessado atraves de uma base que e ela propria `ref Node`
 // (o caso do append recursivo: `_append(node.proximo, v)` com `node: ref`).
-// Antes: "contextual property reference base must be an instance".
+// Antes: `n == null` dava false (ref para o slot); na recursao seguinte, com
+// essa ref-para-slot como base e o slot contendo null, o deref da base dava
+// null e o opcode morria com "contextual property reference base must be an
+// instance".
 func TestNullRefFieldThroughRefBaseForwardsNull(t *testing.T) {
 	requireBoolResults(t, refNullForwardingPrelude+`
 func via_ref(node: ref Node) -> bool

--- a/noxy_examples/bst.nx
+++ b/noxy_examples/bst.nx
@@ -28,7 +28,7 @@ end
 
 // Busca um valor na árvore
 func search(node: ref TreeNode, valor: int) -> bool
-    if *node == null then
+    if node == null then
         return false
     end
     if node.valor == valor then
@@ -43,7 +43,7 @@ end
 
 // Travessia In-Order (esquerda, raiz, direita) - imprime em ordem crescente
 func inorder(node: ref TreeNode)
-    if *node == null then
+    if node == null then
         return
     end
     inorder(node.esquerda)
@@ -53,7 +53,7 @@ end
 
 // Encontra o valor mínimo da árvore
 func find_min(node: ref TreeNode) -> int
-    if *node == null then
+    if node == null then
         return -1
     end
     let current: ref TreeNode = node
@@ -65,7 +65,7 @@ end
 
 // Encontra o valor máximo da árvore
 func find_max(node: ref TreeNode) -> int
-    if *node == null then
+    if node == null then
         return -1
     end
     let current: ref TreeNode = node
@@ -77,7 +77,7 @@ end
 
 // Conta o número de nós na árvore
 func count_nodes(node: ref TreeNode) -> int
-    if *node == null then
+    if node == null then
         return 0
     end
     return 1 + count_nodes(node.esquerda) + count_nodes(node.direita)
@@ -85,7 +85,7 @@ end
 
 // Calcula a altura da árvore
 func height(node: ref TreeNode) -> int
-    if *node == null then
+    if node == null then
         return 0
     end
     let left_height: int = height(node.esquerda)

--- a/noxy_examples/linked_list.nx
+++ b/noxy_examples/linked_list.nx
@@ -4,10 +4,13 @@ struct Node
 end
 
 func _append(node: ref Node, valor: int)
-    // '*node == null' pergunta se o SLOT apontado esta vazio (padrao
-    // fill-null-slot); 'node == null' perguntaria sobre o proprio ref.
-    if *node == null then
-        *node = Node(valor, null)
+    // Quem liga o no novo e o ULTIMO no existente, escrevendo no proprio
+    // campo 'proximo'. O no novo precisa ser uma variavel (L-value) para
+    // virar 'ref novo'. Um campo 'ref' nulo passado adiante chega como ref
+    // nula ('node == null'), nao como "slot vazio para preencher".
+    if node.proximo == null then
+        let novo: Node = Node(valor, null)
+        node.proximo = ref novo
     else
         _append(node.proximo, valor)
     end


### PR DESCRIPTION
## Summary
- `OP_CONTEXT_REF_PROPERTY`/`OP_CONTEXT_REF_INDEX`: campo de struct, elemento de `(ref T)[]` e valor de `map[K, ref T]` cujo tipo estático já é `ref T`, passados a parâmetro `ref T`, encaminham o valor armazenado como está — **inclusive `null`** (spec §2.3 regra 2 / §4.2), igual ao que uma variável `ref T` já fazia. Antes, slot com `null` virava uma ref fabricada para o próprio slot: dentro da função `n == null` era `false`, e um `_append` recursivo por `_append(node.proximo, v)` morria com "contextual property reference base must be an instance".
- Chave ausente em `map[K, ref T]` encaminha `null`, igual à leitura plana `m[k]` (o zero-value de `value.Value` é `VAL_BOOL`, por isso `NewNull()` explícito).
- **BREAKING — fim do padrão fill-null-slot**: `*node == null` / `*node = Node(...)` sobre um slot recebido contextualmente gravava um `Node` cru no campo `ref Node` (um `let viz: ref Node = no.proximo` seguido de `*viz = ...` falhava com "expected reference value, got object"; `type(ref viz)` cai no erro do marcador em vez de devolver `"ref"`). Agora o `null` chega como ref nula e `*node = ...` é `cannot update null reference`. Migração: a função recebe o **pai** e liga pelo campo — `let novo: Node = Node(v, null)` + `node.proximo = ref novo`.
- Valor referente **cru** num slot `ref T` (`json_loads` com payload compatível; `campo = T` via base `ref`, que o compilador não rejeita) segue embrulhado em ref-para-o-slot ao ser passado adiante — shim temporário, comentado, até a #50.
- Spec §4.2 ganha o parágrafo sobre encaminhamento de `ref T` (inclusive `null`) com o `append_node` idiomático; CHANGELOG `[0.9.1]` com entry **Changed (BREAKING)**, migração, o que não muda e a pendência.
- **Revisão externa aplicada:** (1) `json_loads` com alvo `ref any` nulo vindo de campo não morre mais em `OP_MARK_REF_JSON_DYNAMIC` ("dynamic target marker requires a reference") — o marcador deixa o `null` passar e `json_loads` devolve `false`; (2/3) CHANGELOG registra que o encaminhamento vale para toda posição contextual (`ref a.campo`, construtor, `return ref`, `append`, alvo de `json_loads`) e a mudança de comportamento do `json_loads` com alvo `ref T` nulo; (4) teste de escrita através do `null` encaminhado cobre array, valor nulo de map e chave ausente, com a migração (`m["k"] = ref novo`); (5) issue #52 (`break` não fecha upvalues — atinge o padrão `let novo` + `ref novo` em laços) aberta e referenciada na migração; (7) `bst.nx` usa `node == null` (campos `ref`; `binary_tree.nx` mantido — campos por valor, `*node != null` é a pergunta certa); (9) comentário do teste `via_ref` corrigido; (10) heading `### 2.3` duplicado na spec virou `### 2.3 References` com `####` internos; evidência `type(campo)` trocada por `let viz: ref T = campo; type(ref viz)` (o `type()` auto-dereferencia e não distingue ref de valor cru).

## Components
- `internal/vm/executor.go` — os dois opcodes contextuais: forward de `VAL_REF`/`VAL_NULL`; `NewNull()` para chave ausente de map; shim para valor cru com comentário apontando para #50.
- `internal/vm/ref_null_forwarding_test.go` (novo) — campo, campo via base `ref` (o caso do `_append`), índice de `(ref Node)[]`, chave ausente de `map[string, ref Node]`, e guarda de regressão do caso não-nulo (identidade preservada ao escrever pelo parâmetro).
- `internal/vm/function_types_test.go` — `TestReferenceFieldArgumentCanFillNullSlot` → `TestReferenceFieldArgumentForwardsNullSlot` + `TestWritingThroughForwardedNullFieldIsRuntimeError`.
- `internal/vm/native_signatures_test.go` — `TestContextualReferenceCallsCanFillNullIndexSlots` → `TestContextualReferenceCallsForwardNullIndexSlots` + `TestWritingThroughForwardedNullIndexSlotIsRuntimeError`.
- `noxy_examples/linked_list.nx` — `_append` migrado para a forma idiomática (liga pelo campo do pai); comentário atualizado.
- `docs/NOXY_LANGUAGE_SPEC.md` §4.2; `CHANGELOG.md` `[0.9.1] - 2026-08-20`.
- `internal/vm/rc_uniqueness_test.go` — `TestSpawnRetainsArgSynchronouslyAndReleasesWhenThreadFrameEnds` mede "durante" com o worker bloqueado num gate (`make_chan`/`chan_recv`) em vez de supor timing (flake no Actions windows-latest; test-only).
- `internal/version/version.go` → `v0.9.1`; `README.md` badge e banner do REPL → `0.9.1`.

## Related Issues
- Follow-up: #50 — checagem de campo pulada com base `ref` (`string` em campo `int`, `Node` cru em `ref Node`), `json_loads` com referente cru e remoção do shim. **Não** é fechada por este PR.

## Test Plan
- [x] TDD: os 5 testes de `ref_null_forwarding_test.go` vistos falhando antes do fix (`esperava true, veio false`) e passando depois; os 2 testes antigos do fill-null-slot reescritos para a semântica nova
- [x] `go test ./...` verde (`internal/vm` ~42s)
- [x] `go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx` — 171/171
- [x] Diff de saída main×branch de todos os 171 exemplos não-interativos: 151 idênticos; os 20 diferentes são apenas tempo, ordem de iteração de map, `argv[0]`, timestamp, endereços e random
- [x] Reproduções: `f(a.proximo)` com campo nulo → `n == null` true (campo, índice, chave ausente, via base `ref`); algoritmo original com `*node = ...` → `cannot update null reference` (antes: "base must be an instance"); `_append` idiomático imprime 10…100; `bst.nx`, `binary_tree.nx`, `stack.nx`, `test_explicit_deref.nx` com saída idêntica
- [x] Bump de versão: **v0.9.1** (`version.go`, CHANGELOG `[0.9.1] - 2026-08-20`, badge e banner do README) — patch por decisão de release; o próximo BREAKING (#50) leva o 0.10.0
- [x] Teste flaky `TestSpawnRetainsArgSynchronouslyAndReleasesWhenThreadFrameEnds` (CI windows) tornado determinístico com gate por canal — 2.400 execuções locais sem falha; `sqlite_demo.nx` no job de exemplos é flake pré-existente (três exemplos compartilham `loja.db` em paralelo, sem `busy_timeout`), fora do escopo
- [x] Revisão externa: item 1 reproduzido (`rev_item1.nx` → "dynamic target marker requires a reference" no branch; `ok = true` + slot preenchido cru na main), teste `TestTypedJSONLoadsIntoNullRefAnyFieldReturnsFalse` visto RED antes do passthrough e GREEN depois; itens 3 e 5 reproduzidos no binário (4 posições encaminham `null`; `break` + `ref novo` → "only instances/maps have properties", controle sem `break` → 101); `bst.nx` com saída idêntica à main após `node == null`; `binary_tree.nx` quebrava com a mesma troca (campos por valor) e foi mantido; `go test ./internal/vm ./internal/compiler` e runner 171/171 verdes após todas as edições
- [ ] Revisar a remoção do padrão fill-null-slot (era intencional: comentário em `linked_list.nx`, dois testes nomeados como feature, entry do CHANGELOG 0.7.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
