### PR TITLE
perf/issue-37-value-layout - Value 48→32 B, header comum nos compostos e pop inlinável em run() (issue #37, estágios 1 e 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.14.2)
+**Versão**: 1.0 (Noxy VM 0.14.3)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [0.14.3] - 2026-08-22
+
+Fase 2 de performance do VM (issue #37, estágios 1 e 2 mais o "extra barato"
+do `pop`). Nenhuma mudança de sintaxe, semântica, bytecode, saída ou mensagem
+de erro — só o layout interno do operando da VM e o caminho do contador de
+referências. Corpus 177/177 e diff de saída base × head sem divergência.
+Números por estágio em `benchmarks/RESULTS.md`.
+
+### Performance
+
+- **`value.Value` de 48 para 32 bytes.** Tag em `uint8`, um único campo para
+  `int64`/`float64` (bits) e o `bool` no padding; a pilha de operandos cai de
+  96 KB para 64 KB e cada `push`/`pop`/cópia de operando move um terço a
+  menos. Leitura pelos acessores `Int()`/`Float()`/`Bool()` (os campos
+  `AsInt`/`AsFloat`/`AsBool` deixaram de existir — afeta só quem embute a VM
+  em Go; o único escritor in-place, `OP_INC_LOCAL_INT`, usa `SetInt`).
+  Ler o acessor errado para a tag devolve os bits do campo, não zero — só
+  alcançável chamando uma native crua diretamente com tipo errado
+  (`time_sleep(1.5)`), o que o compilador já tolerava; os wrappers da stdlib
+  são tipados. Isolado: −10 a −14 % em `fib`, `bubblesort`, `call_ref`,
+  `call_readonly`, `share_mutate`.
+- **Header comum nos compostos.** `ObjArray`, `ObjMap` e `ObjInstance`
+  embutem `ObjHeader{Owners}` no offset 0 (layout travado por teste), e
+  `ownersOf` — chamado por todo `Retain`/`Release`/`IsShared` — sai em uma
+  comparação de byte para `string`/struct/`RuntimeTypeInfo` pela dica
+  carimbada nos construtores; compostos seguem pelo type switch, que no `gc`
+  já é comparação de ponteiro (microbench: indistinguível de `unsafe`).
+  `Release` reescrito com comparação única para continuar inlinado (custo
+  80 exato). Isolado: −0,3 a −4,7 %, ruído na maior parte dos benches.
+- **`pop()` volta a ser inlinada dentro de `run()`.** Custava 22 no inliner
+  (orçamento 20 para callee de função grande) e era chamada real em todos os
+  ~84 sites do laço de despacho — 17 % do perfil de `fib`. Mesmo trabalho
+  (zera o `Value` inteiro), forma nova (atribuição dupla com resultado
+  nomeado, custo 18, 79 sites inlinados). Isolado: −6 a −25 % por cima dos
+  dois estágios; guardado em `inline_guard_test.go` junto com `push`,
+  `Retain` e `Release`.
+- **Resultado (mediana de 9, intercalado, v0.14.2 × v0.14.3):** `fib`
+  −17,7 % (2,9x do CPython, antes 4,1x), `bubblesort` −24 a −26 %,
+  `call_readonly` −27 a −33 %, `call_ref` −26 %, `path_update` −27 a −31 %,
+  `loop_arith` −20 %, `generic_vs_hand` −19 %, `share_mutate` −17 %,
+  `conway` −15 %, `mandelbrot` −15 %, `string_ops` −12 %, `map_churn` −5 a
+  −8 %, `spawn_sum` −8 a −13 %; startup neutro.
+
 ## [0.14.2] - 2026-08-22
 
 Os quatro achados do perfil de cobertura de v0.14.1 (issue #61): uma brecha

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.14.2](https://img.shields.io/badge/noxy-0.14.2-blue)](CHANGELOG.md)
+[![noxy 0.14.3](https://img.shields.io/badge/noxy-0.14.3-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.14.2
+Noxy REPL v0.14.3
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,139 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## v0.14.2 (cb8efcb) × fase 2 de perf — layout do `Value` (perf/issue-37-value-layout, ba7f85d)
+
+**Data:** 2026-08-22 · Windows 11 · i7-1165G7 · protocolo intercalado, mediana
+de 9 execuções (mínimo também registrado). Máquina sem `go test` nem
+benchmark concorrente; CPU total entre 1 % e 21 % no início de cada passo
+(Firefox, Slack e o Claude Code abertos, sem Zoom/Chrome). **Os quatro
+binários foram compilados na mesma sessão**, então não há a assimetria de
+piso "build fresco +4–5 ms" da seção anterior — `startup` empata (106–110 ms
+nos quatro). Dados brutos, carga por passo e script em
+[`results/2026-08-22-issue-37-value-layout-raw.md`](results/2026-08-22-issue-37-value-layout-raw.md).
+Spec: `docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md`
+(issue #37, estágios 1 e 2 + "extra barato" do `pop`).
+
+Commits medidos, um binário por estágio: **s1** = `Value` 48 → 32 B
+(`41638e8`); **s1+2** = + `ObjHeader{Owners}` no offset 0 de
+array/map/instância e dica `kind` em `ownersOf` (`e4d5a5f`); **s1+2+pop** =
++ `pop()` inlinada em `run()` (custo 22 → 18, 0 → 79 sites; `ba7f85d`).
+
+**Verificação completa:** `go test ./...` verde (12 pacotes); `go test -race
+./internal/value ./internal/vm` verde (2,0 s / 69,7 s); **corpus 177/177**
+(`run_all_tests_concurrent.nx`); **diff de saída base × head: 146 iguais, 0
+divergentes** (`compare_examples.ps1`); guards de inline verdes (`push` 20,
+`pop` 18, `Retain` 67, `Release` 80).
+
+### Headline — base × s1+2+pop (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | v0142_ms | s12p_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_bubblesort | 4046,3 | 3002,8 | **−25,8 %** | ✅ |
+| bench_call_readonly | 1386,8 | 929,4 | **−33,0 %** | ✅ (a regressão de +10 % da seção anterior fica mais que desfeita) |
+| bench_call_ref | 4160,8 | 3052,1 | **−26,6 %** | ✅ |
+| bench_path_update | 682,4 | 498,2 | **−27,0 %** | ✅ |
+| bench_generic_vs_hand | 904,5 | 732,4 | **−19,0 %** | ✅ |
+| bench_share_mutate | 302,1 | 251,4 | **−16,8 %** | ✅ gate CoW (≤ +5 %) |
+| bench_conway | 2214,9 | 1878,8 | **−15,2 %** | ✅ gate CoW |
+| bench_spawn_sum | 767,1 | 703,7 | −8,3 % | ✅ |
+| bench_map_churn | 479,1 | 442,0 | −7,7 % | ✅ |
+| bench_call_light | 120,3 | 110,7 | −8,0 % | ➖ piso¹ (gate CoW ok) |
+| bench_typed_call_map | 124,5 | 122,9 | −1,3 % | ➖ piso¹ (gate CoW ok) |
+| bench_value_call_mutate | 119,3 | 121,1 | +1,5 % | ➖ piso¹ |
+
+¹ ~100 ms com piso de processo ~84 ms: não decidem nada (seção de 2026-08-22).
+
+### Por estágio — quatro binários na mesma janela (mediana de 9)
+
+"passo" = delta contra o binário imediatamente anterior.
+
+| bench | s1 vs base | s1+2 (passo) | s1+2+pop (passo) | total |
+|---|---|---|---|---|
+| bench_bubblesort | −13,4 % | −2,8 % | −12,8 % | **−26,6 %** |
+| bench_call_ref | −14,3 % | −0,3 % | −13,4 % | **−26,0 %** |
+| bench_call_readonly | −11,7 % | +1,8 % | −19,0 % | **−27,3 %** |
+| bench_path_update | −5,7 % | −1,3 % | −25,5 % | **−30,7 %** |
+| bench_share_mutate | −14,0 % | −4,7 % | +1,5 % | **−16,9 %** |
+| bench_generic_vs_hand | −7,2 % | +1,0 % | −11,0 % | **−16,6 %** |
+| bench_spawn_sum | −7,4 % | +4,1 % | −10,2 % | **−13,5 %** |
+| bench_conway | −1,8 % | −4,0 % | −6,0 % | **−11,4 %** |
+| bench_map_churn | −2,1 % | +1,1 % | −4,2 % | **−5,2 %** |
+| cross `fib` | −10,0 % | −3,2 % | −5,6 % | **−17,7 %** |
+| cross `bubblesort` | −11,5 % | −2,7 % | −11,7 % | **−24,0 %** |
+| cross `loop_arith` | −3,6 % | −3,1 % | −14,6 % | **−20,2 %** |
+| cross `mandelbrot` | −3,3 % | +0,4 % | −12,9 % | **−15,4 %** |
+| cross `string_ops` | −6,5 % | +5,7 % | −10,6 % | **−11,6 %** |
+| cross `map_churn` | +4,1 % | −1,2 % | −9,2 % | **−6,6 %** |
+| cross `startup` | +4,3 % | −0,5 % | −1,2 % | +2,5 % (piso, ruído) |
+
+### Cross-runtime (mínimo de 9, intercalado com CPython 3.13.1 / Lua 5.4.7 / Go 1.24.11)
+
+Tempo líquido (descontado o piso de `startup`, 91 ms nos dois Noxy) e razões;
+tabela completa em [`cross_runtime/results/cross_runtime.md`](cross_runtime/results/cross_runtime.md).
+
+| bench | v0.14.2 | fase 2 | fase 2 ÷ v0.14.2 | ÷ python (antes → agora) | ÷ lua |
+|---|---|---|---|---|---|
+| `fib` | 420,7 | 296,0 | **0,70x** | 4,1x → **2,9x** | 5,6x |
+| `bubblesort` | 625,4 | 423,1 | **0,68x** | 8,1x → **5,5x** | – |
+| `loop_arith` | 327,6 | 272,5 | 0,83x | 1,3x → **1,1x** | 6,5x |
+| `mandelbrot` | 219,1 | 176,9 | 0,81x | 2,4x → **1,9x** | – |
+| `map_churn` | 226,6 | 173,7 | 0,77x | 2,7x → **2,1x** | – |
+| `string_ops` | 145,8 | 134,5 | 0,92x | 4,6x → **4,2x** | – |
+
+### Leitura
+
+**A hipótese da issue ("fib 15–25 % melhor") confirma: −17,7 % na mediana
+intercalada, 0,70x no tempo líquido do cross-runtime.** E o ganho é maior
+onde a linguagem passa o dia — leitura/escrita indexada de array e chamada
+com composto (`bubblesort`, `call_readonly`, `call_ref`, `path_update`: −26 a
+−33 %). A regressão de +10 % em `call_readonly` que a seção anterior apontava
+como "item a investigar" não só some como vira −33 %.
+
+**De onde veio, por estágio:**
+
+- **Estágio 1 (`Value` 32 B): −10 a −14 % em tudo que é chamada/array**
+  (`fib`, `bubblesort`, `call_ref`, `call_readonly`, `share_mutate`), −2 a −7 %
+  no resto. É o efeito previsto: um terço a menos de bytes por `push`/`pop`/
+  cópia de operando e a pilha em 64 KB em vez de 96 KB.
+- **Estágio 2 (header + dica `kind`): −0,3 a −4,7 % nos benches de RC
+  intenso (`share_mutate` −4,7 %, `conway` −4,0 %, `fib` −3,2 %), ruído nos
+  demais (−1 a +6 %).** O microbench Go de `ownersOf` (type switch × dica ×
+  cast `unsafe` do header) dá ~4–5 ns/op para as três formas, indistinguíveis
+  no ruído: no `gc`, o type switch sobre `interface{}` já é "carrega o hash do
+  tipo + ≤ 3 comparações", e o que custa no RC são os atômicos. O estágio 2
+  entrega o header no offset 0 (layout travado por teste) e a saída antecipada
+  de string/struct/RTI; **não vale o `unsafe`** — e a forma "switch no `kind` +
+  assertion por caso" nem cabe no orçamento de inline de `Retain`/`Release`
+  (detalhe na spec §3.2).
+- **`pop()` inlinada: −6 a −25 % por cima dos dois estágios** — o maior item
+  isolado da rodada. Era o achado que a issue não tinha: `pop` custava 22 no
+  inliner e, com `run()` em regime de "big function" (orçamento 20), era
+  chamada real em todos os ~84 sites; o perfil de `fib` a mostrava com **17 %
+  flat** (v0.14.2) contra 3 % depois. O corpo novo faz exatamente o mesmo
+  trabalho (zera o `Value` inteiro) — só a forma muda (atribuição dupla com
+  resultado nomeado, 18 nós). `path_update` (−25,5 % só deste passo) e
+  `call_readonly` (−19 %) são os mais sensíveis porque empilham/desempilham
+  muito por iteração.
+
+**Gates CoW (≤ +5 %):** `typed_call_map` −1,3 %, `share_mutate` −16,8 %,
+`call_light` −8,0 %, `conway` −15,2 % — todos verdes.
+
+**Microbench de chamada** (`BenchmarkNoxyCallOverhead`, `go test -bench`,
+8 repetições por estágio): ver tabela no fim do arquivo bruto; mede o custo
+fixo de uma chamada `leaf(i)` em laço de 1000.
+
+**Sobre o estágio 3 (pré-condição 1 da issue: "1+2 confirmam a tese").**
+Confirmam *pela metade*: a redução de bytes virou tempo (estágio 1), mas
+a parte do `ownersOf` não (estágio 2 é ~ruído). Os 8 bytes restantes
+(`interface{}` → `unsafe.Pointer`) só pagariam pelo mesmo mecanismo do
+estágio 1 (menos bytes copiados, mais `Value` por linha de cache) — o ganho
+marginal de 32 → 24 B é menor que o de 48 → 32 B e vem com 482 type assertions
+a converter e o boxing de string. Com `fib` a 2,9x do CPython e `string_ops`
+a 4,2x, a aposta de melhor relação custo/benefício continua sendo a que a
+própria issue aponta: indexação de array (ainda 5,5x) e o custo de chamada
+(`callPreparedClosure`/`finishFrame` são 26 % do perfil novo de `fib`).
+
 ## v0.6.0 (68209be) × v0.14.1 (4874048) — re-medição com a máquina ociosa
 
 **Data:** 2026-08-22 · Windows 11 · i7-1165G7 · protocolo intercalado. Duas

--- a/benchmarks/cross_runtime/README.md
+++ b/benchmarks/cross_runtime/README.md
@@ -103,6 +103,30 @@ agora a coluna intercalada, não a coluna histórica.
 
 ## Resultados
 
+### Fase 2 de perf (layout do `Value`, issue #37) × v0.14.2 — 2026-08-22
+
+Rodada de uma suíte (mínimo de 9, intercalado, máquina sem outra carga) com
+o binário da fase 2 (`perf/issue-37-value-layout` @ ba7f85d: `Value` 48 → 32 B,
+header comum nos compostos, `pop` inlinada) e **v0.14.2 medido junto**.
+Números completos em [`results/cross_runtime.md`](results/cross_runtime.md)
+e o contexto por estágio em
+[`../results/2026-08-22-issue-37-value-layout-raw.md`](../results/2026-08-22-issue-37-value-layout-raw.md)
+/ [`../RESULTS.md`](../RESULTS.md).
+
+| bench | fase 2 (líquido) | v0.14.2 (líquido) | fase 2 ÷ v0.14.2 | ÷ python | ÷ lua |
+|---|---|---|---|---|---|
+| `loop_arith` | 272,5 | 327,6 | 0,83x | **1,1x** | 6,5x |
+| `mandelbrot` | 176,9 | 219,1 | 0,81x | **1,9x** | – |
+| `map_churn` | 173,7 | 226,6 | 0,77x | **2,1x** | – |
+| `fib` | 296,0 | 420,7 | **0,70x** | **2,9x** | 5,6x |
+| `string_ops` | 134,5 | 145,8 | 0,92x | **4,2x** | – |
+| `bubblesort` | 423,1 | 625,4 | **0,68x** | **5,5x** | – |
+
+O quadro da seção seguinte (v0.14.1 × v0.6.0) continua valendo como
+histórico; a partir daqui, a referência é esta rodada. A ordem dos piores
+pontos não muda — `bubblesort` (indexação) e `string_ops` seguem os mais
+distantes do CPython — mas todos encurtam.
+
 Noxy v0.14.1 (develop @ 4874048) · **Noxy v0.6.0 (68209be) medido junto** ·
 CPython 3.13.1 · Lua 5.4.7 · Go 1.24.11 · i7-1165G7 (4C/8T) · Windows 11 ·
 **três suítes** de 9 execuções intercaladas cada, mínimo por suíte e mediana

--- a/benchmarks/cross_runtime/results/cross_runtime.md
+++ b/benchmarks/cross_runtime/results/cross_runtime.md
@@ -1,47 +1,47 @@
 # Cross-runtime: Noxy x CPython x Lua x Go
 
-- noxy: `noxy_0141.exe` (Noxy v0.14.1)
-- noxy_v060: `noxy_060.exe` (Noxy v0.6.0)
+- noxy: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ef3672bf-bc7a-4367-818c-fb10c1f93a42\scratchpad\bench\noxy_s12p.exe` (Noxy v0.14.3)
+- v0142: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ef3672bf-bc7a-4367-818c-fb10c1f93a42\scratchpad\bench\noxy_base.exe` (Noxy v0.14.2)
 - python: Python 3.13.1
 - lua: Lua 5.4.7  Copyright (C) 1994-2024 Lua.org, PUC-Rio
 - go: go version go1.24.11 windows/amd64
-- Data: 2026-08-22T12:40:38
+- Data: 2026-08-22T16:43:10
 - Runs por bench: 9, intercalados; **minimo** reportado
 
 ## Tempo total (ms)
 
-| bench | noxy | noxy_v060 | python | lua | go |
+| bench | noxy | v0142 | python | lua | go |
 |---|---|---|---|---|---|
-| `bubblesort` | 646,2 | 608,0 | 161,1 | - | - |
-| `fib` | 481,6 | 447,9 | 199,2 | 114,3 | 68,4 |
-| `loop_arith` | 385,3 | 390,6 | 343,3 | 99,5 | 72,0 |
-| `mandelbrot` | 305,2 | 301,0 | 168,2 | - | - |
-| `map_churn` | 293,9 | 289,2 | 161,9 | - | - |
-| `startup` | 84,8 | 78,2 | 86,0 | 60,5 | 64,6 |
-| `string_ops` | 243,2 | 234,4 | 120,9 | - | - |
+| `bubblesort` | 514,4 | 716,4 | 165,4 | - | - |
+| `fib` | 387,3 | 511,7 | 191,9 | 114,7 | 75,0 |
+| `loop_arith` | 363,8 | 418,6 | 346,4 | 103,9 | 79,7 |
+| `mandelbrot` | 268,2 | 310,1 | 179,1 | - | - |
+| `map_churn` | 265,0 | 317,6 | 171,2 | - | - |
+| `startup` | 91,3 | 91,0 | 88,5 | 61,9 | 71,4 |
+| `string_ops` | 225,8 | 236,8 | 120,4 | - | - |
 
 ## Tempo de execucao, descontado o piso de `startup` (ms)
 
-| bench | noxy | noxy_v060 | python | lua | go |
+| bench | noxy | v0142 | python | lua | go |
 |---|---|---|---|---|---|
-| `bubblesort` | 561,4 | 529,8 | 75,1 | - | - |
-| `fib` | 396,8 | 369,7 | 113,2 | 53,8 | ~0 |
-| `loop_arith` | 300,5 | 312,4 | 257,3 | 39,0 | 7,4 |
-| `mandelbrot` | 220,4 | 222,8 | 82,2 | - | - |
-| `map_churn` | 209,1 | 211,0 | 75,9 | - | - |
-| `string_ops` | 158,4 | 156,2 | 34,9 | - | - |
+| `bubblesort` | 423,1 | 625,4 | 76,9 | - | - |
+| `fib` | 296,0 | 420,7 | 103,4 | 52,8 | ~0 |
+| `loop_arith` | 272,5 | 327,6 | 257,9 | 42,0 | 8,3 |
+| `mandelbrot` | 176,9 | 219,1 | 90,6 | - | - |
+| `map_churn` | 173,7 | 226,6 | 82,7 | - | - |
+| `string_ops` | 134,5 | 145,8 | 31,9 | - | - |
 
 `~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.
 
 ## Razoes sobre o tempo liquido (noxy / outro)
 
-| bench | / noxy_v060 | / python | / lua | / go |
+| bench | / v0142 | / python | / lua | / go |
 |---|---|---|---|---|
-| `bubblesort` | 1,06x | 7,48x | - | - |
-| `fib` | 1,07x | 3,51x | 7,38x | - |
-| `loop_arith` | 0,96x | 1,17x | 7,71x | 40,61x |
-| `mandelbrot` | 0,99x | 2,68x | - | - |
-| `map_churn` | 0,99x | 2,75x | - | - |
-| `string_ops` | 1,01x | 4,54x | - | - |
+| `bubblesort` | 0,68x | 5,50x | - | - |
+| `fib` | 0,70x | 2,86x | 5,61x | - |
+| `loop_arith` | 0,83x | 1,06x | 6,49x | 32,83x |
+| `mandelbrot` | 0,81x | 1,95x | - | - |
+| `map_churn` | 0,77x | 2,10x | - | - |
+| `string_ops` | 0,92x | 4,22x | - | - |
 
 Menor e melhor. `-` = um dos lados cai dentro do ruido do piso e a razao nao tem significado.

--- a/benchmarks/results/2026-08-22-issue-37-value-layout-raw.md
+++ b/benchmarks/results/2026-08-22-issue-37-value-layout-raw.md
@@ -1,0 +1,253 @@
+# Dados brutos — fase 2 de perf (issue #37): v0.14.2 × estágios 1 / 1+2 / 1+2+pop
+
+**Data:** 2026-08-22 · Windows 11 · i7-1165G7 (8 threads lógicas) · Go 1.24.11 ·
+laptop, plano Equilibrado, na tomada.
+
+**Binários** (todos em disco local, fora do OneDrive; mesma sessão de build):
+
+| rótulo | commit | o que é |
+|---|---|---|
+| `base` (v0142) | cb8efcb | `develop` = v0.14.2 |
+| `s1` | 41638e8 | estágio 1: `Value` 48 → 32 B, acessores |
+| `s1+2` | e4d5a5f | + estágio 2: `ObjHeader` no offset 0, dica `kind` em `ownersOf` |
+| `s1+2+pop` | ba7f85d | + `pop()` inlinada em `run()` (custo 22 → 18, 0 → 79 sites) |
+
+**Protocolo:** o de `benchmarks/RESULTS.md` — execuções intercaladas na mesma
+janela de tempo, guard de `CHECKSUM:` entre binários, mediana de 9 (mínimo
+também registrado). A tabela "headline" é o script do repo
+(`interleaved_compare.ps1`, 2 binários); as tabelas por estágio são uma
+generalização do mesmo protocolo para 4 binários (`interleave4.ps1`, reproduzido
+no fim deste arquivo). Fontes `.nx` copiados para disco local antes de medir
+(OneDrive infla ~2x).
+
+**Carga da máquina:** registrada no início de cada passo (`Win32_Processor.LoadPercentage`),
+ver linhas `[passo] inicio ... CPU load`. Firefox, Slack e o Claude Code abertos;
+sem Zoom/Chrome; nenhum `go test` em andamento durante as medições.
+
+Os benches curtos (`bench_call_light`, `bench_typed_call_map`,
+`bench_value_call_mutate`, ~100 ms com piso de processo ~84 ms) **não decidem
+nada** (RESULTS.md, 2026-08-22): um jitter de 5 ms é ±5 %. São listados, não
+interpretados.
+
+## 1. Headline — `interleaved_compare.ps1` base × s1+2+pop (mediana de 9)
+
+`[headline] inicio 16:24:22 | CPU load: 1 %` → `fim 16:28:55`
+
+| bench | v0142_ms | s12p_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 4046.3 | 3002.8 | -25.8% |
+| bench_call_light.nx | 120.3 | 110.7 | -8% |
+| bench_call_readonly.nx | 1386.8 | 929.4 | -33% |
+| bench_call_ref.nx | 4160.8 | 3052.1 | -26.6% |
+| bench_conway.nx | 2214.9 | 1878.8 | -15.2% |
+| bench_generic_vs_hand.nx | 904.5 | 732.4 | -19% |
+| bench_map_churn.nx | 479.1 | 442 | -7.7% |
+| bench_path_update.nx | 682.4 | 498.2 | -27% |
+| bench_share_mutate.nx | 302.1 | 251.4 | -16.8% |
+| bench_spawn_sum.nx | 767.1 | 703.7 | -8.3% |
+| bench_typed_call_map.nx | 124.5 | 122.9 | -1.3% |
+| bench_value_call_mutate.nx | 119.3 | 121.1 | 1.5% |
+
+## 2. Por estágio — 4 binários intercalados (mediana de 9, mínimo entre parênteses)
+
+`[stages_bench_a] inicio 16:29:22 | CPU load: 11 %` · `[stages_bench_b] inicio 16:35:53 | CPU load: 15 %` · `[stages_cr] inicio 16:39:14 | CPU load: 21 %` (o load inclui o próprio PowerShell do passo anterior encerrando)
+
+### 2.1 `benchmarks/bench_*.nx`
+
+| bench | base | s1 | s1+2 | s1+2+pop |
+|---|---|---|---|---|
+| bench_bubblesort.nx | 4144.6 (min 3985.5) | 3589.6 (min 3398.1) | 3489.6 (min 3355.5) | 3041.4 (min 2940.2) |
+| bench_call_light.nx | 126.9 (min 96.2) | 111.7 (min 98.7) | 115.1 (min 97.8) | 129.6 (min 116.5) |
+| bench_call_readonly.nx | 1354.3 (min 1265.5) | 1195.5 (min 1074) | 1216.6 (min 1128.3) | 984.9 (min 907.4) |
+| bench_call_ref.nx | 4150.9 (min 4073.5) | 3559.1 (min 3445.9) | 3548.5 (min 3488.8) | 3073.7 (min 3020.9) |
+| bench_conway.nx | 2191.5 (min 2098.8) | 2152.2 (min 2032.3) | 2066 (min 2026.2) | 1941.7 (min 1803.7) |
+| bench_generic_vs_hand.nx | 880.1 (min 823.4) | 816.6 (min 779.2) | 824.9 (min 802.7) | 733.8 (min 699.7) |
+| bench_map_churn.nx | 480.5 (min 432.7) | 470.6 (min 457) | 475.6 (min 423.2) | 455.5 (min 366.8) |
+| bench_path_update.nx | 671.8 (min 624.7) | 633.7 (min 617.4) | 625.5 (min 585.2) | 465.8 (min 453.9) |
+| bench_share_mutate.nx | 301.8 (min 277.1) | 259.5 (min 241.2) | 247.2 (min 237.8) | 250.9 (min 238.9) |
+| bench_spawn_sum.nx | 781.6 (min 720.1) | 723.5 (min 709.2) | 753 (min 659.7) | 676.1 (min 642.1) |
+| bench_typed_call_map.nx | 127.5 (min 120.6) | 126 (min 116.9) | 125.4 (min 118) | 122.5 (min 118) |
+| bench_value_call_mutate.nx | 129.8 (min 120.8) | 120.7 (min 110.6) | 122.3 (min 113.6) | 122.3 (min 116.6) |
+
+### 2.2 `benchmarks/cross_runtime/*.nx` (só o Noxy, 4 binários)
+
+| bench | base | s1 | s1+2 | s1+2+pop |
+|---|---|---|---|---|
+| cr_bubblesort.nx | 731.5 (min 684.2) | 647.6 (min 606.6) | 630.2 (min 594.3) | 556.2 (min 541.3) |
+| cr_fib.nx | 530.7 (min 478.4) | 477.6 (min 436.5) | 462.5 (min 438.9) | 436.5 (min 423.7) |
+| cr_loop_arith.nx | 455 (min 421.4) | 438.8 (min 407.4) | 425.3 (min 394.6) | 363.2 (min 351.8) |
+| cr_mandelbrot.nx | 350.8 (min 331.3) | 339.3 (min 305.8) | 340.7 (min 305) | 296.7 (min 273.4) |
+| cr_map_churn.nx | 334.6 (min 323.8) | 348.3 (min 327.6) | 344.1 (min 327.4) | 312.4 (min 290.3) |
+| cr_startup.nx | 106.2 (min 102.2) | 110.8 (min 101.1) | 110.2 (min 101.7) | 108.9 (min 100.4) |
+| cr_string_ops.nx | 287.4 (min 265) | 268.8 (min 253.6) | 284.1 (min 250.1) | 254 (min 244.4) |
+
+### 2.3 Deltas derivados das medianas de 2.1/2.2
+
+"vs base" é o acumulado; "passo" é o delta do estágio contra o binário
+imediatamente anterior (s1 vs base, s1+2 vs s1, pop vs s1+2).
+
+| bench | s1 vs base | s1+2 vs base (passo) | s1+2+pop vs base (passo) |
+|---|---|---|---|
+| bench_bubblesort | −13,4 % | −15,8 % (−2,8 %) | **−26,6 %** (−12,8 %) |
+| bench_call_ref | −14,3 % | −14,5 % (−0,3 %) | **−26,0 %** (−13,4 %) |
+| bench_conway | −1,8 % | −5,7 % (−4,0 %) | **−11,4 %** (−6,0 %) |
+| bench_call_readonly | −11,7 % | −10,2 % (+1,8 %) | **−27,3 %** (−19,0 %) |
+| bench_generic_vs_hand | −7,2 % | −6,3 % (+1,0 %) | **−16,6 %** (−11,0 %) |
+| bench_path_update | −5,7 % | −6,9 % (−1,3 %) | **−30,7 %** (−25,5 %) |
+| bench_share_mutate | −14,0 % | −18,1 % (−4,7 %) | **−16,9 %** (+1,5 %) |
+| bench_spawn_sum | −7,4 % | −3,7 % (+4,1 %) | **−13,5 %** (−10,2 %) |
+| bench_map_churn | −2,1 % | −1,0 % (+1,1 %) | **−5,2 %** (−4,2 %) |
+| bench_call_light / typed_call_map / value_call_mutate | piso de processo | piso | piso |
+| cr_fib | −10,0 % | −12,9 % (−3,2 %) | **−17,7 %** (−5,6 %) |
+| cr_bubblesort | −11,5 % | −13,8 % (−2,7 %) | **−24,0 %** (−11,7 %) |
+| cr_loop_arith | −3,6 % | −6,5 % (−3,1 %) | **−20,2 %** (−14,6 %) |
+| cr_mandelbrot | −3,3 % | −2,9 % (+0,4 %) | **−15,4 %** (−12,9 %) |
+| cr_string_ops | −6,5 % | −1,1 % (+5,7 %) | **−11,6 %** (−10,6 %) |
+| cr_map_churn | +4,1 % | +2,8 % (−1,2 %) | **−6,6 %** (−9,2 %) |
+| cr_startup | +4,3 % | +3,8 % | +2,5 % (piso: 100–110 ms, ruído) |
+
+## 3. Perfil de `fib` (`noxy --cpuprofile`, uma execução, amostras de 10 ms)
+
+`[profile] inicio 16:41:28 | CPU load: 7 %`
+
+base (v0.14.2) — 410 ms de amostras:
+
+```
+     flat  flat%        cum   cum%
+    190ms 46.34%      390ms 95.12%  vm.(*VM).run
+     70ms 17.07%       70ms 17.07%  vm.(*VM).pop            ← chamada real, nao inlinada
+     30ms  7.32%       30ms  7.32%  chunk.(*Chunk).GlobalCache
+     30ms  7.32%       30ms  7.32%  vm.(*VM).finalizeCurrentFrame
+     30ms  7.32%       30ms  7.32%  vm.(*VM).push (inline)
+     20ms  4.88%       50ms 12.20%  vm.(*VM).finishFrame
+```
+
+s1+2+pop — 310 ms de amostras:
+
+```
+     flat  flat%        cum   cum%
+    160ms 51.61%      290ms 93.55%  vm.(*VM).run
+     40ms 12.90%       40ms 12.90%  vm.(*VM).push (inline)
+     30ms  9.68%       40ms 12.90%  vm.(*VM).callPreparedClosure
+     20ms  6.45%       20ms  6.45%  vm.(*VM).finalizeCurrentFrame
+     20ms  6.45%       40ms 12.90%  vm.(*VM).finishFrame
+     10ms  3.23%       10ms  3.23%  vm.(*VM).ensureCallCapacity (inline)
+     10ms  3.23%       10ms  3.23%  vm.(*VM).pop (inline)
+```
+
+`pop` sai de 17 % flat (função chamada) para 3 % (inlinada); `push` inlinada
+segue visível porque o perfil atribui ao corpo embutido. O perfil é curto
+(fib(30), ~0,5 s) — serve de indicador de onde o tempo foi, não de medida.
+
+## 4. Cross-runtime — `run_cross_runtime.ps1 -NoxyBaseline` (mínimo de 9, intercalado com CPython/Lua/Go)
+
+`[cross] inicio 16:41:47 | CPU load: 8 %` → `fim 16:43:10`
+
+## Tempo total (ms)
+
+| bench | noxy | v0142 | python | lua | go |
+|---|---|---|---|---|---|
+| `bubblesort` | 514,4 | 716,4 | 165,4 | - | - |
+| `fib` | 387,3 | 511,7 | 191,9 | 114,7 | 75,0 |
+| `loop_arith` | 363,8 | 418,6 | 346,4 | 103,9 | 79,7 |
+| `mandelbrot` | 268,2 | 310,1 | 179,1 | - | - |
+| `map_churn` | 265,0 | 317,6 | 171,2 | - | - |
+| `startup` | 91,3 | 91,0 | 88,5 | 61,9 | 71,4 |
+| `string_ops` | 225,8 | 236,8 | 120,4 | - | - |
+
+## Tempo de execucao, descontado o piso de `startup` (ms)
+
+| bench | noxy | v0142 | python | lua | go |
+|---|---|---|---|---|---|
+| `bubblesort` | 423,1 | 625,4 | 76,9 | - | - |
+| `fib` | 296,0 | 420,7 | 103,4 | 52,8 | ~0 |
+| `loop_arith` | 272,5 | 327,6 | 257,9 | 42,0 | 8,3 |
+| `mandelbrot` | 176,9 | 219,1 | 90,6 | - | - |
+| `map_churn` | 173,7 | 226,6 | 82,7 | - | - |
+| `string_ops` | 134,5 | 145,8 | 31,9 | - | - |
+
+`~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.
+
+## Razoes sobre o tempo liquido (noxy / outro)
+
+| bench | / v0142 | / python | / lua | / go |
+|---|---|---|---|---|
+| `bubblesort` | 0,68x | 5,50x | - | - |
+| `fib` | 0,70x | 2,86x | 5,61x | - |
+| `loop_arith` | 0,83x | 1,06x | 6,49x | 32,83x |
+| `mandelbrot` | 0,81x | 1,95x | - | - |
+| `map_churn` | 0,77x | 2,10x | - | - |
+| `string_ops` | 0,92x | 4,22x | - | - |
+
+Menor e melhor. `-` = um dos lados cai dentro do ruido do piso e a razao nao tem significado.
+
+## 5. `BenchmarkNoxyCallOverhead` por estágio (`go test ./internal/vm -run '^$' -bench NoxyCallOverhead -count 8`)
+
+Rodado em sequência (um worktree por commit, não intercalado) com a máquina
+sem outra carga; 1000 chamadas `leaf(i)` por op. Complementa, não decide.
+
+| estágio | commit | min ns/op | mediana ns/op | max ns/op | mediana vs base |
+|---|---|---|---|---|---|
+| base (v0.14.2) | cb8efcb | 133 029 | 145 098 | 212 789 | — |
+| s1 | 41638e8 | 123 838 | 139 155 | 155 788 | −4,1 % |
+| s1+2 | e4d5a5f | 130 533 | 137 894 | 147 586 | −5,0 % |
+| s1+2+pop | ba7f85d | 120 172 | 126 310 | 141 656 | **−13,0 %** |
+
+## 6. Microbench Go de `ownersOf` (módulo descartável, não entra no repo)
+
+`go test -bench . -count 3 -benchtime 200ms` sobre 1200 Values misturados
+(array/string/int/map/instância/struct) e cargas puras (só arrays, só strings):
+
+| forma | misto ns/op (3 rodadas) | só arrays | só strings |
+|---|---|---|---|
+| A: type switch + checagem de Type (v0.14.2) | 6006 / 5025 / 5415 | 6099 / 6015 / 5189 | 4691 / 5888 / 5954 |
+| B: dica `kind` + type switch (embarcado) | 6123 / 5751 / 5204 | 5387 / 5749 / 5519 | 5152 / 5329 / 4950 |
+| B2: switch no `kind` + assertion por caso + slow path (custo 73, não cabe) | 6133 / 5898 / 6149 | 5428 / 6065 / 5878 | — |
+| C: dica + cast `unsafe` do header (sem slow path) | 5073 / 5355 / 6213 | 5988 / 4964 / 4844 | 4730 / 5367 / 6110 |
+
+~4–5 ns por chamada em todas; a dispersão entre rodadas (±20 %) é maior que
+qualquer diferença entre formas. Conclusão: a discriminação por tipo não é
+custo mensurável no `gc`; o custo do RC são os atômicos (`Load`/`Add`/`CAS`).
+
+## 7. Script dos 4 binários (`interleave4.ps1`)
+
+```powershell
+param([string[]]$Exes, [string[]]$Labels, [string[]]$Files, [int]$Runs = 9, [string]$Out = "")
+# Intercala N binarios na mesma janela de tempo sobre cada arquivo .nx:
+# para cada rodada, roda exe1, exe2, ..., exeN; repete Runs vezes. Reporta
+# mediana (min) por binario. Mesma ideia de benchmarks/interleaved_compare.ps1,
+# generalizada para isolar estagios (base / s1 / s1+2 / s1+2+pop).
+$ErrorActionPreference = "Stop"
+$rows = @("| bench | " + ($Labels -join " | ") + " |", "|---|" + ("---|" * $Labels.Count))
+foreach ($f in $Files) {
+    # guard de equivalencia: todos os binarios tem de concordar no CHECKSUM
+    $sums = @()
+    for ($k = 0; $k -lt $Exes.Count; $k++) {
+        $o = & $Exes[$k] $f 2>&1 | Where-Object { $_ -match "^CHECKSUM:" }
+        if ($o -is [array]) { $o = $o[0] }
+        $sums += "$o"
+    }
+    if (($sums | Select-Object -Unique).Count -ne 1) {
+        Write-Host "$(Split-Path $f -Leaf): PULADO (checksums divergem: $($sums -join ' / '))" -ForegroundColor Yellow
+        $rows += "| $(Split-Path $f -Leaf) | PULADO: " + ($sums -join " / ") + " |"
+        continue
+    }
+    $times = @{}; foreach ($l in $Labels) { $times[$l] = @() }
+    for ($i = 0; $i -lt $Runs; $i++) {
+        for ($k = 0; $k -lt $Exes.Count; $k++) {
+            $ms = (Measure-Command { & $Exes[$k] $f | Out-Null }).TotalMilliseconds
+            $times[$Labels[$k]] += [math]::Round($ms, 1)
+        }
+    }
+    $cells = @()
+    foreach ($l in $Labels) {
+        $sorted = $times[$l] | Sort-Object
+        $med = $sorted[[int](($Runs - 1) / 2)]; $min = $sorted[0]
+        $cells += "$med (min $min)"
+    }
+    $rows += "| $(Split-Path $f -Leaf) | " + ($cells -join " | ") + " |"
+    Write-Host ($rows[-1])
+}
+if ($Out) { $rows | Set-Content $Out; Write-Host "wrote $Out" }
+$rows
+```

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,17 +1,14 @@
-| bench | v060_ms | v0141_ms | delta |
+| bench | v0142_ms | s12p_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 4137.6 | 4141.8 | 0.1% |
-| bench_call_light.nx | 114.5 | 113.5 | -0.9% |
-| bench_call_readonly.nx | 1240 | 1369.3 | 10.4% |
-| bench_call_ref.nx | 3711 | 3838.7 | 3.4% |
-| bench_conway.nx | 2119.2 | 2168.9 | 2.3% |
-| bench_map_churn.nx | 451.4 | 449 | -0.5% |
-| bench_path_update.nx | 634.3 | 641.9 | 1.2% |
-| bench_share_mutate.nx | 266 | 264.7 | -0.5% |
-| bench_spawn_sum.nx | 725.6 | 726.8 | 0.2% |
-| bench_typed_call_map.nx | 109 | 121.9 | 11.8% |
-| bench_value_call_mutate.nx | 120.7 | 115.8 | -4.1% |
-
-Pulados (sem equivalencia entre os dois binarios):
-
-- bench_generic_vs_hand.nx — sem CHECKSUM no v060
+| bench_bubblesort.nx | 4046.3 | 3002.8 | -25.8% |
+| bench_call_light.nx | 120.3 | 110.7 | -8% |
+| bench_call_readonly.nx | 1386.8 | 929.4 | -33% |
+| bench_call_ref.nx | 4160.8 | 3052.1 | -26.6% |
+| bench_conway.nx | 2214.9 | 1878.8 | -15.2% |
+| bench_generic_vs_hand.nx | 904.5 | 732.4 | -19% |
+| bench_map_churn.nx | 479.1 | 442 | -7.7% |
+| bench_path_update.nx | 682.4 | 498.2 | -27% |
+| bench_share_mutate.nx | 302.1 | 251.4 | -16.8% |
+| bench_spawn_sum.nx | 767.1 | 703.7 | -8.3% |
+| bench_typed_call_map.nx | 124.5 | 122.9 | -1.3% |
+| bench_value_call_mutate.nx | 119.3 | 121.1 | 1.5% |

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2104,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.14.2`). It is a module binding, not a
+string `noxy --version` prints (`v0.14.3`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.14.2</span>
+                    <span class="version-badge-tag">v0.14.3</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.14.2
+print(sys.version)           // v0.14.3
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/docs/superpowers/plans/2026-08-22-vm-perf-fase2-value-layout.md
+++ b/docs/superpowers/plans/2026-08-22-vm-perf-fase2-value-layout.md
@@ -1,0 +1,814 @@
+# VM Perf Fase 2 — Layout do `Value` e header comum — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Encolher `value.Value` de 48 para 32 bytes, dar aos compostos um header comum com `Owners` no offset 0 e tirar o type switch do caminho comum de `ownersOf`, medindo cada estágio isoladamente (issue #37, estágios 1 e 2 + extra do `pop`).
+
+**Architecture:** Nenhuma mudança de semântica, sintaxe, bytecode ou saída. (1) `Value{Type uint8, kind uint8, b bool, num uint64, Obj interface{}}` com acessores `Int()/Float()/Bool()` e `SetInt()`; rename mecânico por script. (2) `ObjHeader{Owners}` embutido primeiro em `ObjArray/ObjMap/ObjInstance`; `kind` carimbado pelos construtores de `internal/value`; `ownersOf` decide pelo byte e cai no type switch de hoje quando `kind == 0`. (3) `pop()` limpa só `Obj` para caber no orçamento de inline de `run()`.
+
+**Tech Stack:** Go 1.24, Python 3 (script de rename, CRLF preservado), PowerShell (benchmarks intercalados de `benchmarks/`), `go build -gcflags=-m=2` (guards de inline), `noxy --cpuprofile`.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md`
+
+## Global Constraints
+
+- Branch `perf/issue-37-value-layout` (worktree `.claude/worktrees/perf-issue-37`), base `develop` cb8efcb (v0.14.2). Commits por estágio, nunca squash dos estágios — cada um tem binário e medição próprios.
+- **Semântica idêntica**: mesmos outputs, mesmos erros. Corpus `noxy_examples/` sem falhas e diff de saída base × head vazio (`benchmarks/compare_examples.ps1`).
+- **RC intocado**: nenhum funil retain/release muda de lugar ou de contagem; `Owners` continua `atomic.Int32`.
+- **Tags `ValueType` e opcodes não mudam de valor nem de ordem.**
+- Guards de inline (`internal/vm/inline_guard_test.go`): `push` ≤ 20 e ≥ 100 sites em `executor.go`; `pop` idem (Task 3); `Retain`/`Release` ≤ 80 (Task 2). Conferir com `go build -gcflags=-m=2 ./internal/vm 2>&1 | grep -E "can inline \(\*VM\)\.(push|pop)|can inline .*(Retain|Release|ownersOf)"`.
+- `go test ./...` verde; `go test -race ./internal/value ./internal/vm` verde; `go vet ./internal/value ./internal/vm` limpo.
+- Arquivos Go do repo são **CRLF**: scripts de edição leem/gravam com `newline=''` e preservam `\r\n`; conferir diffs com `git diff --numstat` (nunca diff de arquivo inteiro por EOL).
+- Binários de benchmark ficam em disco local: `$SCRATCH\bench\` onde `$SCRATCH = C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ef3672bf-bc7a-4367-818c-fb10c1f93a42\scratchpad` (`noxy_base.exe` já está lá, buildado de cb8efcb). Se o EDR apagar um .exe, rebuildar; para rodar Noxy ad hoc, `go run ./cmd/noxy arquivo.nx`.
+- Todos os comandos assumem cwd = raiz do worktree, Git Bash ou PowerShell no Windows.
+
+---
+
+### Task 1: Estágio 1 — `Value` de 48 → 32 bytes, acessores e rename mecânico
+
+**Files:**
+- Modify: `internal/value/value.go:11-33` (tipo `ValueType`, struct `Value`), `:648-658` (construtores)
+- Create: `internal/value/layout_test.go`
+- Create (scratch, não commitado): `$SCRATCH\rename_accessors.py`
+- Modify (pelo script): todo `*.go` fora de `.claude/` que leia `.AsInt/.AsFloat/.AsBool` (323/55/49 sites) — e à mão `internal/vm/executor.go:221` (`AsInt +=`)
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `type ValueType uint8`; `func (v Value) Int() int64`; `func (v Value) Float() float64`; `func (v Value) Bool() bool`; `func (v *Value) SetInt(n int64)`; campos `kind objKind` (tipo `objKind uint8`, usado na Task 2), `b bool`, `num uint64` não exportados. `NewInt/NewFloat/NewBool/NewNull` mantêm assinatura.
+
+- [ ] **Step 1: Teste de layout e acessores (falha: Sizeof é 48 e os métodos não existem)**
+
+Criar `internal/value/layout_test.go`:
+
+```go
+package value
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+// O tamanho do Value e o custo de cada push/pop e de cada copia de operando
+// em run(): 48 B (tag int + bool + int64 + float64 + interface) virou 32 B na
+// fase 2 de perf (issue #37, estagio 1). Este teste e a assercao executavel
+// do layout — se alguem acrescentar um campo, o build avisa aqui, nao num
+// benchmark meses depois.
+func TestValueIs32Bytes(t *testing.T) {
+	if got := unsafe.Sizeof(Value{}); got != 32 {
+		t.Fatalf("unsafe.Sizeof(Value{}) = %d, esperado 32 (ver spec 2026-08-22-vm-perf-fase2-value-layout)", got)
+	}
+	if got := unsafe.Sizeof(ValueType(0)); got != 1 {
+		t.Fatalf("ValueType deve ocupar 1 byte, ocupa %d", got)
+	}
+}
+
+func TestValueAccessorsRoundTrip(t *testing.T) {
+	if got := NewInt(-42).Int(); got != -42 {
+		t.Fatalf("Int(): %d", got)
+	}
+	if got := NewInt(math.MaxInt64).Int(); got != math.MaxInt64 {
+		t.Fatalf("Int() MaxInt64: %d", got)
+	}
+	if got := NewFloat(3.5).Float(); got != 3.5 {
+		t.Fatalf("Float(): %v", got)
+	}
+	if got := NewFloat(math.Inf(-1)).Float(); !math.IsInf(got, -1) {
+		t.Fatalf("Float() -Inf: %v", got)
+	}
+	if got := NewFloat(math.NaN()).Float(); !math.IsNaN(got) {
+		t.Fatalf("Float() NaN: %v", got)
+	}
+	if got := NewFloat(math.Copysign(0, -1)).Float(); !math.Signbit(got) {
+		t.Fatalf("Float() -0: perdeu o sinal")
+	}
+	if !NewBool(true).Bool() || NewBool(false).Bool() {
+		t.Fatal("Bool() nao faz round-trip")
+	}
+	var zero Value
+	if zero.Type != VAL_BOOL || zero.Bool() || zero.Int() != 0 || zero.Obj != nil {
+		t.Fatalf("zero value deve continuar sendo VAL_BOOL false: %+v", zero)
+	}
+	v := NewInt(1)
+	v.SetInt(41)
+	v.SetInt(v.Int() + 1)
+	if v.Type != VAL_INT || v.Int() != 42 {
+		t.Fatalf("SetInt: %+v", v)
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/value -run 'TestValueIs32Bytes|TestValueAccessorsRoundTrip'`
+Expected: erro de compilação (`NewInt(-42).Int undefined`) — o teste ainda não compila; é a falha esperada.
+
+- [ ] **Step 3: Novo struct, acessores e construtores em `value.go`**
+
+Substituir as linhas 11 e 26-33 (`type ValueType int` e o struct) por:
+
+```go
+type ValueType uint8
+
+// objKind e a dica que os construtores de internal/value carimbam em Value
+// para ownersOf (cow.go) decidir sem type switch. Zero = "desconhecido":
+// um Value{Type: VAL_OBJ, Obj: x} montado fora dos construtores cai no
+// caminho lento (o type switch de sempre) e continua correto — a dica so
+// acelera, nunca decide sozinha.
+type objKind uint8
+
+const (
+	objKindUnknown  objKind = iota
+	objKindNoOwners         // string, *ObjStruct, *RuntimeTypeInfo: VAL_OBJ sem contador
+	objKindArray
+	objKindMap
+	objKindInstance
+)
+
+// Value e o operando universal da VM: 32 bytes (fase 2 de perf, issue #37).
+// Type e a tag; num guarda int64 (VAL_INT) ou os bits de um float64
+// (VAL_FLOAT); b guarda VAL_BOOL; Obj, o objeto alocado dos demais tipos.
+// Leia pelos acessores Int()/Float()/Bool() — ler o campo errado para a tag
+// devolve lixo (num e compartilhado entre int e float), nunca zero.
+// layout_test.go trava o tamanho.
+type Value struct {
+	Type ValueType
+	kind objKind
+	b    bool
+	num  uint64
+	Obj  interface{} // Heap allocated object
+}
+
+// Int devolve o inteiro de um VAL_INT. Em qualquer outra tag o resultado e
+// indefinido (os bits de num) — o chamador garante a tag.
+func (v Value) Int() int64 { return int64(v.num) }
+
+// Float devolve o float de um VAL_FLOAT (bits em num).
+func (v Value) Float() float64 { return math.Float64frombits(v.num) }
+
+// Bool devolve o valor de um VAL_BOOL.
+func (v Value) Bool() bool { return v.b }
+
+// SetInt grava o inteiro no lugar, sem tocar na tag — e o `AsInt +=` de
+// OP_INC_LOCAL_INT (8 bytes escritos em vez dos 32 de um Value novo).
+func (v *Value) SetInt(n int64) { v.num = uint64(n) }
+```
+
+Acrescentar `"math"` aos imports. Substituir os construtores (linhas 648-658):
+
+```go
+func NewInt(v int64) Value {
+	return Value{Type: VAL_INT, num: uint64(v)}
+}
+
+func NewFloat(v float64) Value {
+	return Value{Type: VAL_FLOAT, num: math.Float64bits(v)}
+}
+
+func NewBool(v bool) Value {
+	return Value{Type: VAL_BOOL, b: v}
+}
+```
+
+Atualizar também `String()` (`value.go:591` usa `v.AsBool`, `:597` usa `v.AsFloat`) — o script do Step 4 cobre esses dois.
+
+- [ ] **Step 4: Script de rename (Write tool, não heredoc) e execução**
+
+`$SCRATCH\rename_accessors.py`:
+
+```python
+import pathlib, re, sys
+ROOT = pathlib.Path(sys.argv[1])
+PAT = {
+    re.compile(r'\.AsInt\b'):   '.Int()',
+    re.compile(r'\.AsFloat\b'): '.Float()',
+    re.compile(r'\.AsBool\b'):  '.Bool()',
+}
+changed = 0
+for p in ROOT.rglob('*.go'):
+    if '.claude' in p.parts or '.git' in p.parts:
+        continue
+    raw = p.read_bytes()
+    text = raw.decode('utf-8')
+    new = text
+    for rx, rep in PAT.items():
+        new = rx.sub(rep, new)
+    if new != text:
+        p.write_bytes(new.encode('utf-8'))   # bytes: CRLF preservado
+        changed += 1
+print('arquivos alterados:', changed)
+```
+
+Run: `python "$SCRATCH/rename_accessors.py" .` → esperado ~80 arquivos. Depois, à mão:
+
+- `internal/vm/executor.go:221`: `vm.stack[frame.LocalBase+int(slot)].Int() += int64(delta)` (inválido) → 
+  ```go
+  slotValue := &vm.stack[frame.LocalBase+int(slot)]
+  slotValue.SetInt(slotValue.Int() + int64(delta))
+  ```
+- `grep -rn "Int() +=\|Float() +=\|Bool() =" --include=*.go .` tem de voltar vazio.
+
+- [ ] **Step 5: Compilar, auditar leituras sem guarda e rodar o pacote**
+
+Run: `go build ./... && go vet ./internal/value ./internal/vm`
+Expected: limpo.
+
+Auditoria (a única mudança de semântica dos acessores é em tag errada — antes zero, agora lixo): listar leituras sem `VAL_`/`Type`/`switch`/`checkType`/`case` nas 4 linhas anteriores e revisar cada uma à mão:
+
+```bash
+grep -rn -B4 '\.\(Int\|Float\|Bool\)()' --include=*.go --exclude-dir=.claude internal cmd \
+  | awk -F'[-:]' '/\.(Int|Float|Bool)\(\)/{print}' > /dev/null
+```
+
+(Na prática: `grep -rn -B4 ... | grep -v -- '--' ` e ler os blocos cujo contexto não menciona `VAL_`, `Type`, `switch`, `case`, `checkType`, `IsInt`, `isInt`, `expect`, `want`, `got`. Registrar no commit os sites revisados que dependiam de zero implícito, se houver — a expectativa, pela exploração, é nenhum.)
+
+Run: `go test ./internal/value ./internal/vm`
+Expected: PASS (inclui `TestPushStaysInlinedInsideRun` — `NewBool`/`NewInt` seguem custo ≤ 20).
+
+- [ ] **Step 6: Commit e binário do estágio**
+
+```bash
+git add -A internal cmd
+git commit -m "perf(value): Value de 48 para 32 bytes — tag uint8, num único p/ int|float, bool no padding; acessores Int()/Float()/Bool()/SetInt (issue #37, estágio 1)"
+go build -o "$SCRATCH/bench/noxy_s1.exe" ./cmd/noxy
+```
+
+---
+
+### Task 2: Estágio 2 — `ObjHeader`, dica `kind` e `ownersOf` sem type switch
+
+**Files:**
+- Modify: `internal/value/value.go` (`ObjArray:348`, `ObjMap:388`, `ObjInstance:472`, construtores `:664-733`, `environment.go:72`)
+- Modify: `internal/value/cow.go:21-34`
+- Modify: `internal/value/owners_test.go`, `internal/value/layout_test.go`
+- Modify: `internal/vm/calls.go:198`
+- Modify: `internal/vm/inline_guard_test.go`
+
+**Interfaces:**
+- Consumes: `objKind` e campo `kind` da Task 1.
+- Produces: `type ObjHeader struct{ Owners atomic.Int32 }` embutido (campo promovido `obj.Owners` continua válido); `func NewInstanceAdopting(def *ObjStruct, fields map[string]Value) Value` (instância cujos campos o chamador JÁ reteve — o análogo de `NewArrayAdopting`); `ownersOf` com caminho rápido.
+
+- [ ] **Step 1: Testes (falham: `ObjHeader` não existe; `kind` não é carimbado)**
+
+Acrescentar a `internal/value/layout_test.go`:
+
+```go
+// O header comum tem de ser o PRIMEIRO campo dos tres compostos: e o que
+// permite a um eventual estagio 3 (unsafe.Pointer) alcancar Owners sem saber
+// o tipo concreto. Hoje ownersOf usa type assertion checada, mas o layout ja
+// fica travado — invariante implicito em codigo de aparencia inocente e o
+// modo de falha mais provavel.
+func TestObjHeaderIsAtOffsetZero(t *testing.T) {
+	if off := unsafe.Offsetof(ObjArray{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjArray.ObjHeader no offset %d, esperado 0", off)
+	}
+	if off := unsafe.Offsetof(ObjMap{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjMap.ObjHeader no offset %d, esperado 0", off)
+	}
+	if off := unsafe.Offsetof(ObjInstance{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjInstance.ObjHeader no offset %d, esperado 0", off)
+	}
+}
+```
+
+Acrescentar a `internal/value/owners_test.go`:
+
+```go
+// Cada construtor carimba a dica kind; ownersOf tem de chegar ao MESMO
+// contador pelo caminho rapido (dica) e pelo lento (Value montado a mao,
+// kind zero) — se divergissem, Retain por um caminho e Release pelo outro
+// contariam em objetos diferentes.
+func TestOwnersOfFastAndSlowPathsAgree(t *testing.T) {
+	arr := NewArray(nil)
+	arrObj := arr.Obj.(*ObjArray)
+	if arr.kind != objKindArray {
+		t.Fatalf("NewArray deve carimbar objKindArray, veio %d", arr.kind)
+	}
+	if ownersOf(arr) != &arrObj.Owners {
+		t.Fatal("ownersOf(array) nao aponta para o Owners do header")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: arrObj}) != &arrObj.Owners {
+		t.Fatal("caminho lento (kind zero) diverge do rapido para array")
+	}
+
+	m := NewMap()
+	mObj := m.Obj.(*ObjMap)
+	if m.kind != objKindMap || ownersOf(m) != &mObj.Owners {
+		t.Fatal("NewMap: dica ou ownersOf errados")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: mObj}) != &mObj.Owners {
+		t.Fatal("caminho lento diverge para map")
+	}
+
+	inst := NewInstance(&ObjStruct{Name: "P"})
+	instObj := inst.Obj.(*ObjInstance)
+	if inst.kind != objKindInstance || ownersOf(inst) != &instObj.Owners {
+		t.Fatal("NewInstance: dica ou ownersOf errados")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: instObj}) != &instObj.Owners {
+		t.Fatal("caminho lento diverge para instance")
+	}
+
+	for _, v := range []Value{NewString("s"), NewStruct("S", nil), NewRuntimeTypeInfo(&RuntimeTypeInfo{})} {
+		if v.kind != objKindNoOwners {
+			t.Fatalf("%s deve carimbar objKindNoOwners, veio %d", v.String(), v.kind)
+		}
+		if ownersOf(v) != nil {
+			t.Fatalf("%s nao tem contador", v.String())
+		}
+	}
+	if ownersOf(NewInt(1)) != nil || ownersOf(NewNull()) != nil || ownersOf(Value{}) != nil {
+		t.Fatal("escalares nao tem contador")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: "crua"}) != nil {
+		t.Fatal("string crua sem carimbo nao tem contador")
+	}
+}
+
+func TestNewInstanceAdoptingDoesNotRetainAgain(t *testing.T) {
+	child := NewArray(nil)
+	Retain(child) // o chamador ja reteve em nome da instancia
+	inst := NewInstanceAdopting(&ObjStruct{Name: "P"}, map[string]Value{"a": child})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("NewInstanceAdopting nao pode reter de novo: Owners=%d, esperado 1", got)
+	}
+	if inst.kind != objKindInstance {
+		t.Fatal("NewInstanceAdopting deve carimbar objKindInstance")
+	}
+}
+```
+
+Em `TestMapAndInstanceAlsoCount` (já existe), trocar `inst := Value{Type: VAL_OBJ, Obj: &ObjInstance{Fields: map[string]Value{}}}` por `inst := NewInstance(&ObjStruct{Name: "P"})` — o caminho lento agora tem teste próprio.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/value -run 'TestObjHeaderIsAtOffsetZero|TestOwnersOfFastAndSlowPathsAgree|TestNewInstanceAdoptingDoesNotRetainAgain'`
+Expected: erro de compilação (`ObjHeader`, `NewInstanceAdopting` indefinidos).
+
+- [ ] **Step 3: Header e carimbo nos construtores (`value.go`, `environment.go`)**
+
+Antes de `type ObjArray struct`:
+
+```go
+// ObjHeader e o prefixo comum dos compostos que o RC rastreia (array, map,
+// instancia). Owners conta referencias duraveis (RC-uniqueness, spec
+// 2026-08-17) e e a unica fonte de unicidade. TEM de ser o primeiro campo
+// das tres structs (offset 0 — layout_test.go trava): e o que um estagio 3
+// com unsafe.Pointer usaria para alcancar o contador sem o tipo concreto.
+type ObjHeader struct {
+	Owners atomic.Int32
+}
+```
+
+Nas três structs, trocar o campo `Owners atomic.Int32` (com o comentário de 3 linhas) por `ObjHeader` **como primeiro campo**:
+
+```go
+type ObjArray struct {
+	ObjHeader
+	Elements    []Value
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
+}
+
+type ObjMap struct {
+	ObjHeader
+	store       *bindingStore
+	storeOnce   sync.Once
+	RuntimeType atomic.Pointer[RuntimeTypeInfo]
+}
+
+type ObjInstance struct {
+	ObjHeader
+	Struct *ObjStruct
+	Fields map[string]Value
+}
+```
+
+Construtores — carimbar `kind`:
+
+```go
+func NewString(v string) Value {
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: v}
+}
+
+func NewRuntimeTypeInfo(v *RuntimeTypeInfo) Value {
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: v}
+}
+
+func NewArray(elements []Value) Value {
+	for _, element := range elements {
+		Retain(element)
+	}
+	return Value{Type: VAL_OBJ, kind: objKindArray, Obj: &ObjArray{Elements: elements}}
+}
+
+func NewArrayAdopting(elements []Value) Value {
+	return Value{Type: VAL_OBJ, kind: objKindArray, Obj: &ObjArray{Elements: elements}}
+}
+
+func NewMap() Value {
+	mapping := &ObjMap{store: newBindingStore(nil)}
+	mapping.ensureStore()
+	return Value{Type: VAL_OBJ, kind: objKindMap, Obj: mapping}
+}
+
+func NewStruct(name string, fields []string) Value {
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: &ObjStruct{Name: name, Fields: fields}}
+}
+
+func NewInstance(def *ObjStruct) Value {
+	return Value{Type: VAL_OBJ, kind: objKindInstance, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
+}
+
+func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value {
+	if fields == nil {
+		fields = make(map[string]Value)
+	}
+	for _, field := range fields {
+		Retain(field)
+	}
+	return NewInstanceAdopting(def, fields)
+}
+
+// NewInstanceAdopting cria uma instancia ADOTANDO campos que o chamador JA
+// reteve em nome dela (move): nao retem de novo — o analogo de
+// NewArrayAdopting. Uso restrito aos sites que transferem posse (o clone CoW
+// de instancia em calls.go); qualquer outro uso precisa de comentario
+// `// RC: move` explicando quem reteve.
+func NewInstanceAdopting(def *ObjStruct, fields map[string]Value) Value {
+	return Value{Type: VAL_OBJ, kind: objKindInstance, Obj: &ObjInstance{Struct: def, Fields: fields}}
+}
+```
+
+`NewMapWithData` já passa por `NewMap()` (herda o carimbo). `environment.go:72`:
+
+```go
+func (environment *GlobalEnvironment) ExportMap() Value {
+	return Value{Type: VAL_OBJ, kind: objKindMap, Obj: &ObjMap{store: environment.local}}
+}
+```
+
+- [ ] **Step 4: `ownersOf` com caminho rápido (`cow.go`)**
+
+```go
+// ownersOf devolve o contador de donos do composto, ou nil para tudo o que
+// o RC nao rastreia. Caminho rapido: a dica kind carimbada pelos
+// construtores de internal/value decide com uma comparacao de byte e uma
+// type assertion checada (uma comparacao de ponteiro de tipo). Caminho
+// lento (kind zero: Value{Type: VAL_OBJ, Obj: x} montado fora dos
+// construtores): o type switch de sempre — correto, so nao acelerado. A
+// dica nunca decide sozinha: um carimbo ausente nao pode virar under-count
+// (owners_test.go compara os dois caminhos).
+//
+// Retain (64) e Release (78) embutem este corpo e sao inlinados em
+// internal/vm com orcamento 80 (fora de run()); inline_guard_test.go trava.
+func ownersOf(v Value) *atomic.Int32 {
+	switch v.kind {
+	case objKindArray:
+		return &v.Obj.(*ObjArray).Owners
+	case objKindMap:
+		return &v.Obj.(*ObjMap).Owners
+	case objKindInstance:
+		return &v.Obj.(*ObjInstance).Owners
+	case objKindNoOwners:
+		return nil
+	}
+	return ownersOfSlow(v)
+}
+
+// ownersOfSlow e o caminho dos Values sem carimbo (kind zero).
+func ownersOfSlow(v Value) *atomic.Int32 {
+	if v.Type != VAL_OBJ {
+		return nil
+	}
+	switch obj := v.Obj.(type) {
+	case *ObjArray:
+		return &obj.Owners
+	case *ObjMap:
+		return &obj.Owners
+	case *ObjInstance:
+		return &obj.Owners
+	}
+	return nil
+}
+```
+
+Se `go build -gcflags=-m=2 ./internal/value 2>&1 | grep -E "can inline (Retain|Release)"` mostrar custo > 80 (ou "cannot inline"), reduzir: marcar `ownersOfSlow` como não-inlinável (`//go:noinline`) já tira o switch grande do corpo embutido; se ainda estourar, converter `Release` para `for { cur := owners.Load(); if cur <= 0 || cur >= ownersSaturation { return }; if owners.CompareAndSwap(cur, cur-1) { return } }` sem variável intermediária — e registrar o custo final no commit.
+
+- [ ] **Step 5: `calls.go:198` usa o construtor**
+
+```go
+	case *value.ObjInstance:
+		cloneCount.Add(1)
+		newFields := make(map[string]value.Value)
+		for k, val := range obj.Fields {
+			value.Retain(val) // RC: filho ganha dono duravel no clone
+			newFields[k] = val
+		}
+		return value.NewInstanceAdopting(obj.Struct, newFields) // RC: move — retidos acima
+```
+
+- [ ] **Step 6: Guard de inline para `Retain`/`Release`**
+
+Em `internal/vm/inline_guard_test.go`, acrescentar um teste:
+
+```go
+// Retain e Release (internal/value/cow.go) embutem ownersOf e sao inlinados
+// nos sites de internal/vm fora de run() (ownSlot, bindOwnedSlot, calls.go…)
+// com o orcamento normal de 80. A fase 2 de perf (issue #37) reescreveu
+// ownersOf com caminho rapido pela dica kind; este teste garante que o corpo
+// novo nao tirou os dois do inline.
+func TestRetainReleaseStayInlinable(t *testing.T) {
+	build := exec.Command("go", "build", "-gcflags=-m=2", "../value")
+	output, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build -gcflags=-m=2 ../value failed: %v\n%s", err, output)
+	}
+	report := string(output)
+	for _, name := range []string{"Retain", "Release"} {
+		pattern := regexp.MustCompile(`can inline ` + name + ` with cost (\d+)`)
+		match := pattern.FindStringSubmatch(report)
+		if match == nil {
+			t.Errorf("o compilador nao inlina value.%s — procure por 'cannot inline %s' em `go build -gcflags=-m=2 ./internal/value`", name, name)
+			continue
+		}
+		cost, convErr := strconv.Atoi(match[1])
+		if convErr != nil {
+			t.Fatalf("custo ilegivel em %q: %v", match[0], convErr)
+		}
+		if cost > inlineNormalMaxCost {
+			t.Errorf("value.%s tem custo de inline %d, maximo %d — enxugue ownersOf (ver cow.go)", name, cost, inlineNormalMaxCost)
+		}
+	}
+}
+```
+
+- [ ] **Step 7: Rodar, verificar custos e commitar**
+
+Run: `go build ./... && go vet ./internal/value ./internal/vm && go test ./internal/value ./internal/vm`
+Expected: PASS. Anotar `go build -gcflags=-m=2 ./internal/value 2>&1 | grep -E "can inline (ownersOf|Retain|Release|IsShared)" | sed 's/ as: .*//'` no corpo do commit.
+
+```bash
+git add internal
+git commit -m "perf(value): header comum ObjHeader{Owners} no offset 0 de array/map/instance; ownersOf decide pela dica kind carimbada nos construtores, type switch só no caminho lento (issue #37, estágio 2)"
+go build -o "$SCRATCH/bench/noxy_s12.exe" ./cmd/noxy
+```
+
+---
+
+### Task 3: Extra — `pop()` inlinável dentro de `run()`
+
+**Files:**
+- Modify: `internal/vm/stack.go:236-241`
+- Modify: `internal/vm/inline_guard_test.go`
+
+**Interfaces:**
+- Consumes: `Value` de 32 B (Task 1).
+- Produces: `pop` com custo ≤ 20 inlinada em `executor.go`.
+
+- [ ] **Step 1: Guard (falha: pop custa 22 e tem 0 sites inlinados)**
+
+Em `TestPushStaysInlinedInsideRun`, depois do bloco de `push` (antes do de `ensureCallCapacity`), acrescentar:
+
+```go
+	// pop e a segunda operacao mais quente; custava 22 (zerar os 48 bytes do
+	// Value inteiro) e nao era inlinada em NENHUM dos ~84 sites de run().
+	// Limpar so Obj (o unico campo que o GC enxerga) a traz para o orcamento.
+	popCostPattern := regexp.MustCompile(`can inline \(\*VM\)\.pop with cost (\d+)`)
+	popMatch := popCostPattern.FindStringSubmatch(report)
+	if popMatch == nil {
+		t.Fatalf("o compilador nao inlina (*VM).pop de jeito nenhum — procure por 'cannot inline (*VM).pop'")
+	}
+	popCost, popConvErr := strconv.Atoi(popMatch[1])
+	if popConvErr != nil {
+		t.Fatalf("custo de inline ilegivel em %q: %v", popMatch[0], popConvErr)
+	}
+	if popCost > inlineBigFunctionMaxCost {
+		t.Errorf("pop tem custo de inline %d, maximo %d para ser inlinada dentro de run() — tire nos do corpo de pop (ver stack.go)", popCost, inlineBigFunctionMaxCost)
+	}
+	popInlined := 0
+	for _, line := range strings.Split(report, "\n") {
+		if strings.Contains(line, "executor.go") && strings.Contains(line, "inlining call to (*VM).pop") {
+			popInlined++
+		}
+	}
+	if popInlined < minPopInlineSitesInRun {
+		t.Errorf("pop foi inlinada em %d call sites de executor.go, esperado >= %d (custo reportado: %d)", popInlined, minPopInlineSitesInRun, popCost)
+	}
+```
+
+e a constante:
+
+```go
+// minPopInlineSitesInRun e uma margem sob os ~84 call sites de pop em
+// executor.go (mesma logica de minPushInlineSitesInRun).
+const minPopInlineSitesInRun = 70
+```
+
+Run: `go test ./internal/vm -run TestPushStaysInlinedInsideRun`
+Expected: FAIL (`pop tem custo de inline 22` e `0 call sites`).
+
+- [ ] **Step 2: `pop` limpa só `Obj`**
+
+```go
+// pop desempilha e limpa SO o ponteiro do slot. Zerar o Value inteiro
+// (48 bytes antes da fase 2, 32 depois) custava 22 no inliner e deixava pop
+// fora do inline em TODOS os ~84 sites de run() (orcamento 20 — ver push);
+// para o GC so Obj interessa, e Type/num/b mortos acima de stackTop sao
+// inertes (os fused jumps ja leem slots acima do topo logo depois de
+// `stackTop -= 2`, sem limpar nada). inline_guard_test.go trava o custo.
+func (vm *VM) pop() value.Value {
+	vm.stackTop--
+	val := vm.stack[vm.stackTop]
+	vm.stack[vm.stackTop].Obj = nil
+	return val
+}
+```
+
+Se o custo ainda for > 20 (checar com `go build -gcflags=-m=2 ./internal/vm 2>&1 | grep 'can inline (\*VM).pop'`), a alternativa que cabe é não limpar nada em `pop` e limpar em `finalizeCurrentFrame`/`OP_RETURN` o trecho acima do novo topo — mas isso muda a retenção de memória; **não fazer sem medir**: se não couber, registrar o custo, deixar a variante `Obj = nil` (já mais barata: 16 B de escrita) e seguir.
+
+- [ ] **Step 3: Rodar, commitar, binário**
+
+Run: `go test ./internal/vm`
+Expected: PASS.
+
+```bash
+git add internal/vm/stack.go internal/vm/inline_guard_test.go
+git commit -m "perf(vm): pop limpa só Obj e volta a caber no orçamento de inline de run() (issue #37, extra barato)"
+go build -o "$SCRATCH/bench/noxy_s12p.exe" ./cmd/noxy
+```
+
+---
+
+### Task 4: Verificação completa (suíte, race, corpus, diff de saída)
+
+**Files:** nenhum alterado (se algo falhar, corrigir no estágio certo com commit `fixup` descritivo).
+
+- [ ] **Step 1: Suíte inteira e race**
+
+Run (pode levar alguns minutos; rodar em background e **confirmar com `Get-Process go`/saída final**, nunca assumir):
+```bash
+go test ./... 2>&1 | tail -40
+go test -race ./internal/value ./internal/vm 2>&1 | tail -10
+```
+Expected: `ok` em todos os pacotes.
+
+- [ ] **Step 2: Corpus de exemplos**
+
+Run: `go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx 2>&1 | tail -15`
+Expected: 0 falhas (o total cresce com exemplos novos; o juiz é "0 falhas").
+
+- [ ] **Step 3: Diff de saída ponta a ponta base × head**
+
+Run (PowerShell): `./benchmarks/compare_examples.ps1 -Baseline "$SCRATCH\bench\noxy_base.exe" -Candidate "$SCRATCH\bench\noxy_s12p.exe"`
+Expected: `divergentes: 0`. Qualquer divergência é bug até prova em contrário (só não-determinismo pode diferir — e esses já estão na lista de exclusão do script).
+
+---
+
+### Task 5: Medição e registro
+
+**Files:**
+- Create: `benchmarks/results/2026-08-22-issue-37-value-layout-raw.md`
+- Modify: `benchmarks/RESULTS.md` (nova seção no topo, "mais recente primeiro")
+- Modify: `benchmarks/cross_runtime/README.md` (seção Resultados, se o protocolo de lá registrar rodadas — seguir o formato existente)
+- Create (scratch): `$SCRATCH\bench\interleave4.ps1`
+
+- [ ] **Step 1: Registrar a carga da máquina**
+
+Run (PowerShell): `(Get-Counter '\Processor(_Total)\% Processor Time' -SampleInterval 1 -MaxSamples 5).CounterSamples.CookedValue | Measure-Object -Average | Select-Object -ExpandProperty Average`
+Anotar no raw.
+
+- [ ] **Step 2: Headline — protocolo do repo, base × final, mediana de 9**
+
+Run: `./benchmarks/interleaved_compare.ps1 -Baseline "$SCRATCH\bench\noxy_base.exe" -Candidate "$SCRATCH\bench\noxy_s12p.exe" -BaselineLabel v0142 -CandidateLabel s12p -Runs 9`
+Copiar `benchmarks/results/interleaved.md` para o raw (seção "headline").
+
+- [ ] **Step 3: Isolamento por estágio — 4 binários na mesma janela**
+
+`$SCRATCH\bench\interleave4.ps1` (Write tool):
+
+```powershell
+param([string[]]$Exes, [string[]]$Labels, [string[]]$Files, [int]$Runs = 9)
+$ErrorActionPreference = "Stop"
+$rows = @("| bench | " + ($Labels -join " | ") + " |", "|---|" + ("---|" * $Labels.Count))
+foreach ($f in $Files) {
+    $times = @{}; foreach ($l in $Labels) { $times[$l] = @() }
+    for ($i = 0; $i -lt $Runs; $i++) {
+        for ($k = 0; $k -lt $Exes.Count; $k++) {
+            $ms = (Measure-Command { & $Exes[$k] $f | Out-Null }).TotalMilliseconds
+            $times[$Labels[$k]] += [math]::Round($ms, 1)
+        }
+    }
+    $cells = @()
+    foreach ($l in $Labels) {
+        $sorted = $times[$l] | Sort-Object
+        $med = $sorted[[int](($Runs - 1) / 2)]; $min = $sorted[0]
+        $cells += "$med (min $min)"
+    }
+    $rows += "| $(Split-Path $f -Leaf) | " + ($cells -join " | ") + " |"
+    Write-Host ($rows[-1])
+}
+$rows
+```
+
+Run, com os benches do repo + `fib.nx`/`loop_arith.nx`/`bubblesort.nx`/`string_ops.nx` de `cross_runtime` copiados para `$SCRATCH\bench\src\` (disco local — OneDrive infla ~2x):
+
+```powershell
+./interleave4.ps1 -Exes @("$SCRATCH\bench\noxy_base.exe","$SCRATCH\bench\noxy_s1.exe","$SCRATCH\bench\noxy_s12.exe","$SCRATCH\bench\noxy_s12p.exe") -Labels @("base","s1","s1+2","s1+2+pop") -Files (Get-ChildItem "$SCRATCH\bench\src\*.nx").FullName -Runs 9
+```
+
+Expected: tabela mediana (min) por binário; deltas calculados contra `base` e contra o estágio anterior no raw.
+
+- [ ] **Step 4: Cross-runtime base × final**
+
+Run: `./benchmarks/cross_runtime/run_cross_runtime.ps1 -Noxy "$SCRATCH\bench\noxy_s12p.exe" -NoxyBaseline "$SCRATCH\bench\noxy_base.exe" -BaselineLabel v0142 -Runs 9`
+Copiar `benchmarks/cross_runtime/results/cross_runtime.md` para o raw.
+
+- [ ] **Step 5: Microbench de chamada e perfil de `fib`**
+
+```bash
+git stash list >/dev/null  # nada pendente
+for rev in cb8efcb HEAD~2 HEAD~1 HEAD; do git checkout -q $rev -- internal 2>/dev/null; go test ./internal/vm -run '^$' -bench NoxyCallOverhead -count 10 2>&1 | grep Benchmark; git checkout -q HEAD -- internal; done
+```
+(Mais simples e seguro: rodar o bench em `develop` no diretório principal e em cada commit via `git worktree`/`git stash`; o que importa é registrar ns/op × estágio.)
+
+Perfil: `"$SCRATCH\bench\noxy_base.exe" --cpuprofile "$SCRATCH\bench\fib_base.prof" benchmarks/cross_runtime/fib.nx` e idem com `noxy_s12p.exe`; `go tool pprof -top -nodecount=15 <exe> <prof>`. Registrar o share de `run`/`push`/`pop`/`ownersOf`/`Retain`/`Release`.
+
+- [ ] **Step 6: Microbench Go de `ownersOf` (registro da variante `unsafe`)**
+
+Em `$SCRATCH\ownersbench\` (módulo Go descartável) comparar três corpos sobre um slice de Values misturado (array/map/instance/string/int): type switch, `kind` + assertion checada (o embarcado), `kind` + cast `(*ObjHeader)` via data word do eface. Registrar ns/op no raw. Não entra no repo.
+
+- [ ] **Step 7: Escrever o raw, a seção de RESULTS.md e commitar**
+
+Seção nova no topo de `benchmarks/RESULTS.md`, no formato das anteriores: cabeçalho `## v0.14.2 (cb8efcb) × fase 2 de perf (<sha>) — layout do Value`, data, máquina, protocolo, carga; tabela headline; tabela por estágio; cross-runtime; leitura (o que confirmou/refutou a hipótese "fib 15–25 %"); gates CoW; perfil. Números como estão — "hipótese a validar, não promessa".
+
+```bash
+git add benchmarks/RESULTS.md benchmarks/results/2026-08-22-issue-37-value-layout-raw.md benchmarks/cross_runtime/README.md
+git commit -m "docs(bench): fase 2 de perf — Value 32 B, header comum e pop inlinável medidos por estágio contra v0.14.2 (issue #37)"
+```
+
+---
+
+### Task 6: CHANGELOG, versão v0.14.3 e docs
+
+**Files:**
+- Modify: `CHANGELOG.md` (nova seção `## [0.14.3] - 2026-08-22`), `internal/version/version.go`, `README.md` (badge linha 1 + banner do REPL), `AGENTS.md` (linha "Versão"), `docs/NOXY_LANGUAGE_SPEC.md` (`sys.version`), `docs/index.html` (`print(sys.version)` ~l.385 **e** `<span class="version-badge-tag">` ~l.58)
+
+- [ ] **Step 1: Localizar os seis pontos**
+
+Run: `grep -rn "v0\.14\.2" README.md AGENTS.md docs/NOXY_LANGUAGE_SPEC.md docs/index.html internal/version/version.go CHANGELOG.md | head -20`
+
+- [ ] **Step 2: Editar**
+
+`version.go`: `const Version = "v0.14.3"`. Demais: trocar `v0.14.2` → `v0.14.3` nos pontos listados. CHANGELOG, acima de `## [0.14.2]`:
+
+```markdown
+## [0.14.3] - 2026-08-22
+
+Fase 2 de performance do VM (issue #37, estágios 1 e 2). Nenhuma mudança de
+sintaxe, semântica, bytecode ou saída — só o layout interno do operando da VM
+e o caminho do contador de referências. Números por estágio em
+`benchmarks/RESULTS.md`.
+
+### Performance
+
+- **`value.Value` de 48 para 32 bytes.** Tag em `uint8`, um único campo para
+  `int64`/`float64` e o `bool` no padding; a pilha de operandos cai de 96 KB
+  para 64 KB e cada `push`/`pop`/cópia de operando move um terço a menos.
+  Leitura pelos acessores `Int()`/`Float()`/`Bool()` (os campos `AsInt`/
+  `AsFloat`/`AsBool` deixaram de existir — afeta só quem embute a VM em Go).
+- **Header comum nos compostos.** `ObjArray`, `ObjMap` e `ObjInstance`
+  embutem `ObjHeader{Owners}` no offset 0 (layout travado por teste), e
+  `ownersOf` — chamado por todo `Retain`/`Release`/`IsShared` — decide pela
+  dica carimbada nos construtores em vez do type switch, que fica só no
+  caminho lento.
+- **`pop()` volta a ser inlinada dentro de `run()`.** Limpa só o ponteiro do
+  slot (o que o GC enxerga) e cabe no orçamento de inline de função grande;
+  antes custava 22 e era chamada real em todos os ~84 sites do laço de
+  despacho. Guardado em `inline_guard_test.go` junto com `push`.
+- Resultado medido (mediana de 9, intercalado, máquina ociosa): <preencher
+  com os números da Task 5 — fib, loop_arith, bubblesort e a suíte bench_*>.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md internal/version/version.go README.md AGENTS.md docs/NOXY_LANGUAGE_SPEC.md docs/index.html
+git commit -m "chore(version): noxy v0.14.3 — CHANGELOG (fase 2 de perf, issue #37), README, AGENTS, spec, site, version.go"
+```
+
+---
+
+### Task 7: PR
+
+- [ ] **Step 1: Push e PR (convenções do repo: título `<branch> - Descrição PT`, base `develop`, label `not available to review`, `--assignee @me`, sem reviewers)**
+
+```bash
+git push -u origin perf/issue-37-value-layout
+gh pr create --base develop --assignee @me --label "not available to review" \
+  --title "perf/issue-37-value-layout - Value 48→32 B, header comum nos compostos e pop inlinável (issue #37, estágios 1 e 2)" \
+  --body-file "$SCRATCH/pr_body.md"
+```
+
+`pr_body.md` segue o template global (Summary / Components / Test Plan com checkboxes; implementados `[x]`, validações pendentes `[ ]`), referencia a issue (`Refs #37` — **não** `Closes`: o estágio 3 continua em aberto lá), e traz a tabela de números por estágio e as decisões tomadas sem consulta (spec §7). Terminar com `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+- [ ] **Step 2: Comentário na issue #37** com o link do PR e o resumo dos números (uma tabela), mencionando explicitamente se a pré-condição 1 do estágio 3 ("1+2 confirmam a tese") foi atendida ou não.

--- a/docs/superpowers/plans/2026-08-22-vm-perf-fase2-value-layout.md
+++ b/docs/superpowers/plans/2026-08-22-vm-perf-fase2-value-layout.md
@@ -555,6 +555,16 @@ go build -o "$SCRATCH/bench/noxy_s12.exe" ./cmd/noxy
 
 ---
 
+> **Nota de execução (Task 2):** a forma planejada de `ownersOf` (switch no
+> `kind` + type assertion checada por caso + `ownersOfSlow` embutido) custou
+> **73** no inliner e tirou `Retain` (105) e `Release` (119) do orçamento de
+> 80; uma *chamada* ao caminho lento custaria 57, pior. Embarcado: early-exit
+> `kind == objKindNoOwners` + o type switch de sempre (35), com `Release`
+> reescrito para uma comparação única em `uint32` (`Release` = 80 exato;
+> `TestReleaseSingleCompareMatchesRange` trava as bordas). O teste
+> `TestOwnersOfFastAndSlowPathsAgree` virou
+> `TestOwnersOfReachesHeaderWithAndWithoutKindHint`. Detalhes na spec §3.2.
+
 ### Task 3: Extra — `pop()` inlinável dentro de `run()`
 
 **Files:**
@@ -638,6 +648,13 @@ go build -o "$SCRATCH/bench/noxy_s12p.exe" ./cmd/noxy
 ```
 
 ---
+
+> **Nota de execução (Task 3):** `vm.stack[vm.stackTop].Obj = nil` custou
+> **23** (duas indexações) e `slot := &vm.stack[top]; slot.Obj = nil` **26** —
+> nenhuma cabe. O que coube foi a atribuição dupla com resultado nomeado
+> (`val, vm.stack[top] = vm.stack[top], value.Value{}`), **18**, que zera o
+> `Value` inteiro como o original (nenhuma mudança para o GC): 79 sites
+> inlinados em `executor.go`. Spec §3.3 atualizada.
 
 ### Task 4: Verificação completa (suíte, race, corpus, diff de saída)
 

--- a/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
@@ -94,29 +94,44 @@ type ObjInstance struct { ObjHeader; Struct *ObjStruct; Fields map[string]Value 
 
 ```go
 func ownersOf(v Value) *atomic.Int32 {
-	switch v.kind {
-	case objKindArray:    return &v.Obj.(*ObjArray).Owners     // 1 cmp de ponteiro de tipo
-	case objKindMap:      return &v.Obj.(*ObjMap).Owners
-	case objKindInstance: return &v.Obj.(*ObjInstance).Owners
-	case objKindNoOwners: return nil
+	if v.kind == objKindNoOwners {   // string, *ObjStruct, *RuntimeTypeInfo: 1 cmp de byte
+		return nil
 	}
-	return ownersOfSlow(v) // o type switch de hoje: Type != VAL_OBJ → nil; array/map/instance
+	switch obj := v.Obj.(type) {     // compostos, escalares (Obj nil) e kind zero
+	case *ObjArray:    return &obj.Owners
+	case *ObjMap:      return &obj.Owners
+	case *ObjInstance: return &obj.Owners
+	}
+	return nil
 }
 ```
 
-- **Correto por construção:** `kind == 0` cai no caminho de hoje. Os ~30
-  sites `value.Value{Type: value.VAL_OBJ, Obj: inst}` (io/sqlite/sys/json,
-  `calls.go:198`) continuam corretos, só não aceleram; o de `calls.go` (clone
-  CoW de instância, semi-quente) passa a usar construtor. Um site novo que
-  esqueça o carimbo **não** produz under-count de RC — só perde a aceleração.
+- **Correto por construção:** a dica só tira do type switch o que *nunca* tem
+  contador; compostos e Values sem carimbo (`kind == 0`: os ~30 sites
+  `value.Value{Type: value.VAL_OBJ, Obj: inst}` em io/sqlite/sys/json) seguem
+  pelo switch de sempre. Um site novo que esqueça o carimbo **não** produz
+  under-count de RC. O de `calls.go:198` (clone CoW de instância) passa a
+  usar `NewInstanceAdopting`. A checagem `Type != VAL_OBJ` sai: o único dono
+  de `*ObjArray/*ObjMap/*ObjInstance` em `Obj` é `VAL_OBJ`, e `Obj == nil`
+  (escalares) cai no `default`.
+- **Achado que mudou o desenho (orçamento de inline).** A forma "switch no
+  `kind` com type assertion checada por caso + caminho lento embutido" custa
+  73 e leva `Retain` a 105 e `Release` a 119 — fora do orçamento de 80 que os
+  mantém inlinados nos 25/13 sites de `internal/vm`; uma *chamada* ao caminho
+  lento custa 57 no inliner, pior ainda. Nenhuma variante com caminho lento
+  separado cabe; a única que cabe é a acima (35, +3 sobre os 32 originais),
+  e mesmo ela empurrava `Release` para 81 — compensado trocando `current <=
+  0 || current >= ownersSaturation` por uma comparação única em `uint32`
+  (semântica idêntica, `owners_test.go` trava as bordas). Resultado: `Retain`
+  67, `Release` **80** (sem folga, como `ensureCallCapacity`).
 - **Sem `unsafe`** no caminho quente. A variante "cast direto para
-  `*ObjHeader` via data word do eface" economizaria uma comparação de
-  ponteiro; é medida em microbench Go (§5) e registrada, não embarcada —
-  critério de confinamento do comentário 2 da issue (unsafe só com ganho
-  mensurável e atrás de asserção executável).
-- `Retain` (custo 64) e `Release` (78) hoje são inlinados em 25/13 sites de
-  `internal/vm` (orçamento 80 fora de `run()`); `ownersOf` novo não pode
-  estourar isso — guard em `inline_guard_test.go`.
+  `*ObjHeader` via data word do eface, sem caminho lento" só cabe no orçamento
+  se o carimbo for *garantido* (kind zero = não rastreado), o que exige guard
+  de grep sobre o repo e transforma um esquecimento em under-count de RC; é
+  medida à parte (§5) e registrada, não embarcada — critério de confinamento
+  do comentário 2 da issue (unsafe só com ganho mensurável e atrás de
+  asserção executável).
+- Guard: `Retain`/`Release` ≤ 80 em `inline_guard_test.go`.
 
 ### 3.3 Extra — `pop()` inlinável
 

--- a/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
@@ -1,0 +1,185 @@
+# VM Perf Fase 2 — Layout do `Value` e header comum dos compostos (issue #37, estágios 1 e 2)
+
+**Data:** 2026-08-22 · **Issue:** [#37](https://github.com/estevaofon/noxy/issues/37) · **Branch:** `perf/issue-37-value-layout` · **Base:** `develop` (cb8efcb, v0.14.2)
+
+## 1. Contexto
+
+Depois da fase 1 de perf (#36, v0.6.0), o perfil de `fib` mostra `push`+`pop` com
+24,4 % do tempo e `value.Value` com **48 bytes** (tag `int` de 8 B, `bool` com
+7 B de padding, `int64` e `float64` mutuamente exclusivos em campos separados,
+`interface{}` de 16 B). A pilha de 2048 slots ocupa 96 KB. `ownersOf`
+(`internal/value/cow.go`), chamado por todo `Retain`/`Release`/`IsShared`, faz
+type switch sobre `interface{}` — no assembly atual: carrega o hash do tipo
+dinâmico, compara com até três constantes e depois o ponteiro do tipo.
+
+A issue propõe três estágios; os comentários fixam a ordem **1 → 2 → 3** e
+condicionam o 3 (`unsafe.Pointer`, 24 B) a números dos dois primeiros. Este
+documento cobre **só os estágios 1 e 2** mais o "extra barato" do `pop`.
+
+Achado de baseline desta sessão (não estava na issue): `pop()` custa **22** no
+inliner e, como `run()` é "big function" (orçamento 20), **não é inlinada em
+nenhum dos ~84 call sites de `executor.go`** — toda `vm.pop()` dentro de
+`run()` é chamada real. `push` custa 20 e é inlinada em 113 sites
+(`inline_guard_test.go` trava isso).
+
+## 2. Objetivo e não-objetivos
+
+**Objetivo:** reduzir o custo estrutural do interpretador (cópia de `Value`,
+pressão de cache da pilha, `ownersOf`) sem mudar semântica, bytecode, saída
+ou mensagens de erro. Hipótese calibrada (comentário 2 da issue): `fib`
+**15–25 % melhor**, não "alcançar o CPython".
+
+**Não-objetivos:** estágio 3 (`unsafe.Pointer`, boxing de string); mudar o
+despacho; mudar a contagem ou os funis de retain/release (spec CoW-RC §4.2);
+reordenar/renumerar tags `ValueType` ou opcodes.
+
+## 3. Desenho
+
+### 3.1 Estágio 1 — `Value` de 48 → 32 bytes
+
+```go
+type ValueType uint8
+
+type Value struct {
+	Type ValueType   // offset 0
+	kind objKind     // offset 1 — dica para ownersOf (§3.2); 0 = desconhecido
+	b    bool        // offset 2 — valor de VAL_BOOL (no padding; sem branch)
+	num  uint64      // offset 8 — int64 (VAL_INT) | bits de float64 (VAL_FLOAT)
+	Obj  interface{} // offset 16
+}                    // unsafe.Sizeof == 32
+```
+
+- **API:** `v.Int() int64`, `v.Float() float64`, `v.Bool() bool` (leitura);
+  `(*Value).SetInt(int64)` para o único escritor in-place do repo
+  (`OP_INC_LOCAL_INT`, `executor.go`: `AsInt += delta`). Construtores
+  `NewInt/NewFloat/NewBool` inalterados na assinatura.
+- **Blast radius (medido, fora de `.claude/worktrees`):** `.AsInt` 323,
+  `.AsFloat` 55, `.AsBool` 49 leituras; 1 escrita; 3 literais (os próprios
+  construtores). Rename por script (Python, CRLF preservado), não à mão.
+- **Mudança de semântica dos acessores em tipo errado:** antes, `v.AsInt` de
+  um `VAL_FLOAT` era 0 (campo separado); agora `v.Int()` devolve os bits do
+  float. Todo site auditado precisa estar sob guarda de `Type` (os de
+  `executor.go`, `builtins_core.go`, `json_strict.go`, `plugin.go`, `stack.go`
+  já estão — verificado na exploração). Auditoria semiautomática: listar
+  leituras sem `VAL_*`/`Type`/`switch` nas ±4 linhas e revisar à mão.
+- **Zero value** preservado: `Value{}` = `VAL_BOOL false`, como hoje.
+- `Value` não é serializado em lugar nenhum (plugins falam JSON; cache de
+  módulos guarda `Value` em memória) e não é comparado com `==`/`DeepEqual`
+  — campos não exportados são seguros.
+
+### 3.2 Estágio 2 — header comum e `ownersOf` sem type switch no caminho comum
+
+```go
+// ObjHeader é o prefixo comum dos compostos rastreados por RC. Tem de ser o
+// PRIMEIRO campo (offset 0) — layout travado por teste.
+type ObjHeader struct {
+	Owners atomic.Int32
+}
+
+type ObjArray struct { ObjHeader; Elements []Value; RuntimeType atomic.Pointer[RuntimeTypeInfo] }
+type ObjMap struct   { ObjHeader; store *bindingStore; storeOnce sync.Once; RuntimeType ... }
+type ObjInstance struct { ObjHeader; Struct *ObjStruct; Fields map[string]Value }
+```
+
+`kind` (byte de `Value`) é **dica carimbada pelos construtores** de
+`internal/value`:
+
+| construtor | kind |
+|---|---|
+| `NewArray`, `NewArrayAdopting` | `objKindArray` |
+| `NewMap`, `NewMapWithData`, view do `GlobalEnvironment` | `objKindMap` |
+| `NewInstance`, `NewInstanceWith` | `objKindInstance` |
+| `NewString`, `NewStruct`, `NewRuntimeTypeInfo` | `objKindNoOwners` |
+| qualquer outro (`Value{Type: VAL_OBJ, Obj: x}` fora do pacote, escalares) | `0` = desconhecido |
+
+```go
+func ownersOf(v Value) *atomic.Int32 {
+	switch v.kind {
+	case objKindArray:    return &v.Obj.(*ObjArray).Owners     // 1 cmp de ponteiro de tipo
+	case objKindMap:      return &v.Obj.(*ObjMap).Owners
+	case objKindInstance: return &v.Obj.(*ObjInstance).Owners
+	case objKindNoOwners: return nil
+	}
+	return ownersOfSlow(v) // o type switch de hoje: Type != VAL_OBJ → nil; array/map/instance
+}
+```
+
+- **Correto por construção:** `kind == 0` cai no caminho de hoje. Os ~30
+  sites `value.Value{Type: value.VAL_OBJ, Obj: inst}` (io/sqlite/sys/json,
+  `calls.go:198`) continuam corretos, só não aceleram; o de `calls.go` (clone
+  CoW de instância, semi-quente) passa a usar construtor. Um site novo que
+  esqueça o carimbo **não** produz under-count de RC — só perde a aceleração.
+- **Sem `unsafe`** no caminho quente. A variante "cast direto para
+  `*ObjHeader` via data word do eface" economizaria uma comparação de
+  ponteiro; é medida em microbench Go (§5) e registrada, não embarcada —
+  critério de confinamento do comentário 2 da issue (unsafe só com ganho
+  mensurável e atrás de asserção executável).
+- `Retain` (custo 64) e `Release` (78) hoje são inlinados em 25/13 sites de
+  `internal/vm` (orçamento 80 fora de `run()`); `ownersOf` novo não pode
+  estourar isso — guard em `inline_guard_test.go`.
+
+### 3.3 Extra — `pop()` inlinável
+
+`vm.stack[vm.stackTop] = value.Value{}` vira `vm.stack[vm.stackTop].Obj = nil`:
+só o ponteiro interessa ao GC; `Type/num/b` mortos acima de `stackTop` são
+inertes (os fused jumps já leem slots acima do topo logo após `stackTop -= 2`,
+sem limpar). Meta: custo ≤ 20 → inlinada nos ~84 sites de `run()`. Guard:
+`inline_guard_test.go` passa a travar `pop` como trava `push`.
+
+Commit separado e medido à parte — o usuário pediu estágios 1 e 2; este item
+é o "extra barato, independente dos três" da issue, promovido a "primeiro item
+medido" no comentário 3. Reversível com um `git revert`.
+
+## 4. Invariantes e guards executáveis
+
+- `unsafe.Sizeof(Value{}) == 32`; `unsafe.Offsetof(ObjArray{}.ObjHeader) == 0`
+  (idem map/instance) — `internal/value/layout_test.go`.
+- `ownersOf(NewArray(...)) == &arr.Owners` e idem para map/instance e para o
+  caminho lento (`Value{Type: VAL_OBJ, Obj: arr}` sem carimbo) —
+  `internal/value/owners_test.go`.
+- `push` custo ≤ 20 e ≥ 100 sites inlinados em `executor.go` (já existe);
+  `pop` idem (novo); `Retain`/`Release` custo ≤ 80 (novo).
+- `go test ./...` verde; `go test -race ./internal/value ./internal/vm` verde
+  (`Owners` segue `atomic.Int32` — tasks paralelas).
+- Corpus `noxy_examples/` sem falhas (`run_all_tests_concurrent.nx`) e
+  **diff de saída ponta a ponta** base × head (`benchmarks/compare_examples.ps1`).
+
+## 5. Medição
+
+Binários em disco local (scratchpad): `noxy_base.exe` (develop cb8efcb),
+`noxy_s1.exe`, `noxy_s12.exe`, `noxy_s12p.exe` (pop). Máquina o mais ociosa
+possível; carga registrada no início.
+
+1. `benchmarks/interleaved_compare.ps1 -Runs 9` base × final (headline, mesmo
+   protocolo de `RESULTS.md`), mais uma intercalação dos quatro binários na
+   mesma janela para isolar cada estágio (script de sessão; dados brutos em
+   `benchmarks/results/2026-08-22-issue-37-value-layout-raw.md`).
+2. `benchmarks/cross_runtime/run_cross_runtime.ps1 -NoxyBaseline` base × final
+   (`fib`, `loop_arith`, `bubblesort`, `string_ops`, `mandelbrot`, `map_churn`,
+   `startup`; mínimo de 9).
+3. `go test ./internal/vm -run '^$' -bench NoxyCallOverhead -count 10` por estágio.
+4. Perfil de `fib` (`noxy --cpuprofile`) base × final: share de `push`/`pop`/
+   `ownersOf` (a métrica da issue).
+5. Microbench Go de `ownersOf`: type switch × kind+assert × kind+unsafe (registro).
+
+Gates: `bench_typed_call_map`, `bench_share_mutate`, `bench_call_light`,
+`bench_conway` ≤ +5 % (os três primeiros estão no piso de processo, ~100 ms
+— delta deles é citado, não decide; ver RESULTS.md 2026-08-22).
+
+## 6. Riscos
+
+| risco | mitigação |
+|---|---|
+| leitura de campo errado passava por zero e agora devolve lixo | auditoria de guardas (§3.1) + suíte + diff de saída do corpus |
+| `push`/`pop`/`Retain`/`Release` saírem do inline sem aviso | guards no `inline_guard_test.go` |
+| `kind` errado num construtor → RC rastreia o objeto errado | só construtores do pacote carimbam; teste por construtor em `owners_test.go`; `kind` errado é impossível fora do pacote (campo não exportado) |
+| ganho não se materializar | é hipótese a validar; o relatório publica os números como estão |
+
+## 7. Decisões tomadas sem consulta (para a review)
+
+1. Ordem 1 → 2 → pop (comentários 1 e 3 da issue).
+2. Bool no próprio byte do padding, não dentro de `num` (evita branch em `NewBool`).
+3. `kind` como dica de 3 estados + tipo, caminho lento preservado; **sem `unsafe`**.
+4. `pop` incluído como commit separado (fora do pedido literal "1 e 2").
+5. Versão **v0.14.3** (patch: perf interna, sem mudança de linguagem —
+   regra "minor só para mudanças maiores").

--- a/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md
@@ -135,11 +135,24 @@ func ownersOf(v Value) *atomic.Int32 {
 
 ### 3.3 Extra — `pop()` inlinável
 
-`vm.stack[vm.stackTop] = value.Value{}` vira `vm.stack[vm.stackTop].Obj = nil`:
-só o ponteiro interessa ao GC; `Type/num/b` mortos acima de `stackTop` são
-inertes (os fused jumps já leem slots acima do topo logo após `stackTop -= 2`,
-sem limpar). Meta: custo ≤ 20 → inlinada nos ~84 sites de `run()`. Guard:
-`inline_guard_test.go` passa a travar `pop` como trava `push`.
+Meta: custo ≤ 20 → inlinada nos ~84 sites de `run()`. O que coube (medido
+com `-gcflags=-m=2`, 1 nó de AST = 1 de custo): **a atribuição dupla com
+resultado nomeado**, que faz exatamente o mesmo trabalho do original (zera o
+`Value` inteiro) em 18 nós:
+
+```go
+func (vm *VM) pop() (val value.Value) {
+	vm.stackTop--
+	val, vm.stack[vm.stackTop] = vm.stack[vm.stackTop], value.Value{}
+	return
+}
+```
+
+Variantes descartadas: limpar só `Obj` com duas indexações (23), `slot :=
+&vm.stack[top]; slot.Obj = nil` (26), `top` em variável local (24). Resultado:
+custo 18, 79 sites inlinados em `executor.go`; nenhuma mudança de semântica
+nem de comportamento do GC. Guard: `inline_guard_test.go` passa a travar
+`pop` (≤ 20, ≥ 70 sites) como trava `push`.
 
 Commit separado e medido à parte — o usuário pediu estágios 1 e 2; este item
 é o "extra barato, independente dos três" da issue, promovido a "primeiro item

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -172,11 +172,11 @@ func ValueToInterface(v value.Value) interface{} {
 	case value.VAL_NULL:
 		return nil
 	case value.VAL_BOOL:
-		return v.AsBool
+		return v.Bool()
 	case value.VAL_INT:
-		return v.AsInt
+		return v.Int()
 	case value.VAL_FLOAT:
-		return v.AsFloat
+		return v.Float()
 	case value.VAL_OBJ:
 		switch o := v.Obj.(type) {
 		case string:

--- a/internal/value/constructors_test.go
+++ b/internal/value/constructors_test.go
@@ -45,7 +45,7 @@ func TestNewInstanceWithRetainsCompositeFields(t *testing.T) {
 	if object.Struct != definition {
 		t.Fatal("NewInstanceWith deve apontar para a definicao recebida")
 	}
-	if object.Fields["data"].Obj != data.Obj || !object.Fields["ok"].AsBool {
+	if object.Fields["data"].Obj != data.Obj || !object.Fields["ok"].Bool() {
 		t.Fatal("NewInstanceWith deve guardar os campos recebidos")
 	}
 	if got := OwnersCount(instance); got != 0 {

--- a/internal/value/cow.go
+++ b/internal/value/cow.go
@@ -18,8 +18,28 @@ func IsShared(v Value) bool {
 // comporta como permanentemente compartilhado (equivalente ao sticky).
 const ownersSaturation = math.MaxInt32 / 2
 
+// ownersOf devolve o contador de donos do composto (o Owners do ObjHeader
+// embutido em array/map/instancia), ou nil para tudo o que o RC nao rastreia.
+//
+// A dica kind carimbada pelos construtores de internal/value tira do type
+// switch os VAL_OBJ que nunca tem contador (string, *ObjStruct,
+// *RuntimeTypeInfo — objKindNoOwners): uma comparacao de byte. O resto
+// (compostos, escalares com Obj nil, Values montados fora dos construtores
+// com kind zero) segue pelo type switch de sempre — a dica nunca decide
+// sozinha, entao um carimbo ausente nao pode virar under-count
+// (owners_test.go cobre os dois caminhos). Nao ha checagem de Type: o unico
+// dono de *ObjArray/*ObjMap/*ObjInstance em Obj e VAL_OBJ, e Obj nil
+// (escalares) cai no default do switch.
+//
+// ORCAMENTO: Retain e Release embutem este corpo e precisam ficar em <= 80
+// (orcamento normal do inliner; sao inlinados nos sites de internal/vm fora
+// de run()). Qualquer no a mais aqui — uma chamada custa 57, um segundo
+// switch por kind com type assertion por caso custa ~40 — tira Release do
+// inline; foi medido: a versao "switch no kind + assertion checada + caminho
+// lento embutido" custava 73 e levou Retain a 105 e Release a 119.
+// inline_guard_test.go (internal/vm) trava a propriedade.
 func ownersOf(v Value) *atomic.Int32 {
-	if v.Type != VAL_OBJ {
+	if v.kind == objKindNoOwners {
 		return nil
 	}
 	switch obj := v.Obj.(type) {
@@ -55,7 +75,14 @@ func Release(v Value) {
 	}
 	for {
 		current := owners.Load()
-		if current <= 0 || current >= ownersSaturation {
+		// Sai quando current esta fora de (0, ownersSaturation): <= 0 e o
+		// clamp do dec a mais, >= ownersSaturation e o "permanentemente
+		// compartilhado". A comparacao unica em uint32 (current-1 negativo
+		// vira um numero enorme) e equivalente a `current <= 0 || current >=
+		// ownersSaturation` e e a forma que cabe no orcamento de inline de
+		// Release (ver ownersOf): duas comparacoes custam os 3 nos que a
+		// dica kind acrescentou la.
+		if uint32(current-1) >= ownersSaturation-1 {
 			return
 		}
 		if owners.CompareAndSwap(current, current-1) {

--- a/internal/value/environment.go
+++ b/internal/value/environment.go
@@ -69,7 +69,7 @@ func (environment *GlobalEnvironment) ReplaceLocal(values map[string]Value) {
 }
 
 func (environment *GlobalEnvironment) ExportMap() Value {
-	return Value{Type: VAL_OBJ, Obj: &ObjMap{store: environment.local}}
+	return Value{Type: VAL_OBJ, kind: objKindMap, Obj: &ObjMap{store: environment.local}}
 }
 
 // Generation soma as gerações dos stores da cadeia de ambientes. Qualquer

--- a/internal/value/environment_test.go
+++ b/internal/value/environment_test.go
@@ -6,7 +6,7 @@ func TestGlobalEnvironmentResolvesAndShadowsParent(t *testing.T) {
 	root := NewGlobalEnvironment(nil)
 	root.SetLocal("value", NewInt(1))
 	child := NewGlobalEnvironment(root)
-	if got, _ := child.Resolve("value"); got.AsInt != 1 {
+	if got, _ := child.Resolve("value"); got.Int() != 1 {
 		t.Fatalf("inherited value=%v", got)
 	}
 	owner, ok := child.ResolveOwner("value")
@@ -27,7 +27,7 @@ func TestGlobalEnvironmentExportsAreLiveAndLocalOnly(t *testing.T) {
 	module.SetLocal("answer", NewInt(41))
 	exports := module.ExportMap().Obj.(*ObjMap)
 	module.SetLocal("answer", NewInt(42))
-	if got, _ := exports.Get("answer"); got.AsInt != 42 {
+	if got, _ := exports.Get("answer"); got.Int() != 42 {
 		t.Fatalf("live export=%v", got)
 	}
 	if _, inherited := exports.Get("builtin"); inherited {
@@ -40,7 +40,7 @@ func TestGlobalEnvironmentLocalOperationsAndSnapshots(t *testing.T) {
 		"seed": NewInt(1),
 	}, nil)
 
-	if got, found := environment.GetLocal("seed"); !found || got.AsInt != 1 {
+	if got, found := environment.GetLocal("seed"); !found || got.Int() != 1 {
 		t.Fatalf("seed=(%v,%t)", got, found)
 	}
 	if environment.DefineLocalIfAbsent("seed", NewInt(2)) {
@@ -52,7 +52,7 @@ func TestGlobalEnvironmentLocalOperationsAndSnapshots(t *testing.T) {
 
 	snapshot := environment.LocalSnapshot()
 	snapshot["seed"] = NewInt(0)
-	if got, _ := environment.GetLocal("seed"); got.AsInt != 1 {
+	if got, _ := environment.GetLocal("seed"); got.Int() != 1 {
 		t.Fatal("local snapshot mutated environment")
 	}
 
@@ -60,7 +60,7 @@ func TestGlobalEnvironmentLocalOperationsAndSnapshots(t *testing.T) {
 	if _, found := environment.GetLocal("seed"); found {
 		t.Fatal("replace retained old local binding")
 	}
-	if got, found := environment.GetLocal("replacement"); !found || got.AsInt != 4 {
+	if got, found := environment.GetLocal("replacement"); !found || got.Int() != 4 {
 		t.Fatalf("replacement=(%v,%t)", got, found)
 	}
 }

--- a/internal/value/format_test.go
+++ b/internal/value/format_test.go
@@ -163,14 +163,14 @@ func TestUpvalueNilReceiverAndOpenCellBasics(t *testing.T) {
 	}
 	slot := NewInt(1)
 	open := NewOpenUpvalue(&slot, nil)
-	if !open.PointsTo(&slot) || !open.Store(NewInt(2)) || slot.AsInt != 2 {
+	if !open.PointsTo(&slot) || !open.Store(NewInt(2)) || slot.Int() != 2 {
 		t.Fatal("upvalue aberto deveria apontar e escrever no slot")
 	}
 	if addr, ok := open.LocationAddress(); !ok || !strings.HasPrefix(addr, "0x") {
 		t.Fatalf("LocationAddress aberto: %q %v", addr, ok)
 	}
 	closed := NewClosedUpvalue(NewInt(7))
-	if v, ok := closed.Load(); !ok || v.AsInt != 7 {
+	if v, ok := closed.Load(); !ok || v.Int() != 7 {
 		t.Fatalf("upvalue fechado: %v %v", v, ok)
 	}
 }

--- a/internal/value/layout_test.go
+++ b/internal/value/layout_test.go
@@ -20,6 +20,23 @@ func TestValueIs32Bytes(t *testing.T) {
 	}
 }
 
+// O header comum tem de ser o PRIMEIRO campo dos tres compostos: e o que
+// permite a um eventual estagio 3 (unsafe.Pointer) alcancar Owners sem saber
+// o tipo concreto. Hoje ownersOf usa type assertion checada, mas o layout ja
+// fica travado — invariante implicito em codigo de aparencia inocente e o
+// modo de falha mais provavel.
+func TestObjHeaderIsAtOffsetZero(t *testing.T) {
+	if off := unsafe.Offsetof(ObjArray{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjArray.ObjHeader no offset %d, esperado 0", off)
+	}
+	if off := unsafe.Offsetof(ObjMap{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjMap.ObjHeader no offset %d, esperado 0", off)
+	}
+	if off := unsafe.Offsetof(ObjInstance{}.ObjHeader); off != 0 {
+		t.Fatalf("ObjInstance.ObjHeader no offset %d, esperado 0", off)
+	}
+}
+
 func TestValueAccessorsRoundTrip(t *testing.T) {
 	if got := NewInt(-42).Int(); got != -42 {
 		t.Fatalf("Int(): %d", got)

--- a/internal/value/layout_test.go
+++ b/internal/value/layout_test.go
@@ -1,0 +1,58 @@
+package value
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+// O tamanho do Value e o custo de cada push/pop e de cada copia de operando
+// em run(): 48 B (tag int + bool + int64 + float64 + interface) virou 32 B na
+// fase 2 de perf (issue #37, estagio 1). Este teste e a assercao executavel
+// do layout — se alguem acrescentar um campo, o build avisa aqui, nao num
+// benchmark meses depois.
+func TestValueIs32Bytes(t *testing.T) {
+	if got := unsafe.Sizeof(Value{}); got != 32 {
+		t.Fatalf("unsafe.Sizeof(Value{}) = %d, esperado 32 (ver spec 2026-08-22-vm-perf-fase2-value-layout)", got)
+	}
+	if got := unsafe.Sizeof(ValueType(0)); got != 1 {
+		t.Fatalf("ValueType deve ocupar 1 byte, ocupa %d", got)
+	}
+}
+
+func TestValueAccessorsRoundTrip(t *testing.T) {
+	if got := NewInt(-42).Int(); got != -42 {
+		t.Fatalf("Int(): %d", got)
+	}
+	if got := NewInt(math.MaxInt64).Int(); got != math.MaxInt64 {
+		t.Fatalf("Int() MaxInt64: %d", got)
+	}
+	if got := NewInt(math.MinInt64).Int(); got != math.MinInt64 {
+		t.Fatalf("Int() MinInt64: %d", got)
+	}
+	if got := NewFloat(3.5).Float(); got != 3.5 {
+		t.Fatalf("Float(): %v", got)
+	}
+	if got := NewFloat(math.Inf(-1)).Float(); !math.IsInf(got, -1) {
+		t.Fatalf("Float() -Inf: %v", got)
+	}
+	if got := NewFloat(math.NaN()).Float(); !math.IsNaN(got) {
+		t.Fatalf("Float() NaN: %v", got)
+	}
+	if got := NewFloat(math.Copysign(0, -1)).Float(); !math.Signbit(got) {
+		t.Fatalf("Float() -0: perdeu o sinal")
+	}
+	if !NewBool(true).Bool() || NewBool(false).Bool() {
+		t.Fatal("Bool() nao faz round-trip")
+	}
+	var zero Value
+	if zero.Type != VAL_BOOL || zero.Bool() || zero.Int() != 0 || zero.Obj != nil {
+		t.Fatalf("zero value deve continuar sendo VAL_BOOL false: %+v", zero)
+	}
+	v := NewInt(1)
+	v.SetInt(41)
+	v.SetInt(v.Int() + 1)
+	if v.Type != VAL_INT || v.Int() != 42 {
+		t.Fatalf("SetInt: %+v", v)
+	}
+}

--- a/internal/value/map_test.go
+++ b/internal/value/map_test.go
@@ -13,7 +13,7 @@ func TestObjMapZeroValueSupportsPublicOperations(t *testing.T) {
 
 	mapping.Set("answer", NewInt(42))
 	snapshot := mapping.Snapshot()
-	if got, found := snapshot["answer"]; !found || got.AsInt != 42 {
+	if got, found := snapshot["answer"]; !found || got.Int() != 42 {
 		t.Fatalf("snapshot answer=(%v,%t)", got, found)
 	}
 	if got := mapping.String(); got != "{answer: 42}" {
@@ -28,11 +28,11 @@ func TestObjMapPreservesInjectedBindingStore(t *testing.T) {
 	if got := mapping.ensureStore(); got != injected {
 		t.Fatal("ensureStore replaced injected store")
 	}
-	if got, found := mapping.Get("seed"); !found || got.AsInt != 7 {
+	if got, found := mapping.Get("seed"); !found || got.Int() != 7 {
 		t.Fatalf("seed=(%v,%t)", got, found)
 	}
 	mapping.Set("added", NewInt(9))
-	if got, found := injected.get("added"); !found || got.AsInt != 9 {
+	if got, found := injected.get("added"); !found || got.Int() != 9 {
 		t.Fatalf("injected added=(%v,%t)", got, found)
 	}
 }
@@ -40,14 +40,14 @@ func TestObjMapPreservesInjectedBindingStore(t *testing.T) {
 func TestObjMapOperationsUseSnapshots(t *testing.T) {
 	mapping := NewMap().Obj.(*ObjMap)
 	mapping.Set("answer", NewInt(42))
-	if got, ok := mapping.Get("answer"); !ok || got.AsInt != 42 {
+	if got, ok := mapping.Get("answer"); !ok || got.Int() != 42 {
 		t.Fatalf("answer=(%v,%t)", got, ok)
 	}
 
 	snapshot := mapping.Snapshot()
 	snapshot["answer"] = NewInt(0)
 	got, _ := mapping.Get("answer")
-	if got.AsInt != 42 {
+	if got.Int() != 42 {
 		t.Fatal("snapshot mutated live map")
 	}
 
@@ -67,7 +67,7 @@ func TestObjMapReplaceReplacesLiveValues(t *testing.T) {
 	if _, found := mapping.Get("old"); found {
 		t.Fatal("replace did not clear old value")
 	}
-	if got, found := mapping.Get("new"); !found || got.AsInt != 2 {
+	if got, found := mapping.Get("new"); !found || got.Int() != 2 {
 		t.Fatalf("new=(%v,%t)", got, found)
 	}
 }
@@ -78,7 +78,7 @@ func TestObjMapReplaceAcceptsSnapshot(t *testing.T) {
 
 	mapping.Replace(mapping.Snapshot())
 
-	if got, found := mapping.Get("answer"); !found || got.AsInt != 42 {
+	if got, found := mapping.Get("answer"); !found || got.Int() != 42 {
 		t.Fatalf("answer=(%v,%t)", got, found)
 	}
 }

--- a/internal/value/native_test.go
+++ b/internal/value/native_test.go
@@ -13,7 +13,7 @@ func TestObjNativeInvokeSupportsLegacyAndContextualHandlers(t *testing.T) {
 	ctx := &testNativeContext{}
 	legacy := NewNative("legacy", func(args []Value) Value { return args[0] })
 	got, err := legacy.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(7)})
-	if err != nil || got.AsInt != 7 {
+	if err != nil || got.Int() != 7 {
 		t.Fatalf("legacy invoke=(%v, %v), want (7, nil)", got, err)
 	}
 
@@ -24,7 +24,7 @@ func TestObjNativeInvokeSupportsLegacyAndContextualHandlers(t *testing.T) {
 		return args[0], nil
 	})
 	got, err = contextual.Obj.(*ObjNative).Invoke(ctx, []Value{NewInt(9)})
-	if err != nil || got.AsInt != 9 {
+	if err != nil || got.Int() != 9 {
 		t.Fatalf("contextual invoke=(%v, %v), want (9, nil)", got, err)
 	}
 }

--- a/internal/value/owners_test.go
+++ b/internal/value/owners_test.go
@@ -1,6 +1,9 @@
 package value
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestRetainReleaseCountsComposites(t *testing.T) {
 	arr := NewArray([]Value{NewInt(1)})
@@ -44,15 +47,116 @@ func TestReleaseClampsAtZero(t *testing.T) {
 	}
 }
 
+// Release decide "sai ou decrementa" com uma comparacao unica em uint32
+// (cow.go) — forma que cabe no orcamento de inline. Este teste trava a
+// equivalencia com `current <= 0 || current >= ownersSaturation` nas bordas.
+func TestReleaseSingleCompareMatchesRange(t *testing.T) {
+	arr := NewArray(nil)
+	owners := ownersOf(arr)
+	cases := []struct {
+		start, want int32
+	}{
+		{0, 0},                                       // clamp: dec a mais nao desce
+		{-1, -1},                                     // negativo nunca e tocado
+		{math.MinInt32, math.MinInt32},               // borda do overflow de current-1
+		{1, 0},                                       // ultimo dono vai a zero
+		{2, 1},                                       // decremento normal
+		{ownersSaturation - 1, ownersSaturation - 2}, // ainda rastreado
+		{ownersSaturation, ownersSaturation},         // saturado: permanentemente compartilhado
+		{ownersSaturation + 5, ownersSaturation + 5}, // acima da saturacao idem
+		{math.MaxInt32, math.MaxInt32},
+	}
+	for _, c := range cases {
+		owners.Store(c.start)
+		Release(arr)
+		if got := owners.Load(); got != c.want {
+			t.Errorf("Release a partir de %d: veio %d, esperado %d", c.start, got, c.want)
+		}
+	}
+}
+
 func TestMapAndInstanceAlsoCount(t *testing.T) {
 	m := NewMap()
 	Retain(m)
 	if OwnersCount(m) != 1 {
 		t.Fatalf("map: esperado 1, veio %d", OwnersCount(m))
 	}
-	inst := Value{Type: VAL_OBJ, Obj: &ObjInstance{Fields: map[string]Value{}}}
+	inst := NewInstance(&ObjStruct{Name: "P"})
 	Retain(inst)
 	if OwnersCount(inst) != 1 {
 		t.Fatalf("instance: esperado 1, veio %d", OwnersCount(inst))
+	}
+}
+
+// Cada construtor carimba a dica kind, e ownersOf tem de chegar ao Owners do
+// ObjHeader tanto no Value carimbado quanto no montado a mao (kind zero) —
+// se divergissem, Retain por um caminho e Release pelo outro contariam em
+// objetos diferentes. A dica so tira do type switch o que nunca tem contador
+// (objKindNoOwners); nunca decide sozinha que algo e composto.
+func TestOwnersOfReachesHeaderWithAndWithoutKindHint(t *testing.T) {
+	arr := NewArray(nil)
+	arrObj := arr.Obj.(*ObjArray)
+	if arr.kind != objKindArray {
+		t.Fatalf("NewArray deve carimbar objKindArray, veio %d", arr.kind)
+	}
+	if NewArrayAdopting(nil).kind != objKindArray {
+		t.Fatal("NewArrayAdopting deve carimbar objKindArray")
+	}
+	if ownersOf(arr) != &arrObj.Owners {
+		t.Fatal("ownersOf(array) nao aponta para o Owners do header")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: arrObj}) != &arrObj.Owners {
+		t.Fatal("caminho lento (kind zero) diverge do rapido para array")
+	}
+
+	m := NewMap()
+	mObj := m.Obj.(*ObjMap)
+	if m.kind != objKindMap || ownersOf(m) != &mObj.Owners {
+		t.Fatal("NewMap: dica ou ownersOf errados")
+	}
+	if NewMapWithData(nil).kind != objKindMap {
+		t.Fatal("NewMapWithData deve carimbar objKindMap")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: mObj}) != &mObj.Owners {
+		t.Fatal("caminho lento diverge para map")
+	}
+
+	inst := NewInstance(&ObjStruct{Name: "P"})
+	instObj := inst.Obj.(*ObjInstance)
+	if inst.kind != objKindInstance || ownersOf(inst) != &instObj.Owners {
+		t.Fatal("NewInstance: dica ou ownersOf errados")
+	}
+	if NewInstanceWith(&ObjStruct{Name: "P"}, nil).kind != objKindInstance {
+		t.Fatal("NewInstanceWith deve carimbar objKindInstance")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: instObj}) != &instObj.Owners {
+		t.Fatal("caminho lento diverge para instance")
+	}
+
+	for _, v := range []Value{NewString("s"), NewStruct("S", nil), NewRuntimeTypeInfo(&RuntimeTypeInfo{})} {
+		if v.kind != objKindNoOwners {
+			t.Fatalf("%s deve carimbar objKindNoOwners, veio %d", v.String(), v.kind)
+		}
+		if ownersOf(v) != nil {
+			t.Fatalf("%s nao tem contador", v.String())
+		}
+	}
+	if ownersOf(NewInt(1)) != nil || ownersOf(NewNull()) != nil || ownersOf(Value{}) != nil {
+		t.Fatal("escalares nao tem contador")
+	}
+	if ownersOf(Value{Type: VAL_OBJ, Obj: "crua"}) != nil {
+		t.Fatal("string crua sem carimbo nao tem contador")
+	}
+}
+
+func TestNewInstanceAdoptingDoesNotRetainAgain(t *testing.T) {
+	child := NewArray(nil)
+	Retain(child) // o chamador ja reteve em nome da instancia
+	inst := NewInstanceAdopting(&ObjStruct{Name: "P"}, map[string]Value{"a": child})
+	if got := OwnersCount(child); got != 1 {
+		t.Fatalf("NewInstanceAdopting nao pode reter de novo: Owners=%d, esperado 1", got)
+	}
+	if inst.kind != objKindInstance {
+		t.Fatal("NewInstanceAdopting deve carimbar objKindInstance")
 	}
 }

--- a/internal/value/task_test.go
+++ b/internal/value/task_test.go
@@ -16,7 +16,7 @@ func TestTaskPublishesFirstOutcomeToEveryWaiter(t *testing.T) {
 	task.Complete(TaskOutcome{Value: NewInt(99)})
 	for range 4 {
 		got := <-seen
-		if got.Type != VAL_INT || got.AsInt != 42 {
+		if got.Type != VAL_INT || got.Int() != 42 {
 			t.Fatalf("outcome = %v, want 42", got)
 		}
 	}

--- a/internal/value/upvalue_cell_test.go
+++ b/internal/value/upvalue_cell_test.go
@@ -14,7 +14,7 @@ func TestNewClosedUpvalueIsDetachedOwnedCell(t *testing.T) {
 		t.Fatal("celula fechada e possuidora, nao emprestada")
 	}
 	got, ok := cell.Load()
-	if !ok || got.Type != VAL_INT || got.AsInt != 42 {
+	if !ok || got.Type != VAL_INT || got.Int() != 42 {
 		t.Fatalf("Load = %#v, %v; esperado 42", got, ok)
 	}
 	var stackSlot Value
@@ -24,7 +24,7 @@ func TestNewClosedUpvalueIsDetachedOwnedCell(t *testing.T) {
 	if !cell.Store(NewInt(7)) {
 		t.Fatal("Store deve funcionar numa celula fechada")
 	}
-	if got, _ := cell.Load(); got.AsInt != 7 {
-		t.Fatalf("Load apos Store = %d, esperado 7", got.AsInt)
+	if got, _ := cell.Load(); got.Int() != 7 {
+		t.Fatalf("Load apos Store = %d, esperado 7", got.Int())
 	}
 }

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -382,13 +382,20 @@ func (oc *ObjClosure) Format(f fmt.State, verb rune) {
 	fmt.Fprint(f, oc.String())
 }
 
+// ObjHeader e o prefixo comum dos compostos que o RC rastreia (array, map,
+// instancia). Owners conta referencias duraveis (RC-uniqueness, spec
+// 2026-08-17) e e a unica fonte de unicidade — o antigo bit sticky Shared foi
+// removido na Task 8. TEM de ser o primeiro campo das tres structs (offset 0
+// — layout_test.go trava): e o que um estagio 3 com unsafe.Pointer usaria
+// para alcancar o contador sem o tipo concreto (issue #37).
+type ObjHeader struct {
+	Owners atomic.Int32
+}
+
 type ObjArray struct {
+	ObjHeader
 	Elements    []Value
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
-	// é a única fonte de unicidade — o antigo bit sticky Shared foi
-	// removido na Task 8.
-	Owners atomic.Int32
 }
 
 func (oa *ObjArray) String() string {
@@ -423,13 +430,10 @@ func (oa *ObjArray) Format(f fmt.State, verb rune) {
 }
 
 type ObjMap struct {
+	ObjHeader
 	store       *bindingStore
 	storeOnce   sync.Once
 	RuntimeType atomic.Pointer[RuntimeTypeInfo]
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
-	// é a única fonte de unicidade — o antigo bit sticky Shared foi
-	// removido na Task 8.
-	Owners atomic.Int32
 }
 
 func (om *ObjMap) String() string {
@@ -507,12 +511,9 @@ func (os *ObjStruct) Format(f fmt.State, verb rune) {
 }
 
 type ObjInstance struct {
+	ObjHeader
 	Struct *ObjStruct
 	Fields map[string]Value
-	// Owners conta referências duráveis (RC-uniqueness, spec 2026-08-17);
-	// é a única fonte de unicidade — o antigo bit sticky Shared foi
-	// removido na Task 8.
-	Owners atomic.Int32
 }
 
 func (oi *ObjInstance) String() string {
@@ -698,12 +699,17 @@ func NewNull() Value {
 	return Value{Type: VAL_NULL}
 }
 
+// Os construtores abaixo carimbam a dica `kind` que ownersOf (cow.go) usa
+// para achar o contador de donos sem type switch. Fora deste pacote nao ha
+// como carimbar (campo nao exportado): um Value{Type: VAL_OBJ, Obj: x}
+// montado a mao cai no caminho lento de ownersOf, que continua correto.
+
 func NewString(v string) Value {
-	return Value{Type: VAL_OBJ, Obj: v}
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: v}
 }
 
 func NewRuntimeTypeInfo(v *RuntimeTypeInfo) Value {
-	return Value{Type: VAL_OBJ, Obj: v}
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: v}
 }
 
 // NewArray cria um array que e DONO DURAVEL de cada elemento composto
@@ -713,7 +719,7 @@ func NewArray(elements []Value) Value {
 	for _, element := range elements {
 		Retain(element)
 	}
-	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+	return Value{Type: VAL_OBJ, kind: objKindArray, Obj: &ObjArray{Elements: elements}}
 }
 
 // NewArrayAdopting cria um array ADOTANDO elementos que o chamador JA reteve
@@ -722,13 +728,13 @@ func NewArray(elements []Value) Value {
 // de causes do call_result (builtins_call_result.go); qualquer outro uso
 // precisa de comentario `// RC: move` explicando quem reteve.
 func NewArrayAdopting(elements []Value) Value {
-	return Value{Type: VAL_OBJ, Obj: &ObjArray{Elements: elements}}
+	return Value{Type: VAL_OBJ, kind: objKindArray, Obj: &ObjArray{Elements: elements}}
 }
 
 func NewMap() Value {
 	mapping := &ObjMap{store: newBindingStore(nil)}
 	mapping.ensureStore()
-	return Value{Type: VAL_OBJ, Obj: mapping}
+	return Value{Type: VAL_OBJ, kind: objKindMap, Obj: mapping}
 }
 
 // NewMapWithData cria um map que e DONO DURAVEL de cada valor composto
@@ -745,14 +751,14 @@ func NewMapWithData(data map[string]Value) Value {
 }
 
 func NewStruct(name string, fields []string) Value {
-	return Value{Type: VAL_OBJ, Obj: &ObjStruct{Name: name, Fields: fields}}
+	return Value{Type: VAL_OBJ, kind: objKindNoOwners, Obj: &ObjStruct{Name: name, Fields: fields}}
 }
 
 // NewInstance cria uma instancia vazia; quem escreve compostos em Fields
 // depois precisa reter a mao (como calls.go:callPreparedValue faz) ou usar
 // NewInstanceWith.
 func NewInstance(def *ObjStruct) Value {
-	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
+	return Value{Type: VAL_OBJ, kind: objKindInstance, Obj: &ObjInstance{Struct: def, Fields: make(map[string]Value)}}
 }
 
 // NewInstanceWith cria uma instancia ja com os campos dados, retendo cada
@@ -766,7 +772,16 @@ func NewInstanceWith(def *ObjStruct, fields map[string]Value) Value {
 	for _, field := range fields {
 		Retain(field)
 	}
-	return Value{Type: VAL_OBJ, Obj: &ObjInstance{Struct: def, Fields: fields}}
+	return NewInstanceAdopting(def, fields)
+}
+
+// NewInstanceAdopting cria uma instancia ADOTANDO campos que o chamador JA
+// reteve em nome dela (move): nao retem de novo — o analogo de
+// NewArrayAdopting. Uso restrito aos sites que transferem posse (o clone CoW
+// de instancia em calls.go); qualquer outro uso precisa de comentario
+// `// RC: move` explicando quem reteve.
+func NewInstanceAdopting(def *ObjStruct, fields map[string]Value) Value {
+	return Value{Type: VAL_OBJ, kind: objKindInstance, Obj: &ObjInstance{Struct: def, Fields: fields}}
 }
 
 func NewFunction(name string, arity int, upvalueCount int, params []ParamInfo, chunk interface{}, environment *GlobalEnvironment) Value {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -2,13 +2,14 @@ package value
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"unsafe"
 )
 
-type ValueType int
+type ValueType uint8
 
 const (
 	VAL_BOOL ValueType = iota
@@ -25,13 +26,49 @@ const (
 	VAL_TASK
 )
 
+// objKind e a dica que os construtores de internal/value carimbam em Value
+// para ownersOf (cow.go) decidir sem type switch. Zero = "desconhecido":
+// um Value{Type: VAL_OBJ, Obj: x} montado fora dos construtores cai no
+// caminho lento (o type switch de sempre) e continua correto — a dica so
+// acelera, nunca decide sozinha.
+type objKind uint8
+
+const (
+	objKindUnknown  objKind = iota
+	objKindNoOwners         // string, *ObjStruct, *RuntimeTypeInfo: VAL_OBJ sem contador
+	objKindArray
+	objKindMap
+	objKindInstance
+)
+
+// Value e o operando universal da VM: 32 bytes (fase 2 de perf, issue #37;
+// eram 48 com tag int, bool com padding e int64/float64 em campos separados).
+// Type e a tag; num guarda int64 (VAL_INT) ou os bits de um float64
+// (VAL_FLOAT); b guarda VAL_BOOL; Obj, o objeto alocado dos demais tipos.
+// Leia pelos acessores Int()/Float()/Bool() — ler o campo errado para a tag
+// devolve lixo (num e compartilhado entre int e float), nunca zero.
+// layout_test.go trava o tamanho.
 type Value struct {
-	Type    ValueType
-	AsBool  bool
-	AsInt   int64
-	AsFloat float64
-	Obj     interface{} // Heap allocated object
+	Type ValueType
+	kind objKind
+	b    bool
+	num  uint64
+	Obj  interface{} // Heap allocated object
 }
+
+// Int devolve o inteiro de um VAL_INT. Em qualquer outra tag o resultado e
+// indefinido (os bits de num) — o chamador garante a tag.
+func (v Value) Int() int64 { return int64(v.num) }
+
+// Float devolve o float de um VAL_FLOAT (bits em num).
+func (v Value) Float() float64 { return math.Float64frombits(v.num) }
+
+// Bool devolve o valor de um VAL_BOOL.
+func (v Value) Bool() bool { return v.b }
+
+// SetInt grava o inteiro no lugar, sem tocar na tag — e o `AsInt +=` de
+// OP_INC_LOCAL_INT (8 bytes escritos em vez dos 32 de um Value novo).
+func (v *Value) SetInt(n int64) { v.num = uint64(n) }
 
 type ParamInfo struct {
 	IsRef    bool
@@ -564,7 +601,7 @@ func (or *ObjRef) String() string {
 	case REF_INDEX:
 		switch or.Index.Type {
 		case VAL_INT:
-			return fmt.Sprintf("<ref index %d>", or.Index.AsInt)
+			return fmt.Sprintf("<ref index %d>", or.Index.Int())
 		case VAL_OBJ:
 			if key, ok := or.Index.Obj.(string); ok {
 				return fmt.Sprintf("<ref index %s>", key)
@@ -588,13 +625,13 @@ func (or *ObjRef) Format(f fmt.State, verb rune) {
 func (v Value) String() string {
 	switch v.Type {
 	case VAL_BOOL:
-		return fmt.Sprintf("%t", v.AsBool)
+		return fmt.Sprintf("%t", v.Bool())
 	case VAL_NULL:
 		return "null"
 	case VAL_INT:
-		return fmt.Sprintf("%d", v.AsInt)
+		return fmt.Sprintf("%d", v.Int())
 	case VAL_FLOAT:
-		return fmt.Sprintf("%f", v.AsFloat)
+		return fmt.Sprintf("%f", v.Float())
 	case VAL_OBJ:
 		switch o := v.Obj.(type) {
 		case *ObjArray:
@@ -646,15 +683,15 @@ func (v Value) String() string {
 
 // Helper constructors
 func NewInt(v int64) Value {
-	return Value{Type: VAL_INT, AsInt: v}
+	return Value{Type: VAL_INT, num: uint64(v)}
 }
 
 func NewFloat(v float64) Value {
-	return Value{Type: VAL_FLOAT, AsFloat: v}
+	return Value{Type: VAL_FLOAT, num: math.Float64bits(v)}
 }
 
 func NewBool(v bool) Value {
-	return Value{Type: VAL_BOOL, AsBool: v}
+	return Value{Type: VAL_BOOL, b: v}
 }
 
 func NewNull() Value {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.14.2"
+const Version = "v0.14.3"

--- a/internal/vm/arithmetic_semantics_test.go
+++ b/internal/vm/arithmetic_semantics_test.go
@@ -75,7 +75,7 @@ test_report([cmp(1.5, 0.5), cmp(0.5, 1.5), cmp(2.0, 2.0)])
 	for i, row := range rows {
 		cells := semArray(t, row)
 		for j, cell := range cells {
-			if cell.Type != value.VAL_BOOL || cell.AsBool != want[i][j] {
+			if cell.Type != value.VAL_BOOL || cell.Bool() != want[i][j] {
 				t.Fatalf("linha %d coluna %d: got %s, want %v", i, j, cell.String(), want[i][j])
 			}
 		}
@@ -93,7 +93,7 @@ test_report(div(7.0, 2.0))
 		t.Fatalf("divisão float/float deveria emitir OP_DIV_FLOAT")
 	}
 	got := captureVMSource(t, source)
-	if got.Type != value.VAL_FLOAT || got.AsFloat != 3.5 {
+	if got.Type != value.VAL_FLOAT || got.Float() != 3.5 {
 		t.Fatalf("7.0 / 2.0 = %s, want 3.500000", got.String())
 	}
 }
@@ -116,7 +116,7 @@ test_report(calc())
 		t.Fatalf("células=%d, want %d", len(cells), len(want))
 	}
 	for i, cell := range cells {
-		if cell.Type != value.VAL_FLOAT || cell.AsFloat != want[i] {
+		if cell.Type != value.VAL_FLOAT || cell.Float() != want[i] {
 			t.Fatalf("célula %d: got %s, want %v", i, cell.String(), want[i])
 		}
 	}
@@ -138,7 +138,7 @@ test_report(cmp())
 		t.Fatalf("células=%d, want %d", len(cells), len(want))
 	}
 	for i, cell := range cells {
-		if cell.Type != value.VAL_BOOL || cell.AsBool != want[i] {
+		if cell.Type != value.VAL_BOOL || cell.Bool() != want[i] {
 			t.Fatalf("célula %d: got %s, want %v", i, cell.String(), want[i])
 		}
 	}
@@ -151,7 +151,7 @@ func TestMixedArithmeticHasStaticTypeFloat(t *testing.T) {
 		t.Fatalf("int = int + float deveria ser erro de tipo (got float), obtido %v", err)
 	}
 	got := captureVMSource(t, "let f: float = 1 + 2.5\ntest_report(f)\n")
-	if got.Type != value.VAL_FLOAT || got.AsFloat != 3.5 {
+	if got.Type != value.VAL_FLOAT || got.Float() != 3.5 {
 		t.Fatalf("float = int + float: got %s, want 3.500000", got.String())
 	}
 }
@@ -173,7 +173,7 @@ test_report(calc())
 	want := []int64{3, -3, 1, -1, 1}
 	cells := semArray(t, got)
 	for i, cell := range cells {
-		if cell.Type != value.VAL_INT || cell.AsInt != want[i] {
+		if cell.Type != value.VAL_INT || cell.Int() != want[i] {
 			t.Fatalf("célula %d: got %s, want %d", i, cell.String(), want[i])
 		}
 	}
@@ -245,7 +245,7 @@ test_report(calc())
 	want := []int64{2, 7, 5, -6, 16, 64, -4}
 	cells := semArray(t, got)
 	for i, cell := range cells {
-		if cell.Type != value.VAL_INT || cell.AsInt != want[i] {
+		if cell.Type != value.VAL_INT || cell.Int() != want[i] {
 			t.Fatalf("célula %d: got %s, want %d", i, cell.String(), want[i])
 		}
 	}
@@ -295,7 +295,7 @@ let less: any = a < b
 test_report([sum == 3.5, cat == "ab", less])
 `)
 	for i, cell := range semArray(t, got) {
-		if cell.Type != value.VAL_BOOL || !cell.AsBool {
+		if cell.Type != value.VAL_BOOL || !cell.Bool() {
 			t.Fatalf("célula %d: got %s, want true", i, cell.String())
 		}
 	}

--- a/internal/vm/builtins_codes_test.go
+++ b/internal/vm/builtins_codes_test.go
@@ -24,7 +24,7 @@ func codesOf(t *testing.T, machine *VM, input value.Value) []int64 {
 		if element.Type != value.VAL_INT {
 			t.Fatalf("element %d = %#v, want int", i, element)
 		}
-		out = append(out, element.AsInt)
+		out = append(out, element.Int())
 	}
 	return out
 }
@@ -87,7 +87,7 @@ else
     test_report(same)
 end`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("codes disagrees with char_at/ord: %#v", captured)
 	}
 }

--- a/internal/vm/builtins_collections.go
+++ b/internal/vm/builtins_collections.go
@@ -47,11 +47,11 @@ func (vm *VM) defineCollectionBuiltins() {
 		start, stop, step := int64(0), int64(0), int64(1)
 		switch len(args) {
 		case 1:
-			stop = args[0].AsInt
+			stop = args[0].Int()
 		case 2:
-			start, stop = args[0].AsInt, args[1].AsInt
+			start, stop = args[0].Int(), args[1].Int()
 		case 3:
-			start, stop, step = args[0].AsInt, args[1].AsInt, args[2].AsInt
+			start, stop, step = args[0].Int(), args[1].Int(), args[2].Int()
 		}
 		if step == 0 {
 			return value.NewNull(), fmt.Errorf("range: step must not be zero")
@@ -140,7 +140,7 @@ func (vm *VM) defineCollectionBuiltins() {
 			if m, ok := mapVal.Obj.(*value.ObjMap); ok {
 				var key interface{}
 				if keyVal.Type == value.VAL_INT {
-					key = keyVal.AsInt
+					key = keyVal.Int()
 				} else if keyVal.Type == value.VAL_OBJ {
 					if str, ok := keyVal.Obj.(string); ok {
 						key = str
@@ -229,8 +229,8 @@ func (vm *VM) defineCollectionBuiltins() {
 			return value.NewNull()
 		}
 		seq := args[0]
-		start := int(args[1].AsInt)
-		end := int(args[2].AsInt)
+		start := int(args[1].Int())
+		end := int(args[2].Int())
 
 		// Clamp logic helper
 		clamp := func(idx, length int) int {
@@ -305,7 +305,7 @@ func (vm *VM) defineCollectionBuiltins() {
 			if mapObj, ok := mapVal.Obj.(*value.ObjMap); ok {
 				var key interface{}
 				if keyVal.Type == value.VAL_INT {
-					key = keyVal.AsInt
+					key = keyVal.Int()
 				} else if keyVal.Type == value.VAL_OBJ {
 					if str, ok := keyVal.Obj.(string); ok {
 						key = str
@@ -336,14 +336,14 @@ func (vm *VM) defineCollectionBuiltins() {
 				bs := make([]byte, len(arr.Elements))
 				for i, el := range arr.Elements {
 					if el.Type == value.VAL_INT {
-						bs[i] = byte(el.AsInt)
+						bs[i] = byte(el.Int())
 					}
 				}
 				return value.NewBytes(string(bs))
 			}
 		case value.VAL_INT:
 			// Single int to single byte
-			return value.NewBytes(string([]byte{byte(arg.AsInt)}))
+			return value.NewBytes(string([]byte{byte(arg.Int())}))
 		}
 		return value.NewBytes("")
 	})

--- a/internal/vm/builtins_collections_test.go
+++ b/internal/vm/builtins_collections_test.go
@@ -72,7 +72,7 @@ func TestLengthAndKeysBuiltins(t *testing.T) {
 	for _, key := range keys.Elements {
 		switch key.Type {
 		case value.VAL_INT:
-			actualKeys = append(actualKeys, fmt.Sprintf("int:%d", key.AsInt))
+			actualKeys = append(actualKeys, fmt.Sprintf("int:%d", key.Int()))
 		case value.VAL_OBJ:
 			keyString, ok := key.Obj.(string)
 			if !ok {

--- a/internal/vm/builtins_concurrency.go
+++ b/internal/vm/builtins_concurrency.go
@@ -118,7 +118,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		size := 0
 		if len(args) > 0 {
 			if args[0].Type == value.VAL_INT {
-				size = int(args[0].AsInt)
+				size = int(args[0].Int())
 			}
 		}
 		return value.NewChannel(size)
@@ -202,7 +202,7 @@ func (vm *VM) defineConcurrencyBuiltins() {
 		}
 		delta := int(0)
 		if args[1].Type == value.VAL_INT {
-			delta = int(args[1].AsInt)
+			delta = int(args[1].Int())
 		}
 		if delta == 0 {
 			return value.NewNull()

--- a/internal/vm/builtins_concurrency_test.go
+++ b/internal/vm/builtins_concurrency_test.go
@@ -260,7 +260,7 @@ func TestSpawnRunsDeferredCleanup(t *testing.T) {
 			machine := New()
 			completed := make(chan int64, 1)
 			machine.DefineNative("spawned_record", func(args []value.Value) value.Value {
-				completed <- args[0].AsInt
+				completed <- args[0].Int()
 				return value.NewNull()
 			})
 

--- a/internal/vm/builtins_convert.go
+++ b/internal/vm/builtins_convert.go
@@ -51,12 +51,12 @@ func describeConversionInput(item value.Value) string {
 func convertValueToInt(item value.Value) (int64, error) {
 	switch item.Type {
 	case value.VAL_INT:
-		return item.AsInt, nil
+		return item.Int(), nil
 	case value.VAL_FLOAT:
-		if math.IsNaN(item.AsFloat) || math.IsInf(item.AsFloat, 0) {
+		if math.IsNaN(item.Float()) || math.IsInf(item.Float(), 0) {
 			return 0, fmt.Errorf("cannot convert %s to int", describeConversionInput(item))
 		}
-		truncated := math.Trunc(item.AsFloat)
+		truncated := math.Trunc(item.Float())
 		if truncated < minInt64AsFloat || truncated >= maxInt64ExclusiveFloat {
 			return 0, fmt.Errorf("cannot convert %s to int: out of range", describeConversionInput(item))
 		}
@@ -79,9 +79,9 @@ func convertValueToInt(item value.Value) (int64, error) {
 func convertValueToFloat(item value.Value) (float64, error) {
 	switch item.Type {
 	case value.VAL_FLOAT:
-		return item.AsFloat, nil
+		return item.Float(), nil
 	case value.VAL_INT:
-		return float64(item.AsInt), nil
+		return float64(item.Int()), nil
 	case value.VAL_OBJ:
 		if text, ok := item.Obj.(string); ok {
 			parsed, parseErr := strconv.ParseFloat(text, 64)

--- a/internal/vm/builtins_convert_test.go
+++ b/internal/vm/builtins_convert_test.go
@@ -41,11 +41,11 @@ func TestConvertToIntResultAccepts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ok := convertResultField(t, machine, "convert_to_int_result", test.input, "ok")
-			if ok.Type != value.VAL_BOOL || !ok.AsBool {
+			if ok.Type != value.VAL_BOOL || !ok.Bool() {
 				t.Fatalf("ok = %#v, want true", ok)
 			}
 			got := convertResultField(t, machine, "convert_to_int_result", test.input, "value")
-			if got.Type != value.VAL_INT || got.AsInt != test.want {
+			if got.Type != value.VAL_INT || got.Int() != test.want {
 				t.Fatalf("value = %#v, want %d", got, test.want)
 			}
 			reason := convertResultField(t, machine, "convert_to_int_result", test.input, "error")
@@ -81,11 +81,11 @@ func TestConvertToIntResultRejects(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ok := convertResultField(t, machine, "convert_to_int_result", test.input, "ok")
-			if ok.Type != value.VAL_BOOL || ok.AsBool {
+			if ok.Type != value.VAL_BOOL || ok.Bool() {
 				t.Fatalf("ok = %#v, want false", ok)
 			}
 			got := convertResultField(t, machine, "convert_to_int_result", test.input, "value")
-			if got.Type != value.VAL_INT || got.AsInt != 0 {
+			if got.Type != value.VAL_INT || got.Int() != 0 {
 				t.Fatalf("value = %#v, want 0", got)
 			}
 			reason := convertResultField(t, machine, "convert_to_int_result", test.input, "error")
@@ -116,7 +116,7 @@ func TestConvertToFloatResultAccepts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ok := convertResultField(t, machine, "convert_to_float_result", test.input, "ok")
-			if ok.Type != value.VAL_BOOL || !ok.AsBool {
+			if ok.Type != value.VAL_BOOL || !ok.Bool() {
 				t.Fatalf("ok = %#v, want true", ok)
 			}
 			got := convertResultField(t, machine, "convert_to_float_result", test.input, "value")
@@ -124,13 +124,13 @@ func TestConvertToFloatResultAccepts(t *testing.T) {
 				t.Fatalf("value = %#v, want float", got)
 			}
 			if math.IsNaN(test.want) {
-				if !math.IsNaN(got.AsFloat) {
-					t.Fatalf("value = %v, want NaN", got.AsFloat)
+				if !math.IsNaN(got.Float()) {
+					t.Fatalf("value = %v, want NaN", got.Float())
 				}
 				return
 			}
-			if got.AsFloat != test.want {
-				t.Fatalf("value = %v, want %v", got.AsFloat, test.want)
+			if got.Float() != test.want {
+				t.Fatalf("value = %v, want %v", got.Float(), test.want)
 			}
 		})
 	}
@@ -141,7 +141,7 @@ func TestConvertToFloatResultAcceptsSpecialStrings(t *testing.T) {
 	for _, literal := range []string{"NaN", "Inf", "+Inf", "-Inf"} {
 		t.Run(literal, func(t *testing.T) {
 			ok := convertResultField(t, machine, "convert_to_float_result", value.NewString(literal), "ok")
-			if ok.Type != value.VAL_BOOL || !ok.AsBool {
+			if ok.Type != value.VAL_BOOL || !ok.Bool() {
 				t.Fatalf("ok = %#v, want true", ok)
 			}
 		})
@@ -163,7 +163,7 @@ func TestConvertToFloatResultRejects(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ok := convertResultField(t, machine, "convert_to_float_result", test.input, "ok")
-			if ok.Type != value.VAL_BOOL || ok.AsBool {
+			if ok.Type != value.VAL_BOOL || ok.Bool() {
 				t.Fatalf("ok = %#v, want false", ok)
 			}
 		})
@@ -192,7 +192,7 @@ func TestConvertResultNeverFailsOnBadArity(t *testing.T) {
 				t.Fatalf("%s returned %#v, want map", native, result)
 			}
 			okField, _ := mapping.Get("ok")
-			if okField.Type != value.VAL_BOOL || okField.AsBool {
+			if okField.Type != value.VAL_BOOL || okField.Bool() {
 				t.Fatalf("ok = %#v, want false", okField)
 			}
 		})
@@ -209,7 +209,7 @@ else
     test_report(false)
 end`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("convert module wrappers = %#v, want true", captured)
 	}
 }
@@ -219,7 +219,7 @@ func TestParseUrlRejectsUnparsablePort(t *testing.T) {
 let u: HttpUrl = parse_url("http://example.com:notaport/path")
 test_report(u.valid)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || captured.AsBool {
+	if captured.Type != value.VAL_BOOL || captured.Bool() {
 		t.Fatalf("parse_url valid = %#v, want false for an unparsable port", captured)
 	}
 }
@@ -233,7 +233,7 @@ else
     test_report(false)
 end`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("parse_url on a valid port = %#v, want true", captured)
 	}
 }
@@ -244,7 +244,7 @@ let raw: bytes = to_bytes("HTTP/1.1 NOPE Weird\r\nHost: a\r\n\r\n")
 let r: HttpResponse = parse_response(raw, length(raw))
 test_report(r.status_code)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_INT || captured.AsInt != 0 {
+	if captured.Type != value.VAL_INT || captured.Int() != 0 {
 		t.Fatalf("parse_response status_code = %#v, want 0", captured)
 	}
 }
@@ -299,7 +299,7 @@ func TestToIntConvertsAcceptedInput(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := callBuiltin(t, machine, "to_int", test.input)
-			if got.Type != value.VAL_INT || got.AsInt != test.want {
+			if got.Type != value.VAL_INT || got.Int() != test.want {
 				t.Fatalf("to_int = %#v, want %d", got, test.want)
 			}
 		})

--- a/internal/vm/builtins_core.go
+++ b/internal/vm/builtins_core.go
@@ -78,7 +78,7 @@ func (vm *VM) defineCoreBuiltins() {
 			return value.NewNull()
 		}
 		if args[0].Type == value.VAL_INT {
-			return value.NewString(fmt.Sprintf("0x%x", args[0].AsInt))
+			return value.NewString(fmt.Sprintf("0x%x", args[0].Int()))
 		}
 		if args[0].Type == value.VAL_BYTES {
 			return value.NewString(fmt.Sprintf("%x", args[0].Obj.(string)))
@@ -145,7 +145,7 @@ func (vm *VM) defineCoreBuiltins() {
 		if args[0].Type != value.VAL_INT {
 			return value.NewString("")
 		}
-		num := args[0].AsInt
+		num := args[0].Int()
 		if num == 0 {
 			return value.NewString("0")
 		}
@@ -284,13 +284,13 @@ func (vm *VM) defineCoreBuiltins() {
 			// Consume args for width/prec
 			if widthHasStar {
 				if argIdx < len(argsData) {
-					newArgs = append(newArgs, argsData[argIdx].AsInt) // Assume int for width
+					newArgs = append(newArgs, argsData[argIdx].Int()) // Assume int for width
 					argIdx++
 				}
 			}
 			if precHasStar {
 				if argIdx < len(argsData) {
-					newArgs = append(newArgs, argsData[argIdx].AsInt) // Assume int for prec
+					newArgs = append(newArgs, argsData[argIdx].Int()) // Assume int for prec
 					argIdx++
 				}
 			}
@@ -311,11 +311,11 @@ func (vm *VM) defineCoreBuiltins() {
 					// Add argument, potentially wrapped or raw
 					switch val.Type {
 					case value.VAL_INT:
-						newArgs = append(newArgs, val.AsInt)
+						newArgs = append(newArgs, val.Int())
 					case value.VAL_FLOAT:
-						newArgs = append(newArgs, val.AsFloat)
+						newArgs = append(newArgs, val.Float())
 					case value.VAL_BOOL:
-						newArgs = append(newArgs, val.AsBool)
+						newArgs = append(newArgs, val.Bool())
 					case value.VAL_NULL:
 						newArgs = append(newArgs, nil)
 					case value.VAL_OBJ:

--- a/internal/vm/builtins_core_test.go
+++ b/internal/vm/builtins_core_test.go
@@ -15,16 +15,16 @@ func assertBuiltinValue(t *testing.T, got, want value.Value) {
 	}
 	switch want.Type {
 	case value.VAL_BOOL:
-		if got.AsBool != want.AsBool {
-			t.Fatalf("bool = %t, want %t", got.AsBool, want.AsBool)
+		if got.Bool() != want.Bool() {
+			t.Fatalf("bool = %t, want %t", got.Bool(), want.Bool())
 		}
 	case value.VAL_INT:
-		if got.AsInt != want.AsInt {
-			t.Fatalf("int = %d, want %d", got.AsInt, want.AsInt)
+		if got.Int() != want.Int() {
+			t.Fatalf("int = %d, want %d", got.Int(), want.Int())
 		}
 	case value.VAL_FLOAT:
-		if got.AsFloat != want.AsFloat {
-			t.Fatalf("float = %v, want %v", got.AsFloat, want.AsFloat)
+		if got.Float() != want.Float() {
+			t.Fatalf("float = %v, want %v", got.Float(), want.Float())
 		}
 	case value.VAL_OBJ, value.VAL_BYTES:
 		gotString, gotOK := got.Obj.(string)

--- a/internal/vm/builtins_crypto.go
+++ b/internal/vm/builtins_crypto.go
@@ -16,7 +16,7 @@ func (vm *VM) defineCryptoBuiltins() {
 		if len(args) < 1 {
 			return value.NewNull()
 		}
-		n := int(args[0].AsInt)
+		n := int(args[0].Int())
 		if n <= 0 {
 			return value.NewNull()
 		}
@@ -42,8 +42,8 @@ func (vm *VM) defineCryptoBuiltins() {
 		} else {
 			salt = []byte(args[1].String())
 		}
-		iteracoes := int(args[2].AsInt)
-		tamanho := int(args[3].AsInt)
+		iteracoes := int(args[2].Int())
+		tamanho := int(args[3].Int())
 
 		if iteracoes <= 0 || tamanho <= 0 {
 			return value.NewNull()

--- a/internal/vm/builtins_io.go
+++ b/internal/vm/builtins_io.go
@@ -396,8 +396,8 @@ func (vm *VM) defineIOBuiltins() {
 		if !ok {
 			return value.NewNull(), nil
 		}
-		offset := args[1].AsInt
-		whence := args[2].AsInt
+		offset := args[1].Int()
+		whence := args[2].Int()
 		result := newIOPositionResult(resultStruct, false, -1, "File not open")
 		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
@@ -488,7 +488,7 @@ func (vm *VM) defineIOBuiltins() {
 		if !ok {
 			return value.NewNull(), nil
 		}
-		count := args[1].AsInt
+		count := args[1].Int()
 		result := newIOReadResult(resultStruct, false, value.NewBytes(""), "File not open")
 		resource, exists := machine.shared.Files.get(fileHandle(machine.shared, inst))
 		if !exists {
@@ -634,7 +634,7 @@ func (vm *VM) defineIOBuiltins() {
 
 func fileHandle(shared *SharedState, instance *value.ObjInstance) int {
 	shared.fileMetaMu.RLock()
-	handle := int(instance.Fields["fd"].AsInt)
+	handle := int(instance.Fields["fd"].Int())
 	shared.fileMetaMu.RUnlock()
 	return handle
 }

--- a/internal/vm/builtins_io_test.go
+++ b/internal/vm/builtins_io_test.go
@@ -127,7 +127,7 @@ func TestFileHandleIsUsableAcrossSharedVMs(t *testing.T) {
 	fileType := testFileDefinition()
 	handle := callBuiltin(t, parent, "io_open", value.NewString(path), value.NewString("w"), fileType)
 	defer callBuiltin(t, parent, "io_close", handle)
-	fd := int(requireBuiltinInstance(t, handle, fileType).Fields["fd"].AsInt)
+	fd := int(requireBuiltinInstance(t, handle, fileType).Fields["fd"].Int())
 	if _, ok := parent.shared.Files.get(fd); !ok {
 		t.Fatalf("file handle %d was not published to shared resources", fd)
 	}
@@ -240,7 +240,7 @@ func TestIOWriteResultReportsSuccessAndFailure(t *testing.T) {
 	assertBuiltinValue(t, success.Fields["bytes_written"], value.NewInt(int64(len([]byte(contents)))))
 	assertBuiltinValue(t, success.Fields["error"], value.NewString(""))
 
-	fd := int(handle.Fields["fd"].AsInt)
+	fd := int(handle.Fields["fd"].Int())
 	resource, ok := machine.shared.Files.get(fd)
 	if !ok {
 		t.Fatalf("open file descriptor %d is absent from shared resources", fd)
@@ -280,7 +280,7 @@ func TestIOCloseResultReportsSuccessAndFailure(t *testing.T) {
 
 	failedHandleValue := callBuiltin(t, machine, "io_open", value.NewString(path), value.NewString("a"), fileDefinition)
 	failedHandle := requireBuiltinInstance(t, failedHandleValue, fileDefinition)
-	failedFD := int(failedHandle.Fields["fd"].AsInt)
+	failedFD := int(failedHandle.Fields["fd"].Int())
 	failedResource, ok := machine.shared.Files.get(failedFD)
 	if !ok {
 		t.Fatalf("open file descriptor %d is absent from shared resources", failedFD)
@@ -314,7 +314,7 @@ func TestIOBuiltinsUseTemporaryFilesAndInvalidateHandles(t *testing.T) {
 	writeHandleValue := callBuiltin(t, machine, "io_open", value.NewString(path), value.NewString("w"), fileDefinition)
 	writeHandle := requireBuiltinInstance(t, writeHandleValue, fileDefinition)
 	assertBuiltinValue(t, writeHandle.Fields["open"], value.NewBool(true))
-	writeFD := int(writeHandle.Fields["fd"].AsInt)
+	writeFD := int(writeHandle.Fields["fd"].Int())
 	if _, ok := machine.shared.Files.get(writeFD); !ok {
 		t.Fatalf("open file descriptor %d is absent from shared resources", writeFD)
 	}
@@ -640,7 +640,7 @@ func TestIOCloseLeavesStdinRegisteredAndUsable(t *testing.T) {
 		fileDefinition := testFileDefinition()
 		handleValue := callBuiltin(t, machine, "io_stdin", fileDefinition)
 		handle := requireBuiltinInstance(t, handleValue, fileDefinition)
-		fd := int(handle.Fields["fd"].AsInt)
+		fd := int(handle.Fields["fd"].Int())
 
 		callBuiltin(t, machine, "io_close", handleValue)
 		if _, ok := machine.shared.Files.get(fd); !ok {
@@ -700,7 +700,7 @@ func TestConcurrentInputAndStdinReadLineShareOneBuffer(t *testing.T) {
 					break
 				}
 				result, ok := got.Obj.(*value.ObjInstance)
-				if !ok || !result.Fields["ok"].AsBool {
+				if !ok || !result.Fields["ok"].Bool() {
 					break
 				}
 				line, _ := result.Fields["data"].Obj.(string)

--- a/internal/vm/builtins_json.go
+++ b/internal/vm/builtins_json.go
@@ -115,11 +115,11 @@ func jsonValToGo(v value.Value) interface{} {
 	case value.VAL_NULL:
 		return nil
 	case value.VAL_BOOL:
-		return v.AsBool
+		return v.Bool()
 	case value.VAL_INT:
-		return v.AsInt
+		return v.Int()
 	case value.VAL_FLOAT:
-		return v.AsFloat
+		return v.Float()
 	case value.VAL_OBJ:
 		switch o := v.Obj.(type) {
 		case string:

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -59,8 +59,8 @@ func networkSocketDescriptor(socket value.Value) (int, error) {
 	if !exists || descriptor.Type != value.VAL_INT {
 		return 0, fmt.Errorf("invalid socket")
 	}
-	handle := int(descriptor.AsInt)
-	if int64(handle) != descriptor.AsInt {
+	handle := int(descriptor.Int())
+	if int64(handle) != descriptor.Int() {
 		return 0, fmt.Errorf("invalid socket")
 	}
 	return handle, nil
@@ -455,7 +455,7 @@ func (vm *VM) defineNetworkBuiltins() {
 			return value.NewNull(), nil
 		}
 		host := args[0].String()
-		port := int(args[1].AsInt)
+		port := int(args[1].Int())
 		listener, listenErr := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 		if listenErr != nil {
 			return socketValue(-1, host, port, false), nil
@@ -489,7 +489,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if !exists {
 			return value.NewNull(), nil
 		}
-		resource, exists := machine.shared.Listeners.get(int(fdValue.AsInt))
+		resource, exists := machine.shared.Listeners.get(int(fdValue.Int()))
 		if !exists {
 			return socketValue(-1, "", 0, false), nil
 		}
@@ -510,7 +510,7 @@ func (vm *VM) defineNetworkBuiltins() {
 			return value.NewNull(), nil
 		}
 		host := args[0].String()
-		port := int(args[1].AsInt)
+		port := int(args[1].Int())
 		connection, connectErr := networkDialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 5*time.Second)
 		if connectErr != nil {
 			return socketValue(-1, host, port, false), nil
@@ -536,11 +536,11 @@ func (vm *VM) defineNetworkBuiltins() {
 			return value.NewNull(), nil
 		}
 		fdValue, _ := socket.Get("fd")
-		resource, exists := machine.shared.Sockets.get(int(fdValue.AsInt))
+		resource, exists := machine.shared.Sockets.get(int(fdValue.Int()))
 		if !exists {
 			return netResult(false, "", 0, "invalid socket"), nil
 		}
-		return receiveSocket(resource, int(args[1].AsInt)), nil
+		return receiveSocket(resource, int(args[1].Int())), nil
 	})
 
 	vm.DefineContextualNative("net_send", func(context value.NativeContext, args []value.Value) (value.Value, error) {
@@ -560,7 +560,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if args[1].Type == value.VAL_BYTES {
 			data = args[1].Obj.(string)
 		}
-		resource, exists := machine.shared.Sockets.get(int(fdValue.AsInt))
+		resource, exists := machine.shared.Sockets.get(int(fdValue.Int()))
 		if !exists {
 			return netResult(false, "", 0, "invalid socket"), nil
 		}
@@ -577,11 +577,11 @@ func (vm *VM) defineNetworkBuiltins() {
 		}
 		fd := 0
 		if args[0].Type == value.VAL_INT {
-			fd = int(args[0].AsInt)
+			fd = int(args[0].Int())
 		} else if args[0].Type == value.VAL_OBJ {
 			if socket, ok := args[0].Obj.(*value.ObjMap); ok {
 				if fdValue, found := socket.Get("fd"); found {
-					fd = int(fdValue.AsInt)
+					fd = int(fdValue.Int())
 				}
 			}
 		} else {
@@ -602,7 +602,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) != 2 || args[1].Type != value.VAL_BOOL || !args[1].AsBool {
+		if len(args) != 2 || args[1].Type != value.VAL_BOOL || !args[1].Bool() {
 			return value.NewNull(), nil
 		}
 		if err := configureNetworkTimeout(machine, args[0], 0); err != nil {
@@ -622,7 +622,7 @@ func (vm *VM) defineNetworkBuiltins() {
 		if args[1].Type != value.VAL_INT {
 			return value.NewNull(), fmt.Errorf("network timeout must be an int")
 		}
-		timeout, err := validateNetworkTimeout(args[1].AsInt)
+		timeout, err := validateNetworkTimeout(args[1].Int())
 		if err != nil {
 			return value.NewNull(), err
 		}

--- a/internal/vm/builtins_net_deadlines_test.go
+++ b/internal/vm/builtins_net_deadlines_test.go
@@ -305,7 +305,7 @@ func TestNetSelectCloseWakesAndOmitsLocalResource(t *testing.T) {
 		machine := New()
 		cleanupNetworkResources(t, machine)
 		listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-		handle := int(builtinMapField(t, listener, "fd").AsInt)
+		handle := int(builtinMapField(t, listener, "fd").Int())
 		resource, exists := machine.shared.Listeners.get(handle)
 		if !exists {
 			t.Fatalf("listener descriptor %d is not registered", handle)
@@ -423,7 +423,7 @@ func TestNetSelectRollbackPoisonWakesBeforeResourceClose(t *testing.T) {
 		machine := New()
 		cleanupNetworkResources(t, machine)
 		listenerValue := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-		handle := int(builtinMapField(t, listenerValue, "fd").AsInt)
+		handle := int(builtinMapField(t, listenerValue, "fd").Int())
 		resource, exists := machine.shared.Listeners.get(handle)
 		if !exists {
 			t.Fatalf("listener descriptor %d is not registered", handle)
@@ -1678,7 +1678,7 @@ func TestAcceptedSocketDoesNotInheritListenerTimeout(t *testing.T) {
 	machine := New()
 	cleanupNetworkResources(t, machine)
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-	listenerHandle := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerHandle := int(builtinMapField(t, listener, "fd").Int())
 	listenerResource, exists := machine.shared.Listeners.get(listenerHandle)
 	if !exists {
 		t.Fatal("listener not registered")

--- a/internal/vm/builtins_net_test.go
+++ b/internal/vm/builtins_net_test.go
@@ -91,7 +91,7 @@ func recordDeferredListenerResource(machine *VM, captured **ListenerResource) {
 		if !ok {
 			return value.NewNull()
 		}
-		*captured, _ = machine.shared.Listeners.get(int(handle.AsInt))
+		*captured, _ = machine.shared.Listeners.get(int(handle.Int()))
 		return value.NewNull()
 	})
 }
@@ -117,7 +117,7 @@ func requireDeferredListenerClosed(t *testing.T, machine *VM, resource *Listener
 
 func requireSocketResource(t *testing.T, machine *VM, socket value.Value) (int, *SocketResource) {
 	t.Helper()
-	handle := int(builtinMapField(t, socket, "fd").AsInt)
+	handle := int(builtinMapField(t, socket, "fd").Int())
 	resource, exists := machine.shared.Sockets.get(handle)
 	if !exists {
 		t.Fatalf("socket descriptor %d is not registered", handle)
@@ -265,7 +265,7 @@ func setupAcceptedLoopback(t *testing.T, machine *VM) (value.Value, value.Value,
 	t.Helper()
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
 	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
-	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerFD := int(builtinMapField(t, listener, "fd").Int())
 	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
 	if !exists {
 		t.Fatalf("listener descriptor %d is not registered", listenerFD)
@@ -299,7 +299,7 @@ func TestNetListenZeroReturnsAssignedPort(t *testing.T) {
 	cleanupNetworkResources(t, machine)
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
 	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
-	assignedPort := builtinMapField(t, listener, "port").AsInt
+	assignedPort := builtinMapField(t, listener, "port").Int()
 	if assignedPort <= 0 {
 		t.Fatalf("net_listen port=%d, want OS-assigned positive port", assignedPort)
 	}
@@ -364,7 +364,7 @@ func TestNetSelectDoesNotAcceptPendingConnection(t *testing.T) {
 	machine := New()
 	cleanupNetworkResources(t, machine)
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerFD := int(builtinMapField(t, listener, "fd").Int())
 	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
 	if !exists {
 		t.Fatalf("listener descriptor %d is not registered", listenerFD)
@@ -446,7 +446,7 @@ func TestNetworkBuiltinsLoopbackLifecycle(t *testing.T) {
 
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
 	assertBuiltinValue(t, builtinMapField(t, listener, "open"), value.NewBool(true))
-	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerFD := int(builtinMapField(t, listener, "fd").Int())
 	listenerResource, exists := machine.shared.Listeners.get(listenerFD)
 	if !exists {
 		t.Fatalf("listener descriptor %d is not registered", listenerFD)

--- a/internal/vm/builtins_sqlite.go
+++ b/internal/vm/builtins_sqlite.go
@@ -52,7 +52,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 			return value.NewNull(), nil
 		}
 
-		resource, exists := machine.shared.Databases.remove(int(databaseInstance.Fields["handle"].AsInt))
+		resource, exists := machine.shared.Databases.remove(int(databaseInstance.Fields["handle"].Int()))
 		if exists {
 			resource.stateMu.Lock()
 			database := resource.database
@@ -176,7 +176,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 		if len(args) < 3 {
 			return value.NewNull(), nil
 		}
-		return bindSQLiteParameter(machine, args, args[2].AsFloat), nil
+		return bindSQLiteParameter(machine, args, args[2].Float()), nil
 	})
 	vm.DefineContextualNative("sqlite_bind_int", func(context value.NativeContext, args []value.Value) (value.Value, error) {
 		machine, err := nativeVM(context)
@@ -186,7 +186,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 		if len(args) < 3 {
 			return value.NewNull(), nil
 		}
-		return bindSQLiteParameter(machine, args, args[2].AsInt), nil
+		return bindSQLiteParameter(machine, args, args[2].Int()), nil
 	})
 
 	vm.DefineContextualNative("sqlite_step_exec", func(context value.NativeContext, args []value.Value) (value.Value, error) {
@@ -206,7 +206,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 			return value.NewNull(), nil
 		}
 
-		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].Int()))
 		if !exists {
 			return sqliteExecError(resultTemplate.Struct, "invalid statement handle"), nil
 		}
@@ -245,7 +245,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 		if !ok {
 			return value.NewNull(), nil
 		}
-		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].Int()))
 		if exists {
 			resource.mu.Lock()
 			if !resource.closed && resource.statement != nil {
@@ -268,7 +268,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 		if !ok {
 			return value.NewNull(), nil
 		}
-		resource, exists := machine.shared.Statements.remove(int(statementInstance.Fields["handle"].AsInt))
+		resource, exists := machine.shared.Statements.remove(int(statementInstance.Fields["handle"].Int()))
 		if !exists {
 			return value.NewNull(), nil
 		}
@@ -356,7 +356,7 @@ func (vm *VM) defineSQLiteBuiltins() {
 }
 
 func sqliteDatabase(machine *VM, instance *value.ObjInstance) (*sql.DB, bool) {
-	resource, ok := machine.shared.Databases.get(int(instance.Fields["handle"].AsInt))
+	resource, ok := machine.shared.Databases.get(int(instance.Fields["handle"].Int()))
 	if !ok {
 		return nil, false
 	}
@@ -373,7 +373,7 @@ func bindSQLiteParameter(machine *VM, args []value.Value, parameter interface{})
 	if !ok {
 		return value.NewNull()
 	}
-	resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+	resource, exists := machine.shared.Statements.get(int(statementInstance.Fields["handle"].Int()))
 	if !exists {
 		return value.NewNull()
 	}
@@ -385,18 +385,18 @@ func bindSQLiteParameter(machine *VM, args []value.Value, parameter interface{})
 	if resource.parameters == nil {
 		resource.parameters = make(map[int]interface{})
 	}
-	resource.parameters[int(args[1].AsInt)] = parameter
+	resource.parameters[int(args[1].Int())] = parameter
 	return value.NewNull()
 }
 
 func sqliteParameter(parameter value.Value) interface{} {
 	switch parameter.Type {
 	case value.VAL_INT:
-		return parameter.AsInt
+		return parameter.Int()
 	case value.VAL_FLOAT:
-		return parameter.AsFloat
+		return parameter.Float()
 	case value.VAL_BOOL:
-		return parameter.AsBool
+		return parameter.Bool()
 	case value.VAL_NULL:
 		return nil
 	case value.VAL_BYTES:

--- a/internal/vm/builtins_sqlite_test.go
+++ b/internal/vm/builtins_sqlite_test.go
@@ -92,8 +92,8 @@ func recordDeferredSQLiteResources(machine *VM, database **DatabaseResource, sta
 		if !databaseOK || !statementOK {
 			return value.NewNull()
 		}
-		*database, _ = machine.shared.Databases.get(int(databaseInstance.Fields["handle"].AsInt))
-		*statement, _ = machine.shared.Statements.get(int(statementInstance.Fields["handle"].AsInt))
+		*database, _ = machine.shared.Databases.get(int(databaseInstance.Fields["handle"].Int()))
+		*statement, _ = machine.shared.Statements.get(int(statementInstance.Fields["handle"].Int()))
 		return value.NewNull()
 	})
 }
@@ -206,7 +206,7 @@ func TestSQLiteHandlesAreSharedAcrossVMs(t *testing.T) {
 		sqliteTemplate(definitions.database),
 	)
 	defer callBuiltin(t, parent, "sqlite_close", database)
-	databaseHandle := int(requireBuiltinInstance(t, database, definitions.database).Fields["handle"].AsInt)
+	databaseHandle := int(requireBuiltinInstance(t, database, definitions.database).Fields["handle"].Int())
 	if _, ok := parent.shared.Databases.get(databaseHandle); !ok {
 		t.Fatalf("database handle %d was not published to shared resources", databaseHandle)
 	}
@@ -221,7 +221,7 @@ func TestSQLiteHandlesAreSharedAcrossVMs(t *testing.T) {
 		sqliteTemplate(definitions.statement),
 	)
 	defer callBuiltin(t, parent, "sqlite_finalize", statement)
-	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].AsInt)
+	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].Int())
 	if _, ok := parent.shared.Statements.get(statementHandle); !ok {
 		t.Fatalf("statement handle %d was not published to shared resources", statementHandle)
 	}
@@ -259,7 +259,7 @@ func TestSQLiteStatementParametersConcurrent(t *testing.T) {
 		sqliteTemplate(definitions.statement),
 	)
 	defer callBuiltin(t, machine, "sqlite_finalize", statement)
-	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].AsInt)
+	statementHandle := int(requireBuiltinInstance(t, statement, definitions.statement).Fields["handle"].Int())
 	if _, ok := machine.shared.Statements.get(statementHandle); !ok {
 		t.Fatalf("statement handle %d was not published to shared resources", statementHandle)
 	}
@@ -307,7 +307,7 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 	databaseValue := callBuiltin(t, machine, "sqlite_open", value.NewString(databasePath), databaseTemplate)
 	database := requireBuiltinInstance(t, databaseValue, definitions.database)
 	assertBuiltinValue(t, database.Fields["open"], value.NewBool(true))
-	databaseHandle := int(database.Fields["handle"].AsInt)
+	databaseHandle := int(database.Fields["handle"].Int())
 	if _, ok := machine.shared.Databases.get(databaseHandle); !ok {
 		t.Fatalf("database handle %d is not registered", databaseHandle)
 	}
@@ -333,7 +333,7 @@ func TestSQLiteBuiltinsTemporaryDatabaseLifecycle(t *testing.T) {
 		sqliteTemplate(definitions.statement),
 	)
 	statement := requireBuiltinInstance(t, statementValue, definitions.statement)
-	statementHandle := int(statement.Fields["handle"].AsInt)
+	statementHandle := int(statement.Fields["handle"].Int())
 	statementResource, ok := machine.shared.Statements.get(statementHandle)
 	if !ok {
 		t.Fatalf("statement handle %d is not registered", statementHandle)

--- a/internal/vm/builtins_strings.go
+++ b/internal/vm/builtins_strings.go
@@ -165,7 +165,7 @@ func (vm *VM) defineStringBuiltins() {
 		if err := requireTextArgument("strings.repeat", args, 0); err != nil {
 			return value.NewNull(), err
 		}
-		return value.NewString(strings.Repeat(args[0].String(), int(args[1].AsInt))), nil
+		return value.NewString(strings.Repeat(args[0].String(), int(args[1].Int()))), nil
 	})
 
 	vm.DefineContextualNative("strings_replace", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
@@ -200,7 +200,7 @@ func (vm *VM) defineStringBuiltins() {
 			}
 		}
 		s := args[0].String()
-		totalLen := int(args[1].AsInt)
+		totalLen := int(args[1].Int())
 		padChar := args[2].String()
 		if len(s) >= totalLen {
 			return value.NewString(s), nil
@@ -245,7 +245,7 @@ func (vm *VM) defineStringBuiltins() {
 		}
 		arrVal := args[0]
 		sep := args[1].String()
-		count := int(args[2].AsInt)
+		count := int(args[2].Int())
 
 		if arrVal.Type == value.VAL_OBJ {
 			if arr, ok := arrVal.Obj.(*value.ObjArray); ok {
@@ -287,8 +287,8 @@ func (vm *VM) defineStringBuiltins() {
 		s := args[0].String()
 		runes := []rune(s)
 		n := len(runes)
-		start := int(args[1].AsInt)
-		end := int(args[2].AsInt)
+		start := int(args[1].Int())
+		end := int(args[2].Int())
 
 		// Negative indices count from the end (Python-style)
 		if start < 0 {
@@ -408,7 +408,7 @@ func (vm *VM) defineStringBuiltins() {
 		}
 		s := args[0].String()
 		runes := []rune(s)
-		idx := int(args[1].AsInt)
+		idx := int(args[1].Int())
 		if idx < 0 || idx >= len(runes) {
 			return value.NewString(""), nil
 		}
@@ -436,7 +436,7 @@ func (vm *VM) defineStringBuiltins() {
 		if len(args) < 1 {
 			return value.NewString("")
 		}
-		return value.NewString(string(rune(args[0].AsInt)))
+		return value.NewString(string(rune(args[0].Int())))
 	})
 	// strings_is_valid_utf8 takes bytes, not text, so it must not go through
 	// requireTextArgument: that guard rejects bytes, which is the opposite of

--- a/internal/vm/builtins_strings_test.go
+++ b/internal/vm/builtins_strings_test.go
@@ -167,7 +167,7 @@ func TestIndexOfReturnsCharacterIndex(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := callBuiltin(t, machine, "strings_index_of", value.NewString(test.subject), value.NewString(test.needle))
-			if got.Type != value.VAL_INT || got.AsInt != test.want {
+			if got.Type != value.VAL_INT || got.Int() != test.want {
 				t.Fatalf("strings_index_of(%q, %q) = %#v, want %d", test.subject, test.needle, got, test.want)
 			}
 		})
@@ -250,7 +250,7 @@ func TestStringNativesRejectBytes(t *testing.T) {
 func TestStringNativesStillAcceptStrings(t *testing.T) {
 	machine := New()
 	got := callBuiltin(t, machine, "strings_contains", value.NewString("hello"), value.NewString("ell"))
-	if got.Type != value.VAL_BOOL || !got.AsBool {
+	if got.Type != value.VAL_BOOL || !got.Bool() {
 		t.Fatalf("strings_contains = %#v, want true", got)
 	}
 }
@@ -260,7 +260,7 @@ func TestSplitRejectsBytesButAcceptsItsStructArgument(t *testing.T) {
 let parts: SplitResult = split(to_str(b"a,b"), ",")
 test_report(parts.count)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_INT || captured.AsInt != 2 {
+	if captured.Type != value.VAL_INT || captured.Int() != 2 {
 		t.Fatalf("split after explicit to_str = %#v, want 2", captured)
 	}
 }
@@ -280,7 +280,7 @@ func TestOrdReturnsCodePoint(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := callBuiltin(t, machine, "ord", value.NewString(test.input))
-			if got.Type != value.VAL_INT || got.AsInt != test.want {
+			if got.Type != value.VAL_INT || got.Int() != test.want {
 				t.Fatalf("ord(%q) = %#v, want %d", test.input, got, test.want)
 			}
 		})
@@ -292,7 +292,7 @@ func TestOrdRoundTripsWithFromCharCode(t *testing.T) {
 	for _, code := range []int64{65, 233, 20013, 128512} {
 		character := callBuiltin(t, machine, "strings_from_char_code", value.NewInt(code))
 		back := callBuiltin(t, machine, "ord", character)
-		if back.Type != value.VAL_INT || back.AsInt != code {
+		if back.Type != value.VAL_INT || back.Int() != code {
 			t.Fatalf("ord(from_char_code(%d)) = %#v, want %d", code, back, code)
 		}
 	}
@@ -320,7 +320,7 @@ func TestCharCodeIsExportedByStrings(t *testing.T) {
 	source := `use strings select *
 test_report(char_code("é") == 233 && from_char_code(233) == "é")`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("char_code round trip = %#v, want true", captured)
 	}
 }
@@ -343,7 +343,7 @@ func TestIsValidUTF8(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := callBuiltin(t, machine, "strings_is_valid_utf8", value.NewBytes(test.input))
-			if got.Type != value.VAL_BOOL || got.AsBool != test.want {
+			if got.Type != value.VAL_BOOL || got.Bool() != test.want {
 				t.Fatalf("strings_is_valid_utf8(%q) = %#v, want %v", test.input, got, test.want)
 			}
 		})
@@ -400,7 +400,7 @@ func TestIsValidUTF8AcceptsBytesFromNoxy(t *testing.T) {
 	source := `use strings select *
 test_report(is_valid_utf8(b"café") && !is_valid_utf8(to_bytes([104, 255, 105])))`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("is_valid_utf8 through the module = %#v, want true", captured)
 	}
 }

--- a/internal/vm/builtins_sys.go
+++ b/internal/vm/builtins_sys.go
@@ -359,7 +359,7 @@ func (vm *VM) defineSystemBuiltins() {
 		if len(args) < 1 {
 			return value.NewNull()
 		}
-		ms := args[0].AsInt
+		ms := args[0].Int()
 		time.Sleep(time.Duration(ms) * time.Millisecond)
 		return value.NewNull()
 	})
@@ -367,7 +367,7 @@ func (vm *VM) defineSystemBuiltins() {
 	vm.DefineNative("sys_exit", func(args []value.Value) value.Value {
 		code := 0
 		if len(args) > 0 {
-			code = int(args[0].AsInt)
+			code = int(args[0].Int())
 		}
 		os.Exit(code)
 		return value.NewNull()

--- a/internal/vm/builtins_sys_exec_signal_test.go
+++ b/internal/vm/builtins_sys_exec_signal_test.go
@@ -66,7 +66,7 @@ test_report([first, again, stopped, stopped_again, rejected])
 		t.Fatalf("células=%d, want %d: %s", len(cells), len(want), got.String())
 	}
 	for i, cell := range cells {
-		if cell.AsBool != want[i] {
+		if cell.Bool() != want[i] {
 			t.Fatalf("célula %d: got %s, want %v (tudo: %s)", i, cell.String(), want[i], got.String())
 		}
 	}

--- a/internal/vm/builtins_tasks.go
+++ b/internal/vm/builtins_tasks.go
@@ -51,7 +51,7 @@ func (vm *VM) defineTaskBuiltins() {
 			if args[1].Type != value.VAL_INT {
 				return value.NewNull(), fmt.Errorf("task_await timeout must be an integer")
 			}
-			timeoutValue := args[1].AsInt
+			timeoutValue := args[1].Int()
 			timeout = &timeoutValue
 		}
 

--- a/internal/vm/builtins_tasks_test.go
+++ b/internal/vm/builtins_tasks_test.go
@@ -378,7 +378,7 @@ func TestSpawnTaskPublishesResultAfterDeferredCleanup(t *testing.T) {
 	machine := New()
 	cleanup := make(chan int64, 1)
 	machine.DefineNative("task_cleanup", func(args []value.Value) value.Value {
-		cleanup <- args[0].AsInt
+		cleanup <- args[0].Int()
 		return value.NewNull()
 	})
 

--- a/internal/vm/builtins_time.go
+++ b/internal/vm/builtins_time.go
@@ -20,7 +20,7 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) != 1 {
 			return value.NewNull()
 		}
-		ms := args[0].AsInt
+		ms := args[0].Int()
 		time.Sleep(time.Duration(ms) * time.Millisecond)
 		return value.NewNull()
 	})
@@ -59,12 +59,12 @@ func (vm *VM) defineTimeBuiltins() {
 
 		// Reconstruct time.Time from fields
 		// Minimal fields: year, month, day, hour, minute, second
-		y := int(inst.Fields["year"].AsInt)
-		m := time.Month(inst.Fields["month"].AsInt)
-		d := int(inst.Fields["day"].AsInt)
-		h := int(inst.Fields["hour"].AsInt)
-		min := int(inst.Fields["minute"].AsInt)
-		s := int(inst.Fields["second"].AsInt)
+		y := int(inst.Fields["year"].Int())
+		m := time.Month(inst.Fields["month"].Int())
+		d := int(inst.Fields["day"].Int())
+		h := int(inst.Fields["hour"].Int())
+		min := int(inst.Fields["minute"].Int())
+		s := int(inst.Fields["second"].Int())
 
 		t := time.Date(y, m, d, h, min, s, 0, time.Local)
 		return value.NewString(t.Format("2006-01-02 15:04:05"))
@@ -77,9 +77,9 @@ func (vm *VM) defineTimeBuiltins() {
 		if !ok {
 			return value.NewString("")
 		}
-		y := int(inst.Fields["year"].AsInt)
-		m := time.Month(inst.Fields["month"].AsInt)
-		d := int(inst.Fields["day"].AsInt)
+		y := int(inst.Fields["year"].Int())
+		m := time.Month(inst.Fields["month"].Int())
+		d := int(inst.Fields["day"].Int())
 		t := time.Date(y, m, d, 0, 0, 0, 0, time.Local)
 		return value.NewString(t.Format("2006-01-02"))
 	})
@@ -91,9 +91,9 @@ func (vm *VM) defineTimeBuiltins() {
 		if !ok {
 			return value.NewString("")
 		}
-		h := int(inst.Fields["hour"].AsInt)
-		min := int(inst.Fields["minute"].AsInt)
-		s := int(inst.Fields["second"].AsInt)
+		h := int(inst.Fields["hour"].Int())
+		min := int(inst.Fields["minute"].Int())
+		s := int(inst.Fields["second"].Int())
 		t := time.Date(0, 1, 1, h, min, s, 0, time.Local)
 		return value.NewString(t.Format("15:04:05"))
 	})
@@ -107,12 +107,12 @@ func (vm *VM) defineTimeBuiltins() {
 			return value.NewNull()
 		}
 
-		y := int(args[1].AsInt)
-		m := time.Month(args[2].AsInt)
-		d := int(args[3].AsInt)
-		h := int(args[4].AsInt)
-		min := int(args[5].AsInt)
-		s := int(args[6].AsInt)
+		y := int(args[1].Int())
+		m := time.Month(args[2].Int())
+		d := int(args[3].Int())
+		h := int(args[4].Int())
+		min := int(args[5].Int())
+		s := int(args[6].Int())
 
 		t := time.Date(y, m, d, h, min, s, 0, time.Local)
 
@@ -148,7 +148,7 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) < 2 {
 			return value.NewNull()
 		}
-		ts := args[0].AsInt
+		ts := args[0].Int()
 		structDef, ok := args[1].Obj.(*value.ObjStruct)
 		if !ok {
 			return value.NewNull()
@@ -172,43 +172,43 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) < 2 {
 			return value.NewInt(0)
 		}
-		ts1 := args[0].AsInt
-		ts2 := args[1].AsInt
+		ts1 := args[0].Int()
+		ts2 := args[1].Int()
 		return value.NewInt(ts1 - ts2)
 	})
 	vm.DefineNative("time_add_days", func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewInt(0)
 		}
-		ts := args[0].AsInt
-		days := args[1].AsInt
+		ts := args[0].Int()
+		days := args[1].Int()
 		return value.NewInt(ts + (days * 86400))
 	})
 	vm.DefineNative("time_before", func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewBool(false)
 		}
-		return value.NewBool(args[0].AsInt < args[1].AsInt)
+		return value.NewBool(args[0].Int() < args[1].Int())
 	})
 	vm.DefineNative("time_after", func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewBool(false)
 		}
-		return value.NewBool(args[0].AsInt > args[1].AsInt)
+		return value.NewBool(args[0].Int() > args[1].Int())
 	})
 	vm.DefineNative("time_is_leap_year", func(args []value.Value) value.Value {
 		if len(args) < 1 {
 			return value.NewBool(false)
 		}
-		year := args[0].AsInt
+		year := args[0].Int()
 		return value.NewBool(year%4 == 0 && (year%100 != 0 || year%400 == 0))
 	})
 	vm.DefineNative("time_days_in_month", func(args []value.Value) value.Value {
 		if len(args) < 2 {
 			return value.NewInt(0)
 		}
-		year := int(args[0].AsInt)
-		month := time.Month(args[1].AsInt)
+		year := int(args[0].Int())
+		month := time.Month(args[1].Int())
 		// Trick: go to next month day 0
 		t := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC)
 		return value.NewInt(int64(t.Day()))
@@ -217,7 +217,7 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) < 1 {
 			return value.NewString("")
 		}
-		wd := time.Weekday(args[0].AsInt)
+		wd := time.Weekday(args[0].Int())
 
 		names := []string{
 			"Domingo", "Segunda-feira", "Terça-feira", "Quarta-feira",
@@ -232,7 +232,7 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) < 1 {
 			return value.NewString("")
 		}
-		m := time.Month(args[0].AsInt)
+		m := time.Month(args[0].Int())
 		names := map[time.Month]string{
 			time.January: "Janeiro", time.February: "Fevereiro", time.March: "Março",
 			time.April: "Abril", time.May: "Maio", time.June: "Junho",
@@ -254,12 +254,12 @@ func (vm *VM) defineTimeBuiltins() {
 		}
 		fmtStr := args[1].Obj.(string)
 
-		y := int(inst.Fields["year"].AsInt)
-		m := time.Month(inst.Fields["month"].AsInt)
-		d := int(inst.Fields["day"].AsInt)
-		h := int(inst.Fields["hour"].AsInt)
-		min := int(inst.Fields["minute"].AsInt)
-		s := int(inst.Fields["second"].AsInt)
+		y := int(inst.Fields["year"].Int())
+		m := time.Month(inst.Fields["month"].Int())
+		d := int(inst.Fields["day"].Int())
+		h := int(inst.Fields["hour"].Int())
+		min := int(inst.Fields["minute"].Int())
+		s := int(inst.Fields["second"].Int())
 		// t := time.Date(y, m, d, h, min, s, 0, time.Local) // Unused in this simple implementation
 
 		// Simplified replacement for strftime
@@ -334,16 +334,16 @@ func (vm *VM) defineTimeBuiltins() {
 		if len(args) < 2 {
 			return value.NewInt(0)
 		}
-		ts := args[0].AsInt
-		secs := args[1].AsInt
+		ts := args[0].Int()
+		secs := args[1].Int()
 		return value.NewInt(ts + secs)
 	})
 	vm.DefineNative("time_diff_duration", func(args []value.Value) value.Value {
 		if len(args) < 3 {
 			return value.NewNull()
 		}
-		ts1 := args[0].AsInt
-		ts2 := args[1].AsInt
+		ts1 := args[0].Int()
+		ts2 := args[1].Int()
 		structDef, ok := args[2].Obj.(*value.ObjStruct)
 		if !ok {
 			return value.NewNull()

--- a/internal/vm/call_static_test.go
+++ b/internal/vm/call_static_test.go
@@ -16,7 +16,7 @@ func double(n: int) -> int
 end
 test_report(double(21))
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 42 {
+	if result.Type != value.VAL_INT || result.Int() != 42 {
 		t.Fatalf("esperado 42, obtido %s", result.String())
 	}
 }
@@ -83,7 +83,7 @@ op = dec
 let b: int = op(10)
 test_report(a * 100 + b)
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 1109 {
+	if result.Type != value.VAL_INT || result.Int() != 1109 {
 		t.Fatalf("esperado 1109 (11*100+9), obtido %s", result.String())
 	}
 }

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -195,7 +195,7 @@ func (vm *VM) copyValue(v value.Value) value.Value {
 			value.Retain(val) // RC: filho ganha dono duravel no clone
 			newFields[k] = val
 		}
-		return value.Value{Type: value.VAL_OBJ, Obj: &value.ObjInstance{Struct: obj.Struct, Fields: newFields}}
+		return value.NewInstanceAdopting(obj.Struct, newFields) // RC: move — retidos acima
 	default:
 		return v
 	}

--- a/internal/vm/compiler_warnings_module_test.go
+++ b/internal/vm/compiler_warnings_module_test.go
@@ -16,7 +16,7 @@ func TestModuleCompileWarningsGoToStderr(t *testing.T) {
 	stderr := captureConcurrencyStderr(t, func() {
 		stdout = captureConcurrencyStdout(t, func() {
 			got := captureVMSourceAtRoot(t, root, "use avisos\ntest_report(1)\n")
-			if got.AsInt != 1 {
+			if got.Int() != 1 {
 				t.Errorf("programa nao rodou ate o fim: %v", got)
 			}
 		})

--- a/internal/vm/constant_pool_overflow_test.go
+++ b/internal/vm/constant_pool_overflow_test.go
@@ -39,8 +39,8 @@ func TestGlobalResolutionSurvivesLargeConstantPool(t *testing.T) {
 	if captured.Type != value.VAL_INT {
 		t.Fatalf("test_report value = %#v, want int", captured)
 	}
-	if captured.AsInt != 111222 {
-		t.Fatalf("first*1000+last = %d, want 111222 (first or last resolved to the wrong global)", captured.AsInt)
+	if captured.Int() != 111222 {
+		t.Fatalf("first*1000+last = %d, want 111222 (first or last resolved to the wrong global)", captured.Int())
 	}
 }
 
@@ -60,7 +60,7 @@ func TestPropertyAccessSurvivesLargeConstantPool(t *testing.T) {
 	body.WriteString("test_report(target.value)\n")
 
 	captured := captureVMSource(t, body.String())
-	if captured.Type != value.VAL_INT || captured.AsInt != 778 {
+	if captured.Type != value.VAL_INT || captured.Int() != 778 {
 		t.Fatalf("target.value = %#v, want 778", captured)
 	}
 }
@@ -81,7 +81,7 @@ func TestFunctionCallSurvivesLargeConstantPool(t *testing.T) {
 	body.WriteString("test_report(first_fn() * 1000 + last_fn())\n")
 
 	captured := captureVMSource(t, body.String())
-	if captured.Type != value.VAL_INT || captured.AsInt != 111222 {
+	if captured.Type != value.VAL_INT || captured.Int() != 111222 {
 		t.Fatalf("first_fn()*1000+last_fn() = %#v, want 111222", captured)
 	}
 }

--- a/internal/vm/cow_equality_test.go
+++ b/internal/vm/cow_equality_test.go
@@ -145,7 +145,7 @@ func main()
 end
 main()
 `)
-			if got.Type != value.VAL_BOOL || got.AsBool != tc.want {
+			if got.Type != value.VAL_BOOL || got.Bool() != tc.want {
 				t.Fatalf("%s: %s = %v, esperado %v", tc.name, tc.expr, got, tc.want)
 			}
 		})
@@ -182,7 +182,7 @@ func main()
 end
 main()
 `)
-			if got.Type != value.VAL_BOOL || got.AsBool != tc.want {
+			if got.Type != value.VAL_BOOL || got.Bool() != tc.want {
 				t.Fatalf("%s: %s = %v, esperado %v", tc.name, tc.expr, got, tc.want)
 			}
 		})

--- a/internal/vm/cow_nested_container_test.go
+++ b/internal/vm/cow_nested_container_test.go
@@ -42,7 +42,7 @@ func assertIntRows(t *testing.T, got value.Value, want [][]int64) {
 			t.Fatalf("linha %d: %s, want %v", i, row.String(), want[i])
 		}
 		for j, cell := range cells {
-			if cell.Type != value.VAL_INT || cell.AsInt != want[i][j] {
+			if cell.Type != value.VAL_INT || cell.Int() != want[i][j] {
 				t.Fatalf("linha %d: %s, want %v", i, row.String(), want[i])
 			}
 		}

--- a/internal/vm/defer_test.go
+++ b/internal/vm/defer_test.go
@@ -68,7 +68,7 @@ func TestInvokePreparedCallDoesNotCopyArgumentsAgainAndRestoresStack(t *testing.
 	if received.Obj != prepared.Arguments[0].Obj {
 		t.Fatal("prepared dispatch copied argument a second time")
 	}
-	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+	if machine.stackTop != base || machine.stack[0].Int() != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
 	for i := base; i < base+2; i++ {
@@ -95,7 +95,7 @@ func TestInvokePreparedConstructorClearsAllTemporarySlots(t *testing.T) {
 	if err := machine.invokePreparedCall(prepared); err != nil {
 		t.Fatalf("invoke prepared constructor: %v", err)
 	}
-	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+	if machine.stackTop != base || machine.stack[0].Int() != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
 	for i := base; i < base+3; i++ {
@@ -122,7 +122,7 @@ func TestInvokePreparedClosureClearsAllTemporarySlots(t *testing.T) {
 	if err := machine.invokePreparedCall(prepared); err != nil {
 		t.Fatalf("invoke prepared closure: %v", err)
 	}
-	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+	if machine.stackTop != base || machine.stack[0].Int() != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
 	for i := base; i < base+2; i++ {
@@ -149,7 +149,7 @@ func TestInvokePreparedCallRestoresStackAfterNativeFailure(t *testing.T) {
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("error=%v, want wrapped cleanup failure", err)
 	}
-	if machine.stackTop != base || machine.stack[0].AsInt != 42 {
+	if machine.stackTop != base || machine.stack[0].Int() != 42 {
 		t.Fatalf("stackTop=%d stack[0]=%v, want restored base %d", machine.stackTop, machine.stack[0], base)
 	}
 	for i := base; i < base+2; i++ {

--- a/internal/vm/dynamic_boundary_test.go
+++ b/internal/vm/dynamic_boundary_test.go
@@ -108,7 +108,7 @@ func TestZerosWithRuntimeSizeBuildsZeroFilledArray(t *testing.T) {
 		t.Fatalf("zeros(3) = %s, want 3 elementos", got.String())
 	}
 	for i, cell := range cells {
-		if cell.Type != value.VAL_INT || cell.AsInt != 0 {
+		if cell.Type != value.VAL_INT || cell.Int() != 0 {
 			t.Fatalf("zeros(3)[%d] = %s, want 0", i, cell.String())
 		}
 	}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -139,7 +139,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if condition.Type != value.VAL_BOOL {
 				return vm.runtimeError(c, ip, "condition must be bool, got %s", runtimeTypeName(condition))
 			}
-			if !condition.AsBool {
+			if !condition.Bool() {
 				ip += offset
 			}
 
@@ -150,7 +150,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if condition.Type != value.VAL_BOOL {
 				return vm.runtimeError(c, ip, "condition must be bool, got %s", runtimeTypeName(condition))
 			}
-			if condition.AsBool {
+			if condition.Bool() {
 				ip += offset
 			}
 
@@ -166,7 +166,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt < vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() < vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -174,7 +174,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt <= vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() <= vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -182,7 +182,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt > vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() > vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -190,7 +190,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt >= vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() >= vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -198,7 +198,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt == vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() == vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -206,7 +206,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			offset := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			vm.stackTop -= 2
-			if vm.stack[vm.stackTop].AsInt != vm.stack[vm.stackTop+1].AsInt {
+			if vm.stack[vm.stackTop].Int() != vm.stack[vm.stackTop+1].Int() {
 				ip += offset
 			}
 
@@ -218,7 +218,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			slot := c.Code[ip]
 			delta := int8(c.Code[ip+1])
 			ip += 2
-			vm.stack[frame.LocalBase+int(slot)].AsInt += int64(delta)
+			slotValue := &vm.stack[frame.LocalBase+int(slot)]
+			slotValue.SetInt(slotValue.Int() + int64(delta))
 
 		case chunk.OP_TRUE:
 			vm.push(value.NewBool(true))
@@ -471,7 +472,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 						if idx.Type != value.VAL_INT {
 							return vm.runtimeError(c, ip, "array index must be integer")
 						}
-						arrayIndex := int(idx.AsInt)
+						arrayIndex := int(idx.Int())
 						if arrayIndex < 0 || arrayIndex >= len(collection.Elements) {
 							return vm.runtimeError(c, ip, "array index out of bounds")
 						}
@@ -549,7 +550,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				if idx.Type != value.VAL_INT {
 					return vm.runtimeError(c, ip, "array index must be integer")
 				}
-				arrayIndex := int(idx.AsInt)
+				arrayIndex := int(idx.Int())
 				if arrayIndex < 0 || arrayIndex >= len(array.Elements) {
 					return vm.runtimeError(c, ip, "array index out of bounds")
 				}
@@ -661,14 +662,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt + b.AsInt))
+				vm.push(value.NewInt(a.Int() + b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(a.AsFloat + b.AsFloat))
+				vm.push(value.NewFloat(a.Float() + b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(float64(a.AsInt) + b.AsFloat))
+				vm.push(value.NewFloat(float64(a.Int()) + b.Float()))
 
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				vm.push(value.NewFloat(a.AsFloat + float64(b.AsInt)))
+				vm.push(value.NewFloat(a.Float() + float64(b.Int())))
 			} else if a.Type == value.VAL_OBJ && b.Type == value.VAL_OBJ {
 				// Check if both are strings
 				strA, okA := a.Obj.(string)
@@ -693,99 +694,99 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// result replaces a (at stackTop-2)
 			// b (at stackTop-1) is cleared
 			// stackTop decrements by 1
-			vm.stack[vm.stackTop-2] = value.NewInt(vm.stack[vm.stackTop-2].AsInt + vm.stack[vm.stackTop-1].AsInt)
+			vm.stack[vm.stackTop-2] = value.NewInt(vm.stack[vm.stackTop-2].Int() + vm.stack[vm.stackTop-1].Int())
 			vm.stack[vm.stackTop-1] = value.Value{}
 			vm.stackTop--
 
 		case chunk.OP_ADD_FLOAT:
 			// Espelho float de OP_ADD_INT: sem zerar, escalar nao carrega ponteiro.
-			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat + vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].Float() + vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 
 		case chunk.OP_SUBTRACT:
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt - b.AsInt))
+				vm.push(value.NewInt(a.Int() - b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(a.AsFloat - b.AsFloat))
+				vm.push(value.NewFloat(a.Float() - b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(float64(a.AsInt) - b.AsFloat))
+				vm.push(value.NewFloat(float64(a.Int()) - b.Float()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				vm.push(value.NewFloat(a.AsFloat - float64(b.AsInt)))
+				vm.push(value.NewFloat(a.Float() - float64(b.Int())))
 			} else {
 				return vm.runtimeError(c, ip, "operands must be numbers")
 			}
 		case chunk.OP_SUB_INT:
 			b := vm.pop()
 			a := vm.pop()
-			vm.push(value.NewInt(a.AsInt - b.AsInt))
+			vm.push(value.NewInt(a.Int() - b.Int()))
 		case chunk.OP_SUB_FLOAT:
 			// Espelho float de OP_SUB_INT.
-			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat - vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].Float() - vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 		case chunk.OP_MULTIPLY:
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt * b.AsInt))
+				vm.push(value.NewInt(a.Int() * b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(a.AsFloat * b.AsFloat))
+				vm.push(value.NewFloat(a.Float() * b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(float64(a.AsInt) * b.AsFloat))
+				vm.push(value.NewFloat(float64(a.Int()) * b.Float()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				vm.push(value.NewFloat(a.AsFloat * float64(b.AsInt)))
+				vm.push(value.NewFloat(a.Float() * float64(b.Int())))
 			} else {
 				return vm.runtimeError(c, ip, "operands must be numbers")
 			}
 		case chunk.OP_MUL_INT:
 			b := vm.pop()
 			a := vm.pop()
-			vm.push(value.NewInt(a.AsInt * b.AsInt))
+			vm.push(value.NewInt(a.Int() * b.Int()))
 		case chunk.OP_MUL_FLOAT:
 			// Espelho float de OP_MUL_INT.
-			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat * vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].Float() * vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 		case chunk.OP_DIVIDE:
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				if b.AsInt == 0 {
+				if b.Int() == 0 {
 					return vm.runtimeError(c, ip, "division by zero")
 				}
-				vm.push(value.NewInt(a.AsInt / b.AsInt))
+				vm.push(value.NewInt(a.Int() / b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				if b.AsFloat == 0 {
+				if b.Float() == 0 {
 					return vm.runtimeError(c, ip, "division by zero")
 				}
-				vm.push(value.NewFloat(a.AsFloat / b.AsFloat))
+				vm.push(value.NewFloat(a.Float() / b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				if b.AsFloat == 0 {
+				if b.Float() == 0 {
 					return vm.runtimeError(c, ip, "division by zero")
 				}
-				vm.push(value.NewFloat(float64(a.AsInt) / b.AsFloat))
+				vm.push(value.NewFloat(float64(a.Int()) / b.Float()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				if b.AsInt == 0 {
+				if b.Int() == 0 {
 					return vm.runtimeError(c, ip, "division by zero")
 				}
-				vm.push(value.NewFloat(a.AsFloat / float64(b.AsInt)))
+				vm.push(value.NewFloat(a.Float() / float64(b.Int())))
 			} else {
 				return vm.runtimeError(c, ip, "operands must be numbers")
 			}
 		case chunk.OP_DIV_INT:
 			b := vm.pop()
 			a := vm.pop()
-			if b.AsInt == 0 {
+			if b.Int() == 0 {
 				return vm.runtimeError(c, ip, "division by zero")
 			}
-			vm.push(value.NewInt(a.AsInt / b.AsInt))
+			vm.push(value.NewInt(a.Int() / b.Int()))
 		case chunk.OP_DIV_FLOAT:
 			// Mesma mensagem de erro do ramo float de OP_DIVIDE (generico):
 			// divisor 0.0 e erro de runtime, nao +Inf/NaN.
-			if vm.stack[vm.stackTop-1].AsFloat == 0 {
+			if vm.stack[vm.stackTop-1].Float() == 0 {
 				return vm.runtimeError(c, ip, "division by zero")
 			}
-			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].AsFloat / vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewFloat(vm.stack[vm.stackTop-2].Float() / vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 		case chunk.OP_LEN:
 			val := vm.pop()
@@ -826,7 +827,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// Top is CaseN_Mode.
 			// Iterating i from count-1 down to 0:
 			for i := count - 1; i >= 0; i-- {
-				mode := vm.pop().AsInt
+				mode := vm.pop().Int()
 				val := vm.pop()
 				chVal := vm.pop()
 
@@ -883,17 +884,17 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				if b.AsInt == 0 {
+				if b.Int() == 0 {
 					return vm.runtimeError(c, ip, "modulo by zero")
 				}
-				vm.push(value.NewInt(a.AsInt % b.AsInt))
+				vm.push(value.NewInt(a.Int() % b.Int()))
 			} else {
 				return vm.runtimeError(c, ip, "operands for %% must be integers")
 			}
 		case chunk.OP_MOD_INT:
 			// Inline pop/pop/push
-			b := vm.stack[vm.stackTop-1].AsInt
-			a := vm.stack[vm.stackTop-2].AsInt
+			b := vm.stack[vm.stackTop-1].Int()
+			a := vm.stack[vm.stackTop-2].Int()
 			if b == 0 {
 				return vm.runtimeError(c, ip, "modulo by zero")
 			}
@@ -905,7 +906,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt & b.AsInt))
+				vm.push(value.NewInt(a.Int() & b.Int()))
 			} else if a.Type == value.VAL_BYTES && b.Type == value.VAL_BYTES {
 				sA := a.Obj.(string)
 				sB := b.Obj.(string)
@@ -925,7 +926,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt | b.AsInt))
+				vm.push(value.NewInt(a.Int() | b.Int()))
 			} else if a.Type == value.VAL_BYTES && b.Type == value.VAL_BYTES {
 				sA := a.Obj.(string)
 				sB := b.Obj.(string)
@@ -945,7 +946,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewInt(a.AsInt ^ b.AsInt))
+				vm.push(value.NewInt(a.Int() ^ b.Int()))
 			} else if a.Type == value.VAL_BYTES && b.Type == value.VAL_BYTES {
 				sA := a.Obj.(string)
 				sB := b.Obj.(string)
@@ -964,7 +965,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_BIT_NOT:
 			a := vm.pop()
 			if a.Type == value.VAL_INT {
-				vm.push(value.NewInt(^a.AsInt))
+				vm.push(value.NewInt(^a.Int()))
 			} else if a.Type == value.VAL_BYTES {
 				sA := a.Obj.(string)
 				res := make([]byte, len(sA))
@@ -980,10 +981,10 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				if b.AsInt < 0 {
+				if b.Int() < 0 {
 					return vm.runtimeError(c, ip, "negative shift count")
 				}
-				vm.push(value.NewInt(a.AsInt << uint64(b.AsInt)))
+				vm.push(value.NewInt(a.Int() << uint64(b.Int())))
 			} else {
 				return vm.runtimeError(c, ip, "operands for << must be integers")
 			}
@@ -992,26 +993,26 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				if b.AsInt < 0 {
+				if b.Int() < 0 {
 					return vm.runtimeError(c, ip, "negative shift count")
 				}
-				vm.push(value.NewInt(a.AsInt >> uint64(b.AsInt)))
+				vm.push(value.NewInt(a.Int() >> uint64(b.Int())))
 			} else {
 				return vm.runtimeError(c, ip, "operands for >> must be integers")
 			}
 		case chunk.OP_NEGATE:
 			v := vm.pop()
 			if v.Type == value.VAL_INT {
-				vm.push(value.NewInt(-v.AsInt))
+				vm.push(value.NewInt(-v.Int()))
 			} else if v.Type == value.VAL_FLOAT {
-				vm.push(value.NewFloat(-v.AsFloat))
+				vm.push(value.NewFloat(-v.Float()))
 			} else {
 				return vm.runtimeError(c, ip, "operand must be number")
 			}
 		case chunk.OP_NOT:
 			v := vm.pop()
 			if v.Type == value.VAL_BOOL {
-				vm.push(value.NewBool(!v.AsBool))
+				vm.push(value.NewBool(!v.Bool()))
 			} else {
 				return vm.runtimeError(c, ip, "operand must be boolean")
 			}
@@ -1020,7 +1021,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if countVal.Type != value.VAL_INT {
 				return vm.runtimeError(c, ip, "zeros size must be integer")
 			}
-			count := int(countVal.AsInt)
+			count := int(countVal.Int())
 			if count < 0 {
 				// Sem o guard, make() panica no lado Go (makeslice: len out
 				// of range) e o panic atravessa a VM — fora do alcance de
@@ -1038,7 +1039,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if countVal.Type != value.VAL_INT {
 				return vm.runtimeError(c, ip, "array size must be integer")
 			}
-			count := int(countVal.AsInt)
+			count := int(countVal.Int())
 			if count < 0 {
 				return vm.runtimeError(c, ip, "array size must be non-negative, got %d", count)
 			}
@@ -1053,13 +1054,13 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewBool(a.AsInt > b.AsInt))
+				vm.push(value.NewBool(a.Int() > b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewBool(a.AsFloat > b.AsFloat))
+				vm.push(value.NewBool(a.Float() > b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewBool(float64(a.AsInt) > b.AsFloat))
+				vm.push(value.NewBool(float64(a.Int()) > b.Float()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				vm.push(value.NewBool(a.AsFloat > float64(b.AsInt)))
+				vm.push(value.NewBool(a.Float() > float64(b.Int())))
 			} else if strA, strB, ok := stringOperands(a, b); ok {
 				// Ordenacao lexicografica byte a byte — para UTF-8 valido
 				// (invariante de toda string Noxy) coincide com a ordem por
@@ -1072,22 +1073,22 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_GREATER_INT:
 			b := vm.pop()
 			a := vm.pop()
-			vm.push(value.NewBool(a.AsInt > b.AsInt))
+			vm.push(value.NewBool(a.Int() > b.Int()))
 		case chunk.OP_GREATER_FLOAT:
 			// Espelho float de OP_GREATER_INT.
-			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat > vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].Float() > vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 		case chunk.OP_LESS:
 			b := vm.pop()
 			a := vm.pop()
 			if a.Type == value.VAL_INT && b.Type == value.VAL_INT {
-				vm.push(value.NewBool(a.AsInt < b.AsInt))
+				vm.push(value.NewBool(a.Int() < b.Int()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewBool(a.AsFloat < b.AsFloat))
+				vm.push(value.NewBool(a.Float() < b.Float()))
 			} else if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-				vm.push(value.NewBool(float64(a.AsInt) < b.AsFloat))
+				vm.push(value.NewBool(float64(a.Int()) < b.Float()))
 			} else if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-				vm.push(value.NewBool(a.AsFloat < float64(b.AsInt)))
+				vm.push(value.NewBool(a.Float() < float64(b.Int())))
 			} else if strA, strB, ok := stringOperands(a, b); ok {
 				// Mesma ordenacao lexicografica de OP_GREATER; `>=`/`<=`
 				// compilam como NOT(OP_LESS)/NOT(OP_GREATER) e herdam isto.
@@ -1097,12 +1098,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 		case chunk.OP_LESS_INT:
 			// Inline pop/pop/push
-			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsInt < vm.stack[vm.stackTop-1].AsInt)
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].Int() < vm.stack[vm.stackTop-1].Int())
 			vm.stack[vm.stackTop-1] = value.Value{}
 			vm.stackTop--
 		case chunk.OP_LESS_FLOAT:
 			// Espelho float de OP_LESS_INT.
-			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].AsFloat < vm.stack[vm.stackTop-1].AsFloat)
+			vm.stack[vm.stackTop-2] = value.NewBool(vm.stack[vm.stackTop-2].Float() < vm.stack[vm.stackTop-1].Float())
 			vm.stackTop--
 		case chunk.OP_EQUAL:
 			b := vm.pop()
@@ -1120,7 +1121,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_EQUAL_INT:
 			b := vm.pop()
 			a := vm.pop()
-			vm.push(value.NewBool(a.AsInt == b.AsInt))
+			vm.push(value.NewBool(a.Int() == b.Int()))
 		case chunk.OP_CALL:
 			argCount := int(c.Code[ip])
 			ip++
@@ -1318,7 +1319,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 
 				var key interface{}
 				if keyVal.Type == value.VAL_INT {
-					key = keyVal.AsInt
+					key = keyVal.Int()
 				} else if keyVal.Type == value.VAL_OBJ {
 					if str, ok := keyVal.Obj.(string); ok {
 						key = str
@@ -1379,7 +1380,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					if indexVal.Type != value.VAL_INT {
 						return vm.runtimeError(c, ip, "array index must be integer")
 					}
-					idx := int(indexVal.AsInt)
+					idx := int(indexVal.Int())
 					if idx < 0 || idx >= len(arr.Elements) {
 						return vm.runtimeError(c, ip, "array index out of bounds")
 					}
@@ -1388,7 +1389,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
 					var key interface{}
 					if indexVal.Type == value.VAL_INT {
-						key = indexVal.AsInt
+						key = indexVal.Int()
 					} else if indexVal.Type == value.VAL_OBJ {
 						if str, ok := indexVal.Obj.(string); ok {
 							key = str
@@ -1411,7 +1412,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					if indexVal.Type != value.VAL_INT {
 						return vm.runtimeError(c, ip, "string index must be integer")
 					}
-					idx := int(indexVal.AsInt)
+					idx := int(indexVal.Int())
 					runes := []rune(str) // Expensive but correct for now
 					if idx < 0 || idx >= len(runes) {
 						return vm.runtimeError(c, ip, "string index out of bounds")
@@ -1426,7 +1427,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				if indexVal.Type != value.VAL_INT {
 					return vm.runtimeError(c, ip, "bytes index must be integer")
 				}
-				idx := int(indexVal.AsInt)
+				idx := int(indexVal.Int())
 				if idx < 0 || idx >= len(str) {
 					return vm.runtimeError(c, ip, "bytes index out of bounds")
 				}
@@ -1445,7 +1446,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					if indexVal.Type != value.VAL_INT {
 						return vm.runtimeError(c, ip, "array index must be integer")
 					}
-					idx := int(indexVal.AsInt)
+					idx := int(indexVal.Int())
 					if idx < 0 || idx >= len(arr.Elements) {
 						return vm.runtimeError(c, ip, "array index out of bounds")
 					}
@@ -1466,7 +1467,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
 					var key interface{}
 					if indexVal.Type == value.VAL_INT {
-						key = indexVal.AsInt
+						key = indexVal.Int()
 					} else if indexVal.Type == value.VAL_OBJ {
 						if str, ok := indexVal.Obj.(string); ok {
 							key = str
@@ -1730,7 +1731,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					if indexVal.Type != value.VAL_INT {
 						return vm.runtimeError(c, ip, "array index must be integer")
 					}
-					idx := int(indexVal.AsInt)
+					idx := int(indexVal.Int())
 					if idx < 0 || idx >= len(arr.Elements) {
 						return vm.runtimeError(c, ip, "array index out of bounds")
 					}

--- a/internal/vm/float_ops_test.go
+++ b/internal/vm/float_ops_test.go
@@ -27,8 +27,8 @@ test_report(mandel_step(-0.5, 0.25))
 	if result.Type != value.VAL_FLOAT {
 		t.Fatalf("esperado float, obtido %s", result.String())
 	}
-	if math.IsNaN(result.AsFloat) || math.IsInf(result.AsFloat, 0) {
-		t.Fatalf("resultado invalido: %v", result.AsFloat)
+	if math.IsNaN(result.Float()) || math.IsInf(result.Float(), 0) {
+		t.Fatalf("resultado invalido: %v", result.Float())
 	}
 	// Valor exato: 10 iteracoes de z = z^2+c a partir de z=0, c=-0.5+0.25i,
 	// reproduzidas em float64 puro (Python e Go concordam bit a bit — ver
@@ -37,8 +37,8 @@ test_report(mandel_step(-0.5, 0.25))
 	// (ex.: OP_MUL_FLOAT calculando a-b) passaria pela suite sem detectar,
 	// desde que o resultado continuasse sendo um float finito.
 	const want = 0x1.76b0f0f446e8ep-03
-	if result.AsFloat != want {
-		t.Fatalf("resultado incorreto: got %v (%x), want %v (%x)", result.AsFloat, result.AsFloat, want, want)
+	if result.Float() != want {
+		t.Fatalf("resultado incorreto: got %v (%x), want %v (%x)", result.Float(), result.Float(), want, want)
 	}
 }
 

--- a/internal/vm/fused_jump_test.go
+++ b/internal/vm/fused_jump_test.go
@@ -43,15 +43,15 @@ func runFusedJump(t *testing.T, op chunk.OpCode, a, b int64) (jumped bool) {
 	switch machine.stackTop {
 	case 2: // closure + marcador: saltou e pousou exatamente certo
 		top := machine.stack[1]
-		if top.Type != value.VAL_INT || top.AsInt != 888 {
+		if top.Type != value.VAL_INT || top.Int() != 888 {
 			t.Fatalf("pouso do salto incorreto: top=%s", top.String())
 		}
 		return true
 	case 3: // closure + sentinela + marcador: nao saltou
 		sentinelTop := machine.stack[1]
 		markerTop := machine.stack[2]
-		if sentinelTop.Type != value.VAL_INT || sentinelTop.AsInt != 777 ||
-			markerTop.Type != value.VAL_INT || markerTop.AsInt != 888 {
+		if sentinelTop.Type != value.VAL_INT || sentinelTop.Int() != 777 ||
+			markerTop.Type != value.VAL_INT || markerTop.Int() != 888 {
 			t.Fatalf("pilha inesperada (nao saltou): sentinela=%s marcador=%s", sentinelTop.String(), markerTop.String())
 		}
 		return false
@@ -106,7 +106,7 @@ while i < 5 do
 end
 test_report(acc)
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 7 {
+	if result.Type != value.VAL_INT || result.Int() != 7 {
 		t.Fatalf("esperado 7 (fib 0..4 = 0+1+1+2+3), obtido %s", result.String())
 	}
 }
@@ -132,11 +132,11 @@ end
 test_report(f(%d, %d))
 `
 	trueCase := captureVMSource(t, fmt.Sprintf(source, 1, 2))
-	if trueCase.Type != value.VAL_INT || trueCase.AsInt != 10 {
+	if trueCase.Type != value.VAL_INT || trueCase.Int() != 10 {
 		t.Fatalf("esperado 10 (a<b), obtido %s", trueCase.String())
 	}
 	falseCase := captureVMSource(t, fmt.Sprintf(source, 2, 1))
-	if falseCase.Type != value.VAL_INT || falseCase.AsInt != 0 {
+	if falseCase.Type != value.VAL_INT || falseCase.Int() != 0 {
 		t.Fatalf("esperado 0 (a>=b), obtido %s", falseCase.String())
 	}
 }

--- a/internal/vm/global_cache_test.go
+++ b/internal/vm/global_cache_test.go
@@ -21,7 +21,7 @@ x = 2
 let second: int = get()
 test_report(first * 10 + second)
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 12 {
+	if result.Type != value.VAL_INT || result.Int() != 12 {
 		t.Fatalf("esperado 12 (first=1, second=2), obtido %s", result.String())
 	}
 }
@@ -45,14 +45,14 @@ func TestGlobalCacheKeyedByEnvironment(t *testing.T) {
 	if err := machine.InterpretWithEnvironment(code, envA); err != nil {
 		t.Fatalf("vm error (envA): %v", err)
 	}
-	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 1 {
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.Int() != 1 {
 		t.Fatalf("envA: esperado 1, obtido %s", got.String())
 	}
 
 	if err := machine.InterpretWithEnvironment(code, envB); err != nil {
 		t.Fatalf("vm error (envB): %v", err)
 	}
-	if got := machine.stack[1]; got.Type != value.VAL_INT || got.AsInt != 2 {
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.Int() != 2 {
 		t.Fatalf("envB: cache vazou o valor do envA — esperado 2, obtido %s", got.String())
 	}
 }

--- a/internal/vm/http_parser_framing_test.go
+++ b/internal/vm/http_parser_framing_test.go
@@ -14,7 +14,7 @@ func captureParserInt(t *testing.T, body string) int64 {
 	if captured.Type != value.VAL_INT {
 		t.Fatalf("test_report value = %#v, want int", captured)
 	}
-	return captured.AsInt
+	return captured.Int()
 }
 
 func captureParserString(t *testing.T, body string) string {
@@ -32,7 +32,7 @@ func captureParserBool(t *testing.T, body string) bool {
 	if captured.Type != value.VAL_BOOL {
 		t.Fatalf("test_report value = %#v, want bool", captured)
 	}
-	return captured.AsBool
+	return captured.Bool()
 }
 
 func TestFindHeaderEndFromResumesScan(t *testing.T) {

--- a/internal/vm/http_server_framing_test.go
+++ b/internal/vm/http_server_framing_test.go
@@ -18,7 +18,7 @@ func captureServerInt(t *testing.T, body string) int64 {
 	if captured.Type != value.VAL_INT {
 		t.Fatalf("test_report value = %#v, want int", captured)
 	}
-	return captured.AsInt
+	return captured.Int()
 }
 
 func captureServerBool(t *testing.T, body string) bool {
@@ -27,7 +27,7 @@ func captureServerBool(t *testing.T, body string) bool {
 	if captured.Type != value.VAL_BOOL {
 		t.Fatalf("test_report value = %#v, want bool", captured)
 	}
-	return captured.AsBool
+	return captured.Bool()
 }
 
 func TestNewServerInstallsDefaults(t *testing.T) {
@@ -180,7 +180,7 @@ test_report(ok)`, port, payloadSize)
 	if interpretErr := interpretVMSourceWithinBound(t, machine, source); interpretErr != nil {
 		t.Fatal(interpretErr)
 	}
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("send_all = %#v, want true", captured)
 	}
 
@@ -246,7 +246,7 @@ test_report(ok)`, port)
 		t.Fatal(interpretErr)
 	}
 	<-closed
-	if captured.Type != value.VAL_BOOL || captured.AsBool {
+	if captured.Type != value.VAL_BOOL || captured.Bool() {
 		t.Fatalf("send_all = %#v, want false", captured)
 	}
 }
@@ -282,7 +282,7 @@ func startNoxyHTTPServer(t *testing.T, handlerBody string, config string) *noxyH
 	machine.DefineNative("harness_ready", func(args []value.Value) value.Value {
 		port := 0
 		if len(args) == 1 {
-			port = int(args[0].AsInt)
+			port = int(args[0].Int())
 		}
 		ready <- port
 		return value.NewNull()

--- a/internal/vm/inc_local_test.go
+++ b/internal/vm/inc_local_test.go
@@ -29,7 +29,7 @@ func TestIncLocalInt(t *testing.T) {
 		t.Fatalf("vm error: %v", err)
 	}
 	got := machine.stack[1]
-	if got.Type != value.VAL_INT || got.AsInt != 7 {
+	if got.Type != value.VAL_INT || got.Int() != 7 {
 		t.Fatalf("esperado slot=7, obtido %s", got.String())
 	}
 }
@@ -50,7 +50,7 @@ func count() -> int
 end
 test_report(count())
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 10080 {
+	if result.Type != value.VAL_INT || result.Int() != 10080 {
 		t.Fatalf("esperado 10080 (i=10, downs=80), obtido %s", result.String())
 	}
 }
@@ -78,7 +78,7 @@ func make() -> int
 end
 test_report(make())
 `)
-	if result.Type != value.VAL_INT || result.AsInt != 7 {
+	if result.Type != value.VAL_INT || result.Int() != 7 {
 		t.Fatalf("esperado 7 (closure deve ver escrita pos-captura via fusao), obtido %s", result.String())
 	}
 }

--- a/internal/vm/inline_guard_test.go
+++ b/internal/vm/inline_guard_test.go
@@ -51,6 +51,32 @@ func TestPushStaysInlinedInsideRun(t *testing.T) {
 		t.Errorf("push foi inlinada em %d call sites de executor.go, esperado >= %d (custo reportado: %d)", inlined, minPushInlineSitesInRun, cost)
 	}
 
+	// pop e a segunda operacao mais quente; na forma de sempre custava 22 e
+	// nao era inlinada em NENHUM dos ~84 sites de run(). A atribuicao dupla
+	// com resultado nomeado (stack.go) faz o mesmo trabalho em 18 nos —
+	// issue #37, "extra barato".
+	popCostPattern := regexp.MustCompile(`can inline \(\*VM\)\.pop with cost (\d+)`)
+	popMatch := popCostPattern.FindStringSubmatch(report)
+	if popMatch == nil {
+		t.Fatalf("o compilador nao inlina (*VM).pop de jeito nenhum — procure por 'cannot inline (*VM).pop' na saida de `go build -gcflags=-m=2 ./internal/vm`")
+	}
+	popCost, popConvErr := strconv.Atoi(popMatch[1])
+	if popConvErr != nil {
+		t.Fatalf("custo de inline ilegivel em %q: %v", popMatch[0], popConvErr)
+	}
+	if popCost > inlineBigFunctionMaxCost {
+		t.Errorf("pop tem custo de inline %d, maximo %d para ser inlinada dentro de run() — tire nos do corpo de pop (ver o comentario em stack.go)", popCost, inlineBigFunctionMaxCost)
+	}
+	popInlined := 0
+	for _, line := range strings.Split(report, "\n") {
+		if strings.Contains(line, "executor.go") && strings.Contains(line, "inlining call to (*VM).pop") {
+			popInlined++
+		}
+	}
+	if popInlined < minPopInlineSitesInRun {
+		t.Errorf("pop foi inlinada em %d call sites de executor.go, esperado >= %d (custo reportado: %d)", popInlined, minPopInlineSitesInRun, popCost)
+	}
+
 	// ensureCallCapacity (calls.go) e chamada em call()/callPreparedClosure, que
 	// NAO sao "big function" (calls.go fica bem abaixo de 5000 nos de AST), entao
 	// o orcamento de inline aqui e o normal (80), nao os 20 de dentro de run().
@@ -125,6 +151,10 @@ const inlineNormalMaxCost = 80
 // e sobre "push continua inlinada dentro de run()", nao sobre a contagem
 // exata, que muda quando opcodes sao acrescentados ou removidos.
 const minPushInlineSitesInRun = 100
+
+// minPopInlineSitesInRun e uma margem sob os ~84 call sites de pop em
+// executor.go (mesma logica de minPushInlineSitesInRun).
+const minPopInlineSitesInRun = 70
 
 // minEnsureCallCapacityInlineSitesInCalls e uma margem sob o unico call site
 // de hoje (call(), calls.go).

--- a/internal/vm/inline_guard_test.go
+++ b/internal/vm/inline_guard_test.go
@@ -82,6 +82,35 @@ func TestPushStaysInlinedInsideRun(t *testing.T) {
 	}
 }
 
+// Retain e Release (internal/value/cow.go) embutem ownersOf e sao inlinados
+// nos sites de internal/vm fora de run() (ownSlot, bindOwnedSlot, calls.go…)
+// com o orcamento normal de 80. A fase 2 de perf (issue #37) reescreveu
+// ownersOf com caminho rapido pela dica kind; este teste garante que o corpo
+// novo nao tirou os dois do inline.
+func TestRetainReleaseStayInlinable(t *testing.T) {
+	build := exec.Command("go", "build", "-gcflags=-m=2", "../value")
+	output, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build -gcflags=-m=2 ../value failed: %v\n%s", err, output)
+	}
+	report := string(output)
+	for _, name := range []string{"Retain", "Release"} {
+		pattern := regexp.MustCompile(`can inline ` + name + ` with cost (\d+)`)
+		match := pattern.FindStringSubmatch(report)
+		if match == nil {
+			t.Errorf("o compilador nao inlina value.%s — procure por 'cannot inline %s' em `go build -gcflags=-m=2 ./internal/value`", name, name)
+			continue
+		}
+		cost, convErr := strconv.Atoi(match[1])
+		if convErr != nil {
+			t.Fatalf("custo ilegivel em %q: %v", match[0], convErr)
+		}
+		if cost > inlineNormalMaxCost {
+			t.Errorf("value.%s tem custo de inline %d, maximo %d — enxugue ownersOf (ver cow.go)", name, cost, inlineNormalMaxCost)
+		}
+	}
+}
+
 // inlineBigFunctionMaxCost espelha a constante homonima do compilador
 // (cmd/compile/internal/inline): o orcamento por callee dentro de uma funcao
 // grande como run().

--- a/internal/vm/json_strict.go
+++ b/internal/vm/json_strict.go
@@ -33,14 +33,14 @@ func (t *strictJSONTraversal) convert(input value.Value) (interface{}, error) {
 	case value.VAL_NULL:
 		return nil, nil
 	case value.VAL_BOOL:
-		return input.AsBool, nil
+		return input.Bool(), nil
 	case value.VAL_INT:
-		return input.AsInt, nil
+		return input.Int(), nil
 	case value.VAL_FLOAT:
-		if math.IsNaN(input.AsFloat) || math.IsInf(input.AsFloat, 0) {
+		if math.IsNaN(input.Float()) || math.IsInf(input.Float(), 0) {
 			return nil, errJSONNonFinite
 		}
-		return input.AsFloat, nil
+		return input.Float(), nil
 	case value.VAL_OBJ:
 		switch object := input.Obj.(type) {
 		case string:

--- a/internal/vm/loop_break_test.go
+++ b/internal/vm/loop_break_test.go
@@ -15,7 +15,7 @@ func traceVMSource(t *testing.T, source string) []int64 {
 	trace := []int64{}
 	machine.DefineNative("test_trace", func(args []value.Value) value.Value {
 		if len(args) != 0 {
-			trace = append(trace, args[0].AsInt)
+			trace = append(trace, args[0].Int())
 		}
 		return value.NewNull()
 	})

--- a/internal/vm/module_cache_test.go
+++ b/internal/vm/module_cache_test.go
@@ -61,7 +61,7 @@ func TestModuleCacheRetriesFailedLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("result=%v, want 42", got)
 	}
 	if calls.Load() != 2 {

--- a/internal/vm/module_encoding_test.go
+++ b/internal/vm/module_encoding_test.go
@@ -59,7 +59,7 @@ func TestModuleSourceWithAccentedCharactersLoadsNormally(t *testing.T) {
 		t.Fatalf("accented module export=%T, want *value.ObjMap", imported.Obj)
 	}
 	answer, ok := exports.Get("answer")
-	if !ok || answer.Type != value.VAL_INT || answer.AsInt != 42 {
+	if !ok || answer.Type != value.VAL_INT || answer.Int() != 42 {
 		t.Fatalf("accented module answer=%v, want int 42", answer)
 	}
 	greeting, ok := exports.Get("greeting")

--- a/internal/vm/module_exports_test.go
+++ b/internal/vm/module_exports_test.go
@@ -667,7 +667,7 @@ func TestModuleVariableAssignmentViaNamespaceIsCompileError(t *testing.T) {
 		t.Fatalf("error=%v", err)
 	}
 	reported, err := runModuleProgram(t, root, "use calc\ncalc.push()\ntest_report(calc.sp)\n")
-	if err != nil || reported.AsInt != 1 {
+	if err != nil || reported.Int() != 1 {
 		t.Fatalf("live read via namespace: %v / %v", reported, err)
 	}
 }
@@ -687,7 +687,7 @@ let calc: P = P(1)
 calc.x = 2
 test_report(calc.x)
 `)
-	if err != nil || reported.AsInt != 2 {
+	if err != nil || reported.Int() != 2 {
 		t.Fatalf("global let shadowing namespace: %v / %v", reported, err)
 	}
 }

--- a/internal/vm/module_struct_fields_test.go
+++ b/internal/vm/module_struct_fields_test.go
@@ -33,7 +33,7 @@ end
 let w: Wrapper = mk()
 test_report(w.listener.fd)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_INT || captured.AsInt != -1 {
+	if captured.Type != value.VAL_INT || captured.Int() != -1 {
 		t.Fatalf("w.listener.fd = %#v, want -1", captured)
 	}
 }
@@ -45,7 +45,7 @@ func TestHttpServerConstructorWorks(t *testing.T) {
 let s: HttpServer = new_server("127.0.0.1", 8080)
 test_report(s.port)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_INT || captured.AsInt != 8080 {
+	if captured.Type != value.VAL_INT || captured.Int() != 8080 {
 		t.Fatalf("s.port = %#v, want 8080", captured)
 	}
 }
@@ -63,7 +63,7 @@ let sock: Socket = Socket(7, "", 0, true)
 let w: Wrapper = Wrapper(sock)
 test_report(w.listener.fd)`
 	captured := captureVMSource(t, source)
-	if captured.Type != value.VAL_INT || captured.AsInt != 7 {
+	if captured.Type != value.VAL_INT || captured.Int() != 7 {
 		t.Fatalf("w.listener.fd = %#v, want 7", captured)
 	}
 }

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -229,7 +229,7 @@ func TestTypedNativeShallowCopiesOrdinaryComposite(t *testing.T) {
 	if !ok {
 		t.Fatal("missing values global")
 	}
-	if got := global.Obj.(*value.ObjArray).Elements[0].AsInt; got != 1 {
+	if got := global.Obj.(*value.ObjArray).Elements[0].Int(); got != 1 {
 		t.Fatalf("caller value=%d, want 1", got)
 	}
 }
@@ -280,12 +280,12 @@ func TestJSONLoadsUsesModuleFrameGlobals(t *testing.T) {
 	}
 	jsonLoads := jsonLoadsValue.Obj.(*value.ObjNative)
 	result, err := jsonLoads.Invoke(machine, []value.Value{value.NewString(`{"answer":42}`), target})
-	if err != nil || result.Type != value.VAL_BOOL || !result.AsBool {
+	if err != nil || result.Type != value.VAL_BOOL || !result.Bool() {
 		t.Fatal("module-frame global target was rejected")
 	}
 	moduleTarget, _ = moduleEnvironment.GetLocal("target")
 	got := requireTestMapValue(t, moduleTarget.Obj.(*value.ObjMap), "answer")
-	if got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("module target=%v, want answer=42", moduleTarget)
 	}
 	if _, leaked := machine.GetGlobal("target"); leaked {
@@ -409,7 +409,7 @@ func TestPopulateTargetSupportsCompatibleAndNullScalarReplacement(t *testing.T) 
 		if !populateTarget(New(), target, float64(42)) {
 			t.Fatal("null target rejected dynamic scalar replacement")
 		}
-		if stored.Type != value.VAL_INT || stored.AsInt != 42 {
+		if stored.Type != value.VAL_INT || stored.Int() != 42 {
 			t.Fatalf("stored=%v, want int 42", stored)
 		}
 	})
@@ -467,7 +467,7 @@ if ok then
 else
     test_report(0)
 end`)
-		if got.Type != value.VAL_INT || got.AsInt != int64(9223372036854775807) {
+		if got.Type != value.VAL_INT || got.Int() != int64(9223372036854775807) {
 			t.Fatalf("got=%v, want MaxInt64", got)
 		}
 	})
@@ -766,11 +766,11 @@ func TestPopulateTargetRetainsCompatibleCompositeFields(t *testing.T) {
 		t.Fatal("compatible composite fields were rejected")
 	}
 	items := fields["items"].Obj.(*value.ObjArray)
-	if len(items.Elements) != 1 || items.Elements[0].Type != value.VAL_INT || items.Elements[0].AsInt != 42 {
+	if len(items.Elements) != 1 || items.Elements[0].Type != value.VAL_INT || items.Elements[0].Int() != 42 {
 		t.Fatalf("items=%v, want [42]", fields["items"])
 	}
 	metadata := fields["metadata"].Obj.(*value.ObjMap)
-	if got := requireTestMapValue(t, metadata, "answer"); got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got := requireTestMapValue(t, metadata, "answer"); got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("metadata=%v, want answer=42", fields["metadata"])
 	}
 }
@@ -2315,7 +2315,7 @@ test_report(length(sliced) * 10 + length(generated))`
 	machine := New()
 	results := make([]int64, 0, 2)
 	machine.DefineNative("test_report", func(args []value.Value) value.Value {
-		results = append(results, args[0].AsInt)
+		results = append(results, args[0].Int())
 		return value.NewNull()
 	})
 	for i := 0; i < 2; i++ {

--- a/internal/vm/network_poller.go
+++ b/internal/vm/network_poller.go
@@ -562,7 +562,7 @@ func validateNetworkPollArguments(args []value.Value) ([3]*value.ObjArray, time.
 	if args[3].Type != value.VAL_INT {
 		return sets, 0, fmt.Errorf("network poll timeout must be an int")
 	}
-	milliseconds := args[3].AsInt
+	milliseconds := args[3].Int()
 	if milliseconds < 0 {
 		return sets, 0, fmt.Errorf("network poll timeout must be non-negative")
 	}

--- a/internal/vm/network_poller_integration_test.go
+++ b/internal/vm/network_poller_integration_test.go
@@ -119,7 +119,7 @@ func TestNetworkPollIntegrationRepeatedListenerPollsPreservePendingAccept(t *tes
 	machine := New()
 	cleanupNetworkResources(t, machine)
 	listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-	listenerFD := int(builtinMapField(t, listener, "fd").AsInt)
+	listenerFD := int(builtinMapField(t, listener, "fd").Int())
 	resource, exists := machine.shared.Listeners.get(listenerFD)
 	if !exists {
 		t.Fatalf("listener descriptor %d is not registered", listenerFD)
@@ -153,7 +153,7 @@ func TestNetworkPollIntegrationDuplicateOccurrencesPreserveOrder(t *testing.T) {
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 	callBuiltinWithinBound(t, machine, "net_send", client, value.NewBytes("x"))
-	handle := int(builtinMapField(t, server, "fd").AsInt)
+	handle := int(builtinMapField(t, server, "fd").Int())
 	first := socketValue(handle, "first occurrence", 0, true)
 	second := socketValue(handle, "second occurrence", 0, true)
 
@@ -309,7 +309,7 @@ func TestNetworkPollIntegrationCloseWakesAndOmitsLocalResource(t *testing.T) {
 		machine := New()
 		cleanupNetworkResources(t, machine)
 		listener := callBuiltinWithinBound(t, machine, "net_listen", value.NewString("127.0.0.1"), value.NewInt(0))
-		handle := int(builtinMapField(t, listener, "fd").AsInt)
+		handle := int(builtinMapField(t, listener, "fd").Int())
 		resource, exists := machine.shared.Listeners.get(handle)
 		if !exists {
 			t.Fatalf("listener descriptor %d is not registered", handle)

--- a/internal/vm/network_poller_linux_test.go
+++ b/internal/vm/network_poller_linux_test.go
@@ -26,7 +26,7 @@ func TestLinuxNetworkPollDataAndReadHangupCoexistWithoutConsumption(t *testing.T
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
-	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientHandle := int(builtinMapField(t, client, "fd").Int())
 	clientResource, exists := machine.shared.Sockets.get(clientHandle)
 	if !exists {
 		t.Fatalf("client descriptor %d is not registered", clientHandle)
@@ -43,7 +43,7 @@ func TestLinuxNetworkPollDataAndReadHangupCoexistWithoutConsumption(t *testing.T
 		t.Fatal(err)
 	}
 
-	serverHandle := int(builtinMapField(t, server, "fd").AsInt)
+	serverHandle := int(builtinMapField(t, server, "fd").Int())
 	serverResource, exists := machine.shared.Sockets.get(serverHandle)
 	if !exists {
 		t.Fatalf("server descriptor %d is not registered", serverHandle)
@@ -97,7 +97,7 @@ func TestNetworkPollIntegrationLinuxResetCopiesTerminalEventAndPreservesPendingE
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
-	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientHandle := int(builtinMapField(t, client, "fd").Int())
 	clientResource, exists := machine.shared.Sockets.get(clientHandle)
 	if !exists {
 		t.Fatalf("client descriptor %d is not registered", clientHandle)

--- a/internal/vm/network_poller_test.go
+++ b/internal/vm/network_poller_test.go
@@ -196,7 +196,7 @@ func pollSets(read, write, networkErrors []value.Value) [3]*value.ObjArray {
 func resultSet(t *testing.T, result value.Value, name string) []value.Value {
 	t.Helper()
 	mapping := requireBuiltinMap(t, result)
-	count := requireTestMapValue(t, mapping, name+"_count").AsInt
+	count := requireTestMapValue(t, mapping, name+"_count").Int()
 	array := requireTestMapValue(t, mapping, name).Obj.(*value.ObjArray)
 	return array.Elements[:count]
 }
@@ -837,7 +837,7 @@ func requireTestMapFD(t *testing.T, socket value.Value) int64 {
 	t.Helper()
 	mapping := socket.Obj.(*value.ObjMap)
 	fd, _ := mapping.Get("fd")
-	return fd.AsInt
+	return fd.Int()
 }
 
 func TestNetworkPollerWriteOnlyListenerWaitsWithoutNativeDescriptor(t *testing.T) {

--- a/internal/vm/network_poller_windows_test.go
+++ b/internal/vm/network_poller_windows_test.go
@@ -377,7 +377,7 @@ func TestNetworkPollIntegrationWSAPollResetCopiesTerminalEventAndPreservesPendin
 	machine := New()
 	_, client, server := setupAcceptedLoopback(t, machine)
 
-	clientHandle := int(builtinMapField(t, client, "fd").AsInt)
+	clientHandle := int(builtinMapField(t, client, "fd").Int())
 	clientResource, exists := machine.shared.Sockets.get(clientHandle)
 	if !exists {
 		t.Fatalf("client descriptor %d is not registered", clientHandle)

--- a/internal/vm/qualified_struct_fields_test.go
+++ b/internal/vm/qualified_struct_fields_test.go
@@ -8,7 +8,7 @@ import (
 
 func assertReportedInt(t *testing.T, got value.Value, want int64) {
 	t.Helper()
-	if got.Type != value.VAL_INT || got.AsInt != want {
+	if got.Type != value.VAL_INT || got.Int() != want {
 		t.Fatalf("reported %#v, want int %d", got, want)
 	}
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1157,7 +1157,7 @@ main()`
 	if err := interpretVMSource(t, machine, src); err != nil {
 		t.Fatalf("programa falhou: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 200 {
+	if reported.Type != value.VAL_INT || reported.Int() != 200 {
 		t.Fatalf("programa incorreto: %#v", reported)
 	}
 	if n := CloneCountValue(); n > 8 {
@@ -1232,7 +1232,7 @@ main()`
 		t.Fatalf("programa falhou: %v", err)
 	}
 	// 2 nos restantes (0, 20) * 100 + valor removido (30).
-	if reported.Type != value.VAL_INT || reported.AsInt != 230 {
+	if reported.Type != value.VAL_INT || reported.Int() != 230 {
 		t.Fatalf("mutacao atraves do emprestimo ref se perdeu (clone indevido): esperado 230, veio %#v", reported)
 	}
 }
@@ -1302,7 +1302,7 @@ test_report(count(head_a) * 10 + count(head_b))`
 		t.Fatalf("programa falhou: %v", err)
 	}
 	// as duas listas encolhem de 3 para 2 nos: 2*10 + 2 = 22.
-	if reported.Type != value.VAL_INT || reported.AsInt != 22 {
+	if reported.Type != value.VAL_INT || reported.Int() != 22 {
 		t.Fatalf("mutacao atraves de emprestimo ref (global / capturado) se perdeu: esperado 22, veio %#v", reported)
 	}
 }
@@ -1418,7 +1418,7 @@ main()`
 	}
 	// 20 / 77 / 77 — ver o oraculo no comentario do teste (#50: `u` e ref
 	// legitima; `second` e copia independente).
-	if reported.Type != value.VAL_INT || reported.AsInt != 207777 {
+	if reported.Type != value.VAL_INT || reported.Int() != 207777 {
 		t.Fatalf("escrita vazou por dec a menos em slot/caixa emprestada: esperado 207777 (A=20 B=77 C=77), veio %#v", reported)
 	}
 }
@@ -1678,7 +1678,7 @@ main()`
 		t.Fatalf("programa falhou: %v", err)
 	}
 	// 20 / 20 / 77 / 77 — ver o oraculo no comentario do teste (#50).
-	if reported.Type != value.VAL_INT || reported.AsInt != 20207777 {
+	if reported.Type != value.VAL_INT || reported.Int() != 20207777 {
 		t.Fatalf("condicao de emprestimo saiu errada (esperado 20207777 = e/e2 20, f/f2 77), veio %#v", reported)
 	}
 }
@@ -1789,7 +1789,7 @@ main()`
 		}
 	}
 	// 0 + 77 + 30: a escrita via ref alcancou o no da lista.
-	if reported.Type != value.VAL_INT || reported.AsInt != 107 {
+	if reported.Type != value.VAL_INT || reported.Int() != 107 {
 		t.Fatalf("escrita via ref para no de dono unico deveria mutar no lugar (soma 107), veio %#v", reported)
 	}
 }
@@ -2554,7 +2554,7 @@ func defineWaitOwnersProbe(t *testing.T, machine *VM) {
 		if len(args) != 2 || args[1].Type != value.VAL_INT {
 			return value.NewBool(false)
 		}
-		want := int32(args[1].AsInt)
+		want := int32(args[1].Int())
 		const hold = 50 * time.Millisecond
 		deadline := time.Now().Add(statefulBuiltinTimeout)
 		for time.Now().Before(deadline) {
@@ -2654,7 +2654,7 @@ end`); err != nil {
 	}
 	// O MUT clonou (havia mais de um dono): a mutacao nao pode vazar para o
 	// array do chamador.
-	if got := m.Obj.(*value.ObjArray).Elements[0].AsInt; got != 1 {
+	if got := m.Obj.(*value.ObjArray).Elements[0].Int(); got != 1 {
 		t.Fatalf("mutacao dentro da task vazou para o chamador: esperado m[0]=1, veio %d", got)
 	}
 }
@@ -2713,7 +2713,7 @@ main()`
 	if err := interpretVMSource(t, machine, src); err != nil {
 		t.Fatalf("programa falhou: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+	if reported.Type != value.VAL_INT || reported.Int() != 1 {
 		t.Fatalf("rebind de parametro em task defer'd roubou dono de gb (-1 = wait_owners nao estabilizou em 2; 99 = mutacao vazou para arr): esperado 1, veio %#v", reported)
 	}
 }
@@ -2767,7 +2767,7 @@ main()`
 	if err := interpretVMSource(t, machine, src); err != nil {
 		t.Fatalf("programa falhou: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+	if reported.Type != value.VAL_INT || reported.Int() != 1 {
 		t.Fatalf("clone MUT de parametro em task defer'd roubou dono de gb (-1 = wait_owners nao estabilizou em 2; 99 = mutacao vazou para arr): esperado 1, veio %#v", reported)
 	}
 }
@@ -2812,7 +2812,7 @@ main()`
 	if err := interpretVMSource(t, machine, src); err != nil {
 		t.Fatalf("programa falhou: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+	if reported.Type != value.VAL_INT || reported.Int() != 1 {
 		t.Fatalf("controle da rota direta de spawn_task regrediu: esperado 1 (mutacao de gb clona, arr preservado), veio %#v", reported)
 	}
 }
@@ -2886,7 +2886,7 @@ main()`
 	if ownersC != ownersA {
 		t.Fatalf("par send-do-select/chan_recv nao fechou (esperado Owners=%d apos chan_recv, veio %d)", ownersA, ownersC)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 1 {
+	if reported.Type != value.VAL_INT || reported.Int() != 1 {
 		t.Fatalf("send do select sem retain: chan_recv descontou dono alheio e a mutacao vazou para keep: esperado 1, veio %#v", reported)
 	}
 }

--- a/internal/vm/ref_container_and_closure_test.go
+++ b/internal/vm/ref_container_and_closure_test.go
@@ -33,7 +33,7 @@ end
 main()
 `)
 	cells := semArray(t, got)
-	if len(cells) != 2 || cells[0].AsInt != 9 || cells[1].AsInt != 7 {
+	if len(cells) != 2 || cells[0].Int() != 9 || cells[1].Int() != 7 {
 		t.Fatalf("[p.x, a[1]] = %s, want [9, 7]", got.String())
 	}
 }
@@ -57,7 +57,7 @@ let x: int = 1
 fwd(ref x)
 test_report(x)
 `)
-	if got.Type != value.VAL_INT || got.AsInt != 2 {
+	if got.Type != value.VAL_INT || got.Int() != 2 {
 		t.Fatalf("x = %s, want 2", got.String())
 	}
 }
@@ -119,7 +119,7 @@ func outer() -> int
 end
 test_report(outer())
 `)
-	if got.Type != value.VAL_INT || got.AsInt != 11 {
+	if got.Type != value.VAL_INT || got.Int() != 11 {
 		t.Fatalf("closure aninhada devolveu %s, want 11", got.String())
 	}
 }

--- a/internal/vm/ref_equality_strict_runtime_test.go
+++ b/internal/vm/ref_equality_strict_runtime_test.go
@@ -25,8 +25,8 @@ func requireBoolResults(t *testing.T, src string, want []bool) {
 		t.Fatalf("esperava %d resultados, vieram %d", len(want), len(arr.Elements))
 	}
 	for i, expected := range want {
-		if arr.Elements[i].AsBool != expected {
-			t.Errorf("caso %d: esperava %v, veio %v", i, expected, arr.Elements[i].AsBool)
+		if arr.Elements[i].Bool() != expected {
+			t.Errorf("caso %d: esperava %v, veio %v", i, expected, arr.Elements[i].Bool())
 		}
 	}
 }
@@ -65,8 +65,8 @@ while cur != null do
     cur = cur.next
 end
 test_report(soma)`)
-	if got.AsInt != 3 {
-		t.Fatalf("travessia deveria somar 3, veio %d", got.AsInt)
+	if got.Int() != 3 {
+		t.Fatalf("travessia deveria somar 3, veio %d", got.Int())
 	}
 }
 

--- a/internal/vm/ref_operand_semantics_test.go
+++ b/internal/vm/ref_operand_semantics_test.go
@@ -36,7 +36,7 @@ end
 main()
 `)
 	cells := semArray(t, got)
-	if len(cells) != 2 || cells[0].AsInt != 1 || cells[1].AsInt != 2 {
+	if len(cells) != 2 || cells[0].Int() != 1 || cells[1].Int() != 2 {
 		t.Fatalf("[iterações, ramo do if] = %s, want [1, 2]", got.String())
 	}
 }
@@ -84,7 +84,7 @@ end
 main()
 `)
 	cells := semArray(t, got)
-	if len(cells) != 3 || cells[0].AsInt != 3 || cells[1].AsInt != 3 || cells[2].AsInt != 4 {
+	if len(cells) != 3 || cells[0].Int() != 3 || cells[1].Int() != 3 || cells[2].Int() != 4 {
 		t.Fatalf("[x após *rx = ry, x após y = 4, y] = %s, want [3, 3, 4]", got.String())
 	}
 }
@@ -106,7 +106,7 @@ main()
 	cells := semArray(t, got)
 	want := []int64{200, 10, 222, 30}
 	for i, cell := range cells {
-		if cell.Type != value.VAL_INT || cell.AsInt != want[i] {
+		if cell.Type != value.VAL_INT || cell.Int() != want[i] {
 			t.Fatalf("célula %d: got %s, want %d (tudo: %s)", i, cell.String(), want[i], got.String())
 		}
 	}

--- a/internal/vm/ref_slot_invariant_test.go
+++ b/internal/vm/ref_slot_invariant_test.go
@@ -39,7 +39,7 @@ func newCorruptingVM(t *testing.T) *VM {
 	})
 	machine.DefineNative("corrupt_ref_index", func(args []value.Value) value.Value {
 		array := args[0].Obj.(*value.ObjArray)
-		array.Elements[int(args[1].AsInt)] = args[2]
+		array.Elements[int(args[1].Int())] = args[2]
 		return value.NewNull()
 	})
 	machine.DefineNative("corrupt_ref_map", func(args []value.Value) value.Value {

--- a/internal/vm/reference_ownership_test.go
+++ b/internal/vm/reference_ownership_test.go
@@ -42,7 +42,7 @@ func TestModuleFrameGlobalReferenceCapturesSharedFallbackOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := moduleGlobals["captured"]
-	if got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("shared fallback=%v, want 42", got)
 	}
 }
@@ -53,7 +53,7 @@ func TestInterpretWithGlobalsUsesNonNilEmptyEnvironment(t *testing.T) {
 	if err := New().InterpretWithGlobals(code, globals); err != nil {
 		t.Fatal(err)
 	}
-	if got := globals["answer"]; got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got := globals["answer"]; got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("answer=%v", got)
 	}
 }
@@ -70,7 +70,7 @@ func TestModuleGlobalReferenceRetainsResolvedEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, _ := module.GetLocal("module")
-	if got.AsInt != 3 {
+	if got.Int() != 3 {
 		t.Fatalf("module value=%v", got)
 	}
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -10,7 +10,7 @@ import (
 func referenceMapKey(index value.Value) (interface{}, error) {
 	switch index.Type {
 	case value.VAL_INT:
-		return index.AsInt, nil
+		return index.Int(), nil
 	case value.VAL_OBJ:
 		if key, ok := index.Obj.(string); ok {
 			return key, nil
@@ -109,7 +109,7 @@ func (vm *VM) referenceStorage(ref *value.ObjRef) (stored value.Value, exists bo
 			if ref.Index.Type != value.VAL_INT {
 				return value.Value{}, false, nil, fmt.Errorf("array reference index must be integer")
 			}
-			index := int(ref.Index.AsInt)
+			index := int(ref.Index.Int())
 			if index < 0 || index >= len(array.Elements) {
 				return value.Value{}, false, nil, fmt.Errorf("Index out of bounds")
 			}

--- a/internal/vm/references_test.go
+++ b/internal/vm/references_test.go
@@ -111,13 +111,13 @@ func TestGlobalReferenceStorageUsesExplicitOwner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Type != value.VAL_INT || got.AsInt != 41 {
+	if got.Type != value.VAL_INT || got.Int() != 41 {
 		t.Fatalf("lookup=%v, want 41", got)
 	}
 	if err := machine.storeReferenceValue(value.Value{Type: value.VAL_REF, Obj: ref}, value.NewInt(42)); err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := environment.GetLocal("answer"); got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got, _ := environment.GetLocal("answer"); got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("stored value=%v, want 42", got)
 	}
 

--- a/internal/vm/set_property_declared_fields_test.go
+++ b/internal/vm/set_property_declared_fields_test.go
@@ -32,7 +32,7 @@ func TestSetPropertyThroughAnyRejectsUndeclaredField(t *testing.T) {
 func TestSetPropertyThroughAnyStillWritesDeclaredFields(t *testing.T) {
 	got := captureVMSource(t, dynamicBoundaryPrelude+"let p: any = Point(1, 2)\np.x = 9\nlet q: Point = Point(3, 4)\nlet r: ref Point = ref q\nlet a: any = r\na.y = 8\ntest_report([p.x, a.y])\n")
 	cells := semArray(t, got)
-	if len(cells) != 2 || cells[0].AsInt != 9 || cells[1].AsInt != 8 {
+	if len(cells) != 2 || cells[0].Int() != 9 || cells[1].Int() != 8 {
 		t.Fatalf("campos declarados devem continuar escrevendo: %v", got)
 	}
 }

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -233,11 +233,20 @@ func (vm *VM) growFrames() bool {
 	return true
 }
 
-func (vm *VM) pop() value.Value {
+// pop desempilha e zera o slot (solta a referencia para o GC). A FORMA do
+// corpo importa: a versao de sempre (`val := vm.stack[top]; vm.stack[top] =
+// value.Value{}; return val`) custa 22 no inliner e deixava pop fora do
+// inline em TODOS os ~84 sites de run() (orcamento 20 para callee de funcao
+// grande — ver push); a atribuicao dupla com resultado nomeado faz o mesmo
+// trabalho em 18 nos (um statement e uma declaracao a menos) e e inlinada em
+// ~80 sites. Variantes "obvias" sao piores: `slot.Obj = nil` via
+// `&vm.stack[top]` custa 26, limpar so Obj com duas indexacoes custa 23.
+// inline_guard_test.go trava custo e contagem de sites, como faz com push
+// (issue #37, "extra barato").
+func (vm *VM) pop() (val value.Value) {
 	vm.stackTop--
-	val := vm.stack[vm.stackTop]
-	vm.stack[vm.stackTop] = value.Value{} // Clear reference to help GC
-	return val
+	val, vm.stack[vm.stackTop] = vm.stack[vm.stackTop], value.Value{} // Clear reference to help GC
+	return
 }
 
 func (vm *VM) peek(distance int) value.Value {

--- a/internal/vm/stack.go
+++ b/internal/vm/stack.go
@@ -11,13 +11,13 @@ func valuesEqual(a, b value.Value) bool {
 	if a.Type == b.Type {
 		switch a.Type {
 		case value.VAL_BOOL:
-			return a.AsBool == b.AsBool
+			return a.Bool() == b.Bool()
 		case value.VAL_NULL:
 			return true
 		case value.VAL_INT:
-			return a.AsInt == b.AsInt
+			return a.Int() == b.Int()
 		case value.VAL_FLOAT:
-			return a.AsFloat == b.AsFloat
+			return a.Float() == b.Float()
 		case value.VAL_OBJ:
 			// CoW: compostos comparam estruturalmente (identidade de ponteiro
 			// ficou instável sob copy-on-write). Demais objetos (strings via
@@ -115,10 +115,10 @@ func valuesEqual(a, b value.Value) bool {
 
 	// Mixed types
 	if a.Type == value.VAL_INT && b.Type == value.VAL_FLOAT {
-		return float64(a.AsInt) == b.AsFloat
+		return float64(a.Int()) == b.Float()
 	}
 	if a.Type == value.VAL_FLOAT && b.Type == value.VAL_INT {
-		return a.AsFloat == float64(b.AsInt)
+		return a.Float() == float64(b.Int())
 	}
 
 	return false

--- a/internal/vm/stack_characterization_test.go
+++ b/internal/vm/stack_characterization_test.go
@@ -12,7 +12,7 @@ func TestLegacyConstantReaders(t *testing.T) {
 	machine.chunk.Constants = []value.Value{value.NewInt(7), value.NewInt(42)}
 	machine.chunk.Code = []byte{0, 1, 0, 1}
 	machine.ip = 0
-	if got := machine.readConstant(); got.AsInt != 7 {
+	if got := machine.readConstant(); got.Int() != 7 {
 		t.Fatalf("readConstant=%v", got)
 	}
 	machine.ip = 2

--- a/internal/vm/stack_growth_test.go
+++ b/internal/vm/stack_growth_test.go
@@ -16,7 +16,7 @@ func depth(n: int) -> int
     return 1 + depth(n - 1)
 end
 test_report(depth(10000))`)
-	if reported.Type != value.VAL_INT || reported.AsInt != 10000 {
+	if reported.Type != value.VAL_INT || reported.Int() != 10000 {
 		t.Fatalf("depth(10000) = %v, want 10000", reported)
 	}
 }
@@ -66,7 +66,7 @@ func run() -> int
     return contador
 end
 test_report(run())`)
-	if reported.Type != value.VAL_INT || reported.AsInt != 2 {
+	if reported.Type != value.VAL_INT || reported.Int() != 2 {
 		t.Fatalf("contador = %v, want 2", reported)
 	}
 }
@@ -96,7 +96,7 @@ end
 test_report(com_defer())`); err != nil {
 		t.Fatalf("vm error: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 3 {
+	if reported.Type != value.VAL_INT || reported.Int() != 3 {
 		t.Fatalf("reported=%v, want 3", reported)
 	}
 	if machine.frameCount != 0 || machine.currentFrame != nil {
@@ -187,7 +187,7 @@ func TestFunctionWithManyOperandsAndDeferRuns(t *testing.T) {
 	if err := interpretVMSource(t, machine, source); err != nil {
 		t.Fatalf("vm error: %v", err)
 	}
-	if reported.Type != value.VAL_INT || reported.AsInt != 400 {
+	if reported.Type != value.VAL_INT || reported.Int() != 400 {
 		t.Fatalf("reported=%v, want 400", reported)
 	}
 	if !limpou {

--- a/internal/vm/stdlib_hygiene_test.go
+++ b/internal/vm/stdlib_hygiene_test.go
@@ -206,7 +206,7 @@ test_report(r.ok)`, port)
 	if interpretErr != nil {
 		t.Fatal(interpretErr)
 	}
-	if captured.Type != value.VAL_BOOL || !captured.AsBool {
+	if captured.Type != value.VAL_BOOL || !captured.Bool() {
 		t.Fatalf("client request = %#v, want ok", captured)
 	}
 	if len(printed) != 0 {

--- a/internal/vm/string_ordering_test.go
+++ b/internal/vm/string_ordering_test.go
@@ -36,8 +36,8 @@ test_report([
 		t.Fatalf("esperava %d resultados, vieram %d", len(want), len(arr.Elements))
 	}
 	for i, expected := range want {
-		if arr.Elements[i].AsBool != expected {
-			t.Errorf("comparacao %d: esperava %v, veio %v", i, expected, arr.Elements[i].AsBool)
+		if arr.Elements[i].Bool() != expected {
+			t.Errorf("comparacao %d: esperava %v, veio %v", i, expected, arr.Elements[i].Bool())
 		}
 	}
 }
@@ -50,7 +50,7 @@ func TestStringOrderingDereferencesRefOperands(t *testing.T) {
 let s: string = "a"
 let r: ref string = ref s
 test_report(r < "b")`)
-	if !got.AsBool {
+	if !got.Bool() {
 		t.Fatal("ref string < string deveria comparar o valor apontado")
 	}
 }
@@ -61,7 +61,7 @@ func TestStringOrderingThroughAnyBoundary(t *testing.T) {
 	got := captureVMSource(t, `
 let a: any = "abc"
 test_report(a < "abd")`)
-	if !got.AsBool {
+	if !got.Bool() {
 		t.Fatal("any carregando string deveria ordenar lexicograficamente")
 	}
 }

--- a/internal/vm/task_execution_test.go
+++ b/internal/vm/task_execution_test.go
@@ -24,7 +24,7 @@ end`); err != nil {
 	}
 	child := NewWithShared(machine.shared, machine.Config)
 	got, err := child.executePreparedTaskCall(call)
-	if err != nil || got.Type != value.VAL_INT || got.AsInt != 42 {
+	if err != nil || got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("result=%v err=%v", got, err)
 	}
 }
@@ -256,7 +256,7 @@ end`), environment); err != nil {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Type != value.VAL_INT || got.AsInt != 42 {
+	if got.Type != value.VAL_INT || got.Int() != 42 {
 		t.Fatalf("result = %v, want 42", got)
 	}
 	if observedRoot != "caller-root" {

--- a/internal/vm/unwind_test.go
+++ b/internal/vm/unwind_test.go
@@ -12,7 +12,7 @@ func TestDeferredCallsRunLIFOOnExplicitReturn(t *testing.T) {
 	machine := New()
 	var order []int64
 	machine.DefineNative("record", func(args []value.Value) value.Value {
-		order = append(order, args[0].AsInt)
+		order = append(order, args[0].Int())
 		return value.NewNull()
 	})
 	captured := value.NewNull()
@@ -51,7 +51,7 @@ record(0)`, []int64{0, 2, 1}},
 		machine := New()
 		var order []int64
 		machine.DefineNative("record", func(args []value.Value) value.Value {
-			order = append(order, args[0].AsInt)
+			order = append(order, args[0].Int())
 			return value.NewNull()
 		})
 		if err := interpretVMSource(t, machine, test.source); err != nil {
@@ -94,7 +94,7 @@ func TestDeferredCallsRunAllAfterFailuresAndPreserveOrder(t *testing.T) {
 	secondFailure := errors.New("cleanup three failed")
 	var order []int64
 	machine.DefineContextualNative("cleanup", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
-		id := args[0].AsInt
+		id := args[0].Int()
 		order = append(order, id)
 		switch id {
 		case 2:
@@ -135,7 +135,7 @@ func TestRuntimeErrorRunsAllDeferredCalls(t *testing.T) {
 	machine := New()
 	var order []int64
 	machine.DefineNative("record", func(args []value.Value) value.Value {
-		order = append(order, args[0].AsInt)
+		order = append(order, args[0].Int())
 		return value.NewNull()
 	})
 

--- a/internal/vm/value_semantics_test.go
+++ b/internal/vm/value_semantics_test.go
@@ -11,7 +11,7 @@ import (
 
 func expectInt(t *testing.T, got value.Value, want int64, msg string) {
 	t.Helper()
-	if got.Type != value.VAL_INT || got.AsInt != want {
+	if got.Type != value.VAL_INT || got.Int() != want {
 		t.Fatalf("%s: esperado %d, veio %s (%v)", msg, want, got.String(), got.Type)
 	}
 }

--- a/internal/vm/vm_test.go
+++ b/internal/vm/vm_test.go
@@ -59,7 +59,7 @@ func TestRuntimeConditionOnAnyMustBeBool(t *testing.T) {
 		t.Fatalf("error=%v, want runtime bool check", err)
 	}
 	reported := captureVMSource(t, "let a: any = true\nlet n: int = 0\nif a then n = 1 end\ntest_report(n)\n")
-	if reported.AsInt != 1 {
+	if reported.Int() != 1 {
 		t.Fatalf("any bool condition should be taken, got %v", reported)
 	}
 }
@@ -86,16 +86,16 @@ func testExpectedObject(t *testing.T, expected interface{}, actual value.Value) 
 			t.Errorf("object is not Integer. got=%v (%+v)", actual.Type, actual)
 			return
 		}
-		if int(actual.AsInt) != expectedVal {
-			t.Errorf("object has wrong value. got=%d, want=%d", actual.AsInt, expectedVal)
+		if int(actual.Int()) != expectedVal {
+			t.Errorf("object has wrong value. got=%d, want=%d", actual.Int(), expectedVal)
 		}
 	case bool:
 		if actual.Type != value.VAL_BOOL {
 			t.Errorf("object is not Boolean. got=%v (%+v)", actual.Type, actual)
 			return
 		}
-		if actual.AsBool != expectedVal {
-			t.Errorf("object has wrong value. got=%t, want=%t", actual.AsBool, expectedVal)
+		if actual.Bool() != expectedVal {
+			t.Errorf("object has wrong value. got=%t, want=%t", actual.Bool(), expectedVal)
 		}
 	}
 }

--- a/internal/vm/zeros_test.go
+++ b/internal/vm/zeros_test.go
@@ -26,11 +26,11 @@ func TestZerosZeroSizeIsEmptyArray(t *testing.T) {
 
 func TestFixedArrayDeclarationDoesNotUseOperandStack(t *testing.T) {
 	reported := captureVMSource(t, "let buf: int[10000]\ntest_report(length(buf))\n")
-	if reported.Type != value.VAL_INT || reported.AsInt != 10000 {
+	if reported.Type != value.VAL_INT || reported.Int() != 10000 {
 		t.Fatalf("length = %v, want 10000", reported)
 	}
 	reported = captureVMSource(t, "let big: int[100000]\ntest_report(big[99999])\n")
-	if reported.Type != value.VAL_INT || reported.AsInt != 0 {
+	if reported.Type != value.VAL_INT || reported.Int() != 0 {
 		t.Fatalf("big[99999] = %v, want 0", reported)
 	}
 }
@@ -55,7 +55,7 @@ test_report(to_str(fs[1]) + "|" + ss[1] + "|" + to_str(bs[1]) + "|" + to_str(ps[
 // NAO pode aparecer em g[1].
 func TestFixedNestedArrayElementsAreIndependentUnderCoW(t *testing.T) {
 	reported := captureVMSource(t, "let g: int[3][3]\ng[0][0] = 1\ntest_report(g[1][0] + g[0][0] * 10)\n")
-	if reported.Type != value.VAL_INT || reported.AsInt != 10 {
+	if reported.Type != value.VAL_INT || reported.Int() != 10 {
 		t.Fatalf("g[1][0] + 10*g[0][0] = %v, want 10", reported)
 	}
 }


### PR DESCRIPTION
Refs #37 (estágios 1 e 2 + "extra barato" do `pop`; o estágio 3 continua em aberto lá — ver "Sobre o estágio 3" no fim).

## Summary
- **Estágio 1 — `value.Value` de 48 para 32 bytes**: tag `uint8`, um único `num uint64` para `int64`/bits de `float64`, `bool` no padding; acessores `Int()/Float()/Bool()` e `SetInt` (único escritor in-place: `OP_INC_LOCAL_INT`). Rename mecânico por script (487 sites, 81 arquivos). Pilha de operandos 96 KB → 64 KB.
- **Estágio 2 — header comum**: `ObjHeader{Owners}` embutido no **offset 0** de `ObjArray/ObjMap/ObjInstance` (layout travado por teste); dica `kind` carimbada pelos construtores de `internal/value` faz `ownersOf` sair em 1 comparação de byte para `string`/struct/RTI; compostos e `Value`s montados fora do pacote (`kind == 0`) seguem pelo type switch de sempre — **a dica nunca decide sozinha**, então carimbo ausente não vira under-count de RC. **Sem `unsafe`.** `calls.go` usa o novo `NewInstanceAdopting` no clone CoW.
- **Extra — `pop()` inlinada em `run()`**: achado de baseline que a issue não tinha — `pop` custava **22** no inliner e, com `run()` em regime de "big function" (orçamento 20), era **chamada real em todos os ~84 sites** (17 % flat no perfil de `fib`). A forma `val, vm.stack[top] = vm.stack[top], value.Value{}` com resultado nomeado faz o mesmo trabalho em **18** (79 sites inlinados). Commit separado (`ba7f85d`), descartável com `git revert` se você quiser só 1 e 2.
- **Guards executáveis novos**: `TestValueIs32Bytes`, `TestObjHeaderIsAtOffsetZero`, `TestOwnersOfReachesHeaderWithAndWithoutKindHint`, `TestReleaseSingleCompareMatchesRange`, `TestRetainReleaseStayInlinable` (≤ 80), e `pop` no `TestPushStaysInlinedInsideRun` (≤ 20, ≥ 70 sites).
- **Achado que mudou o desenho** (spec §3.2): a forma "switch no `kind` + type assertion por caso + caminho lento embutido" custa 73 e tira `Retain` (105) e `Release` (119) do inline (orçamento 80); uma chamada ao caminho lento custa 57. Embarcado: `ownersOf` 35, `Retain` 67, **`Release` 80 exato** (condição `uint32(current-1) >= ownersSaturation-1`, bordas travadas por teste).
- Versão **v0.14.3** (patch: perf interna, sem mudança de linguagem — me diga se preferir 0.15.0). CHANGELOG, README, AGENTS, spec, site, `version.go`.

## Impacto na performance (mediana de 9, intercalado, máquina sem outra carga — `benchmarks/RESULTS.md`)

| bench | v0.14.2 → fase 2 | s1 | s1+2 (passo) | pop (passo) |
|---|---|---|---|---|
| `fib` (cross) | **−17,7 %** (2,9x do CPython, antes 4,1x) | −10,0 % | −3,2 % | −5,6 % |
| `bubblesort` (cross) | **−24,0 %** | −11,5 % | −2,7 % | −11,7 % |
| `loop_arith` (cross) | **−20,2 %** | −3,6 % | −3,1 % | −14,6 % |
| `mandelbrot` / `string_ops` / `map_churn` (cross) | −15,4 % / −11,6 % / −6,6 % | | | |
| bench_call_readonly | **−27 a −33 %** (a regressão de +10 % da v0.14.1 some) | −11,7 % | +1,8 % | −19,0 % |
| bench_bubblesort / bench_call_ref | **−26 %** | −13 / −14 % | −3 / −0 % | −13 % |
| bench_path_update | **−27 a −31 %** | −5,7 % | −1,3 % | −25,5 % |
| bench_generic_vs_hand / share_mutate / conway | −19 % / −17 % / −15 % | | | |
| gates CoW (≤ +5 %): typed_call_map, share_mutate, call_light, conway | −1,3 / −16,8 / −8,0 / −15,2 % ✅ | | | |
| `startup`, benches no piso de processo | neutro / ruído | | | |

`BenchmarkNoxyCallOverhead`: 145,1 → 126,3 µs/op (−13 %). Microbench Go de `ownersOf` (type switch × dica × `unsafe`): ~4–5 ns/op nas três formas, indistinguíveis — a discriminação por tipo é grátis no `gc`; o custo do RC são os atômicos.

**Leitura:** a hipótese da issue ("fib 15–25 %") confirma; o estágio 1 entrega −10 a −14 % em chamada/array, o estágio 2 é ~ruído (−0,3 a −4,7 %), e o `pop` inlinado é o maior item isolado (−6 a −25 %). **Sobre o estágio 3** (pré-condição 1: "1+2 confirmam a tese"): confirmam pela metade — bytes viraram tempo, `ownersOf` não. Os 8 bytes restantes só pagariam pelo mecanismo do estágio 1, com 482 assertions a converter e boxing de string; indexação de array (ainda 5,5x do CPython) e o custo de chamada (`callPreparedClosure`/`finishFrame` = 26 % do perfil novo) parecem pagar mais.

## Components
- `internal/value/value.go` — `ValueType uint8`, `objKind`, struct `Value` (32 B), acessores, `ObjHeader`, construtores carimbam `kind`, `NewInstanceAdopting`
- `internal/value/cow.go` — `ownersOf` com saída antecipada pela dica; `Release` com comparação única (inline 80)
- `internal/value/environment.go` — `ExportMap` carimba `objKindMap`
- `internal/value/layout_test.go` (novo), `owners_test.go` — guards de layout/offset 0/caminhos/`Release`
- `internal/vm/stack.go` — `pop()` inlinável; `internal/vm/inline_guard_test.go` — guards de `pop`, `Retain`, `Release`
- `internal/vm/executor.go` — `OP_INC_LOCAL_INT` via `SetInt`; `internal/vm/calls.go` — clone CoW via `NewInstanceAdopting`
- 81 arquivos `*.go` — rename `.AsInt/.AsFloat/.AsBool` → `.Int()/.Float()/.Bool()`
- `docs/superpowers/specs/2026-08-22-vm-perf-fase2-value-layout-design.md`, `docs/superpowers/plans/2026-08-22-vm-perf-fase2-value-layout.md`
- `benchmarks/RESULTS.md` (seção nova no topo), `benchmarks/results/2026-08-22-issue-37-value-layout-raw.md` (dados brutos, carga por passo, script de 4 binários), `benchmarks/results/interleaved.md`, `benchmarks/cross_runtime/README.md` + `results/cross_runtime.md`
- `CHANGELOG.md`, `README.md`, `AGENTS.md`, `docs/NOXY_LANGUAGE_SPEC.md`, `docs/index.html`, `internal/version/version.go` — v0.14.3

## Test Plan
- [x] `go test ./...` verde (12 pacotes)
- [x] `go test -race ./internal/value ./internal/vm` verde (2,0 s / 69,7 s)
- [x] Corpus `noxy_examples/run_all_tests_concurrent.nx`: 177/177
- [x] Diff de saída base × head (`compare_examples.ps1`): 146 iguais, 0 divergentes
- [x] Guards de inline: `push` 20 (113 sites), `pop` 18 (79), `Retain` 67, `Release` 80; `Sizeof(Value) == 32`; `Offsetof(ObjHeader) == 0` nos três compostos
- [x] Cada estágio medido isoladamente (4 binários na mesma janela, mediana de 9) + headline pelo `interleaved_compare.ps1` + cross-runtime com CPython/Lua/Go + perfil de `fib` + `BenchmarkNoxyCallOverhead`
- [x] Gates CoW ≤ +5 %: todos negativos
- [x] Auditoria das leituras sem guarda de tipo: as 100 sinalizadas são natives cruas cujos wrappers da stdlib são tipados (só `time_sleep(1.5)` direto, tolerado pelo compilador, muda de "lê 0" para "lê bits" — documentado no CHANGELOG)
- [ ] Decisões tomadas sem consulta, para a review (spec §7): ordem 1 → 2 → pop; bool no próprio byte; dica `kind` como acelerador (nunca decisor), **sem `unsafe`**; `pop` incluído como commit separado; versão v0.14.3 (patch)
- [ ] Validar no workload real (NoxyDB) antes do release, como nas fases anteriores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
