### PR TITLE
feat/repl-line-editing - REPL com edição de linha e histórico (setas) em tty POSIX; seta imprimia ^[[A no Linux/WSL (v0.14.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,13 @@ fmt.Printf("IP: %d, Opcode: %s\n", frame.ip, opcode)
 52
 ```
 
+Em tty POSIX (Linux/macOS/WSL) o REPL lê cada linha pelo editor de linha de
+`internal/lineedit` (setas, Home/End, histórico da sessão, Ctrl-C descarta a
+linha, Ctrl-D sai); a lógica é testável sem tty (`editor_test.go`) e os
+testes de termios/pty rodam só no Linux (`terminal_linux_test.go`). Em pipe e
+no Windows (console cooked já edita a linha) o REPL usa `bufio.Scanner`, como
+sempre — o loop em si é `runREPL(src lineSource, ...)` em `cmd/noxy/main.go`.
+
 ---
 
 ## 📚 Recursos
@@ -399,6 +406,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.14.0)
+**Versão**: 1.0 (Noxy VM 0.14.1)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,8 +298,9 @@ fmt.Printf("IP: %d, Opcode: %s\n", frame.ip, opcode)
 ```
 
 Em tty POSIX (Linux/macOS/WSL) o REPL lê cada linha pelo editor de linha de
-`internal/lineedit` (setas, Home/End, histórico da sessão, Ctrl-C descarta a
-linha, Ctrl-D sai); a lógica é testável sem tty (`editor_test.go`) e os
+`internal/lineedit` (setas, Home/End, histórico da sessão; Ctrl-C encerra o
+REPL com 130, como o SIGINT de sempre; Ctrl-D/`exit` saem com 0); a lógica é
+testável sem tty (`editor_test.go`) e os
 testes de termios/pty rodam só no Linux (`terminal_linux_test.go`). Em pipe e
 no Windows (console cooked já edita a linha) o REPL usa `bufio.Scanner`, como
 sempre — o loop em si é `runREPL(src lineSource, ...)` em `cmd/noxy/main.go`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.14.1] - 2026-08-22
+
+Ergonomia do REPL fora do Windows: no Linux/macOS (WSL incluído) uma seta
+no prompt imprimia `^[[A` em vez de andar pelo histórico, porque o modo
+canônico do tty só entende Backspace/^U/^W e o REPL lia a linha crua. O REPL
+ganha um editor de linha próprio em terminais POSIX; no Windows, onde o
+console em modo cooked já edita a linha e guarda histórico, nada muda.
+
+### Added
+
+- **Edição de linha e histórico no REPL (Linux/macOS).** Quando stdin é um
+  terminal, o REPL lê cada linha com um editor próprio (`internal/lineedit`,
+  no espírito do readline): ←/→ (Ctrl-B/Ctrl-F) movem o cursor, Home/End
+  (Ctrl-A/Ctrl-E) vão às pontas, Backspace/Delete apagam (Ctrl-D com texto =
+  Delete), Ctrl-K/Ctrl-U apagam até o fim/início, Ctrl-W apaga a palavra
+  anterior, Ctrl-L limpa a tela, Tab insere 4 espaços. ↑/↓ (Ctrl-P/Ctrl-N)
+  percorrem o histórico da sessão — só em memória; linha vazia e repetição
+  imediata não entram — preservando a linha que estava sendo digitada ao
+  voltar. Ctrl-C descarta a linha **e o bloco multilinha em andamento** e
+  volta ao prompt `>>>`, com `^C` na tela, como no Python; Ctrl-D numa linha
+  vazia sai. Texto UTF-8 é editado por rune (uma coluna por rune; sem
+  tratamento de largura dupla) e linha mais larga que o terminal rola
+  horizontalmente em vez de quebrar. O tty só fica em modo raw durante a
+  leitura de UMA linha e volta ao modo anterior antes de cada execução —
+  `input()`/`io.read_line` e o shell continuam vendo o modo cooked; `OPOST`
+  fica ligado, então saída de tasks durante a edição não sai "em escada". Em
+  pipe/arquivo (stdin não é tty) e no Windows o REPL lê linhas como antes.
+  Sem dependência nova: termios via `golang.org/x/sys/unix`, já usado.
+
 ## [0.14.0] - 2026-08-22
 
 Dois pedidos pequenos, no espírito do Python: `range` vira builtin do runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ console em modo cooked já edita a linha e guarda histórico, nada muda.
   anterior, Ctrl-L limpa a tela, Tab insere 4 espaços. ↑/↓ (Ctrl-P/Ctrl-N)
   percorrem o histórico da sessão — só em memória; linha vazia e repetição
   imediata não entram — preservando a linha que estava sendo digitada ao
-  voltar. Ctrl-C descarta a linha **e o bloco multilinha em andamento** e
-  volta ao prompt `>>>`, com `^C` na tela, como no Python; Ctrl-D numa linha
-  vazia sai. Texto UTF-8 é editado por rune (uma coluna por rune; sem
+  voltar. Ctrl-C **encerra o REPL** (eco `^C`, código de saída 130 =
+  128+SIGINT), exatamente como o SIGINT encerrava antes e como no Windows —
+  para limpar a linha sem sair use Ctrl-U; Ctrl-D numa linha vazia (ou
+  `exit`) sai com 0. Texto UTF-8 é editado por rune (uma coluna por rune; sem
   tratamento de largura dupla) e linha mais larga que o terminal rola
   horizontalmente em vez de quebrar. O tty só fica em modo raw durante a
   leitura de UMA linha e volta ao modo anterior antes de cada execução —

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.14.0](https://img.shields.io/badge/noxy-0.14.0-blue)](CHANGELOG.md)
+[![noxy 0.14.1](https://img.shields.io/badge/noxy-0.14.1-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.14.0
+Noxy REPL v0.14.1
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5
@@ -115,6 +115,11 @@ Type 'exit' to quit.
 ... end
 Multiline support!
 ```
+
+On Linux and macOS the REPL edits the line in place: ←/→ move the cursor,
+↑/↓ walk the session history, Home/End, Ctrl-A/E/K/U/W/L behave as in
+readline, Ctrl-C discards the line (and the block being typed) and Ctrl-D
+exits. On Windows the console provides the same through its own line editing.
 
 ## Quick Example
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Multiline support!
 
 On Linux and macOS the REPL edits the line in place: ←/→ move the cursor,
 ↑/↓ walk the session history, Home/End, Ctrl-A/E/K/U/W/L behave as in
-readline, Ctrl-C discards the line (and the block being typed) and Ctrl-D
-exits. On Windows the console provides the same through its own line editing.
+readline; Ctrl-C quits the REPL (as it always did) and so does Ctrl-D or
+`exit`. On Windows the console provides the same through its own line editing.
 
 ## Quick Example
 

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -82,7 +82,9 @@ func main() {
 	args := flag.Args()
 
 	if len(args) < 1 {
-		startREPL(*showDisassembly)
+		if code := startREPL(*showDisassembly); code != 0 {
+			os.Exit(code)
+		}
 		return
 	}
 
@@ -157,8 +159,10 @@ func getDir(path string) string {
 // lineSource e de onde o REPL le cada linha: o editor de linha (tty POSIX,
 // com setas e historico) ou o bufio.Scanner (pipe, arquivo, Windows — onde o
 // proprio console edita a linha). ReadLine mostra o prompt e devolve a linha
-// sem terminador; io.EOF encerra o REPL e lineedit.ErrInterrupt (Ctrl-C)
-// descarta a entrada em andamento.
+// sem terminador; io.EOF encerra o REPL normalmente e lineedit.ErrInterrupt
+// (Ctrl-C) o encerra como um SIGINT encerraria — no Windows (console cooked)
+// e no Unix antes do editor, Ctrl-C no prompt matava o processo, e o editor
+// preserva esse contrato.
 type lineSource interface {
 	ReadLine(prompt string) (string, error)
 }
@@ -181,7 +185,10 @@ func (s *scannerSource) ReadLine(prompt string) (string, error) {
 	return s.scanner.Text(), nil
 }
 
-func startREPL(showDisasm bool) {
+// startREPL roda o REPL e devolve o codigo de saida do processo: 0 em `exit`
+// ou EOF (Ctrl-D), 130 (128+SIGINT) quando Ctrl-C encerrou — o mesmo que o
+// shell veria se o processo tivesse morrido pelo sinal.
+func startREPL(showDisasm bool) int {
 	fmt.Printf("Noxy REPL %s\n", version.Version)
 	fmt.Println("Type 'exit' to quit.")
 
@@ -203,11 +210,21 @@ func startREPL(showDisasm bool) {
 	} else {
 		src = &scannerSource{scanner: bufio.NewScanner(os.Stdin)}
 	}
-	runREPL(src, prompt, contPrompt, showDisasm)
+	return replExitCode(runREPL(src, prompt, contPrompt, showDisasm))
+}
+
+// replExitCode traduz o fim do loop em codigo de saida: Ctrl-C vira 130,
+// como um processo morto por SIGINT; o resto e saida normal.
+func replExitCode(err error) int {
+	if errors.Is(err, lineedit.ErrInterrupt) {
+		return 130
+	}
+	return 0
 }
 
 // runREPL e o loop ler-compilar-executar sobre a fonte de linhas dada.
-func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) {
+// Devolve lineedit.ErrInterrupt se Ctrl-C o encerrou e nil em `exit`/EOF.
+func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) error {
 	// Shared VM for persistence
 	machine := vm.NewWithConfig(vm.VMConfig{RootPath: "."})
 
@@ -241,10 +258,9 @@ func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) {
 		}
 		line, err := src.ReadLine(currentPrompt)
 		if errors.Is(err, lineedit.ErrInterrupt) {
-			// Ctrl-C: abandona o bloco em andamento e volta ao prompt
-			// principal, como no Python.
-			inputBuffer = ""
-			continue
+			// Ctrl-C encerra o REPL (o editor ja restaurou o tty e escreveu
+			// "^C"); o chamador sai com 130.
+			return err
 		}
 		if err != nil {
 			break
@@ -354,6 +370,7 @@ func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) {
 
 		inputBuffer = "" // Reset buffer after execution
 	}
+	return nil
 }
 
 func verify() {

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -10,6 +10,7 @@ import (
 	"noxy-vm/internal/compiler"
 	"noxy-vm/internal/console"
 	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/lineedit"
 	"noxy-vm/internal/parser"
 	"noxy-vm/internal/pkgmanager"
 	"noxy-vm/internal/token"
@@ -153,6 +154,33 @@ func getDir(path string) string {
 	return filepath.Dir(path)
 }
 
+// lineSource e de onde o REPL le cada linha: o editor de linha (tty POSIX,
+// com setas e historico) ou o bufio.Scanner (pipe, arquivo, Windows — onde o
+// proprio console edita a linha). ReadLine mostra o prompt e devolve a linha
+// sem terminador; io.EOF encerra o REPL e lineedit.ErrInterrupt (Ctrl-C)
+// descarta a entrada em andamento.
+type lineSource interface {
+	ReadLine(prompt string) (string, error)
+}
+
+// scannerSource le linhas convencionais de stdin.
+type scannerSource struct {
+	scanner *bufio.Scanner
+}
+
+func (s *scannerSource) ReadLine(prompt string) (string, error) {
+	// A crashed raw-mode program (e.g. a terminal game) leaves the shared
+	// console without line input or echo, which would freeze Scan below.
+	console.EnsureLineInput()
+	// os.Stdout nao tem buffer em Go: o prompt sai direto no write, sem Sync
+	// (FlushFileBuffers num pipe do Windows bloqueia ate alguem ler).
+	fmt.Print(prompt)
+	if !s.scanner.Scan() {
+		return "", io.EOF
+	}
+	return s.scanner.Text(), nil
+}
+
 func startREPL(showDisasm bool) {
 	fmt.Printf("Noxy REPL %s\n", version.Version)
 	fmt.Println("Type 'exit' to quit.")
@@ -166,9 +194,22 @@ func startREPL(showDisasm bool) {
 		contPrompt = "\x1b[1;35m... \x1b[0m"
 	}
 
+	// Num tty POSIX o editor de linha cuida de setas, Home/End e historico
+	// (o modo canonico do tty nao sabe: seta virava "^[[A" na tela). Em pipe
+	// e no Windows (console cooked ja edita) fica o Scanner de sempre.
+	var src lineSource
+	if editor := lineedit.Stdin(); editor != nil {
+		src = editor
+	} else {
+		src = &scannerSource{scanner: bufio.NewScanner(os.Stdin)}
+	}
+	runREPL(src, prompt, contPrompt, showDisasm)
+}
+
+// runREPL e o loop ler-compilar-executar sobre a fonte de linhas dada.
+func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) {
 	// Shared VM for persistence
 	machine := vm.NewWithConfig(vm.VMConfig{RootPath: "."})
-	scanner := bufio.NewScanner(os.Stdin)
 
 	// Persist globals, struct definitions (comuns e instancias monomorfizadas
 	// de generico) e o registry de templates genericos entre linhas do REPL
@@ -194,21 +235,20 @@ func startREPL(showDisasm bool) {
 	var inputBuffer string
 
 	for {
-		// A crashed raw-mode program (e.g. a terminal game) leaves the shared
-		// console without line input or echo, which would freeze Scan below.
-		console.EnsureLineInput()
-
-		if inputBuffer == "" {
-			fmt.Print(prompt)
-		} else {
-			fmt.Print(contPrompt)
+		currentPrompt := prompt
+		if inputBuffer != "" {
+			currentPrompt = contPrompt
 		}
-		os.Stdout.Sync()
-
-		if !scanner.Scan() {
+		line, err := src.ReadLine(currentPrompt)
+		if errors.Is(err, lineedit.ErrInterrupt) {
+			// Ctrl-C: abandona o bloco em andamento e volta ao prompt
+			// principal, como no Python.
+			inputBuffer = ""
+			continue
+		}
+		if err != nil {
 			break
 		}
-		line := scanner.Text()
 
 		if strings.TrimSpace(line) == "exit" {
 			break

--- a/cmd/noxy/main_test.go
+++ b/cmd/noxy/main_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"noxy-vm/internal/lineedit"
 )
 
 func captureStdout(t *testing.T, run func()) string {
@@ -61,5 +64,95 @@ func TestLoadScriptMissingFileReportsAndFails(t *testing.T) {
 	}
 	if !strings.Contains(diag.String(), "Error reading file:") {
 		t.Fatalf("diagnostics=%q", diag.String())
+	}
+}
+
+// fakeLine e um passo de entrada do REPL: o texto digitado ou o erro que a
+// fonte devolveria (Ctrl-C, EOF).
+type fakeLine struct {
+	text string
+	err  error
+}
+
+// fakeLines simula a fonte de linhas do REPL e registra os prompts pedidos,
+// para testar o loop sem tty nem editor.
+type fakeLines struct {
+	steps   []fakeLine
+	prompts []string
+}
+
+func (f *fakeLines) ReadLine(prompt string) (string, error) {
+	f.prompts = append(f.prompts, prompt)
+	if len(f.steps) == 0 {
+		return "", io.EOF
+	}
+	step := f.steps[0]
+	f.steps = f.steps[1:]
+	return step.text, step.err
+}
+
+func TestREPLAsksContinuationPromptWhileInputIsIncomplete(t *testing.T) {
+	src := &fakeLines{steps: []fakeLine{{text: "if true then"}, {text: "print(1)"}, {text: "end"}}}
+	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	if !strings.Contains(stdout, "1\n") {
+		t.Fatalf("block did not run; stdout=%q", stdout)
+	}
+	want := []string{">>> ", "... ", "... ", ">>> "}
+	if strings.Join(src.prompts, "|") != strings.Join(want, "|") {
+		t.Fatalf("prompts = %q, want %q", src.prompts, want)
+	}
+}
+
+func TestREPLInterruptDiscardsIncompleteInput(t *testing.T) {
+	diag := withDiagBuffer(t)
+	src := &fakeLines{steps: []fakeLine{
+		{text: "if true then"},
+		{err: lineedit.ErrInterrupt},
+		{text: "print(2)"},
+	}}
+	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	if !strings.Contains(stdout, "2\n") {
+		t.Fatalf("line after Ctrl-C did not run on its own; stdout=%q diag=%q", stdout, diag.String())
+	}
+	// Depois do Ctrl-C o prompt volta ao principal, nao ao de continuacao.
+	if got := src.prompts[2]; got != ">>> " {
+		t.Fatalf("prompt after interrupt = %q, want %q", got, ">>> ")
+	}
+}
+
+func TestREPLStopsOnEOFAndOnExit(t *testing.T) {
+	src := &fakeLines{steps: []fakeLine{{text: "print(3)"}, {text: "exit"}, {text: "print(4)"}}}
+	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	if !strings.Contains(stdout, "3\n") || strings.Contains(stdout, "4\n") {
+		t.Fatalf("exit must stop the loop; stdout=%q", stdout)
+	}
+	src = &fakeLines{steps: []fakeLine{{text: "print(5)"}, {err: io.EOF}, {text: "print(6)"}}}
+	stdout = captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	if !strings.Contains(stdout, "5\n") || strings.Contains(stdout, "6\n") {
+		t.Fatalf("EOF must stop the loop; stdout=%q", stdout)
+	}
+}
+
+func TestScannerSourceReturnsLinesThenEOF(t *testing.T) {
+	src := &scannerSource{scanner: bufio.NewScanner(strings.NewReader("a\nb\n"))}
+	var lines []string
+	stdout := captureStdout(t, func() {
+		for {
+			line, err := src.ReadLine(">>> ")
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			lines = append(lines, line)
+		}
+	})
+	if strings.Join(lines, "|") != "a|b" {
+		t.Fatalf("lines = %q", lines)
+	}
+	if strings.Count(stdout, ">>> ") != 3 {
+		t.Fatalf("prompt must be printed before every read; stdout=%q", stdout)
 	}
 }

--- a/cmd/noxy/main_test.go
+++ b/cmd/noxy/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -103,33 +104,54 @@ func TestREPLAsksContinuationPromptWhileInputIsIncomplete(t *testing.T) {
 	}
 }
 
-func TestREPLInterruptDiscardsIncompleteInput(t *testing.T) {
-	diag := withDiagBuffer(t)
+// Ctrl-C no prompt encerra o REPL, como no Windows (console cooked) e como
+// era no Unix antes do editor de linha (SIGINT matava o processo): o loop
+// para na hora e devolve ErrInterrupt para o chamador sair com 130.
+func TestREPLInterruptStopsTheLoopAndReportsIt(t *testing.T) {
 	src := &fakeLines{steps: []fakeLine{
-		{text: "if true then"},
+		{text: "print(1)"},
 		{err: lineedit.ErrInterrupt},
 		{text: "print(2)"},
 	}}
-	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
-	if !strings.Contains(stdout, "2\n") {
-		t.Fatalf("line after Ctrl-C did not run on its own; stdout=%q diag=%q", stdout, diag.String())
+	var err error
+	stdout := captureStdout(t, func() { err = runREPL(src, ">>> ", "... ", false) })
+	if !errors.Is(err, lineedit.ErrInterrupt) {
+		t.Fatalf("runREPL err = %v, want ErrInterrupt", err)
 	}
-	// Depois do Ctrl-C o prompt volta ao principal, nao ao de continuacao.
-	if got := src.prompts[2]; got != ">>> " {
-		t.Fatalf("prompt after interrupt = %q, want %q", got, ">>> ")
+	if !strings.Contains(stdout, "1\n") || strings.Contains(stdout, "2\n") {
+		t.Fatalf("Ctrl-C must stop the loop; stdout=%q", stdout)
+	}
+	if len(src.prompts) != 2 {
+		t.Fatalf("prompts after interrupt = %q, want exactly 2 reads", src.prompts)
 	}
 }
 
 func TestREPLStopsOnEOFAndOnExit(t *testing.T) {
 	src := &fakeLines{steps: []fakeLine{{text: "print(3)"}, {text: "exit"}, {text: "print(4)"}}}
-	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	var err error
+	stdout := captureStdout(t, func() { err = runREPL(src, ">>> ", "... ", false) })
+	if err != nil {
+		t.Fatalf("exit: runREPL err = %v, want nil", err)
+	}
 	if !strings.Contains(stdout, "3\n") || strings.Contains(stdout, "4\n") {
 		t.Fatalf("exit must stop the loop; stdout=%q", stdout)
 	}
 	src = &fakeLines{steps: []fakeLine{{text: "print(5)"}, {err: io.EOF}, {text: "print(6)"}}}
-	stdout = captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	stdout = captureStdout(t, func() { err = runREPL(src, ">>> ", "... ", false) })
+	if err != nil {
+		t.Fatalf("EOF: runREPL err = %v, want nil", err)
+	}
 	if !strings.Contains(stdout, "5\n") || strings.Contains(stdout, "6\n") {
 		t.Fatalf("EOF must stop the loop; stdout=%q", stdout)
+	}
+}
+
+func TestREPLExitCodeIs130OnInterruptAndZeroOtherwise(t *testing.T) {
+	if got := replExitCode(nil); got != 0 {
+		t.Fatalf("replExitCode(nil) = %d, want 0", got)
+	}
+	if got := replExitCode(lineedit.ErrInterrupt); got != 130 {
+		t.Fatalf("replExitCode(ErrInterrupt) = %d, want 130", got)
 	}
 }
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2071,7 +2071,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.14.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.14.1`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.14.0
+print(sys.version)           // v0.14.1
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/lineedit/editor.go
+++ b/internal/lineedit/editor.go
@@ -1,0 +1,411 @@
+// Package lineedit e um editor de linha minimo, no espirito do readline, para
+// o REPL em terminais POSIX. No Windows o console em modo cooked ja edita a
+// linha e guarda historico sozinho; no Linux/macOS o modo canonico do tty so
+// entende Backspace/^U/^W — uma seta chega como os bytes literais "ESC [ A".
+// O editor poe o tty em modo raw enquanto le UMA linha, desenha o prompt e o
+// texto por conta propria e devolve o terminal ao modo anterior antes de
+// retornar, para o programa Noxy (input(), io.read_line) e o shell verem o
+// modo cooked de sempre.
+//
+// A logica de edicao e independente de SO (reader/writer/Terminal injetados),
+// o que permite testa-la sem tty; so a troca de modo e a largura ficam no
+// Terminal da plataforma.
+package lineedit
+
+import (
+	"errors"
+	"io"
+	"strconv"
+	"unicode/utf8"
+)
+
+// ErrInterrupt e devolvido por ReadLine quando o usuario digita Ctrl-C: a
+// linha em edicao foi descartada e o terminal ja esta restaurado.
+var ErrInterrupt = errors.New("lineedit: interrupted")
+
+// Terminal abstrai o que o editor precisa do tty: entrar em modo raw (com a
+// funcao que desfaz a troca) e a largura em colunas.
+type Terminal interface {
+	MakeRaw() (restore func() error, err error)
+	Width() int
+}
+
+// Editor le linhas editaveis de um terminal. Nao e seguro para uso
+// concorrente.
+type Editor struct {
+	in   io.Reader
+	out  io.Writer
+	term Terminal
+
+	// pending guarda bytes lidos alem da linha atual (colagem de varias
+	// linhas): a proxima ReadLine consome-os antes de voltar ao reader.
+	pending []byte
+
+	// history guarda as linhas aceitas na sessao (sem vazias nem repeticao
+	// consecutiva); histIdx == len(history) e a linha nova em edicao, e
+	// draft preserva essa linha enquanto o usuario navega pelo historico.
+	history []string
+	histIdx int
+	draft   []rune
+
+	// Estado da linha em edicao.
+	prompt      string
+	promptWidth int
+	line        []rune
+	cursor      int // indice em runas
+	start       int // primeira runa visivel (scroll horizontal)
+}
+
+// New cria um editor que le de in, desenha em out e controla o modo via term.
+func New(in io.Reader, out io.Writer, term Terminal) *Editor {
+	return &Editor{in: in, out: out, term: term}
+}
+
+// ReadLine desenha o prompt, edita uma linha ate Enter e a devolve sem o
+// terminador. Erros: io.EOF quando a entrada acaba (ou Ctrl-D numa linha
+// vazia), ErrInterrupt em Ctrl-C. Em qualquer saida o terminal volta ao modo
+// em que estava.
+func (e *Editor) ReadLine(prompt string) (string, error) {
+	restore, err := e.term.MakeRaw()
+	if err != nil {
+		return "", err
+	}
+	defer restore()
+
+	e.prompt = prompt
+	e.promptWidth = visibleWidth(prompt)
+	e.line = e.line[:0]
+	e.cursor = 0
+	e.start = 0
+	e.histIdx = len(e.history)
+	e.refresh()
+
+	for {
+		r, err := e.readRune()
+		if err != nil {
+			e.write("\r\n")
+			return string(e.line), err
+		}
+		switch r {
+		case '\r', '\n':
+			e.write("\r\n")
+			line := string(e.line)
+			e.remember(line)
+			return line, nil
+		case 0x03: // Ctrl-C: descarta a linha, sem historico
+			e.write("^C\r\n")
+			return "", ErrInterrupt
+		case 0x04: // Ctrl-D: EOF na linha vazia, senao Delete
+			if len(e.line) == 0 {
+				e.write("\r\n")
+				return "", io.EOF
+			}
+			e.deleteUnderCursor()
+		case 0x10: // Ctrl-P
+			e.historyPrev()
+		case 0x0e: // Ctrl-N
+			e.historyNext()
+		case 0x7f, 0x08: // DEL, BS
+			e.backspace()
+		case 0x1b: // ESC
+			if err := e.escape(); err != nil {
+				e.write("\r\n")
+				return string(e.line), err
+			}
+		case 0x01: // Ctrl-A
+			e.cursor = 0
+		case 0x05: // Ctrl-E
+			e.cursor = len(e.line)
+		case 0x02: // Ctrl-B
+			e.moveLeft()
+		case 0x06: // Ctrl-F
+			e.moveRight()
+		case 0x0b: // Ctrl-K: apaga do cursor ao fim
+			e.line = e.line[:e.cursor]
+		case 0x15: // Ctrl-U: apaga do inicio ao cursor
+			e.line = append(e.line[:0], e.line[e.cursor:]...)
+			e.cursor = 0
+		case 0x17: // Ctrl-W
+			e.deleteWord()
+		case 0x0c: // Ctrl-L
+			e.write("\x1b[H\x1b[2J")
+		case '\t':
+			for i := 0; i < 4; i++ {
+				e.insert(' ')
+			}
+		default:
+			if r >= 0x20 {
+				e.insert(r)
+			}
+		}
+		e.refresh()
+	}
+}
+
+// escape consome uma sequencia de escape (CSI "ESC [ ... final" ou SS3
+// "ESC O x") e aplica a acao correspondente; sequencias desconhecidas sao
+// engolidas em silencio.
+func (e *Editor) escape() error {
+	b, err := e.readByte()
+	if err != nil {
+		return err
+	}
+	switch b {
+	case '[':
+		var params []byte
+		for {
+			c, err := e.readByte()
+			if err != nil {
+				return err
+			}
+			if c >= 0x40 && c <= 0x7e {
+				e.csi(params, c)
+				return nil
+			}
+			params = append(params, c)
+		}
+	case 'O':
+		c, err := e.readByte()
+		if err != nil {
+			return err
+		}
+		e.csi(nil, c)
+	}
+	return nil
+}
+
+// csi executa o byte final de uma sequencia CSI/SS3. params sao os bytes
+// entre "ESC [" e o final ("3" em "ESC [ 3 ~").
+func (e *Editor) csi(params []byte, final byte) {
+	switch final {
+	case 'A':
+		e.historyPrev()
+	case 'B':
+		e.historyNext()
+	case 'C':
+		e.moveRight()
+	case 'D':
+		e.moveLeft()
+	case 'H':
+		e.cursor = 0
+	case 'F':
+		e.cursor = len(e.line)
+	case '~':
+		switch string(params) {
+		case "1", "7": // Home (vt/rxvt)
+			e.cursor = 0
+		case "4", "8": // End (vt/rxvt)
+			e.cursor = len(e.line)
+		case "3": // Delete
+			e.deleteUnderCursor()
+		}
+	}
+}
+
+func (e *Editor) insert(r rune) {
+	e.line = append(e.line, 0)
+	copy(e.line[e.cursor+1:], e.line[e.cursor:])
+	e.line[e.cursor] = r
+	e.cursor++
+}
+
+func (e *Editor) backspace() {
+	if e.cursor == 0 {
+		return
+	}
+	e.line = append(e.line[:e.cursor-1], e.line[e.cursor:]...)
+	e.cursor--
+}
+
+func (e *Editor) deleteUnderCursor() {
+	if e.cursor >= len(e.line) {
+		return
+	}
+	e.line = append(e.line[:e.cursor], e.line[e.cursor+1:]...)
+}
+
+// remember acrescenta a linha aceita ao historico, pulando vazias e a
+// repeticao imediata da ultima entrada.
+func (e *Editor) remember(line string) {
+	if line == "" {
+		return
+	}
+	if n := len(e.history); n > 0 && e.history[n-1] == line {
+		return
+	}
+	e.history = append(e.history, line)
+}
+
+// historyPrev troca a linha em edicao pela entrada anterior do historico,
+// guardando a linha nova (draft) na primeira subida para o historyNext
+// devolve-la.
+func (e *Editor) historyPrev() {
+	if e.histIdx == 0 {
+		return
+	}
+	if e.histIdx == len(e.history) {
+		e.draft = append(e.draft[:0], e.line...)
+	}
+	e.histIdx--
+	e.setLine([]rune(e.history[e.histIdx]))
+}
+
+// historyNext anda para a entrada seguinte; ao passar da ultima volta a
+// linha nova que estava em edicao (draft).
+func (e *Editor) historyNext() {
+	if e.histIdx >= len(e.history) {
+		return
+	}
+	e.histIdx++
+	if e.histIdx == len(e.history) {
+		e.setLine(e.draft)
+		return
+	}
+	e.setLine([]rune(e.history[e.histIdx]))
+}
+
+func (e *Editor) setLine(text []rune) {
+	e.line = append(e.line[:0], text...)
+	e.cursor = len(e.line)
+}
+
+// deleteWord apaga a palavra antes do cursor (espacos imediatamente antes do
+// cursor incluidos), como o Ctrl-W do readline/tty.
+func (e *Editor) deleteWord() {
+	end := e.cursor
+	i := e.cursor
+	for i > 0 && e.line[i-1] == ' ' {
+		i--
+	}
+	for i > 0 && e.line[i-1] != ' ' {
+		i--
+	}
+	e.line = append(e.line[:i], e.line[end:]...)
+	e.cursor = i
+}
+
+func (e *Editor) moveLeft() {
+	if e.cursor > 0 {
+		e.cursor--
+	}
+}
+
+func (e *Editor) moveRight() {
+	if e.cursor < len(e.line) {
+		e.cursor++
+	}
+}
+
+// refresh redesenha a linha inteira: volta ao inicio da linha fisica,
+// escreve prompt + trecho visivel, apaga o resto e posiciona o cursor. Linhas
+// mais largas que o terminal rolam horizontalmente (o trecho visivel segue o
+// cursor), o que evita lidar com quebra de linha do terminal.
+func (e *Editor) refresh() {
+	cols := e.term.Width()
+	if cols <= 0 {
+		cols = 80
+	}
+	avail := cols - e.promptWidth - 1
+	if avail < 1 {
+		avail = 1
+	}
+	if e.cursor < e.start {
+		e.start = e.cursor
+	}
+	if e.cursor >= e.start+avail {
+		e.start = e.cursor - avail + 1
+	}
+	end := e.start + avail
+	if end > len(e.line) {
+		end = len(e.line)
+	}
+	buf := make([]byte, 0, 64)
+	buf = append(buf, '\r')
+	buf = append(buf, e.prompt...)
+	buf = append(buf, string(e.line[e.start:end])...)
+	buf = append(buf, "\x1b[K\r"...)
+	if col := e.promptWidth + e.cursor - e.start; col > 0 {
+		buf = append(buf, "\x1b["...)
+		buf = strconv.AppendInt(buf, int64(col), 10)
+		buf = append(buf, 'C')
+	}
+	e.out.Write(buf)
+}
+
+func (e *Editor) write(s string) {
+	io.WriteString(e.out, s)
+}
+
+// readRune le uma runa UTF-8 (ou um byte de controle) da entrada.
+func (e *Editor) readRune() (rune, error) {
+	var buf [utf8.UTFMax]byte
+	n := 0
+	for {
+		b, err := e.readByte()
+		if err != nil {
+			return 0, err
+		}
+		buf[n] = b
+		n++
+		if utf8.FullRune(buf[:n]) {
+			r, _ := utf8.DecodeRune(buf[:n])
+			return r, nil
+		}
+		if n == len(buf) {
+			return utf8.RuneError, nil
+		}
+	}
+}
+
+// readByte devolve o proximo byte, servindo primeiro o que sobrou de uma
+// leitura anterior. Em modo raw (VMIN=1) Read bloqueia ate haver ao menos um
+// byte e devolve o que estiver disponivel — numa colagem, varias linhas de
+// uma vez.
+func (e *Editor) readByte() (byte, error) {
+	for len(e.pending) == 0 {
+		var buf [64]byte
+		n, err := e.in.Read(buf[:])
+		if n > 0 {
+			e.pending = append(e.pending, buf[:n]...)
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+	b := e.pending[0]
+	e.pending = e.pending[1:]
+	return b, nil
+}
+
+// visibleWidth conta as colunas que o prompt ocupa, ignorando sequencias de
+// escape ANSI (cor) — uma coluna por runa.
+func visibleWidth(s string) int {
+	const (
+		text = iota
+		afterESC
+		inCSI
+	)
+	width, state := 0, text
+	for _, r := range s {
+		switch state {
+		case afterESC:
+			if r == '[' {
+				state = inCSI
+			} else {
+				state = text // ESC x: sequencia de um caractere
+			}
+		case inCSI:
+			if r >= 0x40 && r <= 0x7e {
+				state = text
+			}
+		default:
+			if r == 0x1b {
+				state = afterESC
+			} else {
+				width++
+			}
+		}
+	}
+	return width
+}

--- a/internal/lineedit/editor_test.go
+++ b/internal/lineedit/editor_test.go
@@ -1,0 +1,367 @@
+package lineedit
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakeTerm registra as trocas de modo e devolve uma largura fixa, para os
+// testes exercitarem o editor sem um tty de verdade.
+type fakeTerm struct {
+	width    int
+	raw      int
+	restored int
+}
+
+func (t *fakeTerm) MakeRaw() (func() error, error) {
+	t.raw++
+	return func() error { t.restored++; return nil }, nil
+}
+
+func (t *fakeTerm) Width() int { return t.width }
+
+func newTestEditor(input string, width int) (*Editor, *bytes.Buffer, *fakeTerm) {
+	out := &bytes.Buffer{}
+	term := &fakeTerm{width: width}
+	return New(strings.NewReader(input), out, term), out, term
+}
+
+func readOne(t *testing.T, input string) string {
+	t.Helper()
+	ed, _, _ := newTestEditor(input, 80)
+	line, err := ed.ReadLine(">>> ")
+	if err != nil {
+		t.Fatalf("ReadLine(%q) error: %v", input, err)
+	}
+	return line
+}
+
+func TestReadLineReturnsTypedLineOnEnter(t *testing.T) {
+	ed, out, _ := newTestEditor("print(1)\r", 80)
+	line, err := ed.ReadLine(">>> ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if line != "print(1)" {
+		t.Fatalf("line = %q, want %q", line, "print(1)")
+	}
+	if !strings.Contains(out.String(), ">>> ") {
+		t.Fatalf("prompt not written; output = %q", out.String())
+	}
+	if !strings.Contains(out.String(), "print(1)") {
+		t.Fatalf("typed text not echoed; output = %q", out.String())
+	}
+	if !strings.HasSuffix(out.String(), "\r\n") {
+		t.Fatalf("Enter must end the line with CRLF; output = %q", out.String())
+	}
+}
+
+func TestReadLineAcceptsLineFeedAsEnter(t *testing.T) {
+	if got := readOne(t, "x\n"); got != "x" {
+		t.Fatalf("line = %q, want %q", got, "x")
+	}
+}
+
+func TestLeftArrowInsertsBeforeCursor(t *testing.T) {
+	if got := readOne(t, "ac\x1b[Db\r"); got != "abc" {
+		t.Fatalf("line = %q, want %q", got, "abc")
+	}
+}
+
+func TestRightArrowMovesCursorForward(t *testing.T) {
+	// "ac", volta duas, avanca uma, insere: a b c
+	if got := readOne(t, "ac\x1b[D\x1b[D\x1b[Cb\r"); got != "abc" {
+		t.Fatalf("line = %q, want %q", got, "abc")
+	}
+}
+
+func TestBackspaceDeletesBeforeCursor(t *testing.T) {
+	if got := readOne(t, "abc\x7f\r"); got != "ab" {
+		t.Fatalf("DEL: line = %q, want %q", got, "ab")
+	}
+	if got := readOne(t, "abc\x08\r"); got != "ab" {
+		t.Fatalf("BS: line = %q, want %q", got, "ab")
+	}
+	if got := readOne(t, "\x7f\x7fok\r"); got != "ok" {
+		t.Fatalf("backspace on empty line must be a no-op; line = %q", got)
+	}
+}
+
+func TestRawModeIsRestoredAfterReadLine(t *testing.T) {
+	ed, _, term := newTestEditor("a\r", 80)
+	if _, err := ed.ReadLine(">>> "); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if term.raw != 1 || term.restored != 1 {
+		t.Fatalf("raw=%d restored=%d, want 1/1", term.raw, term.restored)
+	}
+}
+
+func TestHomeAndEndMoveCursorToLineEdges(t *testing.T) {
+	cases := map[string]string{
+		"CSI H / CSI F": "bc\x1b[Ha\x1b[Fd\r",
+		"CSI 1~ / 4~":   "bc\x1b[1~a\x1b[4~d\r",
+		"CSI 7~ / 8~":   "bc\x1b[7~a\x1b[8~d\r",
+		"SS3 H / F":     "bc\x1bOHa\x1bOFd\r",
+		"Ctrl-A / E":    "bc\x01a\x05d\r",
+	}
+	for name, input := range cases {
+		if got := readOne(t, input); got != "abcd" {
+			t.Errorf("%s: line = %q, want %q", name, got, "abcd")
+		}
+	}
+}
+
+func TestCtrlBAndCtrlFMoveCursor(t *testing.T) {
+	if got := readOne(t, "ac\x02b\x06d\r"); got != "abcd" {
+		t.Fatalf("line = %q, want %q", got, "abcd")
+	}
+}
+
+func TestDeleteRemovesCharUnderCursor(t *testing.T) {
+	if got := readOne(t, "abc\x1b[D\x1b[D\x1b[3~\r"); got != "ac" {
+		t.Fatalf("line = %q, want %q", got, "ac")
+	}
+	if got := readOne(t, "abc\x1b[3~\r"); got != "abc" {
+		t.Fatalf("Delete at end must be a no-op; line = %q", got)
+	}
+}
+
+func TestCtrlKKillsToEndOfLine(t *testing.T) {
+	if got := readOne(t, "abcd\x1b[D\x1b[D\x0b\r"); got != "ab" {
+		t.Fatalf("line = %q, want %q", got, "ab")
+	}
+}
+
+func TestCtrlUKillsToStartOfLine(t *testing.T) {
+	if got := readOne(t, "abcd\x1b[D\x15\r"); got != "d" {
+		t.Fatalf("line = %q, want %q", got, "d")
+	}
+}
+
+func TestCtrlWDeletesWordBeforeCursor(t *testing.T) {
+	if got := readOne(t, "let x = foo\x17bar\r"); got != "let x = bar" {
+		t.Fatalf("line = %q, want %q", got, "let x = bar")
+	}
+	// Espacos antes do cursor sao pulados antes de apagar a palavra.
+	if got := readOne(t, "print(a)  \x17\r"); got != "" {
+		t.Fatalf("line = %q, want empty", got)
+	}
+	if got := readOne(t, "a b c\x1b[D\x1b[D\x17\r"); got != "a  c" {
+		t.Fatalf("mid-line: line = %q, want %q", got, "a  c")
+	}
+}
+
+func TestCtrlLClearsScreenAndRedraws(t *testing.T) {
+	ed, out, _ := newTestEditor("ab\x0c\r", 80)
+	line, err := ed.ReadLine(">>> ")
+	if err != nil || line != "ab" {
+		t.Fatalf("line=%q err=%v", line, err)
+	}
+	if !strings.Contains(out.String(), "\x1b[H\x1b[2J") {
+		t.Fatalf("clear-screen sequence missing; output = %q", out.String())
+	}
+	if !strings.HasSuffix(out.String(), "\x1b[H\x1b[2J\r>>> ab\x1b[K\r\x1b[6C\r\n") {
+		t.Fatalf("line not redrawn after clear; output = %q", out.String())
+	}
+}
+
+func TestTabInsertsFourSpaces(t *testing.T) {
+	if got := readOne(t, "\tx\r"); got != "    x" {
+		t.Fatalf("line = %q, want %q", got, "    x")
+	}
+}
+
+// readAll le linhas ate erro e devolve o que veio, para testar historico e
+// colagem (varias ReadLine no mesmo editor).
+func readAll(t *testing.T, ed *Editor) ([]string, error) {
+	t.Helper()
+	var lines []string
+	for {
+		line, err := ed.ReadLine(">>> ")
+		if err != nil {
+			return lines, err
+		}
+		lines = append(lines, line)
+	}
+}
+
+func TestUpArrowRecallsPreviousLines(t *testing.T) {
+	ed, _, _ := newTestEditor("first\rsecond\r\x1b[A\r\x1b[A\x1b[A\r", 80)
+	lines, err := readAll(t, ed)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	want := []string{"first", "second", "second", "first"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+}
+
+func TestDownArrowReturnsToLineBeingEdited(t *testing.T) {
+	// Digita "new", sobe duas no historico, desce duas: volta a "new".
+	ed, _, _ := newTestEditor("a\rb\rnew\x1b[A\x1b[A\x1b[B\x1b[B\r", 80)
+	lines, _ := readAll(t, ed)
+	if got := lines[len(lines)-1]; got != "new" {
+		t.Fatalf("last line = %q, want %q (lines=%q)", got, "new", lines)
+	}
+}
+
+func TestHistoryNavigationViaCtrlPAndCtrlNAndSS3(t *testing.T) {
+	ed, _, _ := newTestEditor("a\rb\r\x10\x10\x0e\r\x1bOA\r", 80)
+	lines, _ := readAll(t, ed)
+	want := []string{"a", "b", "b", "b"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+}
+
+func TestRecalledLineCanBeEdited(t *testing.T) {
+	ed, _, _ := newTestEditor("print(1)\r\x1b[A\x7f\x7f2)\r", 80)
+	lines, _ := readAll(t, ed)
+	want := []string{"print(1)", "print(2)"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+}
+
+func TestHistorySkipsEmptyAndConsecutiveDuplicates(t *testing.T) {
+	ed, _, _ := newTestEditor("x\rx\r\r\x1b[A\x1b[A\r", 80)
+	lines, _ := readAll(t, ed)
+	// Depois de "x", "x", "" o historico e ["x"]: duas setas acima nao
+	// passam dele.
+	want := []string{"x", "x", "", "x"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+}
+
+func TestUpArrowWithEmptyHistoryIsNoop(t *testing.T) {
+	if got := readOne(t, "\x1b[A\x1b[Bok\r"); got != "ok" {
+		t.Fatalf("line = %q, want %q", got, "ok")
+	}
+}
+
+func TestCtrlCDiscardsLineAndReturnsErrInterrupt(t *testing.T) {
+	ed, out, term := newTestEditor("abc\x03", 80)
+	line, err := ed.ReadLine(">>> ")
+	if !errors.Is(err, ErrInterrupt) {
+		t.Fatalf("err = %v, want ErrInterrupt", err)
+	}
+	if line != "" {
+		t.Fatalf("line = %q, want empty", line)
+	}
+	if !strings.HasSuffix(out.String(), "^C\r\n") {
+		t.Fatalf("output must end with ^C and newline; got %q", out.String())
+	}
+	if term.restored != 1 {
+		t.Fatalf("terminal not restored on Ctrl-C (restored=%d)", term.restored)
+	}
+}
+
+func TestInterruptedLineIsNotAddedToHistory(t *testing.T) {
+	ed, _, _ := newTestEditor("keep\rdrop\x03\x1b[A\r", 80)
+	_, _ = ed.ReadLine(">>> ")
+	_, err := ed.ReadLine(">>> ")
+	if !errors.Is(err, ErrInterrupt) {
+		t.Fatalf("err = %v, want ErrInterrupt", err)
+	}
+	line, err := ed.ReadLine(">>> ")
+	if err != nil || line != "keep" {
+		t.Fatalf("line=%q err=%v, want %q", line, err, "keep")
+	}
+}
+
+func TestCtrlDOnEmptyLineReturnsEOF(t *testing.T) {
+	ed, out, _ := newTestEditor("\x04", 80)
+	_, err := ed.ReadLine(">>> ")
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	if !strings.HasSuffix(out.String(), "\r\n") {
+		t.Fatalf("Ctrl-D exit must move to a fresh line; got %q", out.String())
+	}
+}
+
+func TestCtrlDWithTextDeletesUnderCursor(t *testing.T) {
+	if got := readOne(t, "abc\x1b[D\x1b[D\x04\r"); got != "ac" {
+		t.Fatalf("line = %q, want %q", got, "ac")
+	}
+}
+
+func TestUTF8RunesAreInsertedAndDeletedWhole(t *testing.T) {
+	if got := readOne(t, "çã\x7f\r"); got != "ç" {
+		t.Fatalf("line = %q, want %q", got, "ç")
+	}
+	ed, out, _ := newTestEditor("é\r", 80)
+	if _, err := ed.ReadLine(">>> "); err != nil {
+		t.Fatal(err)
+	}
+	// Uma runa = uma coluna: cursor na coluna 5 (prompt 4 + 1).
+	if !strings.HasSuffix(out.String(), "\r>>> é\x1b[K\r\x1b[5C\r\n") {
+		t.Fatalf("cursor column must count runes, not bytes; got %q", out.String())
+	}
+}
+
+func TestUnknownEscapeSequencesAreIgnored(t *testing.T) {
+	// Bracketed paste start/end, F5, ESC+letra: nada disso vira texto.
+	if got := readOne(t, "\x1b[200~a\x1b[201~\x1b[15~\x1bxb\r"); got != "ab" {
+		t.Fatalf("line = %q, want %q", got, "ab")
+	}
+}
+
+func TestPastedLinesAreServedAcrossCalls(t *testing.T) {
+	ed, _, _ := newTestEditor("one\rtwo\rthree\r", 80)
+	lines, err := readAll(t, ed)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	want := []string{"one", "two", "three"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Fatalf("lines = %q, want %q", lines, want)
+	}
+}
+
+func TestColoredPromptCountsOnlyVisibleColumns(t *testing.T) {
+	ed, out, _ := newTestEditor("a\r", 80)
+	prompt := "\x1b[1;35m>>> \x1b[0m"
+	if _, err := ed.ReadLine(prompt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(out.String(), "\r"+prompt+"a\x1b[K\r\x1b[5C\r\n") {
+		t.Fatalf("cursor must land at column 5 (4 visible + 1); got %q", out.String())
+	}
+}
+
+func TestLongLineScrollsHorizontally(t *testing.T) {
+	// Largura 10, prompt 4 => 5 colunas uteis. "abcdefgh" com o cursor no
+	// fim mostra "efgh"; Home volta ao inicio e mostra "abcde".
+	ed, out, _ := newTestEditor("abcdefgh\x1b[H\r", 10)
+	if _, err := ed.ReadLine(">>> "); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "\r>>> efgh\x1b[K\r\x1b[8C") {
+		t.Fatalf("end of long line not scrolled into view; got %q", s)
+	}
+	if !strings.HasSuffix(s, "\r>>> abcde\x1b[K\r\x1b[4C\r\n") {
+		t.Fatalf("Home must scroll back to the start; got %q", s)
+	}
+}
+
+func TestReadLineReturnsEOFWhenInputEnds(t *testing.T) {
+	ed, _, term := newTestEditor("", 80)
+	line, err := ed.ReadLine(">>> ")
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+	if line != "" {
+		t.Fatalf("line = %q, want empty", line)
+	}
+	if term.restored != 1 {
+		t.Fatalf("terminal not restored on EOF (restored=%d)", term.restored)
+	}
+}

--- a/internal/lineedit/terminal_linux_test.go
+++ b/internal/lineedit/terminal_linux_test.go
@@ -1,0 +1,154 @@
+//go:build linux
+
+package lineedit
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// openPTY abre um par pty (mestre/escravo) via /dev/ptmx. O escravo faz o
+// papel do terminal do usuario; o mestre e "o teclado e a tela".
+func openPTY(t *testing.T) (master, slave *os.File) {
+	t.Helper()
+	mfd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Skipf("no /dev/ptmx: %v", err)
+	}
+	if err := unix.IoctlSetPointerInt(mfd, unix.TIOCSPTLCK, 0); err != nil {
+		t.Fatalf("unlockpt: %v", err)
+	}
+	n, err := unix.IoctlGetInt(mfd, unix.TIOCGPTN)
+	if err != nil {
+		t.Fatalf("ptsname: %v", err)
+	}
+	master = os.NewFile(uintptr(mfd), "ptmx")
+	slave, err = os.OpenFile(fmt.Sprintf("/dev/pts/%d", n), os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Fatalf("open slave: %v", err)
+	}
+	t.Cleanup(func() { slave.Close(); master.Close() })
+	return master, slave
+}
+
+func TestNewUnixTerminalRejectsNonTTY(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	if _, err := newUnixTerminal(int(r.Fd())); err == nil {
+		t.Fatal("pipe accepted as terminal")
+	}
+}
+
+func TestMakeRawDisablesCanonicalModeAndRestoreUndoesIt(t *testing.T) {
+	_, slave := openPTY(t)
+	fd := int(slave.Fd())
+	before, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	term, err := newUnixTerminal(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restore, err := term.MakeRaw()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw.Lflag&(unix.ICANON|unix.ECHO|unix.ISIG|unix.IEXTEN) != 0 {
+		t.Fatalf("raw Lflag=%#x still has ICANON/ECHO/ISIG/IEXTEN", raw.Lflag)
+	}
+	if raw.Iflag&(unix.ICRNL|unix.IXON) != 0 {
+		t.Fatalf("raw Iflag=%#x still has ICRNL/IXON", raw.Iflag)
+	}
+	// OPOST fica ligado: saida de outras goroutines (tasks Noxy) durante a
+	// edicao continua com "\n" -> "\r\n".
+	if raw.Oflag&unix.OPOST == 0 {
+		t.Fatalf("raw mode must keep OPOST; Oflag=%#x", raw.Oflag)
+	}
+	if raw.Cc[unix.VMIN] != 1 || raw.Cc[unix.VTIME] != 0 {
+		t.Fatalf("VMIN/VTIME = %d/%d, want 1/0", raw.Cc[unix.VMIN], raw.Cc[unix.VTIME])
+	}
+	if err := restore(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *after != *before {
+		t.Fatalf("termios not restored:\nbefore=%+v\nafter =%+v", *before, *after)
+	}
+}
+
+func TestWidthReadsWindowSize(t *testing.T) {
+	_, slave := openPTY(t)
+	fd := int(slave.Fd())
+	if err := unix.IoctlSetWinsize(fd, unix.TIOCSWINSZ, &unix.Winsize{Row: 24, Col: 57}); err != nil {
+		t.Fatal(err)
+	}
+	term, err := newUnixTerminal(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := term.Width(); got != 57 {
+		t.Fatalf("Width() = %d, want 57", got)
+	}
+}
+
+func TestStdinReturnsNilWhenStdinIsNotATerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	previous := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = previous })
+	if ed := Stdin(); ed != nil {
+		t.Fatal("Stdin() must be nil for a pipe")
+	}
+	_, slave := openPTY(t)
+	os.Stdin = slave
+	if ed := Stdin(); ed == nil {
+		t.Fatal("Stdin() must return an editor for a pty")
+	}
+}
+
+func TestReadLineThroughRealPTYHonorsArrowKeys(t *testing.T) {
+	master, slave := openPTY(t)
+	fd := int(slave.Fd())
+	term, err := newUnixTerminal(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Entra em raw antes de "digitar", para a disciplina de linha nao
+	// processar os bytes (ICRNL, eco) no modo canonico enquanto esperam.
+	restore, err := term.MakeRaw()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restore()
+	if _, err := master.WriteString("ab\x1b[Dc\r"); err != nil {
+		t.Fatal(err)
+	}
+	ed := New(slave, slave, term)
+	line, err := ed.ReadLine(">>> ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "acb" {
+		t.Fatalf("line = %q, want %q", line, "acb")
+	}
+}

--- a/internal/lineedit/terminal_other.go
+++ b/internal/lineedit/terminal_other.go
@@ -1,0 +1,8 @@
+//go:build !(linux || darwin || freebsd || netbsd || openbsd || dragonfly)
+
+package lineedit
+
+// Stdin e nil fora dos sistemas POSIX suportados. No Windows o console em
+// modo cooked ja oferece edicao de linha e historico (setas) para leituras de
+// linha convencionais, entao o REPL segue com bufio.Scanner la.
+func Stdin() *Editor { return nil }

--- a/internal/lineedit/terminal_unix.go
+++ b/internal/lineedit/terminal_unix.go
@@ -1,0 +1,65 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package lineedit
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// unixTerminal controla um tty POSIX via termios/ioctl (x/sys/unix, ja
+// dependencia do projeto — sem x/term).
+type unixTerminal struct {
+	fd int
+}
+
+// newUnixTerminal devolve o terminal do descritor, ou erro se ele nao e um
+// tty (pipe, arquivo): tcgetattr falha com ENOTTY.
+func newUnixTerminal(fd int) (*unixTerminal, error) {
+	if _, err := unix.IoctlGetTermios(fd, ioctlReadTermios); err != nil {
+		return nil, err
+	}
+	return &unixTerminal{fd: fd}, nil
+}
+
+// MakeRaw desliga o modo canonico, o eco e os sinais de teclado (Ctrl-C vira
+// byte), mantendo OPOST: saida de outras goroutines durante a edicao continua
+// traduzindo "\n" em "\r\n". VMIN=1/VTIME=0: Read bloqueia ate haver ao menos
+// um byte. A funcao devolvida restaura exatamente o termios anterior.
+func (t *unixTerminal) MakeRaw() (func() error, error) {
+	saved, err := unix.IoctlGetTermios(t.fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+	raw := *saved
+	raw.Iflag &^= unix.BRKINT | unix.ICRNL | unix.INLCR | unix.IGNCR | unix.ISTRIP | unix.IXON
+	raw.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	raw.Cc[unix.VMIN] = 1
+	raw.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(t.fd, ioctlWriteTermios, &raw); err != nil {
+		return nil, err
+	}
+	return func() error { return unix.IoctlSetTermios(t.fd, ioctlWriteTermios, saved) }, nil
+}
+
+// Width devolve as colunas do terminal, ou 0 se o ioctl falhar (o editor
+// assume 80).
+func (t *unixTerminal) Width() int {
+	ws, err := unix.IoctlGetWinsize(t.fd, unix.TIOCGWINSZ)
+	if err != nil {
+		return 0
+	}
+	return int(ws.Col)
+}
+
+// Stdin devolve um editor sobre os.Stdin/os.Stdout quando stdin e um tty, ou
+// nil quando nao e (pipe, arquivo) — nesse caso o chamador deve ler linhas
+// do jeito convencional.
+func Stdin() *Editor {
+	term, err := newUnixTerminal(int(os.Stdin.Fd()))
+	if err != nil {
+		return nil
+	}
+	return New(os.Stdin, os.Stdout, term)
+}

--- a/internal/lineedit/termios_bsd.go
+++ b/internal/lineedit/termios_bsd.go
@@ -1,0 +1,11 @@
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly
+
+package lineedit
+
+import "golang.org/x/sys/unix"
+
+// BSDs e macOS: tcgetattr/tcsetattr sao TIOCGETA/TIOCSETA.
+const (
+	ioctlReadTermios  = unix.TIOCGETA
+	ioctlWriteTermios = unix.TIOCSETA
+)

--- a/internal/lineedit/termios_linux.go
+++ b/internal/lineedit/termios_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package lineedit
+
+import "golang.org/x/sys/unix"
+
+// Linux: tcgetattr/tcsetattr sao TCGETS/TCSETS.
+const (
+	ioctlReadTermios  = unix.TCGETS
+	ioctlWriteTermios = unix.TCSETS
+)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.14.0"
+const Version = "v0.14.1"


### PR DESCRIPTION
## Summary
- **Bug**: no Linux/macOS (WSL incluído) uma seta no REPL imprimia `^[[A`/`^[[B` em vez de andar pelo histórico — o REPL lia a linha crua com `bufio.Scanner` e o modo canônico do tty só entende Backspace/^U/^W. No Windows "funcionava" porque o console em modo cooked edita a linha e guarda histórico sozinho.
- **Fix**: novo pacote `internal/lineedit`, um editor de linha mínimo no espírito do readline, usado pelo REPL quando stdin é um tty POSIX: ←/→ (Ctrl-B/F), Home/End (Ctrl-A/E), Delete, Backspace, Ctrl-K/U (apagar até o fim/início), Ctrl-W (palavra), Ctrl-L (limpar tela), Tab = 4 espaços; **↑/↓ (Ctrl-P/N) no histórico da sessão** (só em memória; vazias e repetição imediata não entram) preservando a linha em edição ao voltar; **Ctrl-C encerra o REPL** (eco `^C`, código 130 = 128+SIGINT) — o mesmo contrato do Windows e do Unix antes do editor (SIGINT matava o processo); Ctrl-D em linha vazia e `exit` saem com 0; UTF-8 por rune; linha mais larga que o terminal rola horizontalmente; prompt colorido conta só colunas visíveis.
- O tty só fica em modo raw durante a leitura de UMA linha e volta ao modo anterior antes de cada execução e antes de qualquer saída (`input()`/`io.read_line` e o shell seguem vendo o modo cooked); `OPOST` fica ligado (saída de tasks durante a edição não sai "em escada"). Termios via `golang.org/x/sys/unix`, já dependência — **sem `x/term` nem dependência nova**.
- **Windows e pipe não mudam**: `lineedit.Stdin()` devolve `nil` fora de tty / em SO não suportado e o REPL segue com `Scanner` + `console.EnsureLineInput()`. O loop foi extraído para `runREPL(src lineSource, …) error` para ser testável; `startREPL` devolve o código de saída (`replExitCode`) e `main` faz `os.Exit`. Removido `os.Stdout.Sync()` no prompt (inútil — `os.Stdout` não tem buffer — e `FlushFileBuffers` num pipe do Windows bloqueia até alguém ler, o que travava o teste).
- Bump para **v0.14.1** (bugfix): CHANGELOG, README (badge, banner e nota do REPL), AGENTS.md, spec (`sys.version`), `docs/index.html`.

## Components
- `internal/lineedit/editor.go` — `Editor`, `New(in, out, term)`, `ReadLine(prompt)`, `ErrInterrupt`, interface `Terminal{MakeRaw, Width}`; histórico, redesenho com scroll horizontal, parse de CSI/SS3, UTF-8, bytes pendentes de colagem.
- `internal/lineedit/terminal_unix.go` (+ `termios_linux.go` TCGETS/TCSETS, `termios_bsd.go` TIOCGETA/TIOCSETA) — `unixTerminal` (raw sem ECHO/ICANON/ISIG/IEXTEN/ICRNL/IXON, VMIN=1, OPOST mantido, restore exato), `Width()` via TIOCGWINSZ, `Stdin()`; `terminal_other.go` — `Stdin()` nil (Windows etc.).
- `cmd/noxy/main.go` — `lineSource`, `scannerSource` (Scanner + `EnsureLineInput`), `startREPL` escolhe a fonte e devolve o código de saída, `replExitCode` (Ctrl-C → 130), `runREPL` devolve `ErrInterrupt`/nil.
- Testes: `internal/lineedit/editor_test.go` (sem tty, roda em qualquer SO: teclas, histórico, Ctrl-C/D, UTF-8, CSI desconhecido, colagem multilinha, prompt ANSI, scroll); `internal/lineedit/terminal_linux_test.go` (pty real via `/dev/ptmx`: MakeRaw/restore, Width, `Stdin()` nil em pipe, setas através do pty); `cmd/noxy/main_test.go` (prompt de continuação, Ctrl-C para o loop e devolve `ErrInterrupt`, `exit`/EOF devolvem nil, `replExitCode`, `scannerSource`).
- Docs: `CHANGELOG.md` `[0.14.1]`, `README.md`, `AGENTS.md` (seção REPL), `docs/NOXY_LANGUAGE_SPEC.md`, `docs/index.html`, `internal/version/version.go`.

## Test Plan
- [x] TDD: cada lote de testes visto falhar antes do código (pacote inexistente → teclas → histórico com ↑ antes de ↓ → Ctrl-C/D → Ctrl-C encerra) e passar depois
- [x] `go test ./...` verde no Windows; `go vet` (windows/linux/darwin/freebsd) e gofmt limpos
- [x] Testes de termios/pty rodados **num Linux de verdade**: test binary cross-compilado (`GOOS=linux go test -c`) executado no WSL Ubuntu — 5/5 (`MakeRaw` limpa ICANON/ECHO/ISIG e mantém OPOST, restore devolve o termios byte a byte, `Width()`=57 via TIOCSWINSZ, `Stdin()` nil em pipe / editor em pty, `ab ← c ⏎` → `acb`)
- [x] E2E no WSL com `pty.fork` (python3) contra o `noxy` cross-compilado: `print("hi")`, `2 * 3`, ↑↑⏎ re-executa `print("hi")`, edição no meio (`1 + 1` → `12 + 1` = 13), Home/End, Ctrl-D sai com 0; segunda sessão: Ctrl-C dentro de `if true then` ecoa `^C`, sai com **130** e o tty fica cooked (ICANON+ECHO) depois; nenhum `^[[A` na tela; modo por pipe (`printf | noxy_linux`) igual ao de antes
- [x] Windows: REPL por pipe (`printf 'print(1)\n…' | go run ./cmd/noxy`) inalterado; `noxy --version` → `v0.14.1`
- [x] Feedback do WSL (Ctrl-C só limpava a linha e o REPL seguia) corrigido: Ctrl-C agora encerra, como antes
- [ ] Testar interativamente no seu WSL (setas, histórico, Ctrl-C sai, `input()` dentro do REPL voltando ao modo cooked) e no macOS se houver
- [ ] Revisar as premissas: histórico só em memória (sem `~/.noxy_history`), Tab = 4 espaços, Ctrl-U para limpar a linha, patch bump 0.14.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
