### PR TITLE
fix/container-owners - Contêineres de natives/plugins são donos dos filhos: slice, sqlite.query, task_await, io, strings (#55)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,13 @@ case chunk.OP_NEW_OPCODE:
 2. Registre em `defineNatives()`
 3. Valide argumentos
 4. Documente na spec
+5. **Contêineres devolvidos são donos dos filhos**: construa com `value.NewArray`,
+   `value.NewMapWithData` ou `value.NewInstanceWith(def, fields)` — eles retêm cada
+   filho composto (array/map/instância; no-op em escalares/strings). Nunca escreva
+   um composto em `inst.Fields[...]`/`ObjMap.Set` cru sem `value.Retain`. Só use
+   `value.NewArrayAdopting` para elementos que **você** já reteve em nome do array,
+   com comentário `// RC: move` (sites atuais: `OP_ARRAY`, `copyValue`, merge de
+   `causes` do `call_result`).
 
 ```go
 func (vm *VM) builtinNewFunc(args []value.Value) (value.Value, error) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.10.1] - 2026-08-20
+
+### Fixed — contêineres criados por natives/plugins são donos dos filhos (issue #55)
+
+- **`slice`, `sqlite.query` (`columns`, `rows[i].values`), `task_await` (`value`,
+  `error`), `io.read_lines` (`data`), `strings.split` (`parts`) e plugins
+  (`InterfaceToValue`) devolviam contêineres que não eram donos dos filhos
+  compostos**: a cópia por valor (`let s: Pair[] = slice(t, 0, 2); s[0].a = 9`)
+  mutava o original (`t[0].a` lia 9). Regra do runtime — *todo contêiner é dono
+  durável de cada filho composto* — já valia no bytecode (`OP_ARRAY`/`OP_MAP`/
+  construtor de struct) e passa a valer nos natives: `value.NewArray`/
+  `NewMapWithData` retêm cada filho composto, `NewInstanceWith` constrói
+  instâncias retendo os campos. Os sites que já entregavam filhos retidos
+  (`OP_ARRAY`, clone CoW, merge de `causes` do `call_result`) usam
+  `NewArrayAdopting`; o retain manual do envelope `ok` do `call_result` saiu
+  (o construtor registra a posse). Efeito visível: código que dependia do
+  aliasing acidental passa a ver a cópia independente (e um clone CoW na
+  primeira escrita ao filho ainda compartilhado). Sem mudança de API Noxy.
+- Fase A da #54; itens 1b/1c/1d da #53.
+
 ## [0.10.0] - 2026-08-20
 
 ### Changed (BREAKING) — invariante do slot `ref T`: checagem de campo vale através de base `ref`, `json_loads` cria célula, fim do shim (issue #50)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.10.0](https://img.shields.io/badge/noxy-0.10.0-blue)](CHANGELOG.md)
+[![noxy 0.10.1](https://img.shields.io/badge/noxy-0.10.1-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -76,7 +76,7 @@ go run ./cmd/noxy/main.go program.nx
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.10.0
+Noxy REPL v0.10.1
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/superpowers/plans/2026-08-20-container-owners.md
+++ b/docs/superpowers/plans/2026-08-20-container-owners.md
@@ -1034,3 +1034,25 @@ Expected: vazio.
 - **Cobertura do spec:** §1 construtores → Tasks 1-2; §2 três moves → Task 1 (+ o quarto move implícito, `invokeBoundaryCall`, → Task 2 — não listado na issue, descoberto na leitura: sem ele `r.value` ficaria com 2 donos); §3 remover paliativos → Task 3; §4 `NewInstanceWith` → Task 4; reproduções → Tasks 2 e 4; critérios de aceite: `Owners` unitários (T1/T2), sem double-retain (T2 sondas + `TestCallResultCauseAlias*`), cópia não vaza (T2/T4), `CloneCountValue` (T5), grep (T3/T7), suíte/vet/runner/diff (T7), CHANGELOG+AGENTS (T6), comentários #53/#54 (T8).
 - **Fora de escopo respeitado:** nenhum opcode novo, `ObjMap.Set/Replace` intactos, laços de retain do `json_population.go` intactos, `NewMap()`/`NewInstance()` intactos, builders só-escalares não migrados.
 - **Consistência de nomes:** `NewArrayAdopting(elements []Value)`, `NewInstanceWith(def *ObjStruct, fields map[string]Value)`, `vmWithOwnersProbe`, `probe_owners`, `clones_now`, `test_reset_clones` — iguais em todas as tasks.
+
+---
+
+## Registro da execução (2026-08-20)
+
+**Branch:** `fix/container-owners` (worktree `.claude/worktrees/fix+container-owners`, base `1680266` = `origin/develop` = `origin/main`). **Commits:** `ecb835b` plano+spec → `6d915e8` Task 1 → `58f2cad` Tasks 2+3 (commit único, sem janela de double-retain) → `a1c5e20` Task 4 → `7269cc6` Task 5 → `7ee4d4e` Task 6 (v0.10.1) → `cc0366f` ajustes da revisão → (este) registro.
+
+**Desvios do planejado (todos para melhor):**
+- Tasks 2 e 3 foram fundidas num commit, como a nota do plano recomendava.
+- Task 6 tocou também `README.md` (badge e banner do REPL), espelhando o bump anterior (`c55c39d`).
+- Revisão de código (Task 7 passo 6, subagente independente, 9,5 min): **sem Critical**; Important (1) asserção de `Owners == 1` dos herdados e do irmão em `TestFailureMapMergesInnerCausesWithSiblingsOnPromotion` — única lacuna do critério "Owners dos herdados inalterado" (feito em `cc0366f`); Important (2) evidência do runner/diff (abaixo); Minor: comentário obsoleto em `builtins_call_result_test.go:461-469` (reescrito), bloco de comentário órfão em `builtins_call_result.go` (virou doc de `callResultFailureEnvelope`), nota na spec da #50 §5.3 sobre `retainingArray/Map` (adicionada). O revisor varreu os ~40 call sites dos construtores e todos os `value.Retain(` não-teste e confirmou: nenhum double-retain, nenhuma escrita crua de composto remanescente, `invokeBoundaryCall` exatamente compensado, release symmetry preservada (`pop`/`delete`/`OP_SET_*`).
+
+**TDD — falhas observadas antes de cada mudança (valores previstos no plano):** Task 1 `undefined: NewArrayAdopting/NewInstanceWith`; Task 2 `Owners=0, esperado 1` (value e plugin), `copyValue` pré-condição `Owners=0`, slice `"9|9"`, task_await `"99|99|hacked|hacked"`; Task 4 sqlite `"ZZZ|ZZZ|999|999"`, io/strings `"ZZZ|ZZZ"`; Task 5 passou de primeira com `"0|1|1|0"`. Guardas `TestArrayLiteralElementHasExactlyOneOwner` e `TestCallResultOkValueHasExactlyOneOwner` passam antes e depois (protegem contra double-retain futuro).
+
+**Verificação (Task 7):**
+- `go vet ./...` limpo; gofmt dos arquivos tocados limpo (checado com CRLF normalizado — `gofmt -l` lista todo o checkout Windows, é ruído).
+- `go test ./...` completo, sem `| tail`: 9 pacotes `ok` (`internal/vm` 56 s).
+- `grep -rn "retainingArray\|retainingMap" internal` vazio.
+- Runner `noxy_examples/run_all_tests_concurrent.nx` no worktree: **171/171** (17 s).
+- Diff de saída dos exemplos (script `capture_examples.py`: `go run ./cmd/noxy` por exemplo, exclusões do runner, 171 exemplos em cada árvore, 0 com exit ≠ 0 nas duas): **24 arquivos diferem, todos por não-determinismo ou ambiente** — caminho do binário `go run`/cwd (`cli_example`, `test_basic_import`, `test_sys`), tempos (`fibonacci`, `quicksort_in_place`, `stress_test_json`, `time_demo`), ordem de map (`json_map_test`, `json_test`, `multiline_test`, `test_for_loop`, `json_analogy_test`), rand/uuid/salt (`password_generator`, `rand_demo`, `uuid_demo`, `test_crypto_aes`, `test_crypto_debug` — este já imprime FAIL com exit 0 nas duas árvores, #53 item 4), endereços (`test_addr_struct`, `test_addr_trust`), porta efêmera (`test_http_server`). Dois exigiram verificação: `read_passwords.nx` ("Found 2 passwords" → "Error executing query") é porque `passwords.db` (gitignored) só existe no checkout principal — copiado para o worktree, a saída ficou **idêntica** (o exemplo lê `res.rows[i].values[j]` do envelope novo); `dynamodb_*`/`test_dynamodb_plugin` ("Plugin Load Error: command not found: noxy-plugin-dynamodb") é o binário do plugin presente só no ambiente do checkout principal — e no baseline esses exemplos já terminam em erro 400 da AWS. Nenhuma diferença de valor atribuível à mudança.
+
+**Pendências (Task 8, ações externas — aguardam confirmação do usuário):** push da branch, PR (`fix/container-owners - …`, base `develop`, label `not available to review`, corpo no template Summary/Components/Test Plan), comentários em #53 (itens 1b/1c/1d fechados) e #54 (fase A feita).

--- a/docs/superpowers/plans/2026-08-20-container-owners.md
+++ b/docs/superpowers/plans/2026-08-20-container-owners.md
@@ -1,0 +1,1036 @@
+# Construtores de contêiner retêm filhos (issue #55) — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Os construtores de contêiner de `internal/value` (`NewArray`, `NewMapWithData`, novo `NewInstanceWith`) passam a reter cada filho composto por padrão — a mesma regra que `OP_ARRAY`/`OP_MAP`/construtor de struct já aplicam no bytecode — fechando os vazamentos de semântica de valor em `slice`, `sqlite.query`, `task_await`, `io.read_lines`, `strings.split` e plugins.
+
+**Architecture:** Regra do runtime: *todo contêiner é dono durável de cada filho composto que guarda*. Hoje o bytecode cumpre e os natives esquecem; em vez de consertar ~30 call sites um a um, o retain entra nos construtores (`value.Retain` é no-op em escalares/strings, então é seguro para todos os sites sem allowlist — inclusive `internal/plugin`, que não tem `*VM`). Os quatro lugares que já entregam filhos retidos ("moves") usam `NewArrayAdopting` (OP_ARRAY, `copyValue`, merge de `causes`) ou deixam de reter à mão (`invokeBoundaryCall` → envelope `ok` do `call_result`). Builders que escrevem compostos em campos de instância crua migram para `NewInstanceWith`. Nada de opcode novo, nada em `ObjMap.Set/Replace`, nada em `json_loads` (#53 item 1).
+
+**Tech Stack:** Go 1.x (`go test`, `go vet`, `gofmt`), VM Noxy (`internal/vm`, `internal/value`), runner de exemplos `noxy_examples/run_all_tests_concurrent.nx`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-container-owners-design.md` (cópia literal da issue #55; a issue é a fonte de verdade).
+
+## Global Constraints
+
+- Escopo fechado da issue: **não** tocar em `NewMap()`/`NewInstance(def)` (vazios), `ObjMap.Set/Replace/Delete`, `ObjArray.Elements`, `ObjInstance.Fields`, opcodes (além da troca por `NewArrayAdopting` em `OP_ARRAY`), `json_loads` (#53 item 1), nem converter `NewMap()+Replace`/`NewInstance()+escrita` em outros builders. Builders com campos só escalares ficam como estão — diff mínimo.
+- Os laços `for … { value.Retain(created) }` de `internal/vm/json_population.go` que antecedem `mapObject.Replace(...)`/`instance.Fields[...] =` **continuam** (constroem via `NewMap()`/`NewInstance()`, fora deste PR). Só os usos de `retainingArray`/`retainingMap` mudam.
+- Suíte verde a cada commit: `go test ./internal/value ./internal/vm` (mín.) antes de cada commit; `go test ./...` **sem `| tail`** na verificação final.
+- Programas Noxy embutidos em testes Go vivem em raw string com crase: **nunca** use `` ` `` dentro de comentários Noxy do programa (quebra o arquivo Go). Use `//` com aspas simples.
+- Não editar fontes Go enquanto um `go test`/captura roda em background (memória: ~12 exemplos registraram o erro de compilação do meio da edição).
+- Comandos de shell simples (o harness recusa compostos com `cd`+git no worktree); binários Noxy ad hoc via `go run ./cmd/noxy arquivo.nx` (CrowdStrike apaga .exe frescos).
+- Repositório com `autocrlf`: arquivos novos via Write tool; conferir `git diff --numstat` (sem reescrita de arquivo inteiro).
+- Mensagens de commit no padrão do repo (`feat(vm): …`, `fix(vm): …`, `test(vm): …`, `chore(version): …`, `docs(plan): …`), em português, terminando com `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+## Mapa de arquivos
+
+| Arquivo | Responsabilidade nesta entrega |
+|---|---|
+| `internal/value/value.go` | `NewArray` retém; `NewArrayAdopting` (novo, não retém); `NewMapWithData` retém; `NewInstanceWith` (novo, retém) |
+| `internal/value/constructors_test.go` (novo) | testes unitários de `Owners` dos 4 construtores |
+| `internal/vm/executor.go:1292-1302` | `OP_ARRAY` → `NewArrayAdopting` (move) |
+| `internal/vm/calls.go:168-182` | `copyValue` array → `NewArrayAdopting` (move) |
+| `internal/vm/builtins_call_result.go` | `causes` merge → `NewArrayAdopting`; `invokeBoundaryCall` deixa de reter `result`; `retainingArray/Map` apagados; comentários RC atualizados |
+| `internal/vm/builtins_json.go:186,192`, `internal/vm/json_population.go:334,480` | `retainingArray/Map` → `value.NewArray`/`value.NewMapWithData` |
+| `internal/vm/builtins_sqlite.go:340-351,437-445` | `row`/`result`/`sqliteQueryError` via `NewInstanceWith` |
+| `internal/vm/builtins_io.go:384-390` | `newIOReadResult` via `NewInstanceWith` |
+| `internal/vm/builtins_strings.go:229-238` | `strings_split` via `NewInstanceWith` |
+| `internal/vm/container_owners_test.go` (novo) | sondas `Owners` (literal, `copyValue`, `call_result`), reproduções (slice, task_await, sqlite, io, strings), não-regressão de clones |
+| `internal/vm/cow_test.go:20-28` | remover o `value.Retain(inner)` manual (agora `NewArray` retém) e atualizar comentário |
+| `internal/plugin/plugin_test.go` (novo) | `InterfaceToValue` aninhado → filhos com `Owners == 1` |
+| `CHANGELOG.md`, `AGENTS.md` (§E), `internal/version/version.go` | entrada `### Fixed`, regra para builtins, `v0.10.1` |
+
+---
+
+### Task 1: `NewArrayAdopting` + `NewInstanceWith` em `internal/value`; migrar os 3 moves de array para `NewArrayAdopting`
+
+Sem mudança de comportamento ainda: `NewArray` continua sem reter, `NewArrayAdopting` é idêntico a ele hoje. Esta task só prepara o terreno para que a Task 2 (retain no construtor) não gere double-retain nos moves.
+
+**Files:**
+- Modify: `internal/value/value.go:618-644`
+- Create: `internal/value/constructors_test.go`
+- Modify: `internal/vm/executor.go:1296-1302`
+- Modify: `internal/vm/calls.go:175-182`
+- Modify: `internal/vm/builtins_call_result.go:338-358`
+
+**Interfaces:**
+- Produces: `func NewArrayAdopting(elements []Value) Value` (não retém), `func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value` (retém cada campo composto; `fields == nil` vira map vazio).
+
+- [ ] **Step 1: Escrever os testes unitários (falham: funções não existem)**
+
+Criar `internal/value/constructors_test.go`:
+
+```go
+package value
+
+import "testing"
+
+// Os construtores de contêiner são a única fronteira pela qual natives e
+// plugins criam arrays/maps/instâncias; a regra do runtime — "todo contêiner
+// é dono durável de cada filho composto" — é aplicada aqui para valer para
+// todos os ~30 call sites sem allowlist (Retain em escalar/string é no-op).
+
+func structForTest(fields ...string) *ObjStruct {
+	return NewStruct("Envelope", fields).Obj.(*ObjStruct)
+}
+
+func TestNewArrayAdoptingKeepsOwnersAsReceived(t *testing.T) {
+	child := NewArray(nil)
+	Retain(child) // o chamador já reteve em nome do array (move)
+	adopted := NewArrayAdopting([]Value{child, NewInt(7)})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("NewArrayAdopting nao pode reter de novo: Owners=%d, esperado 1", got)
+	}
+	if got := OwnersCount(adopted); got != 0 {
+		t.Fatalf("o array novo nasce sem dono: Owners=%d", got)
+	}
+	if adopted.Obj.(*ObjArray).Elements[0].Obj != child.Obj {
+		t.Fatal("NewArrayAdopting deve guardar o mesmo objeto filho")
+	}
+}
+
+func TestNewInstanceWithRetainsCompositeFields(t *testing.T) {
+	definition := structForTest("data", "ok", "meta")
+	data := NewArray(nil)
+	meta := NewMap()
+	instance := NewInstanceWith(definition, map[string]Value{
+		"data": data,
+		"ok":   NewBool(true),
+		"meta": meta,
+	})
+	if got := OwnersCount(data); got != 1 {
+		t.Fatalf("campo array deve ter a instancia como dono: Owners=%d", got)
+	}
+	if got := OwnersCount(meta); got != 1 {
+		t.Fatalf("campo map deve ter a instancia como dono: Owners=%d", got)
+	}
+	object := instance.Obj.(*ObjInstance)
+	if object.Struct != definition {
+		t.Fatal("NewInstanceWith deve apontar para a definicao recebida")
+	}
+	if object.Fields["data"].Obj != data.Obj || !object.Fields["ok"].AsBool {
+		t.Fatal("NewInstanceWith deve guardar os campos recebidos")
+	}
+	if got := OwnersCount(instance); got != 0 {
+		t.Fatalf("a instancia nova nasce sem dono: Owners=%d", got)
+	}
+}
+
+func TestNewInstanceWithNilFieldsIsWritable(t *testing.T) {
+	instance := NewInstanceWith(structForTest("x"), nil)
+	instance.Obj.(*ObjInstance).Fields["x"] = NewInt(1) // nao pode entrar em panico (map nil)
+}
+```
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `go test ./internal/value -run 'TestNewArrayAdopting|TestNewInstanceWith' 2>&1 | head -20`
+Expected: erro de compilação `undefined: NewArrayAdopting` / `undefined: NewInstanceWith`.
+
+- [ ] **Step 3: Implementar em `internal/value/value.go`**
+
+Substituir o bloco `NewArray` … `NewInstance` (linhas 618-644) por:
+
+```go
+// NewArray cria um array a partir dos elementos dados. A partir da Task 2
+// deste plano ele e DONO DURAVEL de cada elemento composto (Retain; no-op em
+// escalares e strings) — a mesma regra de OP_ARRAY no executor. Quem ja
+// reteve os elementos em nome do array usa NewArrayAdopting.
+func NewArray(elements []Value) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+
+// NewArrayAdopting cria um array ADOTANDO elementos que o chamador JA reteve
+// em nome do array (move): nao retem de novo. Uso restrito aos sites que
+// transferem posse — OP_ARRAY (executor.go), copyValue (calls.go) e o merge
+// de causes do call_result (builtins_call_result.go); qualquer outro uso
+// precisa de comentario `// RC: move` explicando quem reteve.
+func NewArrayAdopting(elements []Value) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+
+func NewMap() Value {
+	mapping := &ObjMap{store: newBindingStore(nil)}
+	mapping.ensureStore()
+	return Value{Type: VAL_OBJ, Obj: mapping}
+}
+
+func NewMapWithData(data map[string]Value) Value {
+	values := make(map[interface{}]Value, len(data))
+	for k, v := range data {
+		values[k] = v
+	}
+	mapping := NewMap()
+	mapping.Obj.(*ObjMap).Replace(values)
+	return mapping
+}
+
+func NewStruct(name string, fields []string) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjStruct{Name: name, Fields: fields}}
+}
+
+// NewInstance cria uma instancia vazia; quem escreve compostos em Fields
+// depois precisa reter a mao (como calls.go:callPreparedValue faz) ou usar
+// NewInstanceWith.
+func NewInstance(def *ObjStruct) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
+}
+
+// NewInstanceWith cria uma instancia ja com os campos dados, retendo cada
+// valor composto — a mesma regra do construtor de struct em bytecode
+// (calls.go:callPreparedValue, "campo e dono duravel"). Escalares e strings
+// sao no-op em Retain. O map recebido passa a pertencer a instancia.
+func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value {
+	if fields == nil {
+		fields = make(map[string]Value)
+	}
+	for _, field := range fields {
+		Retain(field)
+	}
+	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: fields}}
+}
+```
+
+(`NewArray`/`NewMapWithData` ficam com o corpo de hoje nesta task; o retain entra na Task 2.)
+
+- [ ] **Step 4: Rodar os testes de `internal/value`**
+
+Run: `go test ./internal/value`
+Expected: `ok`.
+
+- [ ] **Step 5: Migrar os três moves de array para `NewArrayAdopting`**
+
+`internal/vm/executor.go` (OP_ARRAY, ~l.1296-1302):
+
+```go
+			elements := make([]value.Value, count)
+			for i := count - 1; i >= 0; i-- {
+				elements[i] = vm.pop()
+				// RC: elemento pode continuar referenciado pela origem
+				value.Retain(elements[i]) // elemento e dono duravel
+			}
+			// RC: move — os elementos ja foram retidos acima em nome do array.
+			vm.push(value.NewArrayAdopting(elements))
+```
+
+`internal/vm/calls.go` (`copyValue`, caso `*value.ObjArray`, ~l.175-182):
+
+```go
+		newElems := make([]value.Value, len(obj.Elements))
+		copy(newElems, obj.Elements)
+		for _, el := range newElems {
+			value.Retain(el) // RC: filho ganha dono duravel no clone
+		}
+		// RC: move — filhos retidos acima em nome do clone.
+		copied := value.NewArrayAdopting(newElems)
+		copied.Obj.(*value.ObjArray).RuntimeType.Store(obj.RuntimeType.Load())
+		return copied
+```
+
+`internal/vm/builtins_call_result.go` (`deferredFailureMap`, ~l.353):
+
+```go
+		// RC: move — os herdados transferem o retain do array antigo, os
+		// irmaos novos foram retidos no laco acima; NewArrayAdopting nao
+		// retem de novo (um dono a mais que ninguem solta deixaria o
+		// composto IsShared para sempre).
+		replacement := value.NewArrayAdopting(causes)
+		value.Retain(replacement)
+		mapping.Set("causes", replacement)
+```
+
+- [ ] **Step 6: Rodar `internal/vm` inteiro (comportamento idêntico a hoje)**
+
+Run: `go test ./internal/value ./internal/vm`
+Expected: `ok` nos dois (≈65 s no vm).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/value/value.go internal/value/constructors_test.go internal/vm/executor.go internal/vm/calls.go internal/vm/builtins_call_result.go
+git commit -m "feat(value): NewArrayAdopting (move) e NewInstanceWith (retém campos); OP_ARRAY, copyValue e merge de causes adotam elementos já retidos (#55 passo 1-2)"
+```
+
+---
+
+### Task 2: `NewArray`/`NewMapWithData` retêm filhos compostos; `invokeBoundaryCall` deixa de reter `result`; reproduções de `slice`, `task_await` e plugin
+
+Esta é a mudança de comportamento. Com os moves já adotantes (Task 1), o único lugar que ainda reteria em dobro é o envelope `ok` do `call_result`: `invokeBoundaryCall` (`builtins_call_result.go:143-162`) retém `result` **em nome do envelope** porque `NewMapWithData` não retinha. Agora o construtor retém, então esse retain manual sai (a regra única: quem registra a posse é o construtor).
+
+**Files:**
+- Modify: `internal/value/value.go` (`NewArray`, `NewMapWithData`)
+- Modify: `internal/value/constructors_test.go`
+- Modify: `internal/vm/builtins_call_result.go:139-162,241-251`
+- Modify: `internal/vm/cow_test.go:20-28`
+- Create: `internal/vm/container_owners_test.go`
+- Create: `internal/plugin/plugin_test.go`
+
+**Interfaces:**
+- Consumes: `value.NewArrayAdopting`, `value.OwnersCount`, `markProbeReadonly` (`rc_uniqueness_test.go:22`), `captureVMSource` (`vm_test_helpers_test.go:56`), `interpretVMSource`.
+- Produces: helper de teste `vmWithOwnersProbe(t) (*VM, *int32)` em `container_owners_test.go` (native `probe_owners(x)` grava `value.OwnersCount(x)`), reutilizado nas Tasks 4-5.
+
+- [ ] **Step 1: Testes unitários dos construtores (falham)**
+
+Acrescentar a `internal/value/constructors_test.go`:
+
+```go
+func TestNewArrayRetainsCompositeElementsOnly(t *testing.T) {
+	child := NewArray(nil)
+	grand := NewMap()
+	array := NewArray([]Value{child, NewInt(1), NewString("s"), grand})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("array deve ser dono duravel do elemento composto: Owners=%d, esperado 1", got)
+	}
+	if got := OwnersCount(grand); got != 1 {
+		t.Fatalf("map filho deve ter o array como dono: Owners=%d", got)
+	}
+	if got := OwnersCount(array); got != 0 {
+		t.Fatalf("o proprio array nasce sem dono: Owners=%d", got)
+	}
+	elements := array.Obj.(*ObjArray).Elements
+	if OwnersCount(elements[1]) != -1 || OwnersCount(elements[2]) != -1 {
+		t.Fatal("escalares e strings nao tem contador (Retain e no-op)")
+	}
+	if OwnersCount(NewArray(nil)) != 0 || len(NewArray(nil).Obj.(*ObjArray).Elements) != 0 {
+		t.Fatal("NewArray(nil) continua valendo como array vazio")
+	}
+}
+
+func TestNewMapWithDataRetainsCompositeValues(t *testing.T) {
+	child := NewArray(nil)
+	mapping := NewMapWithData(map[string]Value{"rows": child, "count": NewInt(2)})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("map deve ser dono duravel do valor composto: Owners=%d, esperado 1", got)
+	}
+	stored, ok := mapping.Obj.(*ObjMap).Get("rows")
+	if !ok || stored.Obj != child.Obj {
+		t.Fatal("NewMapWithData deve guardar o mesmo objeto filho")
+	}
+	if got := OwnersCount(mapping); got != 0 {
+		t.Fatalf("o proprio map nasce sem dono: Owners=%d", got)
+	}
+}
+```
+
+- [ ] **Step 2: Testes de VM — sondas e reproduções (falham)**
+
+Criar `internal/vm/container_owners_test.go`:
+
+```go
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Sondas e reproducoes da issue #55: contêineres criados por natives passam
+// a ser donos duraveis dos filhos compostos (value.NewArray/NewMapWithData/
+// NewInstanceWith retem), com NewArrayAdopting nos moves para nao reter em
+// dobro. Os programas Noxy abaixo falhavam no develop 1680266 (a copia por
+// valor mutava o original).
+
+// vmWithOwnersProbe registra o native de teste probe_owners(x), que grava
+// value.OwnersCount(x) sem reter o argumento (ReadonlyArgs, como as sondas
+// de rc_uniqueness_test.go).
+func vmWithOwnersProbe(t *testing.T) (*VM, *int32) {
+	t.Helper()
+	machine := New()
+	observed := int32(-99)
+	machine.DefineNative("probe_owners", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			observed = value.OwnersCount(args[0])
+		}
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_owners")
+	return machine, &observed
+}
+
+// Literal de array: OP_ARRAY retem e entrega ao construtor adotante — o
+// elemento tem exatamente UM dono (o array). Um NewArray que retivesse de
+// novo deixaria 2 e todo elemento de literal nasceria "compartilhado".
+func TestArrayLiteralElementHasExactlyOneOwner(t *testing.T) {
+	machine, observed := vmWithOwnersProbe(t)
+	src := `
+struct Pair
+    a: int
+    b: int
+end
+let t: Pair[] = [Pair(1, 1)]
+probe_owners(t[0])
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if *observed != 1 {
+		t.Fatalf("elemento de literal deve ter Owners=1 (sem double-retain em OP_ARRAY), veio %d", *observed)
+	}
+}
+
+// copyValue (clone CoW raso): o array novo ganha posse dos filhos — cada
+// filho passa a ter 2 donos (original + clone), nem 1 nem 3.
+func TestCopyValueCloneGivesChildrenASecondOwner(t *testing.T) {
+	machine := New()
+	inner := value.NewArray(nil)
+	outer := value.NewArray([]value.Value{inner}) // NewArray retem: inner Owners=1
+	if got := value.OwnersCount(inner); got != 1 {
+		t.Fatalf("pre-condicao: Owners=%d, esperado 1", got)
+	}
+	clone := machine.copyValue(outer)
+	if got := value.OwnersCount(inner); got != 2 {
+		t.Fatalf("apos copyValue o filho deve ter 2 donos (original + clone), veio %d", got)
+	}
+	if clone.Obj.(*value.ObjArray).Elements[0].Obj != inner.Obj {
+		t.Fatal("clone raso deve compartilhar o filho (mesmo ponteiro)")
+	}
+}
+
+// Envelope ok do call_result: a posse de r.value pelo envelope e registrada
+// UMA vez (pelo NewMapWithData em callResultOkEnvelope); o retain manual de
+// invokeBoundaryCall saiu. Owners=2 aqui significaria valor eternamente
+// IsShared (clone a cada mutacao).
+func TestCallResultOkValueHasExactlyOneOwner(t *testing.T) {
+	machine, observed := vmWithOwnersProbe(t)
+	src := `
+func faz_array() -> int[]
+    return [1, 2, 3]
+end
+let r: any = call_result(faz_array)
+probe_owners(r["value"])
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if *observed != 1 {
+		t.Fatalf("r.value deve ter o envelope como unico dono (Owners=1), veio %d", *observed)
+	}
+}
+
+// slice (builtins_collections.go): a copia e dona dos elementos que leva;
+// mutar a copia nao pode alcancar o original.
+func TestSliceCopyDoesNotAliasOriginal(t *testing.T) {
+	reported := captureVMSource(t, `
+struct Pair
+    a: int
+    b: int
+end
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let s: Pair[] = slice(t, 0, 2)
+s[0].a = 9
+test_report(to_str(t[0].a) + "|" + to_str(s[0].a))
+`)
+	if text, _ := reported.Obj.(string); text != "0|9" {
+		t.Fatalf("slice deve copiar por valor (original intacto): %q, esperado \"0|9\"", text)
+	}
+}
+
+// task_await (builtins_tasks.go): o envelope e dono de value e de error.
+func TestTaskAwaitEnvelopeOwnsValueAndError(t *testing.T) {
+	reported := captureVMSource(t, `
+func mk() -> int[]
+    return [1, 2, 3]
+end
+func boom() -> int
+    let xs: int[] = [1]
+    return xs[5]
+end
+let t1: any = spawn_task(mk)
+let r1: any = task_await(t1)
+let v: any = r1["value"]
+v[0] = 99
+let rv: any = r1["value"]
+let t2: any = spawn_task(boom)
+let r2: any = task_await(t2)
+let e: any = r2["error"]
+e["kind"] = "hacked"
+let re: any = r2["error"]
+test_report(to_str(rv[0]) + "|" + to_str(v[0]) + "|" + re["kind"] + "|" + e["kind"])
+`)
+	if text, _ := reported.Obj.(string); text != "1|99|runtime|hacked" {
+		t.Fatalf("envelope de task_await deve ficar intacto (CoW na copia): %q", text)
+	}
+}
+```
+
+Criar `internal/plugin/plugin_test.go`:
+
+```go
+package plugin
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// InterfaceToValue constroi via value.NewArray/NewMapWithData: o contêiner e
+// dono duravel de cada filho composto sem que o plugin precise de *VM.
+func TestInterfaceToValueContainersOwnNestedChildren(t *testing.T) {
+	converted := InterfaceToValue([]interface{}{
+		map[string]interface{}{"itens": []interface{}{1.0, 2.0}},
+		"texto",
+	})
+	outer, ok := converted.Obj.(*value.ObjArray)
+	if !ok || len(outer.Elements) != 2 {
+		t.Fatalf("esperado array de 2 elementos, veio %#v", converted)
+	}
+	nested := outer.Elements[0]
+	if got := value.OwnersCount(nested); got != 1 {
+		t.Fatalf("map aninhado deve ter o array como unico dono: Owners=%d", got)
+	}
+	items, found := nested.Obj.(*value.ObjMap).Get("itens")
+	if !found {
+		t.Fatal("map aninhado deve conter a chave itens")
+	}
+	if got := value.OwnersCount(items); got != 1 {
+		t.Fatalf("array aninhado deve ter o map como unico dono: Owners=%d", got)
+	}
+	if got := value.OwnersCount(outer.Elements[1]); got != -1 {
+		t.Fatalf("string nao tem contador: Owners=%d", got)
+	}
+	if got := value.OwnersCount(converted); got != 0 {
+		t.Fatalf("o contêiner raiz nasce sem dono: Owners=%d", got)
+	}
+}
+```
+
+- [ ] **Step 3: Rodar e confirmar as falhas**
+
+Run: `go test ./internal/value -run 'TestNewArrayRetains|TestNewMapWithData'`
+Expected: FAIL (`Owners=0, esperado 1`).
+
+Run: `go test ./internal/vm -run 'TestArrayLiteralElement|TestCopyValueClone|TestCallResultOkValue|TestSliceCopy|TestTaskAwaitEnvelope'`
+Expected: `TestSliceCopy` FAIL (`"9|9"`), `TestTaskAwaitEnvelope` FAIL (`"99|99|hacked|hacked"`), `TestCopyValueClone` FAIL na pré-condição (`Owners=0`); `TestArrayLiteralElement` e `TestCallResultOkValue` PASS (são guardas contra double-retain — passam antes e depois).
+
+Run: `go test ./internal/plugin`
+Expected: FAIL (`Owners=0`).
+
+- [ ] **Step 4: Implementar o retain nos construtores**
+
+Em `internal/value/value.go`:
+
+```go
+// NewArray cria um array que e DONO DURAVEL de cada elemento composto
+// (Retain; no-op em escalares e strings) — a mesma regra de OP_ARRAY no
+// executor. Quem ja reteve os elementos em nome do array usa NewArrayAdopting.
+func NewArray(elements []Value) Value {
+	for _, element := range elements {
+		Retain(element)
+	}
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+```
+
+```go
+// NewMapWithData cria um map que e DONO DURAVEL de cada valor composto
+// (Retain; no-op em escalares e strings) — a mesma regra de OP_MAP.
+func NewMapWithData(data map[string]Value) Value {
+	values := make(map[interface{}]Value, len(data))
+	for k, v := range data {
+		Retain(v)
+		values[k] = v
+	}
+	mapping := NewMap()
+	mapping.Obj.(*ObjMap).Replace(values)
+	return mapping
+}
+```
+
+Apagar, no comentário de `NewArray` da Task 1, a frase "A partir da Task 2 deste plano".
+
+- [ ] **Step 5: Remover o retain manual de `invokeBoundaryCall` e atualizar comentários**
+
+`internal/vm/builtins_call_result.go`, l.139-162, passa a:
+
+```go
+	if vm.frameCount > ownerFrameCount {
+		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
+			return value.NewNull(), runErr
+		}
+		// RC: a posse de `result` pelo envelope ok e registrada pelo
+		// construtor (value.NewMapWithData retem em callResultOkEnvelope);
+		// reter aqui tambem deixaria r.value com 2 donos e IsShared para
+		// sempre. Ver TestCallResultOkValueHasExactlyOneOwner.
+		return result, nil
+	}
+	// native/construtor: sem frame novo; resultado no topo da pilha.
+	result = vm.peek(0)
+	return result, nil
+}
+```
+
+E o comentário de `callResultOkEnvelope` (l.241-244) vira:
+
+```go
+// callResultOkEnvelope: NewMapWithData retem `result` (unico campo
+// composto) — e isso, e so isso, que da ao envelope a posse de r.value.
+// Sem esse dono, uma composta devolvida fresca (Owners=0) chegaria a
+// Owners=1 no primeiro `let` do lado Noxy, IsShared ficaria falso e a
+// mutacao nesse binding vazaria para r.value (TestCallResultValueSemantics
+// lia "100|100|3" em vez de "1|100|3").
+func callResultOkEnvelope(result value.Value) value.Value {
+```
+
+- [ ] **Step 6: Ajustar `internal/vm/cow_test.go:20-28`**
+
+O teste retinha `inner` à mão porque `NewArray` não retinha. Substituir:
+
+```go
+	inner := value.NewArray([]value.Value{value.NewInt(1)})
+	outer := value.NewArray([]value.Value{inner})
+	// inner é elemento durável de outer — o OP_ARRAY real teria retido
+	// (Task 5); aqui o array foi montado fora do bytecode, então contamos à
+	// mão para que o clone raso de outer o leve de 1 para 2 donos.
+	value.Retain(inner)
+```
+
+por:
+
+```go
+	inner := value.NewArray([]value.Value{value.NewInt(1)})
+	outer := value.NewArray([]value.Value{inner}) // NewArray retém: inner tem outer como dono (1)
+```
+
+(o resto do teste continua válido: o clone raso leva `inner` a 2 donos → `IsShared`).
+
+- [ ] **Step 7: Rodar os testes-alvo e as suítes**
+
+Run: `go test ./internal/value ./internal/plugin`
+Expected: `ok` nos dois.
+
+Run: `go test ./internal/vm`
+Expected: `ok` — em particular `TestCallResultValueSemantics` (`"1|100|3"`), `TestCallResultCauseAlias*`, `TestCallResultFailureAlias*`, `TestShareByOwnersAndUnicize`, toda a `rc_uniqueness_test.go` e `value_semantics_test.go`. Se algum teste de RC antigo medir `Owners` absoluto de um filho construído por `value.NewArray` em Go, o oráculo dele sobe em 1 — **ler o teste antes de ajustar** e registrar no commit o porquê (é a nova posse real, não acomodação).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/value/value.go internal/value/constructors_test.go internal/vm/builtins_call_result.go internal/vm/cow_test.go internal/vm/container_owners_test.go internal/plugin/plugin_test.go
+git commit -m "fix(value): NewArray/NewMapWithData são donos duráveis dos filhos compostos — fecha slice, task_await e plugins; invokeBoundaryCall deixa de reter result (#55 passo 1)"
+```
+
+---
+
+### Task 3: Remover `retainingArray`/`retainingMap`
+
+Com `NewArray`/`NewMapWithData` retendo, os helpers de `builtins_call_result.go:215-239` viram double-retain (Task 2 os deixou errados por um commit? **Não**: `retainingArray` = Retain + NewArray(que agora retém) = 2 donos — por isso esta task vem imediatamente a seguir; se quiser zero janela, fundir com a Task 2 no mesmo commit).
+
+> Nota ao executor: para evitar a janela de double-retain entre os commits 2 e 3, **execute a Task 3 antes de rodar a suíte da Task 2 Step 7** e faça um commit único com as duas, OU aceite a janela (os testes `TestCallResultFailureAlias*` continuam verdes com 2 donos — só ficariam "eternamente shared"). Recomendado: commit único (Tasks 2+3), mensagem da Task 2 acrescida de "; retainingArray/Map removidos".
+
+**Files:**
+- Modify: `internal/vm/builtins_call_result.go:215-239,253-258,266-273,302-307`
+- Modify: `internal/vm/builtins_json.go:186,192`
+- Modify: `internal/vm/json_population.go:334,480`
+
+- [ ] **Step 1: Apagar os helpers e o comentário-bloco (l.215-239) de `builtins_call_result.go`** e trocar os usos:
+
+```go
+func callResultFailureEnvelope(err error) value.Value {
+	return value.NewMapWithData(map[string]value.Value{
+		"ok":      value.NewBool(false),
+		"value":   value.NewNull(),
+		"failure": failureMap(err),
+	})
+}
+```
+
+```go
+	if panicErr, ok := err.(*boundaryPanicError); ok {
+		return value.NewMapWithData(map[string]value.Value{
+			"kind":    value.NewString("panic"),
+			"message": value.NewString(panicErr.payload),
+			"stack":   value.NewString(panicErr.stack),
+			"causes":  value.NewArray([]value.Value{}),
+		})
+	}
+```
+
+```go
+	return value.NewMapWithData(map[string]value.Value{
+		"kind":    value.NewString("runtime"),
+		"message": value.NewString(message),
+		"stack":   value.NewString(deepestRuntimeStack(primary)),
+		"causes":  value.NewArray(causes),
+	})
+```
+
+No lugar do comentário-bloco apagado, deixar uma nota curta acima de `callResultFailureEnvelope`:
+
+```go
+// A arvore de Failure e construida com value.NewMapWithData/NewArray, que
+// retem cada filho composto (o pai e dono duravel — mesma regra de
+// OP_MAP/OP_ARRAY). Sem esse dono o primeiro `let f: any = r.failure` do
+// lado Noxy levaria o filho a Owners=1, IsShared falso, e a mutacao
+// reescreveria o envelope (TestCallResultFailureAliasDoesNotMutateEnvelope,
+// TestCallResultCauseAliasDoesNotMutateEnvelope).
+```
+
+- [ ] **Step 2: `builtins_json.go:186,192`**
+
+```go
+		return value.NewArray(arr) // RC: o array e dono duravel de cada elemento (construtor retem)
+```
+```go
+		return value.NewMapWithData(m) // RC: o map e dono duravel de cada valor (construtor retem)
+```
+
+- [ ] **Step 3: `json_population.go:334,480`**
+
+```go
+		array := value.NewArray(elements) // RC: o array e dono duravel de cada elemento (construtor retem; espelha OP_ARRAY)
+```
+```go
+		return value.NewArray(elements), true // RC: o array e dono duravel de cada elemento (construtor retem)
+```
+
+- [ ] **Step 4: Verificar que não sobrou referência**
+
+Run: `grep -rn "retainingArray\|retainingMap" internal`
+Expected: saída vazia.
+
+- [ ] **Step 5: Suíte**
+
+Run: `go test ./internal/vm`
+Expected: `ok` (testes de RC de `json_loads`/`json_parse` da #50 e de `call_result` verdes).
+
+- [ ] **Step 6: Commit** (ou fundido com a Task 2)
+
+```bash
+git add internal/vm/builtins_call_result.go internal/vm/builtins_json.go internal/vm/json_population.go
+git commit -m "refactor(vm): retainingArray/retainingMap removidos — o construtor já retém (#55 passo 3)"
+```
+
+---
+
+### Task 4: `NewInstanceWith` nos envelopes `sqlite.query`, `io.read_lines`, `strings.split`
+
+Estes builders escrevem arrays em campos de instância crua (`inst.Fields["x"] = value.NewArray(...)`) sem retain — a instância não é dona do array.
+
+**Files:**
+- Modify: `internal/vm/builtins_sqlite.go:340-351,437-445`
+- Modify: `internal/vm/builtins_io.go:384-390`
+- Modify: `internal/vm/builtins_strings.go:229-238`
+- Modify: `internal/vm/container_owners_test.go`
+
+- [ ] **Step 1: Testes (falham)**
+
+Acrescentar a `internal/vm/container_owners_test.go` (imports extras: `"os"`, `"path/filepath"`, `"strconv"`):
+
+```go
+// sqlite.query (builtins_sqlite.go): QueryResult e dono de columns e rows;
+// cada Row e dona de values.
+func TestSQLiteQueryEnvelopeOwnsColumnsAndRowValues(t *testing.T) {
+	reported := captureVMSource(t, `
+use sqlite
+let db: sqlite.Database = sqlite.open(":memory:")
+sqlite.exec(db, "CREATE TABLE t (id INTEGER, nome TEXT)")
+sqlite.exec(db, "INSERT INTO t VALUES (1, 'a')")
+let res: sqlite.QueryResult = sqlite.query(db, "SELECT * FROM t")
+let cols: string[] = res.columns
+cols[0] = "ZZZ"
+let vals: any[] = res.rows[0].values
+vals[0] = 999
+sqlite.close(db)
+test_report(res.columns[0] + "|" + cols[0] + "|" + to_str(res.rows[0].values[0]) + "|" + to_str(vals[0]))
+`)
+	if text, _ := reported.Obj.(string); text != "id|ZZZ|1|999" {
+		t.Fatalf("envelope de sqlite.query deve ficar intacto (CoW nas copias): %q", text)
+	}
+}
+
+// io.read_lines (builtins_io.go): IOLinesResult e dono de data.
+func TestIOReadLinesEnvelopeOwnsData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "linhas.txt")
+	if err := os.WriteFile(path, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reported := captureVMSource(t, "use io\nlet f: io.File = io.open("+strconv.Quote(path)+", \"r\")\n"+
+		"let r: io.IOLinesResult = io.read_lines(f)\nio.close(f)\n"+
+		"let d: string[] = r.data\nd[0] = \"ZZZ\"\n"+
+		"test_report(r.data[0] + \"|\" + d[0])\n")
+	if text, _ := reported.Obj.(string); text != "a|ZZZ" {
+		t.Fatalf("envelope de io.read_lines deve ficar intacto (CoW na copia): %q", text)
+	}
+}
+
+// strings.split (builtins_strings.go): SplitResult e dono de parts.
+func TestStringsSplitEnvelopeOwnsParts(t *testing.T) {
+	reported := captureVMSource(t, `
+use strings
+let r: strings.SplitResult = strings.split("a,b", ",")
+let p: string[] = r.parts
+p[0] = "ZZZ"
+test_report(r.parts[0] + "|" + p[0])
+`)
+	if text, _ := reported.Obj.(string); text != "a|ZZZ" {
+		t.Fatalf("envelope de strings.split deve ficar intacto (CoW na copia): %q", text)
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e confirmar as falhas**
+
+Run: `go test ./internal/vm -run 'TestSQLiteQueryEnvelope|TestIOReadLinesEnvelope|TestStringsSplitEnvelope'`
+Expected: 3× FAIL com a cópia vazando (`"ZZZ|ZZZ|999|999"`, `"ZZZ|ZZZ"`, `"ZZZ|ZZZ"`). Se a forma da API estiver errada (ex.: modo de `io.open`, nome de tipo), o erro será de compilação/runtime do programa — ajustar o programa, não a asserção.
+
+- [ ] **Step 3: Implementar**
+
+`internal/vm/builtins_sqlite.go` (~l.340-351):
+
+```go
+			// RC: NewInstanceWith retem values — a Row e dona duravel do array.
+			row := value.NewInstanceWith(rowTemplate.Struct, map[string]value.Value{
+				"values": value.NewArray(values),
+			})
+			rowValues = append(rowValues, row)
+		}
+
+		// RC: NewInstanceWith retem columns e rows (compostos); os escalares sao no-op.
+		return value.NewInstanceWith(resultTemplate.Struct, map[string]value.Value{
+			"columns":   value.NewArray(columnValues),
+			"rows":      value.NewArray(rowValues),
+			"row_count": value.NewInt(int64(len(rowValues))),
+			"ok":        value.NewBool(true),
+			"error":     value.NewString(""),
+		}), nil
+```
+
+`sqliteQueryError` (~l.437-445):
+
+```go
+func sqliteQueryError(definition *value.ObjStruct, errorText string) value.Value {
+	// RC: NewInstanceWith retem os arrays vazios (campos compostos).
+	return value.NewInstanceWith(definition, map[string]value.Value{
+		"columns":   value.NewArray(nil),
+		"rows":      value.NewArray(nil),
+		"row_count": value.NewInt(0),
+		"ok":        value.NewBool(false),
+		"error":     value.NewString(errorText),
+	})
+}
+```
+
+`internal/vm/builtins_io.go:384-390`:
+
+```go
+func newIOReadResult(definition *value.ObjStruct, ok bool, data value.Value, errorText string) value.Value {
+	// RC: NewInstanceWith retem data quando composto (array de read_lines);
+	// string/bytes sao no-op.
+	return value.NewInstanceWith(definition, map[string]value.Value{
+		"ok":    value.NewBool(ok),
+		"data":  data,
+		"error": value.NewString(errorText),
+	})
+}
+```
+
+`internal/vm/builtins_strings.go:229-238`:
+
+```go
+		partValues := make([]value.Value, len(parts))
+		for i, p := range parts {
+			partValues[i] = value.NewString(p)
+		}
+		// RC: NewInstanceWith retem parts — SplitResult e dono duravel do array.
+		return value.NewInstanceWith(structDef, map[string]value.Value{
+			"count": value.NewInt(int64(len(parts))),
+			"parts": value.NewArray(partValues),
+		}), nil
+```
+
+(`sqliteExecError`, `sqlite` open/exec, `io` open/close/write, `json_dumps_result`, `sys`, `time` têm campos só escalares — **não migrar**.)
+
+- [ ] **Step 4: Rodar**
+
+Run: `go test ./internal/vm -run 'TestSQLiteQueryEnvelope|TestIOReadLinesEnvelope|TestStringsSplitEnvelope|SQLite|IO|Strings'`
+Expected: PASS.
+
+Run: `go test ./internal/vm`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/vm/builtins_sqlite.go internal/vm/builtins_io.go internal/vm/builtins_strings.go internal/vm/container_owners_test.go
+git commit -m "fix(vm): envelopes de sqlite.query, io.read_lines e strings.split são donos dos arrays (NewInstanceWith) (#55 passo 4)"
+```
+
+---
+
+### Task 5: Não-regressão de clones (`CloneCountValue`)
+
+Critério de aceite: mutar um contêiner com dono único vindo desses natives não clona; a única clonagem nova é a CoW correta quando o filho é de fato compartilhado (ex.: elemento de `slice` ainda presente no original).
+
+**Files:**
+- Modify: `internal/vm/container_owners_test.go`
+
+**Interfaces:**
+- Consumes: `vmWithCloneReset()` (`value_semantics_test.go:244`, native `test_reset_clones`), `CloneCountValue()`, `ResetCloneCount()`.
+
+- [ ] **Step 1: Teste**
+
+```go
+// Nao introduzimos clone desnecessario: r.parts tem dono unico (a instancia)
+// e muta in-place; s[0] e compartilhado com t (slice retem) e clona UMA vez
+// — a segunda escrita ja e in-place. Oraculo: "0|1|1|0".
+func TestNativeContainersDoNotCloneWithSingleOwner(t *testing.T) {
+	machine := vmWithCloneReset()
+	machine.DefineNative("clones_now", func(args []value.Value) value.Value {
+		return value.NewInt(CloneCountValue())
+	})
+	var reported value.Value
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+use strings
+struct Pair
+    a: int
+    b: int
+end
+let r: strings.SplitResult = strings.split("a,b", ",")
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let s: Pair[] = slice(t, 0, 2)
+test_reset_clones()
+r.parts[0] = "x"
+let c1: int = clones_now()
+s[0].a = 9
+let c2: int = clones_now()
+s[0].b = 8
+let c3: int = clones_now()
+test_report(to_str(c1) + "|" + to_str(c2) + "|" + to_str(c3) + "|" + to_str(t[0].a))
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if text, _ := reported.Obj.(string); text != "0|1|1|0" {
+		t.Fatalf("clones (parts in-place | 1 clone do Pair compartilhado | sem clone extra | original intacto): %q", text)
+	}
+}
+```
+
+- [ ] **Step 2: Rodar**
+
+Run: `go test ./internal/vm -run TestNativeContainersDoNotCloneWithSingleOwner -v`
+Expected: PASS com `"0|1|1|0"`. Se vier `"0|1|2|0"`, há clone a mais na segunda escrita — investigar antes de ajustar o oráculo (provável retain a mais na escrita de volta em `s[0]`). Se vier `"1|…"`, `r.parts` está IsShared indevidamente (double-retain em `NewInstanceWith`+`NewArray`? — `NewArray` retém os *elementos*, não o array; `NewInstanceWith` retém o array: isso dá 1 dono, correto).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/vm/container_owners_test.go
+git commit -m "test(vm): contêineres de natives com dono único não clonam; slice clona o Pair compartilhado uma vez (#55 critério de aceite)"
+```
+
+---
+
+### Task 6: CHANGELOG, AGENTS.md (§E) e versão `v0.10.1`
+
+**Files:**
+- Modify: `CHANGELOG.md:1-3`
+- Modify: `AGENTS.md:103-123`
+- Modify: `internal/version/version.go:3`
+
+- [ ] **Step 1: CHANGELOG** — inserir acima de `## [0.10.0] - 2026-08-20`:
+
+```markdown
+## [0.10.1] - 2026-08-20
+
+### Fixed — contêineres criados por natives/plugins são donos dos filhos (issue #55)
+
+- **`slice`, `sqlite.query` (`columns`, `rows[i].values`), `task_await` (`value`,
+  `error`), `io.read_lines` (`data`), `strings.split` (`parts`) e plugins
+  (`InterfaceToValue`) devolviam contêineres que não eram donos dos filhos
+  compostos**: a cópia por valor (`let s: Pair[] = slice(t, 0, 2); s[0].a = 9`)
+  mutava o original (`t[0].a` lia 9). Regra do runtime — *todo contêiner é dono
+  durável de cada filho composto* — já valia no bytecode (`OP_ARRAY`/`OP_MAP`/
+  construtor de struct) e passa a valer nos natives: `value.NewArray`/
+  `NewMapWithData` retêm cada filho composto, `NewInstanceWith` constrói
+  instâncias retendo os campos. Os sites que já entregavam filhos retidos
+  (`OP_ARRAY`, clone CoW, merge de `causes` do `call_result`) usam
+  `NewArrayAdopting`; o retain manual do envelope `ok` do `call_result` saiu
+  (o construtor registra a posse). Efeito visível: código que dependia do
+  aliasing acidental passa a ver a cópia independente (e um clone CoW na
+  primeira escrita ao filho ainda compartilhado). Sem mudança de API Noxy.
+- Fase A da #54; itens 1b/1c/1d da #53.
+```
+
+- [ ] **Step 2: AGENTS.md §E "Adicionar Função Builtin"** — acrescentar após o item 4 da lista (antes do bloco de código):
+
+```markdown
+5. **Contêineres devolvidos são donos dos filhos**: construa com `value.NewArray`,
+   `value.NewMapWithData` ou `value.NewInstanceWith(def, fields)` — eles retêm cada
+   filho composto (array/map/instância; no-op em escalares/strings). Nunca escreva
+   um composto em `inst.Fields[...]`/`ObjMap.Set` cru sem `value.Retain`. Só use
+   `value.NewArrayAdopting` para elementos que **você** já reteve em nome do array,
+   com comentário `// RC: move` (sites atuais: `OP_ARRAY`, `copyValue`, merge de
+   `causes` do `call_result`).
+```
+
+- [ ] **Step 3: versão** — `internal/version/version.go`: `const Version = "v0.10.1"`.
+
+- [ ] **Step 4: Conferir que nada mais cita a versão antiga como atual**
+
+Run: `grep -rn "v0.10.0\|0\.10\.0" --include=*.go --include=*.md --include=*.nx . | grep -v CHANGELOG | grep -v docs/superpowers | head`
+Expected: nada além de referências históricas (se `README.md` ou `noxy.mod` citarem a versão corrente, atualizar do mesmo jeito que o commit `c55c39d` fez — `git show c55c39d --stat` mostra os arquivos tocados no bump anterior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md AGENTS.md internal/version/version.go
+git commit -m "chore(version): noxy v0.10.1 — contêineres de natives/plugins são donos dos filhos (slice, sqlite.query, task_await, io, strings); CHANGELOG e AGENTS §E"
+```
+
+---
+
+### Task 7: Verificação final (critérios de aceite da issue)
+
+- [ ] **Step 1: formatação e vet**
+
+Run: `gofmt -l internal/value internal/vm internal/plugin`
+Expected: vazio (se listar `rc_uniqueness_test.go`, é o gofmt pré-existente da #53 item 3 — não tocar; qualquer outro arquivo listado deve ser formatado).
+
+Run: `go vet ./...`
+Expected: sem saída.
+
+- [ ] **Step 2: suíte completa sem `| tail`**
+
+Run (background, saída para o scratchpad): `go test ./... > <scratchpad>/final_test.log 2>&1`
+Expected: `ok` em todos os pacotes com testes; conferir com `grep -v "no test files" <scratchpad>/final_test.log`.
+
+- [ ] **Step 3: runner dos exemplos**
+
+Run: `go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx > <scratchpad>/runner_after.log 2>&1`
+Expected: `171/171` (ou o total atual do runner) passando; comparar com o mesmo comando rodado no checkout `develop` (`D:\OneDrive\Documentos\go_projects\noxy`, `1680266`).
+
+- [ ] **Step 4: diff de saída dos exemplos contra o `develop`**
+
+Escrever no scratchpad `capture_examples.py` que, para cada `noxy_examples/*.nx` fora da lista de exclusão do runner (ler `run_all_tests_concurrent.nx` para a lista: interativos/rede/longos), executa `go run ./cmd/noxy <arquivo>` com timeout de 60 s e grava stdout+stderr em `<out_dir>/<nome>.txt`; rodar uma vez com cwd no checkout `develop` (`out_dir=before`) e uma vez no worktree (`out_dir=after`), com a árvore **parada** (sem edição concorrente); depois `diff -r before after`.
+Expected: só diferenças de não-determinismo (ordem de map, timestamps, rand/uuid, endereços de memória, cwd/nome do binário, rede). Qualquer diferença de valor é regressão — investigar.
+
+- [ ] **Step 5: grep dos helpers removidos**
+
+Run: `grep -rn "retainingArray\|retainingMap" internal`
+Expected: vazio.
+
+- [ ] **Step 6: revisão de código** (skill `superpowers:requesting-code-review`) sobre `git diff develop...HEAD`, com foco em: double-retain nos moves, retain esquecido em algum builder que escreve composto cru, comentários RC obsoletos, testes com oráculo acomodado.
+
+---
+
+### Task 8: Entrega
+
+- [ ] **Step 1: Registrar execução no plano** (seção "Registro da execução" no fim deste arquivo: o que mudou em relação ao planejado, achados da revisão, tempos) e commitar: `docs(plan): registro da execução da #55`.
+- [ ] **Step 2: Texto do PR** no template do usuário (Summary / Components / Test Plan com checkboxes), título `fix/container-owners - Contêineres de natives/plugins são donos dos filhos (#55)`, base `develop`, label `not available to review` (convenção em memória `noxy-pr-conventions`) — **push e abertura do PR só com confirmação do usuário** (ação externa).
+- [ ] **Step 3: Comentários nas issues** #53 (itens 1b/1c/1d fechados aqui) e #54 (fase A feita) — também só após confirmação, junto com o PR.
+
+---
+
+## Self-review (feito ao escrever)
+
+- **Cobertura do spec:** §1 construtores → Tasks 1-2; §2 três moves → Task 1 (+ o quarto move implícito, `invokeBoundaryCall`, → Task 2 — não listado na issue, descoberto na leitura: sem ele `r.value` ficaria com 2 donos); §3 remover paliativos → Task 3; §4 `NewInstanceWith` → Task 4; reproduções → Tasks 2 e 4; critérios de aceite: `Owners` unitários (T1/T2), sem double-retain (T2 sondas + `TestCallResultCauseAlias*`), cópia não vaza (T2/T4), `CloneCountValue` (T5), grep (T3/T7), suíte/vet/runner/diff (T7), CHANGELOG+AGENTS (T6), comentários #53/#54 (T8).
+- **Fora de escopo respeitado:** nenhum opcode novo, `ObjMap.Set/Replace` intactos, laços de retain do `json_population.go` intactos, `NewMap()`/`NewInstance()` intactos, builders só-escalares não migrados.
+- **Consistência de nomes:** `NewArrayAdopting(elements []Value)`, `NewInstanceWith(def *ObjStruct, fields map[string]Value)`, `vmWithOwnersProbe`, `probe_owners`, `clones_now`, `test_reset_clones` — iguais em todas as tasks.

--- a/docs/superpowers/specs/2026-08-20-container-owners-design.md
+++ b/docs/superpowers/specs/2026-08-20-container-owners-design.md
@@ -1,0 +1,152 @@
+# Construtores de contêiner retêm filhos por padrão (fase A da #54) — Design
+
+> Cópia literal da issue [estevaofon/noxy#55](https://github.com/estevaofon/noxy/issues/55)
+> (aberta em 2026-08-20), que é o spec desta entrega. O corpo abaixo é o texto da issue
+> no momento em que o plano `docs/superpowers/plans/2026-08-20-container-owners.md` foi
+> escrito; a issue continua sendo a fonte de verdade. Relacionadas: #54 (design completo,
+> fases B/C adiadas), #53 (itens 1b/1c/1d), #50.
+
+---
+
+## Summary
+
+Fase 1 (e única por ora) da #54, recortada para ser **pequena, fechada e sem ambiguidade**: os construtores de contêiner de `internal/value` passam a **reter os filhos compostos por padrão**, com um construtor "adotante" explícito para os três lugares que entregam filhos já retidos. Isso fecha de uma vez quatro bugs observáveis de semântica de valor (cópia por valor mutando o original) sem tocar em opcode, em `json_loads` (#53 item 1) nem em API de mutação.
+
+- **Regra do runtime que este PR faz valer nos natives:** *todo contêiner (array, map, instância) é dono durável de cada filho composto que guarda* — o bytecode já faz isso (`OP_ARRAY`/`OP_MAP` retêm cada elemento, o construtor de struct retém cada campo, `executor.go`), os natives esquecem.
+- **Por que nos construtores:** `value.Retain` em escalar é no-op (`internal/value/cow.go:ownersOf` só rastreia array/map/instância), então reter dentro de `NewArray`/`NewMapWithData` é correto para **todos** os ~30 call sites sem allowlist — inclusive `internal/plugin`, que não tem `*VM`.
+- **Bugs que isto corrige** (todos reproduzidos no `develop` `1680266`, programas abaixo): `slice`, envelope do `sqlite.query` (`rows`/`columns`/`values`), envelope do `task_await` (`value`/`error`), `io` (`read_lines` → `data`), `strings` (`parts`), e qualquer plugin que devolva composto aninhado (`InterfaceToValue`).
+
+## Escopo — faça exatamente isto
+
+### 1. `internal/value/value.go`
+
+```go
+// NewArray cria um array que e DONO DURAVEL de cada elemento composto
+// (Retain; no-op em escalares) — a mesma regra de OP_ARRAY no executor.
+func NewArray(elements []Value) Value {
+	for _, element := range elements {
+		Retain(element)
+	}
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+
+// NewArrayAdopting cria um array ADOTANDO elementos que o chamador JA reteve
+// em nome do array (move) — nao retem de novo. Uso restrito aos tres sites
+// listados na issue; qualquer outro uso precisa de comentario `// RC: move`.
+func NewArrayAdopting(elements []Value) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+
+// NewMapWithData cria um map que e DONO DURAVEL de cada valor composto.
+func NewMapWithData(data map[string]Value) Value { /* como hoje + Retain(v) por valor */ }
+
+// NewInstanceWith cria uma instancia com os campos dados, retendo cada valor
+// composto — a mesma regra do construtor de struct (calls.go:callPreparedValue).
+func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value
+```
+
+`NewMap()` e `NewInstance(def)` (vazios) **não mudam**. `ObjMap.Set/Replace`, `ObjArray.Elements`, `ObjInstance.Fields` **não mudam** (fora de escopo — #54 fase C).
+
+### 2. Os três **moves** (filhos já retidos por quem entrega) → `NewArrayAdopting`, mantendo o retain manual que já existe
+
+| Site | Hoje | Depois |
+|---|---|---|
+| `internal/vm/executor.go` ~l.1302 (`OP_ARRAY`: `value.Retain(elements[i])` no laço e depois `value.NewArray(elements)`) | retain manual + NewArray | retain manual + `NewArrayAdopting(elements)` |
+| `internal/vm/calls.go` ~l.170-180 (`copyValue`: `value.Retain(el)` no laço e depois `value.NewArray(newElems)`) | idem | idem |
+| `internal/vm/builtins_call_result.go` ~l.340-357 (`causes`: herdados **transferem** o retain do array antigo, irmãos novos recebem `value.Retain(sibling)`; depois `value.NewArray(causes)`) | retain manual dos irmãos + NewArray | retain manual dos irmãos + `NewArrayAdopting(causes)` — os herdados **não** podem ser retidos de novo |
+
+Nenhum outro site é move. Em particular **não** são moves (a nova posse é real, o retain do construtor é o correto): `slice` (`builtins_collections.go:204`, elementos copiados de outro array que continua dono), `network_poller.go:589` (`fixedNetworkSet`), `plugin.go:228/234`, sqlite/tasks/net/convert/io/strings/sys.
+
+### 3. Remover os paliativos que viram redundantes
+
+- `retainingArray`/`retainingMap` (`internal/vm/builtins_call_result.go` ~l.227-239) → apagar; chamadores usam `value.NewArray`/`value.NewMapWithData` direto (`builtins_call_result.go`, `builtins_json.go:186,192`, `json_population.go:334,480`).
+- **Não mexer** nos laços `for … { value.Retain(created) }` de `json_population.go` que antecedem `mapObject.Replace(...)` / `instance.Fields` — esses maps/instâncias são construídos por `NewMap()`+`Replace` e `NewInstance()`+escrita, caminhos fora deste PR; os laços continuam corretos.
+
+### 4. Compostos colocados em **campo de instância** por builders de envelope → `NewInstanceWith`
+
+Os únicos sites onde um builder põe um **composto** num campo via escrita crua (sem `Retain`):
+
+| Site | Campo composto |
+|---|---|
+| `internal/vm/builtins_sqlite.go` ~l.335-350 (`row`: `values`; `result`: `columns`, `rows`) e ~l.436-443 (`columns`/`rows` vazios no erro) | arrays |
+| `internal/vm/builtins_io.go` ~l.384-389 (`newIOReadResult`: `data`, que em `newIOLinesResult` é array) | array |
+| `internal/vm/builtins_strings.go` ~l.236 (`parts`) | array |
+
+Construir essas instâncias com `value.NewInstanceWith(definition, map[string]value.Value{...})` (retém os compostos; escalares no-op). Builders cujos campos são **todos escalares** (`sqlite` `exec`/`open`, `io` open/close/write, `json_dumps` result, etc.) podem ficar como estão — **não migrar** por "consistência"; diff mínimo.
+
+## Fora de escopo (não fazer neste PR)
+
+- API de mutação (`Mutate*`/`Prepare*`), acessores de escrita (`SetElements`/`SetField`), teste de arquitetura — #54 fases B/C, adiadas.
+- CoW do `json_loads` em alvo compartilhado (#53 item 1), benchmarks dos guards (#53 item 2), higiene (#53 item 3), `test_crypto_debug.nx` (#53 item 4).
+- Qualquer mudança em opcodes além da troca por `NewArrayAdopting` em `OP_ARRAY`; qualquer mudança em `ObjMap.Set/Replace/Delete`; mover funções de arquivo; renomear `NewMapWithData`.
+- Converter `NewMap()`+`Replace` ou `NewInstance()`+escrita em outros builders.
+
+## Reproduções (hoje falham; depois passam) — usar como base dos testes
+
+```noxy
+// slice — builtins_collections.go:204
+struct Pair
+    a: int
+    b: int
+end
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let s: Pair[] = slice(t, 0, 2)
+s[0].a = 9
+print(t[0].a)                     // hoje 9; esperado 0
+```
+
+```noxy
+// sqlite — builtins_sqlite.go:341-347
+use sqlite select *
+use sqlite
+let db: Database = sqlite.open(":memory:")
+sqlite.exec(db, "CREATE TABLE t (id INTEGER, nome TEXT)")
+sqlite.exec(db, "INSERT INTO t VALUES (1, 'a')")
+let res: QueryResult = sqlite.query(db, "SELECT * FROM t")
+let cols: string[] = res.columns
+cols[0] = "ZZZ"
+print(res.columns[0])             // hoje ZZZ; esperado id
+let vals: any[] = res.rows[0].values
+vals[0] = 999
+print(res.rows[0].values[0])      // hoje 999; esperado 1
+```
+
+```noxy
+// task_await — builtins_tasks.go:157-177
+func mk() -> int[]
+    return [1, 2, 3]
+end
+let t: any = spawn_task(mk)
+let r: any = task_await(t)
+let v: any = r["value"]
+v[0] = 99
+print(r["value"][0])              // hoje 99; esperado 1
+```
+
+## Critérios de aceite
+
+- [ ] `internal/value`: testes unitários — `NewArray` deixa elemento composto com `Owners == 1` e não toca escalar; `NewArrayAdopting` deixa `Owners` como recebeu; `NewMapWithData` retém valores compostos; `NewInstanceWith` retém campos compostos.
+- [ ] Sem double-retain nos três moves: literal `[Pair(1,1)]` → elemento com `Owners == 1` (sonda `OwnersCount` via native de teste, padrão de `internal/vm/rc_uniqueness_test.go`); `copyValue` (clone CoW) → filho com `Owners == 2`; `call_result` com `causes` herdados — testes existentes `TestCallResultCauseAlias*`/`TestCallResultFailureAlias*` verdes e `Owners` dos herdados inalterado.
+- [ ] Testes "cópia por valor não vaza" em `internal/vm`: `slice`, `sqlite.query` (`columns` e `rows[i].values`), `task_await` (`value` e `error`), `io` `read_lines` (`data`), `strings` (`parts`); e em `internal/plugin`: `InterfaceToValue` com array/map aninhado → filho com `Owners == 1`.
+- [ ] `CloneCountValue()` não cresce ao mutar um contêiner com dono único vindo desses natives (não introduzimos clone desnecessário).
+- [ ] `retainingArray`/`retainingMap` removidos; `grep -rn "retainingArray\|retainingMap" internal` vazio.
+- [ ] `go test ./...` verde sem `| tail`; `go vet`; `noxy_examples/run_all_tests_concurrent.nx` 171/171; diff de saída dos exemplos contra o `develop` só com não-determinismo (ordem de map, tempo, rand/uuid, endereços).
+- [ ] CHANGELOG `### Fixed` (uma entrada: "contêineres criados por natives/plugins são donos dos filhos — `slice`, `sqlite.query`, `task_await`, `io`, `strings`, plugins") + `AGENTS.md` seção "Adicionar Função Builtin": *construa com `value.NewArray`/`NewMapWithData`/`NewInstanceWith`; só use `NewArrayAdopting` para filhos que você já reteve, com comentário `// RC: move`*.
+- [ ] Comentar na #53 que os itens 1b/1c/1d foram fechados aqui; na #54 que a fase A está feita.
+
+## Components
+- `internal/value/value.go` (+ testes em `internal/value/`)
+- `internal/vm/executor.go` (`OP_ARRAY`), `internal/vm/calls.go` (`copyValue`), `internal/vm/builtins_call_result.go` (`causes`, remoção dos helpers)
+- `internal/vm/builtins_json.go`, `internal/vm/json_population.go` (só troca de helper)
+- `internal/vm/builtins_sqlite.go`, `internal/vm/builtins_io.go`, `internal/vm/builtins_strings.go` (`NewInstanceWith`)
+- `internal/plugin/plugin.go` (sem mudança de código — coberto pelo construtor; só o teste)
+- `CHANGELOG.md`, `AGENTS.md`
+
+## Test Plan
+- [x] Bugs reproduzidos no `develop` `1680266` (programas acima; `slice`, sqlite, `task_await`).
+- [x] Moves identificados por inspeção dos 31 call sites de `NewArray`/`NewMapWithData` em `internal/` (lista fechada acima).
+- [ ] Implementar na ordem 1 → 2 → 3 → 4 com a suíte verde a cada commit (TDD: teste de `Owners` primeiro).
+- [ ] Verificações do critério de aceite (suíte, runner, diff de exemplos).
+
+Relacionadas: #54 (design completo; este é a fase A, B/C adiadas), #53 (itens 1b/1c/1d), #50 (onde a classe ficou evidente).
+

--- a/docs/superpowers/specs/2026-08-20-ref-slot-invariant-design.md
+++ b/docs/superpowers/specs/2026-08-20-ref-slot-invariant-design.md
@@ -156,7 +156,7 @@ func NewClosedUpvalue(v Value) *ObjUpvalue
 
 ### 5.3 RC dos builders JSON (under-count pré-existente)
 
-Modelo a espelhar (já é o do bytecode): **todo contêiner que guarda um composto conta como um dono** — `OP_ARRAY`/`OP_MAP` retêm cada elemento/valor, o construtor de struct retém cada campo, `OP_SET_INDEX`/`OP_SET_PROPERTY` fazem retain-novo/release-velho, `storeReferenceValue` idem com consciência de empréstimo. Precedente em Go: `retainingArray`/`retainingMap` de `internal/vm/builtins_call_result.go` (reutilizados como estão — mesmo pacote; a mudança de arquivo foi dispensada na implementação para manter o diff focado).
+Modelo a espelhar (já é o do bytecode): **todo contêiner que guarda um composto conta como um dono** — `OP_ARRAY`/`OP_MAP` retêm cada elemento/valor, o construtor de struct retém cada campo, `OP_SET_INDEX`/`OP_SET_PROPERTY` fazem retain-novo/release-velho, `storeReferenceValue` idem com consciência de empréstimo. Precedente em Go: `retainingArray`/`retainingMap` de `internal/vm/builtins_call_result.go` (reutilizados como estão — mesmo pacote; a mudança de arquivo foi dispensada na implementação para manter o diff focado). *(Nota posterior: na v0.10.1 — issue #55, fase A da #54 — esses helpers foram substituídos pelos próprios construtores `value.NewArray`/`value.NewMapWithData`, que passaram a reter os filhos compostos por padrão; ver `docs/superpowers/specs/2026-08-20-container-owners-design.md`.)*
 
 Mudanças em `internal/vm/json_population.go` e `builtins_json.go`:
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,37 @@
+package plugin
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// InterfaceToValue constroi via value.NewArray/NewMapWithData: o contêiner e
+// dono duravel de cada filho composto sem que o plugin precise de *VM.
+func TestInterfaceToValueContainersOwnNestedChildren(t *testing.T) {
+	converted := InterfaceToValue([]interface{}{
+		map[string]interface{}{"itens": []interface{}{1.0, 2.0}},
+		"texto",
+	})
+	outer, ok := converted.Obj.(*value.ObjArray)
+	if !ok || len(outer.Elements) != 2 {
+		t.Fatalf("esperado array de 2 elementos, veio %#v", converted)
+	}
+	nested := outer.Elements[0]
+	if got := value.OwnersCount(nested); got != 1 {
+		t.Fatalf("map aninhado deve ter o array como unico dono: Owners=%d", got)
+	}
+	items, found := nested.Obj.(*value.ObjMap).Get("itens")
+	if !found {
+		t.Fatal("map aninhado deve conter a chave itens")
+	}
+	if got := value.OwnersCount(items); got != 1 {
+		t.Fatalf("array aninhado deve ter o map como unico dono: Owners=%d", got)
+	}
+	if got := value.OwnersCount(outer.Elements[1]); got != -1 {
+		t.Fatalf("string nao tem contador: Owners=%d", got)
+	}
+	if got := value.OwnersCount(converted); got != 0 {
+		t.Fatalf("o contêiner raiz nasce sem dono: Owners=%d", got)
+	}
+}

--- a/internal/value/constructors_test.go
+++ b/internal/value/constructors_test.go
@@ -1,0 +1,59 @@
+package value
+
+import "testing"
+
+// Os construtores de contêiner são a única fronteira pela qual natives e
+// plugins criam arrays/maps/instâncias; a regra do runtime — "todo contêiner
+// é dono durável de cada filho composto" — é aplicada aqui para valer para
+// todos os ~30 call sites sem allowlist (Retain em escalar/string é no-op).
+
+func structForTest(fields ...string) *ObjStruct {
+	return NewStruct("Envelope", fields).Obj.(*ObjStruct)
+}
+
+func TestNewArrayAdoptingKeepsOwnersAsReceived(t *testing.T) {
+	child := NewArray(nil)
+	Retain(child) // o chamador já reteve em nome do array (move)
+	adopted := NewArrayAdopting([]Value{child, NewInt(7)})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("NewArrayAdopting nao pode reter de novo: Owners=%d, esperado 1", got)
+	}
+	if got := OwnersCount(adopted); got != 0 {
+		t.Fatalf("o array novo nasce sem dono: Owners=%d", got)
+	}
+	if adopted.Obj.(*ObjArray).Elements[0].Obj != child.Obj {
+		t.Fatal("NewArrayAdopting deve guardar o mesmo objeto filho")
+	}
+}
+
+func TestNewInstanceWithRetainsCompositeFields(t *testing.T) {
+	definition := structForTest("data", "ok", "meta")
+	data := NewArray(nil)
+	meta := NewMap()
+	instance := NewInstanceWith(definition, map[string]Value{
+		"data": data,
+		"ok":   NewBool(true),
+		"meta": meta,
+	})
+	if got := OwnersCount(data); got != 1 {
+		t.Fatalf("campo array deve ter a instancia como dono: Owners=%d", got)
+	}
+	if got := OwnersCount(meta); got != 1 {
+		t.Fatalf("campo map deve ter a instancia como dono: Owners=%d", got)
+	}
+	object := instance.Obj.(*ObjInstance)
+	if object.Struct != definition {
+		t.Fatal("NewInstanceWith deve apontar para a definicao recebida")
+	}
+	if object.Fields["data"].Obj != data.Obj || !object.Fields["ok"].AsBool {
+		t.Fatal("NewInstanceWith deve guardar os campos recebidos")
+	}
+	if got := OwnersCount(instance); got != 0 {
+		t.Fatalf("a instancia nova nasce sem dono: Owners=%d", got)
+	}
+}
+
+func TestNewInstanceWithNilFieldsIsWritable(t *testing.T) {
+	instance := NewInstanceWith(structForTest("x"), nil)
+	instance.Obj.(*ObjInstance).Fields["x"] = NewInt(1) // nao pode entrar em panico (map nil)
+}

--- a/internal/value/constructors_test.go
+++ b/internal/value/constructors_test.go
@@ -57,3 +57,40 @@ func TestNewInstanceWithNilFieldsIsWritable(t *testing.T) {
 	instance := NewInstanceWith(structForTest("x"), nil)
 	instance.Obj.(*ObjInstance).Fields["x"] = NewInt(1) // nao pode entrar em panico (map nil)
 }
+
+func TestNewArrayRetainsCompositeElementsOnly(t *testing.T) {
+	child := NewArray(nil)
+	grand := NewMap()
+	array := NewArray([]Value{child, NewInt(1), NewString("s"), grand})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("array deve ser dono duravel do elemento composto: Owners=%d, esperado 1", got)
+	}
+	if got := OwnersCount(grand); got != 1 {
+		t.Fatalf("map filho deve ter o array como dono: Owners=%d", got)
+	}
+	if got := OwnersCount(array); got != 0 {
+		t.Fatalf("o proprio array nasce sem dono: Owners=%d", got)
+	}
+	elements := array.Obj.(*ObjArray).Elements
+	if OwnersCount(elements[1]) != -1 || OwnersCount(elements[2]) != -1 {
+		t.Fatal("escalares e strings nao tem contador (Retain e no-op)")
+	}
+	if OwnersCount(NewArray(nil)) != 0 || len(NewArray(nil).Obj.(*ObjArray).Elements) != 0 {
+		t.Fatal("NewArray(nil) continua valendo como array vazio")
+	}
+}
+
+func TestNewMapWithDataRetainsCompositeValues(t *testing.T) {
+	child := NewArray(nil)
+	mapping := NewMapWithData(map[string]Value{"rows": child, "count": NewInt(2)})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("map deve ser dono duravel do valor composto: Owners=%d, esperado 1", got)
+	}
+	stored, ok := mapping.Obj.(*ObjMap).Get("rows")
+	if !ok || stored.Obj != child.Obj {
+		t.Fatal("NewMapWithData deve guardar o mesmo objeto filho")
+	}
+	if got := OwnersCount(mapping); got != 0 {
+		t.Fatalf("o proprio map nasce sem dono: Owners=%d", got)
+	}
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -615,11 +615,13 @@ func NewRuntimeTypeInfo(v *RuntimeTypeInfo) Value {
 	return Value{Type: VAL_OBJ, Obj: v}
 }
 
-// NewArray cria um array a partir dos elementos dados. A partir da Task 2
-// deste plano ele e DONO DURAVEL de cada elemento composto (Retain; no-op em
-// escalares e strings) — a mesma regra de OP_ARRAY no executor. Quem ja
-// reteve os elementos em nome do array usa NewArrayAdopting.
+// NewArray cria um array que e DONO DURAVEL de cada elemento composto
+// (Retain; no-op em escalares e strings) — a mesma regra de OP_ARRAY no
+// executor. Quem ja reteve os elementos em nome do array usa NewArrayAdopting.
 func NewArray(elements []Value) Value {
+	for _, element := range elements {
+		Retain(element)
+	}
 	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
 }
 
@@ -638,9 +640,12 @@ func NewMap() Value {
 	return Value{Type: VAL_OBJ, Obj: mapping}
 }
 
+// NewMapWithData cria um map que e DONO DURAVEL de cada valor composto
+// (Retain; no-op em escalares e strings) — a mesma regra de OP_MAP.
 func NewMapWithData(data map[string]Value) Value {
 	values := make(map[interface{}]Value, len(data))
 	for k, v := range data {
+		Retain(v)
 		values[k] = v
 	}
 	mapping := NewMap()

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -615,7 +615,20 @@ func NewRuntimeTypeInfo(v *RuntimeTypeInfo) Value {
 	return Value{Type: VAL_OBJ, Obj: v}
 }
 
+// NewArray cria um array a partir dos elementos dados. A partir da Task 2
+// deste plano ele e DONO DURAVEL de cada elemento composto (Retain; no-op em
+// escalares e strings) — a mesma regra de OP_ARRAY no executor. Quem ja
+// reteve os elementos em nome do array usa NewArrayAdopting.
 func NewArray(elements []Value) Value {
+	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+}
+
+// NewArrayAdopting cria um array ADOTANDO elementos que o chamador JA reteve
+// em nome do array (move): nao retem de novo. Uso restrito aos sites que
+// transferem posse — OP_ARRAY (executor.go), copyValue (calls.go) e o merge
+// de causes do call_result (builtins_call_result.go); qualquer outro uso
+// precisa de comentario `// RC: move` explicando quem reteve.
+func NewArrayAdopting(elements []Value) Value {
 	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
 }
 
@@ -639,8 +652,25 @@ func NewStruct(name string, fields []string) Value {
 	return Value{Type: VAL_OBJ, Obj: &ObjStruct{Name: name, Fields: fields}}
 }
 
+// NewInstance cria uma instancia vazia; quem escreve compostos em Fields
+// depois precisa reter a mao (como calls.go:callPreparedValue faz) ou usar
+// NewInstanceWith.
 func NewInstance(def *ObjStruct) Value {
 	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
+}
+
+// NewInstanceWith cria uma instancia ja com os campos dados, retendo cada
+// valor composto — a mesma regra do construtor de struct em bytecode
+// (calls.go:callPreparedValue, "campo e dono duravel"). Escalares e strings
+// sao no-op em Retain. O map recebido passa a pertencer a instancia.
+func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value {
+	if fields == nil {
+		fields = make(map[string]Value)
+	}
+	for _, field := range fields {
+		Retain(field)
+	}
+	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: fields}}
 }
 
 func NewFunction(name string, arity int, upvalueCount int, params []ParamInfo, chunk interface{}, environment *GlobalEnvironment) Value {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.10.0"
+const Version = "v0.10.1"

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -140,25 +140,14 @@ func (vm *VM) invokeBoundaryCall(call PreparedCall) (result value.Value, err err
 		if runErr := vm.run(ownerFrameCount+1, &result); runErr != nil {
 			return value.NewNull(), runErr
 		}
-		// RC: o envelope ok (callResultOkEnvelope) guarda `result` no campo
-		// "value" via NewMapWithData, que — ao contrario de OP_MAP/OP_ARRAY —
-		// NAO retem os valores que recebe. Sem este retain, uma composta
-		// devolvida sem dono previo (Owners=0, caso comum de um retorno
-		// fresco) apareceria com Owners=1 apos o PRIMEIRO `let` no lado Noxy
-		// que capturar r.value; IsShared ficaria falso e uma mutacao nesse
-		// primeiro binding aconteceria in-place, vazando para qualquer outra
-		// leitura de r.value (mesmo objeto, guardado por referencia no mapa)
-		// — corrupcao comprovada por TestCallResultValueSemantics antes deste
-		// retain ("100|100|3" em vez de "1|100|3"). O retain aqui da ao
-		// envelope o mesmo dono-duravel que OP_MAP teria registrado se este
-		// valor tivesse sido escrito por bytecode Noxy comum.
-		value.Retain(result)
+		// RC: a posse de `result` pelo envelope ok e registrada pelo
+		// construtor (value.NewMapWithData retem em callResultOkEnvelope);
+		// reter aqui tambem deixaria r.value com 2 donos e IsShared para
+		// sempre. Ver TestCallResultOkValueHasExactlyOneOwner.
 		return result, nil
 	}
-	// native/construtor: sem frame novo; resultado no topo da pilha. Mesmo
-	// retain do ramo acima, mesma justificativa.
+	// native/construtor: sem frame novo; resultado no topo da pilha.
 	result = vm.peek(0)
-	value.Retain(result)
 	return result, nil
 }
 
