### PR TITLE
chore/remove-dead-code - Remove código morto: 5 opcodes nunca emitidos (OP_AND/OP_OR/OP_INVOKE/OP_PRINT/OP_SWAP), ramo bytes em OP_ADD, 3 funções do parser e verify() (#61)

### DIFF
--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -373,34 +373,6 @@ func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) error {
 	return nil
 }
 
-func verify() {
-	input := `
-	func main()
-		struct Point
-			x: int
-			y: int
-		end
-
-		print(111)
-		let p1: Point = Point(1, 2)
-		print(222)
-		print(p1)
-		
-		print(333)
-		let points: Point[] = [p1, Point(3, 4)]
-		print(444)
-		
-		print(555)
-		print(points)
-		print(666)
-		print(points[0])
-	end
-	main()
-	`
-	fmt.Printf("Verifying with input:\n%s\n", input)
-	runWithConfig("verify.nx", input, ".", true)
-}
-
 // runWithConfig devolve o codigo de saida (0 sucesso, 1 erro) em vez de
 // chamar os.Exit diretamente — quem chama (runFile) precisa da chance de
 // rodar seus proprios defers (parar/gravar profile) antes do processo

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -40,8 +40,6 @@ const (
 	OP_GREATER
 	OP_LESS
 	OP_EQUAL
-	OP_AND
-	OP_OR
 	OP_BIT_AND
 	OP_BIT_OR
 	OP_BIT_XOR
@@ -50,9 +48,7 @@ const (
 	OP_SHIFT_RIGHT
 	OP_CALL
 	OP_DEFER
-	OP_INVOKE
 	OP_RETURN
-	OP_PRINT
 	OP_IMPORT
 	OP_IMPORT_FROM_ALL
 	OP_DUP
@@ -83,7 +79,6 @@ const (
 	OP_STORE_VIA_REF
 	OP_STORE_REF
 	OP_SET_PROPERTY_DEREF
-	OP_SWAP
 	OP_COPY
 	OP_ADDR
 	OP_MARK_REF_JSON_DYNAMIC
@@ -263,10 +258,6 @@ func (op OpCode) String() string {
 		return "OP_LESS"
 	case OP_EQUAL:
 		return "OP_EQUAL"
-	case OP_AND:
-		return "OP_AND"
-	case OP_OR:
-		return "OP_OR"
 	case OP_BIT_AND:
 		return "OP_BIT_AND"
 	case OP_BIT_OR:
@@ -283,12 +274,8 @@ func (op OpCode) String() string {
 		return "OP_CALL"
 	case OP_DEFER:
 		return "OP_DEFER"
-	case OP_INVOKE:
-		return "OP_INVOKE"
 	case OP_RETURN:
 		return "OP_RETURN"
-	case OP_PRINT:
-		return "OP_PRINT"
 	case OP_IMPORT:
 		return "OP_IMPORT"
 	case OP_IMPORT_FROM_ALL:
@@ -325,8 +312,6 @@ func (op OpCode) String() string {
 		return "OP_STORE_REF"
 	case OP_SET_PROPERTY_DEREF:
 		return "OP_SET_PROPERTY_DEREF"
-	case OP_SWAP:
-		return "OP_SWAP"
 	case OP_COPY:
 		return "OP_COPY"
 	case OP_ADDR:
@@ -522,10 +507,6 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_DIVIDE", offset)
 	case OP_NOT:
 		return c.simpleInstruction("OP_NOT", offset)
-	case OP_AND:
-		return c.simpleInstruction("OP_AND", offset)
-	case OP_OR:
-		return c.simpleInstruction("OP_OR", offset)
 	case OP_BIT_AND:
 		return c.simpleInstruction("OP_BIT_AND", offset)
 	case OP_BIT_OR:
@@ -540,8 +521,6 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_SHIFT_RIGHT", offset)
 	case OP_NEGATE:
 		return c.simpleInstruction("OP_NEGATE", offset)
-	case OP_PRINT:
-		return c.simpleInstruction("OP_PRINT", offset)
 	case OP_JUMP:
 		return c.shortInstruction("OP_JUMP", offset)
 	case OP_JUMP_IF_FALSE:
@@ -658,8 +637,6 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_STORE_REF", offset)
 	case OP_SET_PROPERTY_DEREF:
 		return c.constantInstruction("OP_SET_PROPERTY_DEREF", offset)
-	case OP_SWAP:
-		return c.simpleInstruction("OP_SWAP", offset)
 	case OP_COPY:
 		return c.simpleInstruction("OP_COPY", offset)
 	case OP_ADDR:

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -42,7 +42,7 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				chunk.OP_CALL_STATIC,
 				chunk.OP_DEFER, chunk.OP_REF_LOCAL, chunk.OP_REF_UPVALUE,
 				chunk.OP_GET_LOCAL_MUT, chunk.OP_GET_UPVALUE_MUT,
-				chunk.OP_SET_PROPERTY_DEREF, chunk.OP_INVOKE,
+				chunk.OP_SET_PROPERTY_DEREF,
 				// RC (Task 7): gemeos de emprestimo e a marca de upvalue —
 				// operando de 1 byte. Sem eles aqui o walker le o operando como
 				// opcode e dessincroniza, perdendo a contagem dos opcodes

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -206,25 +206,6 @@ func (p *Parser) parseStatement() ast.Statement {
 	}
 }
 
-func (p *Parser) parseAssignStatement() *ast.AssignStmt {
-	stmt := &ast.AssignStmt{Token: p.peekToken} // The '=' token
-
-	// Parse Target (Identifier)
-	stmt.Target = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-	p.nextToken() // Eat Identifier
-	p.nextToken() // Eat '='
-
-	stmt.Value = p.parseExpression(LOWEST)
-
-	// Optional newline
-	if p.peekToken.Type == token.NEWLINE {
-		p.nextToken()
-	}
-
-	return stmt
-}
-
 func (p *Parser) parseIfStatement() *ast.IfStatement {
 	stmt := &ast.IfStatement{Token: p.curToken}
 
@@ -496,40 +477,6 @@ func (p *Parser) parseWhenStatement() *ast.WhenStatement {
 	}
 
 	if p.curTokenIs(token.END) {
-		p.nextToken()
-	}
-
-	return stmt
-}
-
-func (p *Parser) parseCaseBlock() *ast.BlockStatement {
-	block := &ast.BlockStatement{Token: p.curToken}
-	block.Statements = []ast.Statement{}
-
-	if p.curTokenIs(token.NEWLINE) {
-		p.nextToken()
-	}
-
-	for !p.curTokenIs(token.CASE) && !p.curTokenIs(token.DEFAULT) && !p.curTokenIs(token.END) && !p.curTokenIs(token.EOF) {
-		stmt := p.parseStatement()
-		if stmt != nil {
-			block.Statements = append(block.Statements, stmt)
-		}
-		p.nextToken()
-		if p.curTokenIs(token.NEWLINE) {
-			p.nextToken() // skip separators
-		}
-	}
-	return block
-}
-
-func (p *Parser) parseExpressionStatement() *ast.ExpressionStmt {
-	stmt := &ast.ExpressionStmt{Token: p.curToken}
-
-	stmt.Expression = p.parseExpression(LOWEST)
-
-	// Optional newline
-	if p.peekToken.Type == token.NEWLINE {
 		p.nextToken()
 	}
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -677,12 +677,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					vm.push(value.NewString(strA + strB))
 					continue // Added continue for cleaner flow
 				}
-				// VAL_BYTES types are stored internally as strings.
-				if a.Type == value.VAL_BYTES && b.Type == value.VAL_BYTES {
-					vm.push(value.NewBytes(a.Obj.(string) + b.Obj.(string)))
-					continue
-				}
-
+				// bytes e VAL_BYTES (nunca VAL_OBJ): o caso bytes+bytes e o
+				// ramo seguinte; aqui so sobra objeto nao-string.
 				return vm.runtimeError(c, ip, "operands must be numbers, strings or bytes")
 			} else if a.Type == value.VAL_BYTES && b.Type == value.VAL_BYTES {
 				// Case where types are explicit VAL_BYTES (not VAL_OBJ)
@@ -1019,22 +1015,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			} else {
 				return vm.runtimeError(c, ip, "operand must be boolean")
 			}
-		case chunk.OP_AND:
-			b := vm.pop()
-			a := vm.pop()
-			if a.Type == value.VAL_BOOL && b.Type == value.VAL_BOOL {
-				vm.push(value.NewBool(a.AsBool && b.AsBool))
-			} else {
-				return vm.runtimeError(c, ip, "operands for & must be boolean")
-			}
-		case chunk.OP_OR:
-			b := vm.pop()
-			a := vm.pop()
-			if a.Type == value.VAL_BOOL && b.Type == value.VAL_BOOL {
-				vm.push(value.NewBool(a.AsBool || b.AsBool))
-			} else {
-				return vm.runtimeError(c, ip, "operands for | must be boolean")
-			}
 		case chunk.OP_ZEROS:
 			countVal := vm.pop()
 			if countVal.Type != value.VAL_INT {
@@ -1141,19 +1121,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			vm.push(value.NewBool(a.AsInt == b.AsInt))
-		case chunk.OP_PRINT:
-			v := vm.pop()
-			if v.Type == value.VAL_REF {
-				ref, err := extractReferenceValue(v)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				if _, _, _, err := vm.referenceStorage(ref); err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-			}
-			fmt.Println(v)
-
 		case chunk.OP_CALL:
 			argCount := int(c.Code[ip])
 			ip++
@@ -1854,13 +1821,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 		// OP_MARK_SHARED morto pos-RC (Task 8): compilador nao emite mais;
 		// case removido do switch (sem default, opcode nao tratado e no-op).
-
-		case chunk.OP_SWAP:
-			// Swap top two stack elements: [a, b] -> [b, a]
-			b := vm.pop()
-			a := vm.pop()
-			vm.push(b)
-			vm.push(a)
 
 		case chunk.OP_COPY:
 			// CoW: deref para contexto de valor passa o valor adiante sem


### PR DESCRIPTION
## Summary
- Remove o código morto confirmado pelo perfil de cobertura de 2026-08-22 (seção "Fora de escopo" da #61): **5 opcodes nunca emitidos** pelo compilador — `OP_AND`/`OP_OR` (`&&`/`||` compilam com `OP_JUMP_IF_FALSE`/`OP_JUMP_IF_TRUE`), `OP_PRINT` (`print` é native), `OP_SWAP` e `OP_INVOKE` (declarados, jamais emitidos) — com seus `case` no executor, em `OpCode.String()` e no disassembler.
- Remove o ramo bytes-dentro-de-`VAL_OBJ` em `OP_ADD` (inalcançável: `bytes` é `VAL_BYTES`; o caso bytes+bytes é o ramo seguinte, mantido).
- Remove três funções do parser sem nenhum chamador (`parseAssignStatement`, `parseCaseBlock`, `parseExpressionStatement`) e `main.verify()` (sem chamador).
- **Não** remove: os walkers `collectBoundNames*`/`collectFree*` de `generics.go` (usados por `collectFreeIdentifiers` na checagem de shadowing de template importado — só falta cobertura Go, comentário de correção na #61), `OP_MARK_SHARED` (declarado sem `case`, decisão anterior documentada no executor) e o `case 'T'` dos `Format()` de `internal/value` (item 4 da #61 pede decisão de fonte única antes).
- Renumerar opcodes é seguro: não há bytecode persistido (o cache de módulos é só em memória); o teste de nomes contíguos/disassembler (`internal/chunk/chunk_test.go`) continua valendo. Nenhuma mudança de comportamento: −147 linhas, +3.

## Components
- `internal/chunk/chunk.go` — constantes `OP_AND`, `OP_OR`, `OP_INVOKE`, `OP_PRINT`, `OP_SWAP` + entradas de `String()` e `disassembleInstruction`.
- `internal/vm/executor.go` — `case` de `OP_AND`/`OP_OR`/`OP_PRINT`/`OP_SWAP` em `run()`; ramo morto de `OP_ADD` (comentário explica o que resta).
- `internal/parser/parser.go` — `parseAssignStatement`, `parseCaseBlock`, `parseExpressionStatement`.
- `cmd/noxy/main.go` — `verify()`.
- `internal/compiler/cow_lowering_test.go` — `chunk.OP_INVOKE` retirado da lista de opcodes com operando de 1 byte do walker do teste.

## Test Plan
- [x] `go build ./...`, `go vet` nos pacotes tocados e gofmt (em cópia LF — working tree é CRLF por `autocrlf`) limpos; `git diff` só com as remoções
- [x] `go test ./internal/... ./cmd/...` — todos os pacotes ok (vm ~89 s)
- [x] `run_all_tests_concurrent.nx` com o binário recompilado — 177/177
- [x] grep sem referências restantes aos símbolos removidos em `internal/`, `cmd/`, `docs/`, `AGENTS.md`, `CHANGELOG.md`
- [ ] Decidir se entra no CHANGELOG (não há seção Unreleased; é limpeza sem efeito observável) e em que versão
- [ ] Revisar a decisão de manter `OP_MARK_SHARED` e o `case 'T'` dos `Format()` (ver #61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
