### PR TITLE
fix/issue-61-coverage-findings - Achados do perfil de cobertura (#61): let sem inicializador p/ chan/func, campo não declarado via any, aviso em diagOut, %T morto (v0.14.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.15.0)
+**Versão**: 1.0 (Noxy VM 0.14.2)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,11 @@ case chunk.OP_NEW_OPCODE:
 6. **Saída: stdout é do programa, stderr é do diagnóstico.** `print`/`iprint`
    escrevem em stdout; `eprint`/`eiprint` em stderr. Nunca use `fmt.Print*` para
    erro, aviso ou trace — escreva em `os.Stderr` (na VM) ou em `diagOut`
-   (`cmd/noxy/main.go`), o único destino dos diagnósticos da CLI.
+   (`cmd/noxy/main.go`), o único destino dos diagnósticos da CLI. No
+   **compilador** não escreva em lugar nenhum: aviso é `c.warn(msg)`
+   (`internal/compiler/warnings.go`), que acumula em `Compiler.Warnings()`;
+   quem chama `Compile` imprime — CLI/REPL em `diagOut`, loader de módulos
+   da VM (`internal/vm/modules.go`) em `os.Stderr`.
 
 ```go
 func (vm *VM) builtinNewFunc(args []value.Value) (value.Value, error) {
@@ -407,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.14.1)
+**Versão**: 1.0 (Noxy VM 0.15.0)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [0.15.0] - 2026-08-22
+## [0.14.2] - 2026-08-22
 
 Os quatro achados do perfil de cobertura de v0.14.1 (issue #61): uma brecha
 do `let` sem inicializador, uma brecha do struct na fronteira `any`, um aviso
 do compilador no lugar errado e código morto nos `Format()`. Duas das
-correções fecham comportamento que programas podiam estar usando — daí a
-versão menor.
+correções fecham comportamento que programas podiam estar usando — as seções
+BREAKING abaixo dizem como migrar.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## [0.15.0] - 2026-08-22
+
+Os quatro achados do perfil de cobertura de v0.14.1 (issue #61): uma brecha
+do `let` sem inicializador, uma brecha do struct na fronteira `any`, um aviso
+do compilador no lugar errado e código morto nos `Format()`. Duas das
+correções fecham comportamento que programas podiam estar usando — daí a
+versão menor.
+
+### Changed (BREAKING)
+
+- **`let nome: chan T` / `let nome: func...` sem `= valor` é erro de
+  compilação.** A forma `let nome: tipo` (sem inicializador) sempre existiu
+  e usava o "default" do tipo — `0`, `0.0`, `false`, `""`, `b""`, `[]`, `{}`
+  e `null` para o resto. Só que `chan` e os tipos função **não são
+  nuláveis** (`let c: chan int = null` já era "type mismatch"), e o `null`
+  fabricado pelo `let` sem valor era a única brecha: em `chan` o marcador de
+  runtime estourava com `runtime value metadata conflicts with static
+  context` (um programa bem-formado falhava em runtime); em `func` passava
+  em silêncio, um `null` num tipo que o checador nunca aceitaria. Agora o
+  compilador diz `variable 'c' needs an initializer: chan int has no default
+  value; hint: write 'let c: chan int = ...'` — também para o elemento de um
+  array dimensionado (`let cs: (chan int)[2]`). Struct, `ref T` e `any`
+  continuam começando em `null`; escalares, arrays dinâmicos e maps, no seu
+  default. Spec §3, "Declaration without an initializer". **Migração**:
+  `let c: chan int` → `let c: chan int = make_chan(n)`; `let f: func` →
+  declare com o valor (ou `let f: any` se precisa de "ainda não tem").
+- **Escrever num campo não declarado através de `any` é erro.** `let d: any
+  = Point(1, 2)` seguido de `d.zzz = 1` criava o campo `zzz` na instância
+  em silêncio (ler `d.zzz` já era `undefined property 'zzz'`, e com base
+  tipada o compilador rejeita com `unknown field`). Struct é nominal, de
+  campos fixos (spec §5): `OP_SET_PROPERTY` passa a devolver o mesmo
+  `undefined property 'zzz'` da leitura quando o nome não está na
+  declaração. Campos declarados que uma native tenha deixado por preencher
+  continuam aceitando escrita. Caminho quente inalterado — a declaração só é
+  consultada quando o nome não está na instância.
+
+### Fixed
+
+- **Aviso `rebinding ref parameter ... has no effect outside function` saía
+  em stdout.** O compilador escrevia com `fmt.Printf`, misturado à saída do
+  programa (contra a regra "stdout é do programa, stderr é do diagnóstico").
+  O compilador agora não escreve em lugar nenhum: acumula `Warning`s
+  estruturados (`Compiler.Warnings()` — mensagem, arquivo, linha) e quem
+  chama decide o destino: `noxy arquivo.nx` e o REPL imprimem em `diagOut`
+  (stderr), um módulo carregado por `use` imprime em stderr pela VM. Mesmo
+  texto de antes (`warning: ...` + `  --> arquivo:linha`), mesmo código de
+  saída (aviso não é erro). Os exemplos `ref_pointer_semantics.nx` e
+  `test_ref_case.nx`, que demonstram o rebind local de propósito, só mudam
+  de canal.
+- **`ArrayType.String()` de array de `chan`/`ref` ganha parênteses.**
+  `(chan int)[]` imprimia `chan int[]`, que re-parseia como canal de `int[]`
+  (o prefixo captura o `[]`); agora imprime `(chan int)[]`, como já fazia
+  para funções — é o que aparece no hint do `let` sem inicializador e em
+  mensagens de tipo.
+
+### Removed
+
+- **`case 'T'` nos `Format()` de `internal/value`** (`ObjArray`, `ObjMap`,
+  `ObjStruct`, `ObjInstance`, `ObjChannel`, `ObjWaitGroup`, `ObjRef`,
+  `BytesWrapper`): código morto — o pacote `fmt` resolve `%T` antes de
+  consultar `Formatter`, e o builtin `fmt` da Noxy troca `%T` por
+  `runtimeTypeName` antes de formatar. Os nomes dos dois lugares já
+  divergiam sem ninguém perceber; agora há uma fonte só
+  (`runtimeTypeName`). Sem mudança visível.
+
 ## [0.14.1] - 2026-08-22
 
 Ergonomia do REPL fora do Windows: no Linux/macOS (WSL incluído) uma seta

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.15.0](https://img.shields.io/badge/noxy-0.15.0-blue)](CHANGELOG.md)
+[![noxy 0.14.2](https://img.shields.io/badge/noxy-0.14.2-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.15.0
+Noxy REPL v0.14.2
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.14.1](https://img.shields.io/badge/noxy-0.14.1-blue)](CHANGELOG.md)
+[![noxy 0.15.0](https://img.shields.io/badge/noxy-0.15.0-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.14.1
+Noxy REPL v0.15.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/cmd/noxy/main.go
+++ b/cmd/noxy/main.go
@@ -338,6 +338,11 @@ func runREPL(src lineSource, prompt, contPrompt string, showDisasm bool) error {
 		c.SetSessionLets(replLets)
 		c.SetModuleState(replModules)
 		chunk, _, err := c.Compile(program)
+		// Avisos do compilador sao diagnostico: diagOut, nunca stdout
+		// (issue #61 item 3). Saem mesmo quando a compilacao falha depois.
+		for _, warning := range c.Warnings() {
+			fmt.Fprintln(diagOut, warning)
+		}
 		if err != nil {
 			fmt.Fprintf(diagOut, "Compiler error: %s\n", err)
 			inputBuffer = "" // Reset
@@ -392,6 +397,11 @@ func runWithConfig(filename string, input string, rootPath string, showDisasm bo
 
 	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), filename, rootPath)
 	chunk, _, err := c.Compile(program)
+	// Avisos do compilador sao diagnostico: diagOut, nunca stdout (issue
+	// #61 item 3). Saem mesmo quando a compilacao falha depois.
+	for _, warning := range c.Warnings() {
+		fmt.Fprintln(diagOut, warning)
+	}
 	if err != nil {
 		fmt.Fprintf(diagOut, "Compiler error: %s\n", err)
 		return 1

--- a/cmd/noxy/warnings_test.go
+++ b/cmd/noxy/warnings_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #61 item 3: aviso do compilador ("rebinding ref parameter") e
+// diagnostico — sai em diagOut, nunca em stdout (AGENTS.md E.6), e nao muda
+// o codigo de saida nem a saida do programa. Vale para `noxy arquivo.nx` e
+// para o REPL.
+
+const rebindWarningProgram = "func f(r: ref int)\n    let y: int = 10\n    r = ref y\nend\nlet x: int = 1\nf(ref x)\nprint(x)\n"
+
+func TestCompilerWarningsGoToDiagOutNotStdout(t *testing.T) {
+	diag := withDiagBuffer(t)
+	var code int
+	stdout := captureStdout(t, func() { code = runWithConfig("warn.nx", rebindWarningProgram, ".", false) })
+	if code != 0 {
+		t.Fatalf("exit code=%d, want 0 (aviso nao e erro)", code)
+	}
+	want := "warning: rebinding ref parameter 'r' has no effect outside function\n  --> warn.nx:3\n"
+	if !strings.Contains(diag.String(), want) {
+		t.Fatalf("diagnostics=%q, want %q", diag.String(), want)
+	}
+	if stdout != "1\n" {
+		t.Fatalf("stdout=%q, want so a saida do programa", stdout)
+	}
+}
+
+func TestREPLCompilerWarningsGoToDiagOut(t *testing.T) {
+	diag := withDiagBuffer(t)
+	src := &fakeLines{steps: []fakeLine{
+		{text: "func f(r: ref int)"},
+		{text: "let y: int = 10"},
+		{text: "r = ref y"},
+		{text: "end"},
+		{text: "print(7)"},
+	}}
+	stdout := captureStdout(t, func() { runREPL(src, ">>> ", "... ", false) })
+	if !strings.Contains(diag.String(), "warning: rebinding ref parameter 'r' has no effect outside function") || !strings.Contains(diag.String(), "--> REPL:3") {
+		t.Fatalf("diagnostics=%q", diag.String())
+	}
+	if strings.Contains(stdout, "warning") || !strings.Contains(stdout, "7\n") {
+		t.Fatalf("stdout=%q", stdout)
+	}
+}

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -513,6 +513,33 @@ let name: type = value
 
 Variables can be reassigned, but the new value **MUST** be of the same type as declared.
 
+### Declaration without an initializer
+
+`let name: type` (no `= value`) is allowed only for types that have a
+**default value**, and the variable starts with it:
+
+| Type | Default |
+|------|---------|
+| `int`, `float`, `bool`, `string`, `bytes` | `0`, `0.0`, `false`, `""`, `b""` |
+| `T[]`, `map[K, V]` | `[]`, `{}` (empty) |
+| `T[N]` | `N` copies of `T`'s default — so `T` must have one |
+| struct, `ref T`, `any` | `null` (the types that accept `null`, §2.3, §5) |
+
+`chan T` and function types (`func`, `func(A) -> R`) have **no default**:
+`null` is not a value of those types (`let c: chan int = null` is a type
+error), so a declaration without an initializer is a compile-time error —
+give the value up front:
+
+```noxy
+let p: Point              // ✓ null
+let r: ref int            // ✓ null
+let n: int                // ✓ 0
+let cs: (chan int)[]      // ✓ [] — the array is empty, no element default needed
+let c: chan int           // ERROR: variable 'c' needs an initializer: chan int has no default value
+let f: func(int) -> int   // ERROR: same rule — func(int) -> int has no default value
+let ch: chan int = make_chan(1)   // ✓
+```
+
 ### Redeclaration vs. reassignment
 
 `let` introduces a new binding; `=` updates an existing one. Declaring a
@@ -660,7 +687,7 @@ Use parentheses for an array whose elements are exact functions. Without parenth
 
 ```noxy
 let transforms: (func(int) -> int)[] = [double, increment]
-let factory: func(int) -> int[]
+let factory: func(int) -> int[] = make_list   // one function returning int[]
 ```
 
 Exact function types may also appear in parameters, returns, struct fields, map values, channels, and references. `any`, native functions, plugins, and untyped module exports remain dynamic boundaries and retain runtime validation; an unknown native value cannot be implicitly narrowed to an exact function type.
@@ -733,6 +760,12 @@ let p: Point = Point(10, 20)
 // Field Access
 p.x = 15
 ```
+
+A struct is **nominal and its fields are fixed** by the declaration. Reading
+or writing a name that is not declared is an error — at compile time on a
+typed base (`unknown field`), and at runtime through a dynamic one
+(`undefined property 'zzz'` for `let d: any = p` followed by `d.zzz` **or**
+`d.zzz = 1`). No path adds a field to an instance.
 
 ### Self-Reference
 Structs can reference themselves using `ref`.
@@ -2071,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.14.1`). It is a module binding, not a
+string `noxy --version` prints (`v0.15.0`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2104,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.15.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.14.2`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.15.0
+print(sys.version)           // v0.14.2
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.13.0</span>
+                    <span class="version-badge-tag">v0.14.2</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.14.1
+print(sys.version)           // v0.15.0
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -87,7 +87,13 @@ func (at *ArrayType) String() string {
 		return "any[]"
 	}
 	element := at.ElementType.String()
-	if _, ok := at.ElementType.(*FunctionType); ok {
+	// Tipos-prefixo (func, chan, ref) capturam o `[]` que vier depois —
+	// `chan int[]` e um canal de int[] — entao o elemento de um array deles
+	// se escreve entre parenteses, `(chan int)[]`, e a string tem de
+	// round-trippar do mesmo jeito (e o que o hint de `let` sem
+	// inicializador mostra ao usuario).
+	switch at.ElementType.(type) {
+	case *FunctionType, *ChanType, *RefType:
 		element = "(" + element + ")"
 	}
 	return element + "[]"

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -119,6 +119,12 @@ type Compiler struct {
 	// programLets acumula os `let` top-level da compilacao corrente
 	// (preenchido pelo predeclare) para o REPL ler via ProgramLets.
 	programLets map[string]int
+	// warnings e a lista de avisos COMPARTILHADA pela arvore de compiladores
+	// (raiz + NewChild): ponteiro, como generics/instances, para que o aviso
+	// emitido dentro de um corpo de funcao suba ate o compilador raiz, que e
+	// o que a CLI consulta via Warnings(). O scratch do pass 1 dos genericos
+	// (newPass1Compiler) tem a SUA lista, descartada — o pass 2 reemite.
+	warnings *[]Warning
 }
 
 type callEmission struct {
@@ -161,6 +167,7 @@ func NewWithStateAndRoot(globals map[string]ast.NoxyType, structs map[string]*as
 		FileName:     fileName,
 		moduleRoot:   moduleRoot,
 		moduleName:   "main",
+		warnings:     &[]Warning{},
 	}
 	c.currentChunk.FileName = fileName
 	return c
@@ -180,8 +187,12 @@ func NewChild(parent *Compiler) *Compiler {
 		childNamespaceImports[name] = module
 	}
 	childNamespaceOrder := append([]string(nil), parent.namespaceOrder...)
+	if parent.warnings == nil {
+		parent.warnings = &[]Warning{}
+	}
 	c := &Compiler{
 		enclosing:        parent,
+		warnings:         parent.warnings,
 		currentChunk:     chunk.New(),
 		locals:           []Local{},
 		globals:          childGlobals,
@@ -378,7 +389,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 			valType = t
 		} else {
-			// Default value
+			// Default value — so para tipos que TEM um (issue #61 item 1):
+			// chan e func nao tem, e o null que saia daqui era o unico
+			// caminho para um null num tipo que o checador nao nulifica.
+			if err := c.defaultInitError(n.Name.Value, n.Type); err != nil {
+				return nil, nil, err
+			}
 			if err := c.emitDefaultInit(n.Type); err != nil {
 				return nil, nil, err
 			}
@@ -565,11 +581,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s", c.currentLine, ident.Value, localType.String(), valType.String())
 						}
 
-						// Check if trying to rebind a ref parameter
+						// Check if trying to rebind a ref parameter. Aviso, nao
+						// erro (o rebind local e um padrao legitimo — percorrer
+						// uma lista pelo proprio parametro); vai para a lista de
+						// Warnings, nunca para stdout (issue #61 item 3).
 						local := c.locals[arg]
 						if local.IsParam {
-							fmt.Printf("warning: rebinding ref parameter '%s' has no effect outside function\n", ident.Value)
-							fmt.Printf("  --> %s:%d\n", c.FileName, c.currentLine)
+							c.warn(fmt.Sprintf("rebinding ref parameter '%s' has no effect outside function", ident.Value))
 						}
 						if err := c.emitRuntimeValueType(localType); err != nil {
 							return nil, nil, err

--- a/internal/compiler/default_init.go
+++ b/internal/compiler/default_init.go
@@ -1,0 +1,43 @@
+package compiler
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// typeWithoutDefault responde qual (sub)tipo impede `let nome: tipo` sem
+// inicializador (issue #61 item 1). chan e os tipos funcao NAO tem valor
+// default: `= null` e rejeitado pelo checador (acceptsNull so admite
+// any/null/ref/struct), e o null que emitDefaultInit fabricava para eles era
+// a unica brecha — em chan o marcador de runtime estourava com "runtime value
+// metadata conflicts with static context"; em func passava em silencio.
+// Array dimensionado repete o default do ELEMENTO, entao herda a restricao;
+// array dinamico e map comecam vazios e nao precisam de default de elemento.
+// Devolve nil quando o tipo tem default.
+func typeWithoutDefault(t ast.NoxyType) ast.NoxyType {
+	switch typed := t.(type) {
+	case *ast.ChanType, *ast.FunctionType:
+		return t
+	case *ast.PrimitiveType:
+		if isBareFunctionType(typed) {
+			return t
+		}
+	case *ast.ArrayType:
+		if typed.Size > 0 {
+			return typeWithoutDefault(typed.ElementType)
+		}
+	}
+	return nil
+}
+
+// defaultInitError e o erro de `let nome: tipo` sem valor quando o tipo (ou
+// o elemento do array dimensionado) nao tem default; nil quando tem.
+func (c *Compiler) defaultInitError(name string, declared ast.NoxyType) error {
+	culprit := typeWithoutDefault(declared)
+	if culprit == nil {
+		return nil
+	}
+	return fmt.Errorf("[line %d] variable '%s' needs an initializer: %s has no default value; hint: write 'let %s: %s = ...'",
+		c.currentLine, name, culprit.String(), name, declared.String())
+}

--- a/internal/compiler/let_default_init_test.go
+++ b/internal/compiler/let_default_init_test.go
@@ -1,0 +1,62 @@
+package compiler
+
+import (
+	"testing"
+)
+
+// Issue #61 item 1: `let nome: tipo` sem `= valor` usa o default do tipo —
+// 0, 0.0, false, "", b"", [], {} e null para struct/ref/any. `chan` e os
+// tipos funcao NAO tem default: `let c: chan int = null` ja era rejeitado
+// pelo checador (acceptsNull so admite any/null/ref/struct) e o `let` sem
+// valor era a unica brecha que fabricava um null num tipo nao-nulavel — em
+// chan o marcador de runtime estourava com "runtime value metadata conflicts
+// with static context"; em func passava em silencio. Agora e erro de
+// compilacao que nomeia o tipo sem default (inclusive o elemento de um array
+// dimensionado, que emitDefaultInit preenche com o default do elemento).
+
+func TestLetWithoutInitializerRejectsTypesWithoutDefault(t *testing.T) {
+	cases := []struct{ name, src, variable, culprit, hint string }{
+		{"chan", "let c: chan int\n", "c", "chan int", "let c: chan int = ..."},
+		{"bare func", "let f: func\n", "f", "func", "let f: func = ..."},
+		{"exact func", "let g: func(int) -> int\n", "g", "func(int) -> int", "let g: func(int) -> int = ..."},
+		{"sized array of chan", "let cs: (chan int)[2]\n", "cs", "chan int", "let cs: (chan int)[] = ..."},
+		{"sized array of func", "let fs: (func(int) -> int)[2]\n", "fs", "func(int) -> int", "let fs: (func(int) -> int)[] = ..."},
+		// `chan int[]` e um CANAL de int[] (o prefixo captura o `[]`), nao
+		// um array de canais — sem default como qualquer chan.
+		{"chan of arrays", "let c: chan int[]\n", "c", "chan int[]", "let c: chan int[] = ..."},
+		{"inside a function body", "func f()\n    let c: chan int\nend\n", "c", "chan int", "let c: chan int = ..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compileFunctionSource(t, tc.src)
+			requireErrorMentions(t, err,
+				"variable '"+tc.variable+"' needs an initializer",
+				tc.culprit+" has no default value",
+				"hint: write '"+tc.hint+"'")
+			requireNotMentions(t, err, "type mismatch")
+		})
+	}
+	_, err := compileFunctionSource(t, "let x: int = 1\nlet c: chan int\n")
+	requireErrorMentions(t, err, "[line 2]")
+}
+
+func TestLetWithoutInitializerUsesTypeDefault(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{"struct is null", "struct P\n    x: int\nend\nlet p: P\n"},
+		{"ref is null", "let r: ref int\n"},
+		{"any is null", "let a: any\n"},
+		{"scalars", "let n: int\nlet f: float\nlet b: bool\nlet s: string\nlet by: bytes\n"},
+		{"containers are empty", "let xs: int[]\nlet m: map[string, int]\n"},
+		{"dynamic array of chan is empty", "let cs: (chan int)[]\n"},
+		{"dynamic array of ref is empty", "let rs: (ref int)[]\n"},
+		{"dynamic array of func is empty", "let fs: (func(int) -> int)[]\n"},
+		{"sized array of a defaultable type", "let ns: int[3]\nlet ps: string[2]\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := compileFunctionSource(t, tc.src); err != nil {
+				t.Fatalf("%s deveria compilar: %v", tc.src, err)
+			}
+		})
+	}
+}