@@ -212,36 +201,20 @@ func (vm *VM) hardUnwindTo(target int) {
 
 var errBoundaryPanic = fmt.Errorf("call_result: unwinding after Go panic")
 
-// retainingMap e retainingArray espelham OP_MAP/OP_ARRAY (executor.go,
-// "elemento e dono duravel"): o composto pai vira dono duravel de cada filho
-// composto que guarda. value.NewMapWithData/value.NewArray, ao contrario dos
-// opcodes, NAO retem o que recebem — sem estes funis a arvore de Failure
-// nasceria com Owners=0 nos filhos e o PRIMEIRO `let` do lado Noxy que
-// capturasse r.failure (ou uma entrada de causes) levaria o filho a Owners=1:
-// IsShared falso, mutacao aplicada in-place e o envelope reescrito por baixo
-// (corrupcao comprovada — ver TestCallResultFailureAliasDoesNotMutateEnvelope
-// e TestCallResultCauseAliasDoesNotMutateEnvelope). Com o retain do pai, o
-// mesmo `let` chega a Owners=2 e a mutacao clona, como em qualquer composto
-// escrito por bytecode Noxy comum. Strings e escalares dispensam o funil:
-// ownersOf so rastreia compostos, entao Retain neles e no-op.
-func retainingMap(data map[string]value.Value) value.Value {
-	for _, item := range data {
-		value.Retain(item)
-	}
-	return value.NewMapWithData(data)
-}
+// A arvore de Failure e construida com value.NewMapWithData/NewArray, que
+// retem cada filho composto (o pai e dono duravel — mesma regra de
+// OP_MAP/OP_ARRAY). Sem esse dono o primeiro `let f: any = r.failure` do
+// lado Noxy levaria o filho a Owners=1, IsShared falso, e a mutacao
+// reescreveria o envelope (TestCallResultFailureAliasDoesNotMutateEnvelope,
+// TestCallResultCauseAliasDoesNotMutateEnvelope). Strings e escalares sao
+// no-op em Retain (ownersOf so rastreia compostos).
 
-func retainingArray(elements []value.Value) value.Value {
-	for _, element := range elements {
-		value.Retain(element)
-	}
-	return value.NewArray(elements)
-}
-
-// callResultOkEnvelope NAO usa retainingMap de proposito: `result` ja foi
-// retido por invokeBoundaryCall (comentario "RC" la), e um segundo retain
-// aqui deixaria o valor eternamente IsShared — clonaria a cada mutacao. Os
-// outros dois campos sao escalares.
+// callResultOkEnvelope: NewMapWithData retem `result` (unico campo
+// composto) — e isso, e so isso, que da ao envelope a posse de r.value.
+// Sem esse dono, uma composta devolvida fresca (Owners=0) chegaria a
+// Owners=1 no primeiro `let` do lado Noxy, IsShared ficaria falso e a
+// mutacao nesse binding vazaria para r.value (TestCallResultValueSemantics
+// lia "100|100|3" em vez de "1|100|3").
 func callResultOkEnvelope(result value.Value) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
 		"ok":      value.NewBool(true),
@@ -251,7 +224,7 @@ func callResultOkEnvelope(result value.Value) value.Value {
 }
 
 func callResultFailureEnvelope(err error) value.Value {
-	return retainingMap(map[string]value.Value{
+	return value.NewMapWithData(map[string]value.Value{
 		"ok":      value.NewBool(false),
 		"value":   value.NewNull(),
 		"failure": failureMap(err),
@@ -265,11 +238,11 @@ func callResultFailureEnvelope(err error) value.Value {
 // demais sob as causes dela (design §2, "Cleanup as first failure").
 func failureMap(err error) value.Value {
 	if panicErr, ok := err.(*boundaryPanicError); ok {
-		return retainingMap(map[string]value.Value{
+		return value.NewMapWithData(map[string]value.Value{
 			"kind":    value.NewString("panic"),
 			"message": value.NewString(panicErr.payload),
 			"stack":   value.NewString(panicErr.stack),
-			"causes":  retainingArray([]value.Value{}),
+			"causes":  value.NewArray([]value.Value{}),
 		})
 	}
 	if unwind, ok := err.(*UnwindError); ok {
@@ -299,11 +272,11 @@ func failureMapWithCauses(primary error, deferred []DeferredError) value.Value {
 	if primary != nil {
 		message = primary.Error()
 	}
-	return retainingMap(map[string]value.Value{
+	return value.NewMapWithData(map[string]value.Value{
 		"kind":    value.NewString("runtime"),
 		"message": value.NewString(message),
 		"stack":   value.NewString(deepestRuntimeStack(primary)),
-		"causes":  retainingArray(causes),
+		"causes":  value.NewArray(causes),
 	})
 }
 

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -201,14 +201,6 @@ func (vm *VM) hardUnwindTo(target int) {
 
 var errBoundaryPanic = fmt.Errorf("call_result: unwinding after Go panic")
 
-// A arvore de Failure e construida com value.NewMapWithData/NewArray, que
-// retem cada filho composto (o pai e dono duravel — mesma regra de
-// OP_MAP/OP_ARRAY). Sem esse dono o primeiro `let f: any = r.failure` do
-// lado Noxy levaria o filho a Owners=1, IsShared falso, e a mutacao
-// reescreveria o envelope (TestCallResultFailureAliasDoesNotMutateEnvelope,
-// TestCallResultCauseAliasDoesNotMutateEnvelope). Strings e escalares sao
-// no-op em Retain (ownersOf so rastreia compostos).
-
 // callResultOkEnvelope: NewMapWithData retem `result` (unico campo
 // composto) — e isso, e so isso, que da ao envelope a posse de r.value.
 // Sem esse dono, uma composta devolvida fresca (Owners=0) chegaria a
@@ -223,6 +215,14 @@ func callResultOkEnvelope(result value.Value) value.Value {
 	})
 }
 
+// callResultFailureEnvelope: a arvore de Failure (este envelope, failureMap
+// e as causes) e construida com value.NewMapWithData/NewArray, que retem
+// cada filho composto (o pai e dono duravel — mesma regra de OP_MAP/
+// OP_ARRAY). Sem esse dono o primeiro `let f: any = r.failure` do lado Noxy
+// levaria o filho a Owners=1, IsShared falso, e a mutacao reescreveria o
+// envelope (TestCallResultFailureAliasDoesNotMutateEnvelope,
+// TestCallResultCauseAliasDoesNotMutateEnvelope). Strings e escalares sao
+// no-op em Retain (ownersOf so rastreia compostos).
 func callResultFailureEnvelope(err error) value.Value {
 	return value.NewMapWithData(map[string]value.Value{
 		"ok":      value.NewBool(false),

--- a/internal/vm/builtins_call_result.go
+++ b/internal/vm/builtins_call_result.go
@@ -345,12 +345,16 @@ func deferredFailureMap(deferred *DeferredError, siblings []DeferredError) value
 			value.Retain(sibling) // filho novo: o array vira dono duravel
 			causes = append(causes, sibling)
 		}
+		// RC: move — os herdados transferem o retain do array antigo, os
+		// irmaos novos foram retidos no laco acima; NewArrayAdopting nao
+		// retem de novo (um dono a mais que ninguem solta deixaria o
+		// composto IsShared para sempre).
 		// RC: ObjMap.Set NAO solta o valor sobrescrito (bindingStore.set so
 		// escreve) — quem faz retain-novo/release-velho no map-set do Noxy e
 		// o funil de OP_SET_INDEX no executor. Aqui a troca e a mao e segue a
 		// mesma ordem: o array novo ganha `mapping` como dono ANTES do antigo
 		// perder o dele (nunca soltar primeiro; um dec a mais nao tem volta).
-		replacement := value.NewArray(causes)
+		replacement := value.NewArrayAdopting(causes)
 		value.Retain(replacement)
 		mapping.Set("causes", replacement)
 		if hadPrevious {

--- a/internal/vm/builtins_call_result_test.go
+++ b/internal/vm/builtins_call_result_test.go
@@ -242,6 +242,18 @@ func TestFailureMapMergesInnerCausesWithSiblingsOnPromotion(t *testing.T) {
 	if got := causeMessage(array.Elements[1]); got != "outer sibling failure" {
 		t.Fatalf("second cause should be the outer sibling, got %q", got)
 	}
+
+	// RC (#55): o array de causes e montado por NewArrayAdopting — o herdado
+	// TRANSFERE o retain do array antigo e o irmao novo recebe um retain
+	// manual; cada um termina com exatamente UM dono (o array novo). Um
+	// NewArray aqui retaria de novo e deixaria os herdados com 2 donos
+	// (IsShared para sempre, clone a cada mutacao).
+	if got := value.OwnersCount(array.Elements[0]); got != 1 {
+		t.Fatalf("inherited cause must keep exactly one owner (the new causes array), got %d", got)
+	}
+	if got := value.OwnersCount(array.Elements[1]); got != 1 {
+		t.Fatalf("promoted sibling must have exactly one owner (the new causes array), got %d", got)
+	}
 }
 
 // TestCallResultAggregatesDeferFailures cobre a agregacao ponta-a-ponta: o
@@ -448,13 +460,15 @@ test_report(to_str(original[0]) + "|" + to_str(copia[0]) + "|" + to_str(length(o
 
 // TestCallResultFailureAliasDoesNotMutateEnvelope espelha
 // TestCallResultValueSemantics no ramo de FALHA: a arvore de Failure e
-// construida por Go (NewMapWithData/NewArray), que — ao contrario de
-// OP_MAP/OP_ARRAY — nao retem os filhos compostos. Sem o retain do pai, o
-// mapa `failure` chegava ao Noxy com Owners=0; o primeiro `let f: any =
-// r.failure` o levava a Owners=1, IsShared ficava falso e `f["message"] =
-// ...` mutava IN-PLACE o mesmo objeto guardado no envelope — r.failure.message
-// passava a ler "hacked". Com o envelope como dono duravel, o `let` chega a
-// Owners=2 e a mutacao clona (CoW), deixando o envelope intacto.
+// construida por Go (NewMapWithData/NewArray). Desde a v0.10.1 (#55) esses
+// construtores retem os filhos compostos, como OP_MAP/OP_ARRAY; antes o
+// retain do pai era feito a mao (retainingMap/retainingArray). Sem o retain
+// do pai, o mapa `failure` chegava ao Noxy com Owners=0; o primeiro
+// `let f: any = r.failure` o levava a Owners=1, IsShared ficava falso e
+// `f["message"] = ...` mutava IN-PLACE o mesmo objeto guardado no envelope —
+// r.failure.message passava a ler "hacked". Com o envelope como dono
+// duravel, o `let` chega a Owners=2 e a mutacao clona (CoW), deixando o
+// envelope intacto.
 func TestCallResultFailureAliasDoesNotMutateEnvelope(t *testing.T) {
 	source := `
 func quebra(texto: string) -> int

--- a/internal/vm/builtins_io.go
+++ b/internal/vm/builtins_io.go
@@ -382,11 +382,13 @@ func readFileContents(file *os.File) ([]byte, bool, string) {
 }
 
 func newIOReadResult(definition *value.ObjStruct, ok bool, data value.Value, errorText string) value.Value {
-	result := value.NewInstance(definition).Obj.(*value.ObjInstance)
-	result.Fields["ok"] = value.NewBool(ok)
-	result.Fields["data"] = data
-	result.Fields["error"] = value.NewString(errorText)
-	return value.Value{Type: value.VAL_OBJ, Obj: result}
+	// RC: NewInstanceWith retem data quando composto (array de read_lines);
+	// string/bytes sao no-op.
+	return value.NewInstanceWith(definition, map[string]value.Value{
+		"ok":    value.NewBool(ok),
+		"data":  data,
+		"error": value.NewString(errorText),
+	})
 }
 
 func newIOLinesResult(definition *value.ObjStruct, ok bool, lines []string, errorText string) value.Value {

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -183,13 +183,13 @@ func goValToNoxy(i interface{}) value.Value {
 		for idx, el := range v {
 			arr[idx] = goValToNoxy(el)
 		}
-		return retainingArray(arr) // RC: o array e dono duravel de cada elemento
+		return value.NewArray(arr) // RC: o array e dono duravel de cada elemento (construtor retem)
 	case map[string]interface{}:
 		m := make(map[string]value.Value)
 		for k, val := range v {
 			m[k] = goValToNoxy(val)
 		}
-		return retainingMap(m) // RC: o map e dono duravel de cada valor (NewMapWithData nao retem)
+		return value.NewMapWithData(m) // RC: o map e dono duravel de cada valor (construtor retem)
 	}
 	return value.NewString(fmt.Sprintf("%v", i))
 }

--- a/internal/vm/builtins_sqlite.go
+++ b/internal/vm/builtins_sqlite.go
@@ -337,18 +337,21 @@ func (vm *VM) defineSQLiteBuiltins() {
 				}
 				values[index] = converted
 			}
-			row := value.NewInstance(rowTemplate.Struct).Obj.(*value.ObjInstance)
-			row.Fields["values"] = value.NewArray(values)
-			rowValues = append(rowValues, value.Value{Type: value.VAL_OBJ, Obj: row})
+			// RC: NewInstanceWith retem values — a Row e dona duravel do array.
+			row := value.NewInstanceWith(rowTemplate.Struct, map[string]value.Value{
+				"values": value.NewArray(values),
+			})
+			rowValues = append(rowValues, row)
 		}
 
-		result := value.NewInstance(resultTemplate.Struct).Obj.(*value.ObjInstance)
-		result.Fields["columns"] = value.NewArray(columnValues)
-		result.Fields["rows"] = value.NewArray(rowValues)
-		result.Fields["row_count"] = value.NewInt(int64(len(rowValues)))
-		result.Fields["ok"] = value.NewBool(true)
-		result.Fields["error"] = value.NewString("")
-		return value.Value{Type: value.VAL_OBJ, Obj: result}, nil
+		// RC: NewInstanceWith retem columns e rows (compostos); os escalares sao no-op.
+		return value.NewInstanceWith(resultTemplate.Struct, map[string]value.Value{
+			"columns":   value.NewArray(columnValues),
+			"rows":      value.NewArray(rowValues),
+			"row_count": value.NewInt(int64(len(rowValues))),
+			"ok":        value.NewBool(true),
+			"error":     value.NewString(""),
+		}), nil
 	})
 }
 
@@ -435,13 +438,14 @@ func sqliteExecError(definition *value.ObjStruct, errorText string) value.Value 
 }
 
 func sqliteQueryError(definition *value.ObjStruct, errorText string) value.Value {
-	instance := value.NewInstance(definition).Obj.(*value.ObjInstance)
-	instance.Fields["columns"] = value.NewArray(nil)
-	instance.Fields["rows"] = value.NewArray(nil)
-	instance.Fields["row_count"] = value.NewInt(0)
-	instance.Fields["ok"] = value.NewBool(false)
-	instance.Fields["error"] = value.NewString(errorText)
-	return value.Value{Type: value.VAL_OBJ, Obj: instance}
+	// RC: NewInstanceWith retem os arrays vazios (campos compostos).
+	return value.NewInstanceWith(definition, map[string]value.Value{
+		"columns":   value.NewArray(nil),
+		"rows":      value.NewArray(nil),
+		"row_count": value.NewInt(0),
+		"ok":        value.NewBool(false),
+		"error":     value.NewString(errorText),
+	})
 }
 
 // sqliteValue converts a scanned column that carries no text payload. TEXT and

--- a/internal/vm/builtins_strings.go
+++ b/internal/vm/builtins_strings.go
@@ -226,16 +226,15 @@ func (vm *VM) defineStringBuiltins() {
 
 		parts := strings.Split(s, sep)
 
-		inst := value.NewInstance(structDef).Obj.(*value.ObjInstance)
-		inst.Fields["count"] = value.NewInt(int64(len(parts)))
-
 		partValues := make([]value.Value, len(parts))
 		for i, p := range parts {
 			partValues[i] = value.NewString(p)
 		}
-		inst.Fields["parts"] = value.NewArray(partValues)
-
-		return value.Value{Type: value.VAL_OBJ, Obj: inst}, nil
+		// RC: NewInstanceWith retem parts — SplitResult e dono duravel do array.
+		return value.NewInstanceWith(structDef, map[string]value.Value{
+			"count": value.NewInt(int64(len(parts))),
+			"parts": value.NewArray(partValues),
+		}), nil
 	})
 	vm.DefineContextualNative("strings_join_count", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
 		if len(args) < 3 {

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -177,7 +177,8 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 		for _, el := range newElems {
 			value.Retain(el) // RC: filho ganha dono duravel no clone
 		}
-		copied := value.NewArray(newElems)
+		// RC: move — filhos retidos acima em nome do clone.
+		copied := value.NewArrayAdopting(newElems)
 		copied.Obj.(*value.ObjArray).RuntimeType.Store(obj.RuntimeType.Load())
 		return copied
 	case *value.ObjMap:

--- a/internal/vm/container_owners_test.go
+++ b/internal/vm/container_owners_test.go
@@ -1,6 +1,9 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"noxy-vm/internal/value"
@@ -131,5 +134,55 @@ test_report(to_str(rv[0]) + "|" + to_str(v[0]) + "|" + re["kind"] + "|" + e["kin
 `)
 	if text, _ := reported.Obj.(string); text != "1|99|runtime|hacked" {
 		t.Fatalf("envelope de task_await deve ficar intacto (CoW na copia): %q", text)
+	}
+}
+
+// sqlite.query (builtins_sqlite.go): QueryResult e dono de columns e rows;
+// cada Row e dona de values.
+func TestSQLiteQueryEnvelopeOwnsColumnsAndRowValues(t *testing.T) {
+	reported := captureVMSource(t, `
+use sqlite
+let db: sqlite.Database = sqlite.open(":memory:")
+sqlite.exec(db, "CREATE TABLE t (id INTEGER, nome TEXT)")
+sqlite.exec(db, "INSERT INTO t VALUES (1, 'a')")
+let res: sqlite.QueryResult = sqlite.query(db, "SELECT * FROM t")
+let cols: string[] = res.columns
+cols[0] = "ZZZ"
+let vals: any[] = res.rows[0].values
+vals[0] = 999
+sqlite.close(db)
+test_report(res.columns[0] + "|" + cols[0] + "|" + to_str(res.rows[0].values[0]) + "|" + to_str(vals[0]))
+`)
+	if text, _ := reported.Obj.(string); text != "id|ZZZ|1|999" {
+		t.Fatalf("envelope de sqlite.query deve ficar intacto (CoW nas copias): %q", text)
+	}
+}
+
+// io.read_lines (builtins_io.go): IOLinesResult e dono de data.
+func TestIOReadLinesEnvelopeOwnsData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "linhas.txt")
+	if err := os.WriteFile(path, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reported := captureVMSource(t, "use io\nlet f: io.File = io.open("+strconv.Quote(path)+", \"r\")\n"+
+		"let r: io.IOLinesResult = io.read_lines(f)\nio.close(f)\n"+
+		"let d: string[] = r.data\nd[0] = \"ZZZ\"\n"+
+		"test_report(r.data[0] + \"|\" + d[0])\n")
+	if text, _ := reported.Obj.(string); text != "a|ZZZ" {
+		t.Fatalf("envelope de io.read_lines deve ficar intacto (CoW na copia): %q", text)
+	}
+}
+
+// strings.split (builtins_strings.go): SplitResult e dono de parts.
+func TestStringsSplitEnvelopeOwnsParts(t *testing.T) {
+	reported := captureVMSource(t, `
+use strings
+let r: strings.SplitResult = strings.split("a,b", ",")
+let p: string[] = r.parts
+p[0] = "ZZZ"
+test_report(r.parts[0] + "|" + p[0])
+`)
+	if text, _ := reported.Obj.(string); text != "a|ZZZ" {
+		t.Fatalf("envelope de strings.split deve ficar intacto (CoW na copia): %q", text)
 	}
 }

--- a/internal/vm/container_owners_test.go
+++ b/internal/vm/container_owners_test.go
@@ -186,3 +186,44 @@ test_report(r.parts[0] + "|" + p[0])
 		t.Fatalf("envelope de strings.split deve ficar intacto (CoW na copia): %q", text)
 	}
 }
+
+// Nao introduzimos clone desnecessario: r.parts tem dono unico (a instancia)
+// e muta in-place; s[0] e compartilhado com t (slice retem) e clona UMA vez
+// — a segunda escrita ja e in-place. Oraculo: "0|1|1|0".
+func TestNativeContainersDoNotCloneWithSingleOwner(t *testing.T) {
+	machine := vmWithCloneReset()
+	machine.DefineNative("clones_now", func(args []value.Value) value.Value {
+		return value.NewInt(CloneCountValue())
+	})
+	var reported value.Value
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	src := `
+use strings
+struct Pair
+    a: int
+    b: int
+end
+let r: strings.SplitResult = strings.split("a,b", ",")
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let s: Pair[] = slice(t, 0, 2)
+test_reset_clones()
+r.parts[0] = "x"
+let c1: int = clones_now()
+s[0].a = 9
+let c2: int = clones_now()
+s[0].b = 8
+let c3: int = clones_now()
+test_report(to_str(c1) + "|" + to_str(c2) + "|" + to_str(c3) + "|" + to_str(t[0].a))
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if text, _ := reported.Obj.(string); text != "0|1|1|0" {
+		t.Fatalf("clones (parts in-place | 1 clone do Pair compartilhado | sem clone extra | original intacto): %q", text)
+	}
+}

--- a/internal/vm/container_owners_test.go
+++ b/internal/vm/container_owners_test.go
@@ -1,0 +1,135 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Sondas e reproducoes da issue #55: contêineres criados por natives passam
+// a ser donos duraveis dos filhos compostos (value.NewArray/NewMapWithData/
+// NewInstanceWith retem), com NewArrayAdopting nos moves para nao reter em
+// dobro. Os programas Noxy abaixo falhavam no develop 1680266 (a copia por
+// valor mutava o original).
+
+// vmWithOwnersProbe registra o native de teste probe_owners(x), que grava
+// value.OwnersCount(x) sem reter o argumento (ReadonlyArgs, como as sondas
+// de rc_uniqueness_test.go).
+func vmWithOwnersProbe(t *testing.T) (*VM, *int32) {
+	t.Helper()
+	machine := New()
+	observed := int32(-99)
+	machine.DefineNative("probe_owners", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			observed = value.OwnersCount(args[0])
+		}
+		return value.NewNull()
+	})
+	markProbeReadonly(t, machine, "probe_owners")
+	return machine, &observed
+}
+
+// Literal de array: OP_ARRAY retem e entrega ao construtor adotante — o
+// elemento tem exatamente UM dono (o array). Um NewArray que retivesse de
+// novo deixaria 2 e todo elemento de literal nasceria "compartilhado".
+func TestArrayLiteralElementHasExactlyOneOwner(t *testing.T) {
+	machine, observed := vmWithOwnersProbe(t)
+	src := `
+struct Pair
+    a: int
+    b: int
+end
+let t: Pair[] = [Pair(1, 1)]
+probe_owners(t[0])
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if *observed != 1 {
+		t.Fatalf("elemento de literal deve ter Owners=1 (sem double-retain em OP_ARRAY), veio %d", *observed)
+	}
+}
+
+// copyValue (clone CoW raso): o array novo ganha posse dos filhos — cada
+// filho passa a ter 2 donos (original + clone), nem 1 nem 3.
+func TestCopyValueCloneGivesChildrenASecondOwner(t *testing.T) {
+	machine := New()
+	inner := value.NewArray(nil)
+	outer := value.NewArray([]value.Value{inner}) // NewArray retem: inner Owners=1
+	if got := value.OwnersCount(inner); got != 1 {
+		t.Fatalf("pre-condicao: Owners=%d, esperado 1", got)
+	}
+	clone := machine.copyValue(outer)
+	if got := value.OwnersCount(inner); got != 2 {
+		t.Fatalf("apos copyValue o filho deve ter 2 donos (original + clone), veio %d", got)
+	}
+	if clone.Obj.(*value.ObjArray).Elements[0].Obj != inner.Obj {
+		t.Fatal("clone raso deve compartilhar o filho (mesmo ponteiro)")
+	}
+}
+
+// Envelope ok do call_result: a posse de r.value pelo envelope e registrada
+// UMA vez (pelo NewMapWithData em callResultOkEnvelope); o retain manual de
+// invokeBoundaryCall saiu. Owners=2 aqui significaria valor eternamente
+// IsShared (clone a cada mutacao).
+func TestCallResultOkValueHasExactlyOneOwner(t *testing.T) {
+	machine, observed := vmWithOwnersProbe(t)
+	src := `
+func faz_array() -> int[]
+    return [1, 2, 3]
+end
+let r: any = call_result(faz_array)
+probe_owners(r["value"])
+`
+	if err := interpretVMSource(t, machine, src); err != nil {
+		t.Fatalf("programa falhou: %v", err)
+	}
+	if *observed != 1 {
+		t.Fatalf("r.value deve ter o envelope como unico dono (Owners=1), veio %d", *observed)
+	}
+}
+
+// slice (builtins_collections.go): a copia e dona dos elementos que leva;
+// mutar a copia nao pode alcancar o original.
+func TestSliceCopyDoesNotAliasOriginal(t *testing.T) {
+	reported := captureVMSource(t, `
+struct Pair
+    a: int
+    b: int
+end
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let s: Pair[] = slice(t, 0, 2)
+s[0].a = 9
+test_report(to_str(t[0].a) + "|" + to_str(s[0].a))
+`)
+	if text, _ := reported.Obj.(string); text != "0|9" {
+		t.Fatalf("slice deve copiar por valor (original intacto): %q, esperado \"0|9\"", text)
+	}
+}
+
+// task_await (builtins_tasks.go): o envelope e dono de value e de error.
+func TestTaskAwaitEnvelopeOwnsValueAndError(t *testing.T) {
+	reported := captureVMSource(t, `
+func mk() -> int[]
+    return [1, 2, 3]
+end
+func boom() -> int
+    let xs: int[] = [1]
+    return xs[5]
+end
+let t1: any = spawn_task(mk)
+let r1: any = task_await(t1)
+let v: any = r1["value"]
+v[0] = 99
+let rv: any = r1["value"]
+let t2: any = spawn_task(boom)
+let r2: any = task_await(t2)
+let e: any = r2["error"]
+e["kind"] = "hacked"
+let re: any = r2["error"]
+test_report(to_str(rv[0]) + "|" + to_str(v[0]) + "|" + re["kind"] + "|" + e["kind"])
+`)
+	if text, _ := reported.Obj.(string); text != "1|99|runtime|hacked" {
+		t.Fatalf("envelope de task_await deve ficar intacto (CoW na copia): %q", text)
+	}
+}

--- a/internal/vm/cow_test.go
+++ b/internal/vm/cow_test.go
@@ -20,11 +20,7 @@ func shareByOwners(v value.Value) {
 func TestShareByOwnersAndUnicize(t *testing.T) {
 	machine := New()
 	inner := value.NewArray([]value.Value{value.NewInt(1)})
-	outer := value.NewArray([]value.Value{inner})
-	// inner é elemento durável de outer — o OP_ARRAY real teria retido
-	// (Task 5); aqui o array foi montado fora do bytecode, então contamos à
-	// mão para que o clone raso de outer o leve de 1 para 2 donos.
-	value.Retain(inner)
+	outer := value.NewArray([]value.Value{inner}) // NewArray retém: inner tem outer como dono (1)
 
 	if value.IsShared(outer) {
 		t.Fatal("array novo não deve nascer Shared")

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1299,7 +1299,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				// RC: elemento pode continuar referenciado pela origem
 				value.Retain(elements[i]) // elemento e dono duravel
 			}
-			vm.push(value.NewArray(elements))
+			// RC: move — os elementos ja foram retidos acima em nome do array.
+			vm.push(value.NewArrayAdopting(elements))
 
 		case chunk.OP_MAP:
 			count := int(c.Code[ip])<<8 | int(c.Code[ip+1])

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -331,7 +331,7 @@ func buildTypedJSONValue(schema *value.RuntimeTypeInfo, data interface{}) (value
 			}
 			elements[i] = created
 		}
-		array := retainingArray(elements) // RC: o array e dono duravel de cada elemento (espelha OP_ARRAY)
+		array := value.NewArray(elements) // RC: o array e dono duravel de cada elemento (construtor retem; espelha OP_ARRAY)
 		array.Obj.(*value.ObjArray).RuntimeType.Store(schema)
 		return array, true
 	case value.TYPE_MAP:
@@ -477,7 +477,7 @@ func dynamicJSONValue(data interface{}) (value.Value, bool) {
 			}
 			elements[i] = converted
 		}
-		return retainingArray(elements), true // RC: o array e dono duravel de cada elemento
+		return value.NewArray(elements), true // RC: o array e dono duravel de cada elemento (construtor retem)
 	case map[string]interface{}:
 		mapping := value.NewMap()
 		mapObject := mapping.Obj.(*value.ObjMap)


### PR DESCRIPTION
## Summary
- Regra do runtime aplicada aos natives: *todo contêiner (array, map, instância) é dono durável de cada filho composto*. O bytecode já cumpria (`OP_ARRAY`/`OP_MAP`/construtor de struct); os construtores de `internal/value` passam a reter por padrão — `value.NewArray`/`value.NewMapWithData` retêm cada filho composto (no-op em escalares/strings), novo `value.NewInstanceWith(def, fields)` constrói instâncias retendo os campos. Cobre os ~30 call sites de natives e `internal/plugin` (sem `*VM`) sem allowlist.
- Novo `value.NewArrayAdopting(elements)` (não retém) para os *moves* — sites que já entregam filhos retidos: `OP_ARRAY` (`executor.go`), `copyValue` (`calls.go`), merge de `causes` em `deferredFailureMap` (`builtins_call_result.go`), sempre com comentário `// RC: move`.
- `invokeBoundaryCall` deixa de reter `result` à mão (o retain existia só porque `NewMapWithData` não retinha); `callResultOkEnvelope` registra a posse via construtor — `TestCallResultOkValueHasExactlyOneOwner` garante `Owners == 1` (2 deixaria `r.value` eternamente `IsShared`).
- `retainingArray`/`retainingMap` removidos (`builtins_call_result.go`, `builtins_json.go`, `json_population.go` usam os construtores direto). Laços de retain que antecedem `Replace`/escrita em `NewMap()`/`NewInstance()` mantidos (fora de escopo).
- Envelopes que escreviam arrays em campos crus migrados para `NewInstanceWith`: `sqlite.query` (`Row.values`, `QueryResult.columns/rows`, `sqliteQueryError`), `io.read_lines` (`newIOReadResult`), `strings.split` (`parts`). Builders só-escalares não mudam (diff mínimo).
- Bugs fechados (reproduzidos no `develop` `1680266`, todos com a cópia por valor mutando o original): `slice`, `sqlite.query` (`columns`, `rows[i].values`), `task_await` (`value`, `error`), `io.read_lines` (`data`), `strings.split` (`parts`), plugins (`InterfaceToValue`). Efeito visível: código que dependia do aliasing acidental passa a ver a cópia independente (um clone CoW na primeira escrita ao filho ainda compartilhado). Sem mudança de API Noxy.
- Versão `v0.10.1`; CHANGELOG `### Fixed`; `AGENTS.md` §E item 5 (regra para builtins novos). Fase A da #54; fecha itens 1b/1c/1d da #53.

## Components
- `internal/value/value.go` — `NewArray`/`NewMapWithData` retêm; `NewArrayAdopting`; `NewInstanceWith`; `internal/value/constructors_test.go` (Owners unitários dos 4 construtores)
- `internal/vm/executor.go` (`OP_ARRAY`), `internal/vm/calls.go` (`copyValue`) — `NewArrayAdopting` nos moves
- `internal/vm/builtins_call_result.go` — `causes` via `NewArrayAdopting`; `invokeBoundaryCall` sem retain manual; helpers `retainingArray/Map` apagados; comentários RC atualizados
- `internal/vm/builtins_json.go`, `internal/vm/json_population.go` — troca de helper pelos construtores
- `internal/vm/builtins_sqlite.go`, `internal/vm/builtins_io.go`, `internal/vm/builtins_strings.go` — envelopes via `NewInstanceWith`
- `internal/vm/container_owners_test.go` (novo) — sondas `Owners` (literal == 1, `copyValue` filho == 2, `call_result` value == 1), reproduções (slice, task_await value/error, sqlite.query, io.read_lines, strings.split), não-regressão de clones (`CloneCountValue`, oráculo `"0|1|1|0"`); `internal/vm/cow_test.go` (retain manual de `inner` removido)
- `internal/plugin/plugin_test.go` (novo) — `InterfaceToValue` aninhado → filhos com `Owners == 1`
- `CHANGELOG.md` (`## [0.10.1]`), `AGENTS.md` (§E), `README.md` (badge/REPL), `internal/version/version.go`
- `docs/superpowers/specs/2026-08-20-container-owners-design.md` (cópia da issue), `docs/superpowers/plans/2026-08-20-container-owners.md` (plano + registro da execução)

## Test Plan
- [x] TDD por task: cada teste novo falhou antes da mudança com o valor previsto (`"9|9"`, `"99|99|hacked|hacked"`, `"ZZZ|ZZZ|999|999"`, `Owners=0`) e passou depois
- [x] `go test ./internal/value ./internal/vm ./internal/plugin` verde a cada commit
- [x] `go test ./...` completo (sem `| tail`): 9 pacotes `ok`
- [x] `go vet ./...` limpo; gofmt dos arquivos tocados (normalizando CRLF) limpo
- [x] `grep -rn "retainingArray\|retainingMap" internal` vazio
- [x] `noxy_examples/run_all_tests_concurrent.nx`: 171/171 no worktree
- [x] diff de saída dos exemplos contra o `develop` `1680266` (171 exemplos em cada árvore, 0 com exit ≠ 0): 24 arquivos diferem, todos por não-determinismo (binário/cwd, tempos, ordem de map, rand/uuid/salt, endereços, porta) ou ambiente (`passwords.db` e plugin DynamoDB só no checkout principal; `read_passwords.nx` idêntico com o db copiado) — detalhes no registro da execução do plano
- [x] revisão de código independente: sem Critical; Important (asserção `Owners == 1` dos herdados no merge de `causes`) e Minors (comentários obsoletos, nota na spec da #50) aplicados em `cc0366f`
- [x] comentários postados em #53 (itens 1b/1c/1d fechados aqui; parte do item 3) e #54 (fase A feita; 4º move não listado registrado)
- [ ] merge em `develop` (depois: fechar #55)