--- a/internal/compiler/warnings.go
+++ b/internal/compiler/warnings.go
@@ -1,0 +1,45 @@
+package compiler
+
+import "fmt"
+
+// Warning e um diagnostico NAO fatal do compilador. O compilador nunca
+// escreve em stdout/stderr (AGENTS.md E.6: stdout e do programa, stderr e do
+// diagnostico): acumula os avisos e quem chamou Compile decide o destino — a
+// CLI e o REPL imprimem em diagOut, o loader de modulos da VM em os.Stderr.
+// Issue #61 item 3.
+type Warning struct {
+	Message string
+	File    string
+	Line    int
+}
+
+// String e o texto que a CLI mostra: duas linhas, no formato dos erros.
+func (w Warning) String() string {
+	return fmt.Sprintf("warning: %s\n  --> %s:%d", w.Message, w.File, w.Line)
+}
+
+// warn registra um aviso na lista compartilhada por toda a arvore de
+// compiladores (raiz + NewChild dos corpos de funcao): e o compilador RAIZ
+// que a CLI consulta. Aviso repetido (mesmo arquivo/linha/mensagem — um
+// template generico instanciado N vezes) entra uma vez.
+func (c *Compiler) warn(message string) {
+	if c.warnings == nil {
+		c.warnings = &[]Warning{}
+	}
+	w := Warning{Message: message, File: c.FileName, Line: c.currentLine}
+	for _, existing := range *c.warnings {
+		if existing == w {
+			return
+		}
+	}
+	*c.warnings = append(*c.warnings, w)
+}
+
+// Warnings devolve os avisos acumulados por este compilador e seus filhos,
+// na ordem de emissao (nil quando nao houve nenhum).
+func (c *Compiler) Warnings() []Warning {
+	if c.warnings == nil || len(*c.warnings) == 0 {
+		return nil
+	}
+	return append([]Warning(nil), (*c.warnings)...)
+}

--- a/internal/compiler/warnings_test.go
+++ b/internal/compiler/warnings_test.go
@@ -1,0 +1,108 @@
+package compiler
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+	"noxy-vm/internal/parser"
+)
+
+// Issue #61 item 3: o aviso "rebinding ref parameter" saia em STDOUT via
+// fmt.Printf — misturado a saida do programa, contra a regra do AGENTS.md
+// (stdout e do programa, stderr e do diagnostico). O compilador nao escreve
+// em lugar nenhum: acumula Warnings estruturados e quem chama Compile (CLI,
+// REPL, loader de modulos da VM) decide o destino.
+
+func captureCompilerStdout(t *testing.T, run func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stdout
+	os.Stdout = writer
+	run()
+	_ = writer.Close()
+	os.Stdout = previous
+	out, _ := io.ReadAll(reader)
+	return string(out)
+}
+
+func compileNamedSource(t *testing.T, fileName, input string) (*Compiler, error) {
+	t.Helper()
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if len(p.Errors()) > 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	c := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), fileName)
+	_, _, err := c.Compile(program)
+	return c, err
+}
+
+const rebindRefParamSource = "func f(r: ref int)\n    let y: int = 10\n    r = ref y\nend\n"
+
+func TestRebindingRefParameterIsAStructuredWarningNotStdout(t *testing.T) {
+	var c *Compiler
+	var err error
+	stdout := captureCompilerStdout(t, func() { c, err = compileNamedSource(t, "prog.nx", rebindRefParamSource) })
+	if err != nil {
+		t.Fatalf("rebind de parametro ref continua valido: %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("compilador escreveu em stdout: %q", stdout)
+	}
+	warnings := c.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exatamente 1", warnings)
+	}
+	w := warnings[0]
+	if w.Message != "rebinding ref parameter 'r' has no effect outside function" || w.File != "prog.nx" || w.Line != 3 {
+		t.Fatalf("warning = %+v", w)
+	}
+	if got := w.String(); got != "warning: rebinding ref parameter 'r' has no effect outside function\n  --> prog.nx:3" {
+		t.Fatalf("String() = %q", got)
+	}
+}
+
+// O corpo de funcao e compilado por um compilador filho (NewChild): o aviso
+// tem de subir ate o compilador raiz, que e o que a CLI consulta. Funcoes
+// aninhadas (closure) idem.
+func TestWarningsPropagateFromNestedFunctionCompilers(t *testing.T) {
+	src := "func outer()\n    func inner(r: ref int)\n        let y: int = 1\n        r = ref y\n    end\nend\n"
+	c, err := compileNamedSource(t, "nested.nx", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Warnings(); len(got) != 1 || got[0].Line != 4 {
+		t.Fatalf("warnings = %v, want 1 na linha 4", got)
+	}
+}
+
+// Programa com genericos passa pelo two-pass (pass 1 descartavel + pass 2):
+// o aviso nao pode sair duas vezes.
+func TestWarningsAreNotDuplicatedByGenericsTwoPass(t *testing.T) {
+	src := "func id<T>(x: T) -> T\n    return x\nend\n" + rebindRefParamSource + "let v: int = id(1)\n"
+	c, err := compileNamedSource(t, "gen.nx", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Warnings(); len(got) != 1 {
+		t.Fatalf("warnings = %v, want 1", got)
+	}
+}
+
+func TestProgramWithoutRebindHasNoWarnings(t *testing.T) {
+	src := "func f(r: ref int)\n    *r = 2\nend\nfunc g(r: ref int)\n    let local: ref int = r\n    local = r\nend\n"
+	c, err := compileNamedSource(t, "clean.nx", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Warnings(); len(got) != 0 {
+		t.Fatalf("warnings = %v, want nenhum", got)
+	}
+}

--- a/internal/value/format_test.go
+++ b/internal/value/format_test.go
@@ -35,6 +35,13 @@ func TestObjectFormatVerbs(t *testing.T) {
 			if got := fmt.Sprintf("%d", tc.obj); got != tc.badFmt {
 				t.Fatalf("%%d = %q, want %q", got, tc.badFmt)
 			}
+			// %T nunca chega a Format: o pacote fmt resolve o verbo antes de
+			// consultar Formatter e imprime o tipo Go — o nome Noxy vem de
+			// runtimeTypeName no builtin `fmt` (issue #61 item 4: os antigos
+			// `case 'T'` eram codigo morto).
+			if got := fmt.Sprintf("%T", tc.obj); !strings.HasPrefix(got, "*value.") && !strings.HasPrefix(got, "value.") {
+				t.Fatalf("%%T = %q, want o tipo Go (Format nao intercepta %%T)", got)
+			}
 		})
 	}
 	if got := fmt.Sprintf("%q|%x", BytesWrapper{Str: "ab"}, BytesWrapper{Str: "ab"}); got != "\"ab\"|6162" {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -378,8 +378,6 @@ func (oa *ObjArray) String() string {
 
 func (oa *ObjArray) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "array")
 	case 's', 'v':
 		fmt.Fprint(f, oa.String())
 	default:
@@ -414,8 +412,6 @@ func (om *ObjMap) String() string {
 
 func (om *ObjMap) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "map")
 	case 's', 'v':
 		fmt.Fprint(f, om.String())
 	default:
@@ -442,14 +438,30 @@ func (os *ObjStruct) FieldIsRef(name string) bool {
 	return os != nil && os.RefFields[name]
 }
 
+// HasField informa se name e um campo DECLARADO do struct (nil-safe). E a
+// fonte de runtime para "este nome existe na declaracao?" — OP_SET_PROPERTY
+// consulta so no caminho frio, quando o nome nao esta em instance.Fields
+// (issue #61 item 2: escrita via `any` num campo inexistente criava a
+// propriedade em silencio). Varredura linear: structs tem poucos campos e o
+// caminho quente (campo presente) nunca chega aqui.
+func (os *ObjStruct) HasField(name string) bool {
+	if os == nil {
+		return false
+	}
+	for _, field := range os.Fields {
+		if field == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (os *ObjStruct) String() string {
 	return fmt.Sprintf("<struct %s>", os.Name)
 }
 
 func (os *ObjStruct) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "struct definition") // Or just "struct"
 	case 's', 'v':
 		fmt.Fprint(f, os.String())
 	default:
@@ -472,8 +484,6 @@ func (oi *ObjInstance) String() string {
 
 func (oi *ObjInstance) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, oi.Struct.Name)
 	case 's', 'v':
 		fmt.Fprint(f, oi.String())
 	default:
@@ -494,8 +504,6 @@ func (oc *ObjChannel) String() string {
 
 func (oc *ObjChannel) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "channel")
 	case 's', 'v':
 		fmt.Fprint(f, oc.String())
 	default:
@@ -513,8 +521,6 @@ func (ow *ObjWaitGroup) String() string {
 
 func (ow *ObjWaitGroup) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "waitgroup")
 	case 's', 'v':
 		fmt.Fprint(f, ow.String())
 	default:
@@ -572,8 +578,6 @@ func (or *ObjRef) String() string {
 
 func (or *ObjRef) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "reference")
 	case 's', 'v':
 		fmt.Fprint(f, or.String())
 	default:
@@ -760,8 +764,6 @@ func NewWaitGroup() Value {
 
 func (bw BytesWrapper) Format(f fmt.State, verb rune) {
 	switch verb {
-	case 'T':
-		fmt.Fprint(f, "bytes")
 	case 's', 'v':
 		fmt.Fprint(f, bw.Str)
 	case 'q':

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.15.0"
+const Version = "v0.14.2"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.14.1"
+const Version = "v0.15.0"

--- a/internal/vm/compiler_warnings_module_test.go
+++ b/internal/vm/compiler_warnings_module_test.go
@@ -1,0 +1,31 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #61 item 3: um modulo carregado por `use` e compilado em RUNTIME
+// (modules.go) — o aviso do compilador que ele gerar e diagnostico da VM e
+// vai para stderr (AGENTS.md E.6), nunca para stdout nem para o silencio.
+
+func TestModuleCompileWarningsGoToStderr(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "avisos.nx", "func rebind(r: ref int)\n    let y: int = 10\n    r = ref y\nend\n")
+	var stdout string
+	stderr := captureConcurrencyStderr(t, func() {
+		stdout = captureConcurrencyStdout(t, func() {
+			got := captureVMSourceAtRoot(t, root, "use avisos\ntest_report(1)\n")
+			if got.AsInt != 1 {
+				t.Errorf("programa nao rodou ate o fim: %v", got)
+			}
+		})
+	})
+	want := "warning: rebinding ref parameter 'r' has no effect outside function\n  --> "
+	if !strings.Contains(stderr, want) || !strings.Contains(stderr, "avisos.nx:3") {
+		t.Fatalf("stderr = %q, want aviso com arquivo:linha do modulo", stderr)
+	}
+	if strings.Contains(stdout, "warning") {
+		t.Fatalf("aviso vazou para stdout: %q", stdout)
+	}
+}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1562,6 +1562,19 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return vm.runtimeError(c, ip, "only instances have properties")
 			}
 
+			// Struct e nominal, de campos fixos (spec §5): escrever num nome
+			// fora da declaracao e o mesmo "undefined property" da leitura
+			// (issue #61 item 2 — antes a escrita criava o campo em silencio).
+			// Via base tipada o compilador ja rejeitou (`unknown field`); aqui
+			// so dispara em fronteira dinamica (`any`). O caminho quente e o
+			// lookup em instance.Fields que a troca abaixo ja fazia; a
+			// declaracao so e consultada quando o nome nao esta na instancia
+			// (native que deixou o campo por preencher, ou nome inexistente).
+			old, exists := instance.Fields[name]
+			if !exists && !instance.Struct.HasField(name) {
+				return vm.runtimeError(c, ip, "undefined property '%s'", name)
+			}
+
 			// Guard do slot ref (spec 2026-08-20-ref-slot-invariant §6.3):
 			// via base tipada o compilador ja rejeitou; aqui so dispara em
 			// fronteira dinamica (`any`). Lookup em mapa nil e gratuito.
@@ -1571,7 +1584,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 			// RC: retain-antes-de-release (campo e dono duravel); Release
 			// em campo inexistente (Value{} zero) e no-op (nao e VAL_OBJ)
-			old := instance.Fields[name]
 			value.Retain(val)
 			instance.Fields[name] = val
 			value.Release(old)

--- a/internal/vm/modules.go
+++ b/internal/vm/modules.go
@@ -195,6 +195,11 @@ func (vm *VM) compileAndRunModule(source resolvedModule, content string) (value.
 	}
 	c := compiler.NewWithStateAndRoot(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), compilerPath, vm.Config.RootPath)
 	code, _, err := c.Compile(program)
+	// Aviso do compilador de um modulo carregado em runtime e diagnostico
+	// da VM: os.Stderr (AGENTS.md E.6), nunca stdout (issue #61 item 3).
+	for _, warning := range c.Warnings() {
+		fmt.Fprintln(os.Stderr, warning)
+	}
 	if err != nil {
 		return value.NewNull(), err
 	}

--- a/internal/vm/ref_container_and_closure_test.go
+++ b/internal/vm/ref_container_and_closure_test.go
@@ -124,19 +124,19 @@ test_report(outer())
 	}
 }
 
-// `let p: Point` e `let f: func` sem inicializador começam em null.
-// (`let c: chan int` sem inicializador hoje falha em runtime com "runtime
-// value metadata conflicts with static context" — comportamento não fixado
-// aqui de propósito; ver relatório da rodada.)
-func TestDefaultInitializationOfStructAndFuncIsNull(t *testing.T) {
+// `let p: Point` e `let r: ref int` sem inicializador começam em null — os
+// tipos que o checador aceita como nuláveis. (`let f: func` e `let c: chan
+// int` sem inicializador são erro de compilação desde a issue #61 item 1:
+// esses tipos não têm default; ver internal/compiler/let_default_init_test.go.)
+func TestDefaultInitializationOfStructAndRefIsNull(t *testing.T) {
 	got := captureVMSource(t, `
 struct Point
     x: int
 end
 let p: Point
-let f: func
-let g: func(int) -> int
-test_report([to_str(p), to_str(f), to_str(g)])
+let r: ref int
+let a: any
+test_report([to_str(p), to_str(r), to_str(a)])
 `)
 	for i, cell := range semArray(t, got) {
 		if s, ok := cell.Obj.(string); !ok || s != "null" {

--- a/internal/vm/set_property_declared_fields_test.go
+++ b/internal/vm/set_property_declared_fields_test.go
@@ -1,0 +1,38 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #61 item 2: na fronteira dinamica (`any`) LER um campo inexistente
+// ja era "undefined property"; ESCREVER criava o campo em silencio
+// (OP_SET_PROPERTY nao conferia a declaracao) — struct e nominal, de campos
+// fixos (spec §5). Agora a escrita num nome que nao esta na declaracao do
+// struct e o mesmo erro da leitura; com base tipada o compilador ja rejeitava
+// (`unknown field`).
+
+func TestSetPropertyThroughAnyRejectsUndeclaredField(t *testing.T) {
+	cases := []struct{ name, body, want string }{
+		{"instance", "let p: any = Point(1, 2)\np.zzz = 1\n", "undefined property 'zzz'"},
+		{"through ref", "let q: Point = Point(1, 2)\nlet r: ref Point = ref q\nlet a: any = r\na.www = 5\n", "undefined property 'www'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := interpretVMSource(t, New(), dynamicBoundaryPrelude+tc.body)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("esperava %q, obtido %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// (`let a: any = r` guarda uma COPIA do valor apontado — `any` nao carrega
+// ref —, por isso o oraculo le a.y, nao q.y.)
+func TestSetPropertyThroughAnyStillWritesDeclaredFields(t *testing.T) {
+	got := captureVMSource(t, dynamicBoundaryPrelude+"let p: any = Point(1, 2)\np.x = 9\nlet q: Point = Point(3, 4)\nlet r: ref Point = ref q\nlet a: any = r\na.y = 8\ntest_report([p.x, a.y])\n")
+	cells := semArray(t, got)
+	if len(cells) != 2 || cells[0].AsInt != 9 || cells[1].AsInt != 8 {
+		t.Fatalf("campos declarados devem continuar escrevendo: %v", got)
+	}
+}


### PR DESCRIPTION
Fecha #61 (os quatro achados do perfil de cobertura de v0.14.1). Versão **0.14.2** — patch (minor reservada a mudanças maiores); dois itens fecham comportamento que programas podiam estar usando, com migração no CHANGELOG.

## Summary
- **(1) `let nome: chan T` / `let nome: func...` sem `= valor` é erro de compilação** (`variable 'c' needs an initializer: chan int has no default value; hint: write 'let c: chan int = ...'`). Raiz: `emitDefaultInit` fabricava `null` para tipos que o próprio checador não nulifica (`acceptsNull` só admite any/null/ref/struct — `let c: chan int = null` já era type mismatch); em `chan` o marcador de runtime estourava (`runtime value metadata conflicts with static context`), em `func` passava em silêncio. Escolhida a saída **"exigir o `=`"** da issue, porque a outra ("aceitar null para chan") contradiria o checador estático; struct/`ref`/`any` seguem em `null`, escalares/`[]`/`{}` no default; vale para o elemento de array dimensionado (`(chan int)[2]`). Documentado na spec §3 ("Declaration without an initializer").
- **(2) Escrever em campo não declarado via `any` é erro** — `OP_SET_PROPERTY` devolve o mesmo `undefined property 'zzz'` da leitura quando o nome não está na declaração (`ObjStruct.HasField`, consultado só no caminho frio: nome ausente em `instance.Fields`). Campos declarados que uma native deixou por preencher continuam aceitando escrita. Spec §5 ganha a nota de campos fixos.
- **(3) Aviso "rebinding ref parameter" sai de stdout** — opção (b) da issue: o compilador acumula `Warning{Message, File, Line}` (`c.warn()`, lista compartilhada raiz + `NewChild`, sem duplicata); `Compiler.Warnings()` é impresso em `diagOut` por `noxy arquivo.nx` e pelo REPL, e em `os.Stderr` pelo loader de módulos da VM. Mesmo texto, mesmo exit code. Não virou erro (c): o rebind local é padrão legítimo (percorrer lista pelo parâmetro), demonstrado de propósito em `ref_pointer_semantics.nx`/`test_ref_case.nx`.
- **(4) `case 'T'` removido dos 8 `Format()`** de `internal/value` — `fmt` resolve `%T` antes de `Formatter` e o builtin `fmt` usa `runtimeTypeName`; fonte única agora.
- Colateral necessário: `ArrayType.String()` parentesiza elemento `chan`/`ref` (`(chan int)[]` imprimia `chan int[]`, que re-parseia como canal de `int[]`) — é o que o hint do item 1 mostra.

## Components
- `internal/compiler/default_init.go` (novo): `typeWithoutDefault` / `defaultInitError`; `compiler.go`: check antes de `emitDefaultInit`, `c.warn()` no lugar do `fmt.Printf`, campo `warnings` (ponteiro compartilhado em `NewWithStateAndRoot`/`NewChild`)
- `internal/compiler/warnings.go` (novo): `Warning`, `String()`, `warn`, `Warnings()`
- `internal/vm/executor.go`: `OP_SET_PROPERTY` checa declaração; `internal/vm/modules.go`: imprime `Warnings()` em `os.Stderr`
- `internal/value/value.go`: `ObjStruct.HasField`; 8 `case 'T'` removidos
- `internal/ast/ast.go`: `ArrayType.String()` com parênteses para `chan`/`ref`
- `cmd/noxy/main.go`: `Warnings()` → `diagOut` (arquivo e REPL)
- Docs: `docs/NOXY_LANGUAGE_SPEC.md` §3 (nova subseção + tabela de defaults), §4.2 exemplo `factory` com valor, §5 nota; `AGENTS.md` E.6 (`c.warn`); `CHANGELOG.md` [0.14.2]; bump em `internal/version/version.go`, README (badge + banner), `docs/index.html`, spec
- Testes novos: `internal/compiler/let_default_init_test.go`, `internal/compiler/warnings_test.go`, `internal/vm/set_property_declared_fields_test.go`, `internal/vm/compiler_warnings_module_test.go`, `cmd/noxy/warnings_test.go`; `internal/value/format_test.go` pina `%T` = tipo Go; `TestDefaultInitializationOfStructAndFuncIsNull` → `...StructAndRefIsNull`

## Test Plan
- [x] `go build ./...` e `go vet ./...` limpos
- [x] `go test ./... -count=1`: 12 pacotes ok
- [x] `go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx`: 177 passaram, 0 falharam
- [x] Sondas no binário: `let c: chan int` → erro de compilação com hint; `p.zzz = 1` via `any` → `undefined property 'zzz'`; programa com rebind → stdout só com a saída do programa, aviso em stderr; `noxy_examples/ref_pointer_semantics.nx` idem
- [x] `noxy --version` → `Noxy v0.14.2`
- [ ] Confirmar a decisão de linguagem do item 1 (exigir `=` p/ chan/func em vez de nulificar chan) — trocar é pequeno se preferir a outra saída
- [ ] Merge em `develop` e release v0.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
