### PR TITLE
perf/issue-66-typed-array-index - Indexação tipada de array (issue #66, item 1) — v0.15.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.14.3)
+**Versão**: 1.0 (Noxy VM 0.15.0)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [0.15.0] - 2026-08-22
+
+Indexação tipada de array (issue #66, item 1 do roadmap pós-fase 2). Nenhuma
+mudança de sintaxe, semântica, saída ou mensagem de erro — o compilador passa a
+emitir opcodes especializados onde já sabe que a base é `T[]`, e o VM executa
+o mesmo que antes com menos despacho, menos tráfego de pilha e, no caso do
+parâmetro `ref T[]`, sem a maquinaria genérica de resolução de referência.
+Corpus 177/177 e diff de saída base × head sem divergência. Números em
+`benchmarks/RESULTS.md` (seção do topo) e
+`benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md`.
+
+### Performance
+
+- **Seis opcodes novos, por append ao fim de `internal/chunk/chunk.go`**
+  (módulos cacheados continuam válidos): `OP_GET_INDEX_ARRAY` /
+  `OP_SET_INDEX_ARRAY_NORC` para base estaticamente `T[]` em posição genérica
+  (global, upvalue, nível de dentro de `a[i][j]`, índice com chamada);
+  `OP_GET_LOCAL_INDEX_ARRAY` / `OP_SET_LOCAL_INDEX_ARRAY_NORC` para local `T[]`
+  com índice (e valor) sintaticamente sem efeito colateral — o array vem do
+  slot, sem empilhar o seu `Value`; o for-each sobre array usa a mesma
+  leitura fundida; `OP_GET_REF_LOCAL_INDEX_ARRAY` / `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC`
+  para parâmetro `ref T[]`, que resolvem a caixa do ref com uma
+  `Upvalue.Load()` em vez de `referenceStorage` (um `defer`, uma closure
+  alocada e `reflect` por acesso). `NORC` = elemento `int/float/bool/string/bytes`:
+  pula `Retain`/`Release` só depois de conferir em runtime que o valor novo e o
+  velho não têm contador (`value.NeverTracked`) e que o array não é
+  `(ref T)[]`; composto vindo por `any`, array compartilhado (CoW clona como
+  antes) e qualquer container inesperado caem nos funis genéricos
+  (`getIndexGeneric`/`setIndexGeneric`, os corpos de `OP_GET_INDEX`/`OP_SET_INDEX`
+  extraídos em método) — mesmas mensagens, mesma linha.
+- **Resultado (mediana de 9, intercalado, v0.14.3 × v0.15.0):**
+  `bench_bubblesort` **−64,5 %**, `bench_call_ref` **−43,4 %**,
+  `bench_call_readonly` −12,1 %, `bench_path_update` −9,2 %, `bench_conway`
+  −3,7 %; gates CoW (`share_mutate`, `typed_call_map`, `call_light`,
+  `conway`) dentro de ±2 % em rodada focada; `bench_map_churn` −0,2 % (os
+  funis genéricos como chamada não aparecem). Cross-runtime (mínimo de 9,
+  tempo líquido): `bubblesort` 430,6 → **153,6 ms (0,36x; ÷ CPython 5,5x → 1,8x)**; `fib`/`loop_arith`/`mandelbrot`/
+  `map_churn`/`string_ops` entre 0,96x e 1,05x de v0.14.3 (ruído; A/B focado
+  de `map_churn` dá −6,5 %).
+- **Achado da rodada:** o primeiro desenho do fallback de leitura — re-despachar
+  o `case` genérico por `goto` dentro de `run()` — custou +10–14 % no despacho
+  genérico (`bench_generic_vs_hand`, laço sem indexação nenhuma): o rótulo e
+  o corpo extra mudaram o codegen do laço inteiro. Trocado por chamada a
+  `getIndexGeneric` antes do merge; o bench voltou ao ruído (+0,7 %).
+- **Guards novos** em `internal/vm/inline_guard_test.go`: `value.NeverTracked`
+  ≤ 20 e `arrayTagIsRefSlot` ≤ 20 (custa exatamente 20 — sem folga) inlinados
+  nos sites de `executor.go`; `push`/`pop` seguem ≤ 20 (121/85 sites).
+
+### Follow-ups observados (não entram nesta versão)
+
+- `length(x)` compila como chamada de builtin genérica (`callNative`) — 37 %
+  de `bench_call_readonly` é isso, não indexação; um `OP_LEN` estático quando
+  `length` não está sombreado é o próximo passo natural desse bench.
+- O custo restante do acesso via `ref T[]` é a `Upvalue.Load()` (RWMutex da
+  caixa, partilhada com tasks); `bubblesort` fica em ~1,8x do
+  CPython por causa dela.
+- `a[i][j] = v` mantém `OP_GET_INDEX_MUT` genérico no nível de fora;
+  elemento composto (`nodes[i] = n`) segue `OP_SET_INDEX`.
+
 ## [0.14.3] - 2026-08-22
 
 Fase 2 de performance do VM (issue #37, estágios 1 e 2 mais o "extra barato"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.14.3](https://img.shields.io/badge/noxy-0.14.3-blue)](CHANGELOG.md)
+[![noxy 0.15.0](https://img.shields.io/badge/noxy-0.15.0-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.14.3
+Noxy REPL v0.15.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,141 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## v0.14.3 (7eed082) × indexação tipada de array — v0.15.0 (perf/issue-66-typed-array-index, d870a02)
+
+**Data:** 2026-08-22 · Windows 11 · i7-1165G7 · protocolo intercalado, mediana
+de 9 (headline) e de 5 (por estágio), mínimo de 9 no cross-runtime. Máquina
+sem `go test` nem build durante as medições; CPU 4–11 % no início de cada
+passo. Seis binários compilados na mesma sessão (um por estágio, mais o head
+com e sem o `goto` — ver abaixo). Dados brutos, carga por passo, A/Bs focados,
+perfis e scripts em
+[`results/2026-08-22-issue-66-typed-arrays-raw.md`](results/2026-08-22-issue-66-typed-arrays-raw.md).
+Spec: `docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md`
+(issue #66, item 1). Scripts rodados com `pwsh -NoProfile -File`
+(`interleaved_compare.ps1` não parseia no Windows PowerShell 5.1 — UTF-8 sem BOM).
+
+O que mudou: seis opcodes anexados ao fim de `chunk.go` — `OP_GET_INDEX_ARRAY` /
+`OP_SET_INDEX_ARRAY_NORC` (base estaticamente `T[]` em posição genérica) e as
+formas fundidas por slot `OP_GET_LOCAL_INDEX_ARRAY` / `OP_SET_LOCAL_INDEX_ARRAY_NORC`
+(local `T[]`, inclusive o `$collection` do for-each) e `OP_GET_REF_LOCAL_INDEX_ARRAY` /
+`OP_SET_REF_LOCAL_INDEX_ARRAY_NORC` (parâmetro `ref T[]`, que resolve a caixa
+do ref com uma `Upvalue.Load()` em vez de `referenceStorage`). Caminho rápido
+grava o resultado no lugar na pilha; `NORC` pula `Retain`/`Release` só depois
+de conferir em runtime que valor novo e velho não têm contador
+(`value.NeverTracked`) e que o array não é `(ref T)[]`; container inesperado
+cai nos funis genéricos (`getIndexGeneric`/`setIndexGeneric`, os corpos de
+`OP_GET_INDEX`/`OP_SET_INDEX` extraídos em método). Formas fundidas só com
+índice (e valor) sintaticamente sem efeito colateral.
+
+**Verificação completa:** `go test ./...` verde (12 pacotes); `go test -race
+./internal/value ./internal/vm` verde; **corpus 177/177**
+(`run_all_tests_concurrent.nx`); **diff de saída base × head: 146 iguais, 0
+divergentes** (`compare_examples.ps1`); guards de inline verdes (`push` 20 /
+121 sites, `pop` 18 / 85 sites, `Retain` 67, `Release` 80, `NeverTracked` 10,
+`arrayTagIsRefSlot` 20 — sem folga, travado).
+
+### Headline — base × head (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | v0143_ms | typed_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_bubblesort | 3071,2 | 1089,4 | **−64,5 %** | ✅ (meta ≥ −30 %) |
+| bench_call_ref | 3010,6 | 1702,8 | **−43,4 %** | ✅ |
+| bench_call_readonly | 1018,9 | 895,5 | **−12,1 %** | ➖ meta era ≥ −30 %: 37 % desse bench é `callNative` (`length(data)` no `while`), não indexação |
+| bench_path_update | 495,1 | 449,6 | −9,2 % | ✅ |
+| bench_conway | 1871,3 | 1801,2 | −3,7 % | ✅ gate CoW (≤ +5 %) |
+| bench_map_churn | 408,7 | 408,0 | −0,2 % | ✅ (`setIndexGeneric`/`getIndexGeneric` como chamada: sem custo visível) |
+| bench_generic_vs_hand | 730,7 | 736,0 | +0,7 % | ✅ (era **+12,8 %** com o `goto redispatch`, ver abaixo) |
+| bench_spawn_sum | 668,7 | 677,0 | +1,2 % | ➖ ruído |
+| bench_share_mutate | 218,1 | 236,4 | +8,4 % | ✅ gate CoW: rodada focada de 15 dá **+1,6 %** (233,0 → 236,7; a base oscilou 265 → 218 entre rodadas) |
+| bench_typed_call_map | 151,7 | 149,1 | −1,7 % | ➖ piso¹ (gate CoW ok) |
+| bench_call_light | 130,7 | 128,6 | −1,6 % | ➖ piso¹ (gate CoW ok) |
+| bench_value_call_mutate | 139,6 | 140,9 | +0,9 % | ➖ piso¹ |
+
+¹ ~130 ms com piso de processo ~90 ms: não decidem nada (seção de 2026-08-22).
+
+### Por estágio — seis binários na mesma janela (mediana de 5)
+
+`s0` = só o VM (handlers, funis, rótulo `goto`; nada emitido) · `s1` = +
+formas genéricas tipadas · `s2` = + fundidas de local plano e for-each ·
+`s3goto` = + fundidas de `ref` (head com `goto`) · `s3` = head final (fallback
+de leitura por `getIndexGeneric`, sem rótulo). Delta contra `base`.
+
+| bench | s0 | s1 | s2 | s3goto | **s3** |
+|---|---|---|---|---|---|
+| bench_bubblesort | +2,2 % | −2,2 % | +0,8 % | −62,3 % | **−62,3 %** |
+| bench_call_ref | +0,6 % | −3,2 % | −5,5 % | −43,4 % | **−44,0 %** |
+| bench_call_readonly | +1,3 % | −4,1 % | −4,1 % | −5,0 % | **−12,2 %** |
+| bench_path_update | +6,5 % | −5,3 % | −9,4 % | −7,7 % | **−10,4 %** |
+| bench_conway | +0,8 % | −4,8 % | −1,0 % | −3,1 % | **−3,7 %** |
+| bench_map_churn | −4,1 % | −0,2 % | −3,1 % | +0,2 % | **−6,5 %** |
+| bench_generic_vs_hand | **+14,9 %** | +13,1 % | +12,9 % | +13,7 % | **+5,6 %**² |
+| bench_share_mutate | −4,9 % | −7,4 % | −6,9 % | −7,2 % | **+1,3 %** |
+| bench_spawn_sum | +2,1 % | +2,6 % | −5,1 % | −5,1 % | **+2,4 %** |
+
+² tempo de parede; pelo relógio interno do próprio bench (`GEN_MS+HAND_MS`,
+9 intercaladas) `s3` dá +1,3 % (623 → 631 ms) contra +14,6 % do `s3goto`
+(714 ms).
+
+### Cross-runtime (mínimo de 9, intercalado com CPython 3.13.1 / Lua 5.4.7 / Go 1.24.11)
+
+Tempo líquido (descontado o piso de `startup`, 96 ms nos dois Noxy) e razões;
+tabela completa em [`cross_runtime/results/cross_runtime.md`](cross_runtime/results/cross_runtime.md).
+
+| bench | v0.14.3 | v0.15.0 | v0.15.0 ÷ v0.14.3 | ÷ python (antes → agora) | ÷ lua |
+|---|---|---|---|---|---|
+| `bubblesort` | 430,6 | **153,6** | **0,36x** | 5,5x → **1,8x** | – |
+| `fib` | 322,0 | 309,9 | 0,96x | 2,9x → 2,5x | 5,9x |
+| `loop_arith` | 268,5 | 283,2 | 1,05x³ | 1,1x → 1,0x | 6,8x |
+| `mandelbrot` | 185,1 | 187,3 | 1,01x | 1,9x → 2,3x⁴ | – |
+| `map_churn` | 173,6 | 195,3 | 1,12x³ | 2,1x → 2,4x⁴ | – |
+| `string_ops` | 138,8 | 134,4 | 0,97x | 4,2x → 3,3x⁴ | – |
+
+³ A/B focado de 11 intercaladas (raw §3): `loop_arith` empata (372,6 × 372,0 ms,
+mín. 348,7 × 345,1) e `map_churn` sai −6,5 % (316,4 × 295,7) — os dois
+"aumentos" do mínimo-de-9 são ruído; `map_churn.nx` nem passa pelos opcodes
+novos. ⁴ As razões ÷ python de `mandelbrot`/`map_churn`/`string_ops` mudaram
+porque o CPython desta rodada mediu diferente da rodada da fase 2 (80,5 / 80,4
+/ 40,4 ms líquidos contra 90,6 / 82,7 / 31,9), não o Noxy — a coluna
+"v0.15.0 ÷ v0.14.3" é a comparação válida.
+
+### Leitura
+
+**A hipótese da issue ("bubblesort 5,5x → ~2–2,5x do CPython; bench_bubblesort
+≥ −30 %") confirma com folga: 1,8x e −64,5 %.** O ganho é quase todo do
+estágio 3 — a forma fundida de `ref T[]`: o perfil de base mostrava
+`resolveReferenceValue`/`referenceStorage` (um `defer`, uma closure do setter
+alocada por acesso, `validateReferencedValue` com `reflect`) e
+`unicizeThroughRefValue` como **metade do tempo** do bubblesort, e o bench da
+issue passa por `data: ref int[]` — os anchors da issue descreviam o local
+plano, onde o custo é menor. `bench_call_ref` (mutação via ref) vem junto,
+−43 %.
+
+**A segunda meta da issue ("bench_call_readonly ≥ −30 %") não confirma: −12 %.**
+Não é indexação: 37 % desse bench é `callNative` — o `length(data)` da
+condição do `while` compila como chamada de builtin genérica. Um `OP_LEN`
+estático é follow-up (fora do item 1). Os estágios 1 e 2 (formas genéricas
+tipadas e fundidas de local plano, sem `ref`) valem −4 a −10 % em
+`call_readonly`/`path_update`/`conway` — onde o despacho do índice nunca foi
+o gargalo.
+
+**Achado da rodada (custou um commit a mais):** o primeiro desenho do fallback
+de leitura re-despachava o `case` genérico com `instruction = OP_GET_INDEX;
+goto redispatch` — "zero custo no genérico" no papel. `bench_generic_vs_hand`,
+um laço de `length()` **sem indexação nenhuma**, subiu **+10–14 %** já no
+estágio 0 (que não emite opcode novo): o rótulo (que faz de `instruction` um
+phi) e os fallbacks inline mudaram o codegen do laço de `run()` inteiro. A
+chamada a um método (`getIndexGeneric`) no fallback não aparece no mesmo
+bench. Lição para os próximos itens: qualquer mudança em `run()` passa por
+esse bench como sentinela, não só pelos benches do item.
+
+**Gates CoW (≤ +5 %):** `conway` −3,7 %, `typed_call_map` −1,7 %, `call_light`
+−1,6 %, `share_mutate` +1,6 % na rodada focada — verdes. `map_churn`
+(`setIndexGeneric`/`getIndexGeneric` viraram chamada no genérico): −0,2 %.
+
+**O que resta do acesso via `ref`:** `Upvalue.Load()` e os atômicos do seu
+`RWMutex` (~25 % das amostras do head) — é o que separa `bubblesort` de 1,8x
+do CPython; candidato a item do roadmap se precisar.
+
 ## v0.14.2 (cb8efcb) × fase 2 de perf — layout do `Value` (perf/issue-37-value-layout, ba7f85d)
 
 **Data:** 2026-08-22 · Windows 11 · i7-1165G7 · protocolo intercalado, mediana

--- a/benchmarks/cross_runtime/results/cross_runtime.md
+++ b/benchmarks/cross_runtime/results/cross_runtime.md
@@ -1,47 +1,47 @@
 # Cross-runtime: Noxy x CPython x Lua x Go
 
-- noxy: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ef3672bf-bc7a-4367-818c-fb10c1f93a42\scratchpad\bench\noxy_s12p.exe` (Noxy v0.14.3)
-- v0142: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ef3672bf-bc7a-4367-818c-fb10c1f93a42\scratchpad\bench\noxy_base.exe` (Noxy v0.14.2)
+- noxy: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ead4c52f-5869-403e-a45b-22421c6f07b9\scratchpad\bench\noxy_s3.exe` (Noxy v0.15.0)
+- v0143: `C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ead4c52f-5869-403e-a45b-22421c6f07b9\scratchpad\bench\noxy_base.exe` (Noxy v0.14.3)
 - python: Python 3.13.1
 - lua: Lua 5.4.7  Copyright (C) 1994-2024 Lua.org, PUC-Rio
 - go: go version go1.24.11 windows/amd64
-- Data: 2026-08-22T16:43:10
+- Data: 2026-08-22T18:55:12
 - Runs por bench: 9, intercalados; **minimo** reportado
 
 ## Tempo total (ms)
 
-| bench | noxy | v0142 | python | lua | go |
+| bench | noxy | v0143 | python | lua | go |
 |---|---|---|---|---|---|
-| `bubblesort` | 514,4 | 716,4 | 165,4 | - | - |
-| `fib` | 387,3 | 511,7 | 191,9 | 114,7 | 75,0 |
-| `loop_arith` | 363,8 | 418,6 | 346,4 | 103,9 | 79,7 |
-| `mandelbrot` | 268,2 | 310,1 | 179,1 | - | - |
-| `map_churn` | 265,0 | 317,6 | 171,2 | - | - |
-| `startup` | 91,3 | 91,0 | 88,5 | 61,9 | 71,4 |
-| `string_ops` | 225,8 | 236,8 | 120,4 | - | - |
+| `bubblesort` | 249,7 | 526,3 | 169,2 | - | - |
+| `fib` | 406,0 | 417,7 | 209,7 | 112,2 | 76,1 |
+| `loop_arith` | 379,3 | 364,2 | 371,7 | 102,0 | 76,6 |
+| `mandelbrot` | 283,4 | 280,8 | 164,2 | - | - |
+| `map_churn` | 291,4 | 269,3 | 164,1 | - | - |
+| `startup` | 96,1 | 95,7 | 83,7 | 60,1 | 72,2 |
+| `string_ops` | 230,5 | 234,5 | 124,1 | - | - |
 
 ## Tempo de execucao, descontado o piso de `startup` (ms)
 
-| bench | noxy | v0142 | python | lua | go |
+| bench | noxy | v0143 | python | lua | go |
 |---|---|---|---|---|---|
-| `bubblesort` | 423,1 | 625,4 | 76,9 | - | - |
-| `fib` | 296,0 | 420,7 | 103,4 | 52,8 | ~0 |
-| `loop_arith` | 272,5 | 327,6 | 257,9 | 42,0 | 8,3 |
-| `mandelbrot` | 176,9 | 219,1 | 90,6 | - | - |
-| `map_churn` | 173,7 | 226,6 | 82,7 | - | - |
-| `string_ops` | 134,5 | 145,8 | 31,9 | - | - |
+| `bubblesort` | 153,6 | 430,6 | 85,5 | - | - |
+| `fib` | 309,9 | 322,0 | 126,0 | 52,1 | ~0 |
+| `loop_arith` | 283,2 | 268,5 | 288,0 | 41,9 | ~0 |
+| `mandelbrot` | 187,3 | 185,1 | 80,5 | - | - |
+| `map_churn` | 195,3 | 173,6 | 80,4 | - | - |
+| `string_ops` | 134,4 | 138,8 | 40,4 | - | - |
 
 `~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.
 
 ## Razoes sobre o tempo liquido (noxy / outro)
 
-| bench | / v0142 | / python | / lua | / go |
+| bench | / v0143 | / python | / lua | / go |
 |---|---|---|---|---|
-| `bubblesort` | 0,68x | 5,50x | - | - |
-| `fib` | 0,70x | 2,86x | 5,61x | - |
-| `loop_arith` | 0,83x | 1,06x | 6,49x | 32,83x |
-| `mandelbrot` | 0,81x | 1,95x | - | - |
-| `map_churn` | 0,77x | 2,10x | - | - |
-| `string_ops` | 0,92x | 4,22x | - | - |
+| `bubblesort` | 0,36x | 1,80x | - | - |
+| `fib` | 0,96x | 2,46x | 5,95x | - |
+| `loop_arith` | 1,05x | 0,98x | 6,76x | - |
+| `mandelbrot` | 1,01x | 2,33x | - | - |
+| `map_churn` | 1,12x | 2,43x | - | - |
+| `string_ops` | 0,97x | 3,33x | - | - |
 
 Menor e melhor. `-` = um dos lados cai dentro do ruido do piso e a razao nao tem significado.

--- a/benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md
+++ b/benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md
@@ -1,0 +1,306 @@
+# Dados brutos — indexação tipada de array (issue #66, item 1): v0.14.3 × estágios
+
+**Data:** 2026-08-22 · Windows 11 · i7-1165G7 (8 threads lógicas) · Go 1.24.11 ·
+laptop, na tomada.
+
+**Binários** (todos em disco local, fora do OneDrive; mesma sessão de build,
+cada um executado uma vez logo depois do `go build` — o EDR da máquina apaga
+binário recém-compilado que fica parado sem rodar: o `s0` original sumiu
+entre o build e a primeira rodada e foi rebuildado de uma worktree destacada
+no mesmo commit):
+
+| rótulo | commit | o que é |
+|---|---|---|
+| `base` (v0143) | 7eed082 | `develop` = v0.14.3 |
+| `s0` | bf4f995 | só o VM: seis handlers novos (nenhum emitido ainda), `setIndexGeneric`, `unicizeOwnedSlot`/`unicizeBorrowedSlot`, rótulo `goto redispatch` |
+| `s1` | 59c3b57 | + compilador emite `OP_GET_INDEX_ARRAY` / `OP_SET_INDEX_ARRAY_NORC` (formas genéricas tipadas) |
+| `s2` | c252400 | + formas fundidas por slot de local plano (`OP_GET_LOCAL_INDEX_ARRAY`, inclusive for-each; `OP_SET_LOCAL_INDEX_ARRAY_NORC`) |
+| `s3goto` | 4799e1d | + formas fundidas de `ref T[]` (`OP_GET_REF_LOCAL_INDEX_ARRAY` / `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC`) — **ainda com o `goto redispatch`** |
+| `s3` (typed, head) | d870a02 | = s3goto com o fallback de leitura por `getIndexGeneric` (método), sem rótulo — o código que vai no PR |
+
+**Protocolo:** o de `benchmarks/RESULTS.md` — execuções intercaladas na mesma
+janela de tempo, guard de `CHECKSUM:` entre binários, mediana de 9 (headline,
+`interleaved_compare.ps1`) ou de 5 (por estágio, `stages.ps1` reproduzido no
+fim, 5–6 binários). Fontes `.nx` copiados para disco local antes de medir.
+**Scripts rodados com `pwsh -NoProfile -File`** — `interleaved_compare.ps1`
+não parseia no Windows PowerShell 5.1 (UTF-8 sem BOM, travessão na linha 39);
+a primeira tentativa com `powershell -File` saiu com exit 1 sem medir.
+
+**Carga da máquina:** `Win32_Processor.LoadPercentage` no início de cada passo
+(linhas "load antes"); Firefox, Slack e o Claude Code abertos; nenhum `go test`
+nem build durante as medições (os builds de estágio aconteceram antes).
+
+Os benches curtos (`bench_call_light`, `bench_typed_call_map`,
+`bench_value_call_mutate`, ~120 ms com piso de processo ~90 ms) **não decidem
+nada** (RESULTS.md, 2026-08-22): são listados, não interpretados.
+
+## 1. Rodada 1 — com o `goto redispatch` (binário `s3goto`)
+
+### 1.1 Headline — `interleaved_compare.ps1` base × s3goto (mediana de 9)
+
+`load antes: 11 %` · `load depois: 3 %`
+
+| bench | v0143_ms | s3goto_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 3007.7 | 1168.2 | -61.2% |
+| bench_call_light.nx | 131.4 | 126.3 | -3.9% |
+| bench_call_readonly.nx | 1038.5 | 974.4 | -6.2% |
+| bench_call_ref.nx | 3216 | 1760.4 | -45.3% |
+| bench_conway.nx | 1959.2 | 1958.7 | -0% |
+| bench_generic_vs_hand.nx | 734.8 | 829.2 | **12.8%** |
+| bench_map_churn.nx | 449.8 | 430.4 | -4.3% |
+| bench_path_update.nx | 515.2 | 471 | -8.6% |
+| bench_share_mutate.nx | 265.4 | 250 | -5.8% |
+| bench_spawn_sum.nx | 710.9 | 751.2 | 5.7% |
+| bench_typed_call_map.nx | 129.2 | 127.7 | -1.2% |
+| bench_value_call_mutate.nx | 129.9 | 124.8 | -3.9% |
+
+### 1.2 Por estágio — 5 binários intercalados (mediana de 5, tempo de parede)
+
+`load antes: 6 %` · `load depois: 11 %`
+
+| bench | base_ms | s0_ms | s1_ms | s2_ms | s3goto_ms |
+|---|---|---|---|---|---|
+| bench_bubblesort | 3.080,1 | 2.990,4 | 2.954,4 | 2.843,3 | 1.138,6 |
+| bench_call_light | 140,9 | 148,9 | 110,0 | 121,3 | 118,4 |
+| bench_call_readonly | 1.007,5 | 1.089,4 | 980,1 | 943,8 | 981,3 |
+| bench_call_ref | 3.015,2 | 3.053,3 | 2.963,4 | 2.919,6 | 1.736,0 |
+| bench_conway | 1.906,6 | 1.962,4 | 1.811,3 | 1.902,7 | 1.844,8 |
+| bench_generic_vs_hand | 749,1 | 795,7 | 797,6 | 849,3 | 815,4 |
+| bench_map_churn | 419,1 | 433,7 | 446,1 | 458,3 | 435,0 |
+| bench_path_update | 508,1 | 515,6 | 476,3 | 445,8 | 460,2 |
+| bench_share_mutate | 266,8 | 257,9 | 252,1 | 262,1 | 249,4 |
+| bench_spawn_sum | 709,5 | 758,3 | 716,9 | 744,6 | 714,1 |
+| bench_typed_call_map | 134,1 | 127,5 | 117,5 | 118,4 | 128,1 |
+| bench_value_call_mutate | 122,9 | 141,4 | 116,4 | 116,2 | 116,5 |
+
+Leitura: o ganho de `bubblesort`/`call_ref` é todo do estágio 3 (a resolução
+do `ref`); s1 e s2 dão −1 a −8 % em `call_readonly`/`path_update`/`conway`.
+**`generic_vs_hand` sobe já no s0** (+6 %), que não emite opcode novo — só muda
+o código de `run()`. Esse bench não indexa nada (`acc = acc + length(arr)`):
+é regressão de codegen do despacho, não dos opcodes.
+
+### 1.3 A/B focado — `bench_generic_vs_hand`, relógio interno (`GEN_MS+HAND_MS`), 9 intercaladas
+
+Isola o laço quente do piso de processo. Mediana (min/max) e as 9 amostras:
+
+| binário | mediana | min | max | amostras |
+|---|---|---|---|---|
+| base | 610 | 577 | 725 | 603 577 606 605 610 612 644 630 725 |
+| s0 | 669 | 635 | 778 | 669 683 666 653 778 677 635 638 708 |
+| s3goto | 698 | 667 | 756 | 698 673 756 675 667 709 702 712 670 |
+
+s1–s3goto têm o **mesmo** `run()` do s0 (só o compilador muda entre eles), então
++10 % no s0 é o código novo de `run()`: rótulo `redispatch:` (que faz de
+`instruction` um phi com várias definições) + três tails de fallback inline.
+Variante `v1` = s3goto com os fallbacks de leitura chamando `getIndexGeneric`
+(corpo de `OP_GET_INDEX` extraído em método) e sem rótulo:
+
+| binário | mediana | min | max | amostras |
+|---|---|---|---|---|
+| base | 623 | 574 | 731 | 619 574 581 711 599 671 633 623 731 |
+| s3goto | 714 | 624 | 758 | 714 684 727 758 725 674 711 624 716 |
+| v1 (= s3 final) | 631 | 598 | 655 | 654 610 598 600 652 636 617 631 655 |
+
+O rótulo era o custo; a chamada no fallback não aparece. `v1` virou o commit
+d870a02 (= `s3`), e a rodada 2 abaixo remede tudo com ele.
+
+## 2. Rodada 2 — binário final `s3` (d870a02, sem `goto`)
+
+### 2.1 Headline — `interleaved_compare.ps1` base × s3 (mediana de 9)
+
+`load antes: 4 %` · `load depois: 23 %` (o load do fim inclui o próprio pwsh encerrando)
+
+| bench | v0143_ms | typed_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 3071.2 | 1089.4 | -64.5% |
+| bench_call_light.nx | 130.7 | 128.6 | -1.6% |
+| bench_call_readonly.nx | 1018.9 | 895.5 | -12.1% |
+| bench_call_ref.nx | 3010.6 | 1702.8 | -43.4% |
+| bench_conway.nx | 1871.3 | 1801.2 | -3.7% |
+| bench_generic_vs_hand.nx | 730.7 | 736 | 0.7% |
+| bench_map_churn.nx | 408.7 | 408 | -0.2% |
+| bench_path_update.nx | 495.1 | 449.6 | -9.2% |
+| bench_share_mutate.nx | 218.1 | 236.4 | 8.4% |
+| bench_spawn_sum.nx | 668.7 | 677 | 1.2% |
+| bench_typed_call_map.nx | 151.7 | 149.1 | -1.7% |
+| bench_value_call_mutate.nx | 139.6 | 140.9 | 0.9% |
+
+`generic_vs_hand` volta ao ruído (+0,7 %; era +12,8 % com o `goto`).
+`share_mutate` +8,4 % nesta rodada contra −5,8 % na rodada 1, com a própria
+base oscilando 265 → 218 ms entre rodadas — bench de ~230 ms perto do piso.
+Rodada focada, 15 intercaladas, tempo de parede:
+
+| binário | mediana | min | max |
+|---|---|---|---|
+| base | 233,0 | 214,4 | 345,1 |
+| s3 | 236,7 | 217,0 | 298,9 |
+
++1,6 % na mediana, +1,2 % no mínimo: dentro do ruído, gate CoW (≤ +5 %) ok.
+(O caminho que esse bench exercita é o fallback "array compartilhado" da
+escrita fundida — `unicizeOwnedSlot` + `setIndexGeneric` com dois pops e três
+pushes a mais que o caminho rápido; o clone O(n) domina.)
+
+### 2.2 Por estágio — 6 binários intercalados (mediana de 5, tempo de parede)
+
+`load antes: 5 %` · `load depois: 12 %`
+
+| bench | base_ms | s0_ms | s1_ms | s2_ms | s3goto_ms | s3_ms |
+|---|---|---|---|---|---|---|
+| bench_bubblesort | 2.936,1 | 2.999,8 | 2.871,4 | 2.958,5 | 1.108,2 | 1.107,3 |
+| bench_call_light | 124,2 | 123,5 | 119,1 | 117,3 | 104,5 | 135,4 |
+| bench_call_readonly | 997,0 | 1.009,8 | 956,2 | 956,4 | 946,7 | 875,5 |
+| bench_call_ref | 3.094,7 | 3.112,1 | 2.996,2 | 2.924,8 | 1.752,4 | 1.732,3 |
+| bench_conway | 1.928,2 | 1.943,6 | 1.834,8 | 1.908,0 | 1.868,6 | 1.857,2 |
+| bench_generic_vs_hand | 718,2 | 825,3 | 812,3 | 810,8 | 816,7 | 758,4 |
+| bench_map_churn | 442,3 | 424,3 | 441,4 | 428,6 | 443,4 | 413,7 |
+| bench_path_update | 506,3 | 539,0 | 479,6 | 458,9 | 467,2 | 453,6 |
+| bench_share_mutate | 273,9 | 260,4 | 253,6 | 254,9 | 254,3 | 277,4 |
+| bench_spawn_sum | 751,6 | 767,1 | 771,1 | 713,4 | 713,5 | 769,3 |
+| bench_typed_call_map | 125,5 | 126,5 | 116,9 | 129,2 | 136,2 | 137,3 |
+| bench_value_call_mutate | 129,9 | 132,4 | 118,8 | 129,0 | 126,0 | 129,7 |
+
+Deltas `s3` vs `base` (medianas acima): bubblesort −62,3 %, call_ref −44,0 %,
+call_readonly −12,2 %, path_update −10,4 %, conway −3,7 %, map_churn −6,5 %,
+share_mutate +1,3 %, spawn_sum +2,4 %, generic_vs_hand +5,6 % (tempo de parede;
+o relógio interno do bench em §1.3 dá +1,3 % — a coluna `s3goto` mostra os
++13,7 % que o `goto` custava, e `s0`–`s3goto`, que têm o mesmo `run()`,
+empatam entre si em +12,9…+13,7 %).
+
+## 3. Cross-runtime — `run_cross_runtime.ps1 -NoxyBaseline` (mínimo de 9, intercalado com CPython 3.13.1 / Lua 5.4.7 / Go 1.24.11)
+
+`load antes: 4 %` · `load depois: 8 %`. Tabela completa em
+`benchmarks/cross_runtime/results/cross_runtime.md` (sobrescrita por esta rodada).
+
+| bench | noxy (s3) | v0143 | python | lua | go |
+|---|---|---|---|---|---|
+| `bubblesort` | 249,7 | 526,3 | 169,2 | - | - |
+| `fib` | 406,0 | 417,7 | 209,7 | 112,2 | 76,1 |
+| `loop_arith` | 379,3 | 364,2 | 371,7 | 102,0 | 76,6 |
+| `mandelbrot` | 283,4 | 280,8 | 164,2 | - | - |
+| `map_churn` | 291,4 | 269,3 | 164,1 | - | - |
+| `startup` | 96,1 | 95,7 | 83,7 | 60,1 | 72,2 |
+| `string_ops` | 230,5 | 234,5 | 124,1 | - | - |
+
+Tempo líquido (menos `startup`): `bubblesort` 430,6 → **153,6 ms (0,36x)**,
+**÷ CPython 5,50x → 1,80x**; `fib` 0,96x, `loop_arith` 1,05x, `mandelbrot`
+1,01x, `map_churn` 1,12x, `string_ops` 0,97x de v0.14.3.
+
+Os dois que subiram no mínimo-de-9 foram refeitos em A/B focado (11
+intercaladas, tempo de parede, fontes locais):
+
+| programa | base mediana (min) | s3 mediana (min) |
+|---|---|---|
+| `cross_runtime/map_churn.nx` | 316,4 (276,3) | 295,7 (269,2) |
+| `cross_runtime/loop_arith.nx` | 372,6 (348,7) | 372,0 (345,1) |
+
+`map_churn` sai −6,5 % e `loop_arith` empata: o +12 % / +5 % do cross eram
+ruído (`map_churn.nx` nem passa pelos opcodes novos — só map com chave string).
+
+## 4. Perfil de `cross_runtime/bubblesort.nx` (`noxy --cpuprofile`, uma execução, amostras de 10 ms)
+
+**base** (490 ms de amostras, 637 ms de duração):
+
+```
+      flat  flat%   sum%        cum   cum%
+     150ms 30.61% 30.61%      450ms 91.84%  noxy-vm/internal/vm.(*VM).run
+      40ms  8.16% 38.78%      180ms 36.73%  noxy-vm/internal/vm.(*VM).referenceStorage
+      30ms  6.12% 44.90%       60ms 12.24%  noxy-vm/internal/value.(*ObjUpvalue).Load
+      30ms  6.12% 51.02%       40ms  8.16%  noxy-vm/internal/value.IsShared
+      30ms  6.12% 57.14%       30ms  6.12%  runtime.deferprocStack
+      20ms  4.08% 61.22%       20ms  4.08%  noxy-vm/internal/vm.(*VM).pop (inline)
+      20ms  4.08% 65.31%       20ms  4.08%  noxy-vm/internal/vm.(*VM).push (inline)
+      20ms  4.08% 69.39%       90ms 18.37%  noxy-vm/internal/vm.(*VM).resolveReferenceValue
+      20ms  4.08% 73.47%       20ms  4.08%  runtime.cgocall
+      20ms  4.08% 77.55%       30ms  6.12%  runtime.mallocgc
+      20ms  4.08% 81.63%       20ms  4.08%  sync/atomic.(*Int32).Add (inline)
+      10ms  2.04% 83.67%       10ms  2.04%  noxy-vm/internal/value.Release
+```
+
+(Um perfil anterior da mesma base, tirado antes da implementação, dava
+`resolveReferenceValue`/`referenceStorage` 42 % cum, `mallocgc` 15 %,
+`ObjUpvalue.Load` 10,6 %, `unicizeThroughRefValue` 10,6 % — a motivação da
+forma fundida de `ref` na spec §1.)
+
+**head** (160 ms de amostras, 328 ms de duração):
+
+```
+      flat  flat%   sum%        cum   cum%
+      90ms 56.25% 56.25%      130ms 81.25%  noxy-vm/internal/vm.(*VM).run
+      20ms 12.50% 68.75%       20ms 12.50%  runtime.cgocall
+      20ms 12.50% 81.25%       20ms 12.50%  sync/atomic.(*Int32).Add (inline)
+      10ms  6.25% 87.50%       10ms  6.25%  noxy-vm/internal/vm.(*VM).pop (inline)
+      10ms  6.25% 93.75%       10ms  6.25%  noxy-vm/internal/vm.(*VM).push (inline)
+      10ms  6.25%   100%       10ms  6.25%  runtime.unlock2
+         0     0%   100%       20ms 12.50%  noxy-vm/internal/value.(*ObjUpvalue).Load
+```
+
+`referenceStorage`, `resolveReferenceValue`, `IsShared`, `mallocgc` e o `defer`
+somem do perfil; o que resta do acesso via `ref` é `Upvalue.Load` e os
+atômicos do seu `RWMutex` (`atomic.Int32.Add` + `unlock2`, ~25 % das amostras
+do head) — o follow-up natural se `bubblesort` precisar passar de 1,8x.
+
+## 5. Script dos 5–6 binários (`stages.ps1`)
+
+```powershell
+param(
+    [int]$Runs = 5,
+    [string]$Repo = "D:\OneDrive\Documentos\go_projects\noxy\.claude\worktrees\perf-issue-66-arrays"
+)
+# Intercalacao de CINCO binarios (base + 4 estagios) na mesma janela, mediana
+# de $Runs por bench — o "script de sessao" da medicao por estagio (issue #66,
+# item 1). Mesmo principio de benchmarks/interleaved_compare.ps1: os binarios
+# alternam a cada execucao, imunizando contra drift de carga/termico.
+$ErrorActionPreference = "Stop"
+$S = $PSScriptRoot
+$bins = [ordered]@{
+    base = "$S\noxy_base.exe"
+    s0   = "$S\noxy_s0.exe"
+    s1   = "$S\noxy_s1.exe"
+    s2   = "$S\noxy_s2.exe"
+    s3goto = "$S\noxy_s3goto.exe"
+    s3   = "$S\noxy_s3.exe"
+}
+$local = "$S\nx"
+New-Item -ItemType Directory -Force $local | Out-Null
+$benches = Get-ChildItem "$Repo\benchmarks" -Filter "bench_*.nx" | Sort-Object Name
+$benches | ForEach-Object { Copy-Item $_.FullName $local -Force }
+
+$header = "| bench | " + (($bins.Keys | ForEach-Object { "$($_)_ms" }) -join " | ") + " |"
+$sep = "|---|" + (($bins.Keys | ForEach-Object { "---" }) -join "|") + "|"
+$rows = @($header, $sep)
+foreach ($b in $benches) {
+    # guard de equivalencia: mesma linha CHECKSUM em todos
+    $sums = @{}
+    foreach ($k in $bins.Keys) {
+        $out = & $bins[$k] "$local\$($b.Name)" 2>&1 | Where-Object { $_ -match "^CHECKSUM:" }
+        if ($out -is [array]) { $out = $out[0] }
+        $sums[$k] = "$out"
+    }
+    $distinct = $sums.Values | Sort-Object -Unique
+    if ($distinct.Count -ne 1 -or -not $distinct[0]) {
+        $rows += "| $($b.BaseName) | PULADO (checksums: $($sums.Values -join ' / ')) |"
+        Write-Host "$($b.Name): PULADO" -ForegroundColor Yellow
+        continue
+    }
+    $times = @{}
+    $bins.Keys | ForEach-Object { $times[$_] = @() }
+    for ($r = 0; $r -lt $Runs; $r++) {
+        foreach ($k in $bins.Keys) {
+            $sw = [Diagnostics.Stopwatch]::StartNew()
+            & $bins[$k] "$local\$($b.Name)" *> $null
+            $sw.Stop()
+            $times[$k] += $sw.Elapsed.TotalMilliseconds
+        }
+    }
+    $cells = $bins.Keys | ForEach-Object {
+        $sorted = $times[$_] | Sort-Object
+        "{0:N1}" -f $sorted[[int][math]::Floor($sorted.Count / 2)]
+    }
+    $line = "| $($b.BaseName) | " + ($cells -join " | ") + " |"
+    $rows += $line
+    Write-Host $line
+}
+$rows | Set-Content "$S\stages_results.md" -Encoding UTF8
+Write-Host "gravado em $S\stages_results.md"
+```

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,14 +1,14 @@
-| bench | v0142_ms | s12p_ms | delta |
+| bench | v0143_ms | typed_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 4046.3 | 3002.8 | -25.8% |
-| bench_call_light.nx | 120.3 | 110.7 | -8% |
-| bench_call_readonly.nx | 1386.8 | 929.4 | -33% |
-| bench_call_ref.nx | 4160.8 | 3052.1 | -26.6% |
-| bench_conway.nx | 2214.9 | 1878.8 | -15.2% |
-| bench_generic_vs_hand.nx | 904.5 | 732.4 | -19% |
-| bench_map_churn.nx | 479.1 | 442 | -7.7% |
-| bench_path_update.nx | 682.4 | 498.2 | -27% |
-| bench_share_mutate.nx | 302.1 | 251.4 | -16.8% |
-| bench_spawn_sum.nx | 767.1 | 703.7 | -8.3% |
-| bench_typed_call_map.nx | 124.5 | 122.9 | -1.3% |
-| bench_value_call_mutate.nx | 119.3 | 121.1 | 1.5% |
+| bench_bubblesort.nx | 3071.2 | 1089.4 | -64.5% |
+| bench_call_light.nx | 130.7 | 128.6 | -1.6% |
+| bench_call_readonly.nx | 1018.9 | 895.5 | -12.1% |
+| bench_call_ref.nx | 3010.6 | 1702.8 | -43.4% |
+| bench_conway.nx | 1871.3 | 1801.2 | -3.7% |
+| bench_generic_vs_hand.nx | 730.7 | 736 | 0.7% |
+| bench_map_churn.nx | 408.7 | 408 | -0.2% |
+| bench_path_update.nx | 495.1 | 449.6 | -9.2% |
+| bench_share_mutate.nx | 218.1 | 236.4 | 8.4% |
+| bench_spawn_sum.nx | 668.7 | 677 | 1.2% |
+| bench_typed_call_map.nx | 151.7 | 149.1 | -1.7% |
+| bench_value_call_mutate.nx | 139.6 | 140.9 | 0.9% |

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2104,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.14.3`). It is a module binding, not a
+string `noxy --version` prints (`v0.15.0`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.14.3</span>
+                    <span class="version-badge-tag">v0.15.0</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.14.3
+print(sys.version)           // v0.15.0
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-typed-array-index.md
+++ b/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-typed-array-index.md
@@ -269,6 +269,8 @@ git commit -m "feat(chunk): opcodes de indexacao tipada de array — GET/SET_IND
 
 ### Task 3: Handlers no VM, `setIndexGeneric`, `unicizeOwnedSlot`/`unicizeBorrowedSlot`, `goto redispatch`
 
+> **Nota pós-execução (2026-08-22):** a task foi executada como escrita (commit bf4f995), mas a medição por estágio pegou o `goto redispatch` custando +10–14 % no despacho genérico (`bench_generic_vs_hand`, laço sem indexação — relógio interno: base 623 ms, com goto 714, sem goto 631). O commit seguinte trocou os três fallbacks de leitura por uma chamada a `getIndexGeneric(c, ip)` (corpo de `OP_GET_INDEX` extraído em método, como `setIndexGeneric`) e removeu o rótulo; o `case OP_GET_INDEX` genérico passa a chamar o método. Spec §3.2 atualizada. O texto abaixo é o plano original.
+
 **Files:**
 - Create: `internal/vm/index_ops.go` (`setIndexGeneric`)
 - Modify: `internal/vm/cow.go` (`unicizeOwnedSlot`, `unicizeBorrowedSlot`)
@@ -2139,14 +2141,14 @@ git commit -m "docs(bench): indexacao tipada de array medida por estagio contra 
 
 ---
 
-### Task 8: Versão v0.14.4, CHANGELOG, docs
+### Task 8: Versão v0.15.0 (minor, decisão do usuário de 2026-08-22), CHANGELOG, docs
 
 **Files:**
-- Modify: `internal/version/version.go` (`const Version = "v0.14.4"`), `CHANGELOG.md` (nova entrada `## [0.14.4] - 2026-08-22`), `README.md:1` (badge) e `:108` (banner REPL), `AGENTS.md:414`, `docs/NOXY_LANGUAGE_SPEC.md` (linha do `sys.version`), `docs/index.html:58` (hero badge) e `:385` (`print(sys.version)`).
+- Modify: `internal/version/version.go` (`const Version = "v0.15.0"`), `CHANGELOG.md` (nova entrada `## [0.15.0] - 2026-08-22`), `README.md:1` (badge) e `:108` (banner REPL), `AGENTS.md:414`, `docs/NOXY_LANGUAGE_SPEC.md` (linha do `sys.version`), `docs/index.html:58` (hero badge) e `:385` (`print(sys.version)`).
 
 - [ ] **Step 1: Bump nos seis pontos**
 
-`grep -rn "0\.14\.3" README.md AGENTS.md internal/version/version.go docs/index.html docs/NOXY_LANGUAGE_SPEC.md` → trocar cada ocorrência por `0.14.4` (Edit tool, CRLF preservado). Conferir com o mesmo grep que não sobrou nenhuma, e `go test ./internal/vm -run Version`.
+`grep -rn "0\.14\.3" README.md AGENTS.md internal/version/version.go docs/index.html docs/NOXY_LANGUAGE_SPEC.md` → trocar cada ocorrência por `0.15.0` (Edit tool, CRLF preservado). Conferir com o mesmo grep que não sobrou nenhuma, e `go test ./internal/vm -run Version`.
 
 - [ ] **Step 2: CHANGELOG**
 
@@ -2156,7 +2158,7 @@ Entrada no topo, no formato da 0.14.3: parágrafo de contexto (item 1 da #66; ne
 
 ```bash
 git add internal/version/version.go CHANGELOG.md README.md AGENTS.md docs/NOXY_LANGUAGE_SPEC.md docs/index.html
-git commit -m "chore(version): noxy v0.14.4 — CHANGELOG (indexacao tipada de array, issue #66 item 1), README, AGENTS, spec, site, version.go"
+git commit -m "chore(version): noxy v0.15.0 — CHANGELOG (indexacao tipada de array, issue #66 item 1), README, AGENTS, spec, site, version.go"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-typed-array-index.md
+++ b/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-typed-array-index.md
@@ -1,0 +1,2187 @@
+# VM Perf — Indexação tipada de array (issue #66, item 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emitir opcodes de indexação tipada de array (formas genéricas `OP_GET_INDEX_ARRAY`/`OP_SET_INDEX_ARRAY_NORC` e formas fundidas por slot de local plano e de local `ref`) quando o compilador conhece o tipo `T[]`, sem mudar semântica, saída, mensagens de erro ou contagem RC — e medir o impacto (issue #66, item 1).
+
+**Architecture:** Seis opcodes anexados ao fim de `chunk.go`. No VM, cada um tem caminho rápido (array + índice int + bounds, resultado gravado no lugar; escrita sem Retain/Release só quando `value.NeverTracked(val) && value.NeverTracked(old)` e a tag do array não é `(ref T)[]`; formas com slot exigem `Owners <= 1`; a forma `ref` resolve `REF_UPVALUE` com uma `Upvalue.Load()`) e fallback exato: leituras re-despacham o `OP_GET_INDEX` genérico via `goto redispatch`; escritas materializam a pilha e chamam `setIndexGeneric` (o corpo do `OP_SET_INDEX` extraído em método) depois de `unicizeOwnedSlot`/`unicizeBorrowedSlot`/`unicizeThroughRefValue`. No compilador, a forma fundida só sai quando índice (e valor) são sintaticamente livres de efeito colateral (`isSideEffectFree`).
+
+**Tech Stack:** Go 1.24, PowerShell (benchmarks de `benchmarks/`), `go build -gcflags=-m=2` (guards de inline), `noxy --cpuprofile`.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md`
+
+## Global Constraints
+
+- Branch `perf/issue-66-typed-array-index`, worktree `.claude/worktrees/perf-issue-66-arrays`, base `develop` 7eed082 (v0.14.3). Um commit por task; os commits das Tasks 3, 4, 5 e 6 geram binários de estágio (`noxy_s0/s1/s2/s3.exe`) — nunca squash entre eles.
+- **Semântica, saída e mensagens de erro idênticas**; corpus `noxy_examples/` sem falhas (`go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx`) e diff de saída base × head vazio (`benchmarks/compare_examples.ps1`).
+- **RC intocado nos compostos** (spec CoW-RC §4.2): só elemento sem contador pula Retain/Release, e só depois da conferência em runtime (`NeverTracked`). Nenhum funil muda de lugar.
+- **Opcodes só por APPEND** ao fim de `internal/chunk/chunk.go`; tags `ValueType` inalteradas.
+- Guards de inline (`internal/vm/inline_guard_test.go`): `push` ≤ 20 (≥ 100 sites), `pop` ≤ 20 (≥ 70 sites), `Retain`/`Release` ≤ 80, `ensureCallCapacity` ≤ 80 — e o novo `value.NeverTracked` ≤ 20. Conferir com `go build -gcflags=-m=2 ./internal/vm 2>&1 | grep -E "can inline"`.
+- `go test ./...` verde; `go test -race ./internal/value ./internal/vm` verde; `go vet ./internal/value ./internal/vm ./internal/compiler ./internal/chunk` limpo.
+- Repo com `core.autocrlf=true` (índice LF, working tree CRLF): arquivos novos via Write tool (LF) são normalizados no commit; edições em arquivos existentes via Edit tool; conferir diffs com `git diff --numstat`, nunca por diff de arquivo inteiro.
+- Binários de benchmark em disco local: `$S\bench\` onde `$S = C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ead4c52f-5869-403e-a45b-22421c6f07b9\scratchpad` (`noxy_base.exe` já está lá, buildado de 7eed082). Se o EDR apagar um .exe, rebuildar; Noxy ad hoc com `go run ./cmd/noxy arquivo.nx`.
+- Máquina sem `go test` nem build concorrente durante as medições.
+- Todos os comandos assumem cwd = raiz do worktree, Git Bash.
+
+---
+
+### Task 1: `value.NeverTracked` + guard de inline
+
+**Files:**
+- Modify: `internal/value/cow.go` (depois de `IsShared`)
+- Create: `internal/value/never_tracked_test.go`
+- Modify: `internal/vm/inline_guard_test.go` (função `TestRetainReleaseStayInlinable`)
+
+**Interfaces:**
+- Produces: `func NeverTracked(v Value) bool` — true quando `v` certamente não tem contador RC (`Type != VAL_OBJ`, ou `VAL_OBJ` carimbado `objKindNoOwners`: string/struct/RTI dos construtores); false para array/map/instância E para `VAL_OBJ` sem carimbo (conservador).
+
+- [ ] **Step 1: Teste (falha: função não existe)**
+
+Criar `internal/value/never_tracked_test.go`:
+
+```go
+package value
+
+import "testing"
+
+// NeverTracked e o teste que as escritas NORC da indexacao tipada fazem em
+// runtime antes de pular Retain/Release (issue #66, item 1): so pode dizer
+// "true" para o que o RC comprovadamente nao rastreia. A direcao segura e
+// "false" — o chamador cai no caminho generico, que retem.
+func TestNeverTrackedIsTrueOnlyForValuesWithoutOwners(t *testing.T) {
+	inst := NewInstanceWith(&ObjStruct{Name: "P"}, map[string]Value{})
+	cases := []struct {
+		name string
+		v    Value
+		want bool
+	}{
+		{"int", NewInt(1), true},
+		{"float", NewFloat(1.5), true},
+		{"bool", NewBool(true), true},
+		{"null", NewNull(), true},
+		{"string (carimbada)", NewString("x"), true},
+		{"bytes", Value{Type: VAL_BYTES, Obj: "ab"}, true},
+		{"ref", Value{Type: VAL_REF, Obj: &ObjRef{}}, true},
+		{"array", NewArray(nil), false},
+		{"map", NewMap(), false},
+		{"instance", inst, false},
+		// VAL_OBJ montado fora dos construtores (kind zero): nao se sabe,
+		// entao false — o caminho generico decide por ownersOf.
+		{"string sem carimbo", Value{Type: VAL_OBJ, Obj: "x"}, false},
+		{"array sem carimbo", Value{Type: VAL_OBJ, Obj: &ObjArray{}}, false},
+	}
+	for _, tc := range cases {
+		if got := NeverTracked(tc.v); got != tc.want {
+			t.Errorf("%s: NeverTracked = %v, esperado %v", tc.name, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/value -run TestNeverTracked`
+Expected: FAIL — `undefined: NeverTracked`.
+
+- [ ] **Step 3: Implementar**
+
+Em `internal/value/cow.go`, logo depois de `IsShared`:
+
+```go
+// NeverTracked responde se v CERTAMENTE nao tem contador RC: escalares
+// (Type != VAL_OBJ) e os VAL_OBJ que os construtores carimbaram como sem dono
+// (string, *ObjStruct, *RuntimeTypeInfo). E a conferencia que as escritas NORC
+// da indexacao tipada (issue #66, item 1) fazem antes de pular Retain/Release:
+// se o valor novo ou o velho nao for comprovadamente sem contador (composto,
+// ou VAL_OBJ sem carimbo — kind zero), o chamador cai no caminho generico, que
+// retem. Conservador por construcao: nunca devolve true para um composto.
+// Chamada de dentro de run(): tem de caber em 20 no inliner
+// (inline_guard_test.go).
+func NeverTracked(v Value) bool {
+	return v.Type != VAL_OBJ || v.kind == objKindNoOwners
+}
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `go test ./internal/value -run TestNeverTracked`
+Expected: PASS.
+
+- [ ] **Step 5: Guard de inline**
+
+Em `internal/vm/inline_guard_test.go`, no fim de `TestRetainReleaseStayInlinable` (antes do `}` final), acrescentar:
+
+```go
+	// NeverTracked (cow.go) e chamada de DENTRO de run() pelas escritas NORC da
+	// indexacao tipada (issue #66): orcamento de 20, nao 80.
+	neverTrackedPattern := regexp.MustCompile(`can inline NeverTracked with cost (\d+)`)
+	ntMatch := neverTrackedPattern.FindStringSubmatch(report)
+	if ntMatch == nil {
+		t.Fatalf("o compilador nao inlina value.NeverTracked — procure por 'cannot inline NeverTracked' em `go build -gcflags=-m=2 ./internal/value`")
+	}
+	ntCost, ntErr := strconv.Atoi(ntMatch[1])
+	if ntErr != nil {
+		t.Fatalf("custo ilegivel em %q: %v", ntMatch[0], ntErr)
+	}
+	if ntCost > inlineBigFunctionMaxCost {
+		t.Errorf("value.NeverTracked tem custo de inline %d, maximo %d para ser inlinada dentro de run()", ntCost, inlineBigFunctionMaxCost)
+	}
+```
+
+Run: `go test ./internal/vm -run TestRetainReleaseStayInlinable`
+Expected: PASS (custo esperado ~6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/value/cow.go internal/value/never_tracked_test.go internal/vm/inline_guard_test.go
+git commit -m "perf(value): NeverTracked — conferencia barata de 'sem contador RC' para as escritas NORC da indexacao tipada, com guard de inline <= 20 (issue #66, item 1)"
+```
+
+---
+
+### Task 2: Opcodes, `String()`, disassembler e programa de desmontagem
+
+**Files:**
+- Modify: `internal/chunk/chunk.go` (fim da lista de opcodes; `String()`; `disassembleInstruction`)
+- Modify: `internal/chunk/chunk_test.go` (sentinela em `TestEveryOpcodeHasASymbolicNameWithoutGaps`; `disassemblyProgram`)
+
+**Interfaces:**
+- Produces: `chunk.OP_GET_INDEX_ARRAY`, `chunk.OP_SET_INDEX_ARRAY_NORC` (sem operando), `chunk.OP_GET_LOCAL_INDEX_ARRAY`, `chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC`, `chunk.OP_GET_REF_LOCAL_INDEX_ARRAY`, `chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC` (operando `[slot u8]`), nessa ordem, depois de `OP_GREATER_FLOAT`.
+
+- [ ] **Step 1: Teste (falha: sentinela aponta para o novo último opcode, que não existe)**
+
+Em `internal/chunk/chunk_test.go`, trocar a sentinela:
+
+```go
+	if last := int(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC); firstUnnamed >= 0 && firstUnnamed <= last {
+```
+
+E acrescentar ao fim de `disassemblyProgram` (depois de `xs[0] = 9`) um trecho que, quando o compilador emitir (Tasks 4–6), passa pelos seis opcodes — hoje compila para os genéricos:
+
+```
+func soma_local(v: int[]) -> int
+    let acc: int = 0
+    let i: int = 0
+    while i < length(v) do
+        acc = acc + v[i]
+        i = i + 1
+    end
+    v[0] = acc
+    return acc
+end
+
+func zera_ref(r: ref int[]) -> void
+    let k: int = 0
+    while k < length(r) do
+        r[k] = r[k] - r[0]
+        k = k + 1
+    end
+end
+
+func grade(g: int[][]) -> int
+    g[0][0] = g[1][1] + 1
+    return g[0][0]
+end
+
+for item in xs do
+    print(item)
+end
+soma_local(xs)
+zera_ref(ref xs)
+grade([[1, 2], [3, 4]])
+```
+
+Run: `go test ./internal/chunk`
+Expected: FAIL — `undefined: chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC`.
+
+- [ ] **Step 2: Declarar os opcodes**
+
+Em `internal/chunk/chunk.go`, depois de `OP_GREATER_FLOAT` e antes do `)`:
+
+```go
+	// perf issue #66 (item 1): indexacao tipada de array. Emitidos so quando o
+	// compilador sabe que a base e T[] (ou que o local e `ref T[]`). Semantica
+	// e mensagens de erro identicas as dos genericos; container que nao e
+	// array em runtime cai no caminho generico (leituras re-despacham
+	// OP_GET_INDEX; escritas chamam setIndexGeneric). NORC = elemento
+	// estaticamente sem contador RC (int/float/bool/string/bytes): o VM confere
+	// em runtime (value.NeverTracked do valor novo e do velho, tag do array nao
+	// e (ref T)[]) antes de pular Retain/Release. Os de escrita NAO empilham
+	// resultado (atribuicao e statement; o compilador nao emite OP_POP depois).
+	OP_GET_INDEX_ARRAY                // pops index, container; push elemento
+	OP_SET_INDEX_ARRAY_NORC           // pops val, index, container
+	OP_GET_LOCAL_INDEX_ARRAY          // [slot]; pops index; container = local T[]
+	OP_SET_LOCAL_INDEX_ARRAY_NORC     // [slot]; pops val, index; local T[] possuidor (Owners<=1, senao uniciza como GET_LOCAL_MUT)
+	OP_GET_REF_LOCAL_INDEX_ARRAY      // [slot]; pops index; local `ref T[]` (REF_UPVALUE resolvido com uma Load(); outros refs pelo caminho de OP_DEREF)
+	OP_SET_REF_LOCAL_INDEX_ARRAY_NORC // [slot]; pops val, index; local `ref T[]` (Owners<=1, senao unicizeThroughRefValue)
+```
+
+- [ ] **Step 3: `String()` e disassembler**
+
+Em `String()`, depois de `case OP_GREATER_FLOAT:`:
+
+```go
+	case OP_GET_INDEX_ARRAY:
+		return "OP_GET_INDEX_ARRAY"
+	case OP_SET_INDEX_ARRAY_NORC:
+		return "OP_SET_INDEX_ARRAY_NORC"
+	case OP_GET_LOCAL_INDEX_ARRAY:
+		return "OP_GET_LOCAL_INDEX_ARRAY"
+	case OP_SET_LOCAL_INDEX_ARRAY_NORC:
+		return "OP_SET_LOCAL_INDEX_ARRAY_NORC"
+	case OP_GET_REF_LOCAL_INDEX_ARRAY:
+		return "OP_GET_REF_LOCAL_INDEX_ARRAY"
+	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+		return "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC"
+```
+
+Em `disassembleInstruction`, depois de `case OP_GREATER_FLOAT:`:
+
+```go
+	case OP_GET_INDEX_ARRAY:
+		return c.simpleInstruction("OP_GET_INDEX_ARRAY", offset)
+	case OP_SET_INDEX_ARRAY_NORC:
+		return c.simpleInstruction("OP_SET_INDEX_ARRAY_NORC", offset)
+	case OP_GET_LOCAL_INDEX_ARRAY:
+		return c.byteInstruction("OP_GET_LOCAL_INDEX_ARRAY", offset)
+	case OP_SET_LOCAL_INDEX_ARRAY_NORC:
+		return c.byteInstruction("OP_SET_LOCAL_INDEX_ARRAY_NORC", offset)
+	case OP_GET_REF_LOCAL_INDEX_ARRAY:
+		return c.byteInstruction("OP_GET_REF_LOCAL_INDEX_ARRAY", offset)
+	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+		return c.byteInstruction("OP_SET_REF_LOCAL_INDEX_ARRAY_NORC", offset)
+```
+
+- [ ] **Step 4: Rodar**
+
+Run: `go test ./internal/chunk`
+Expected: PASS (os três testes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/chunk/chunk.go internal/chunk/chunk_test.go
+git commit -m "feat(chunk): opcodes de indexacao tipada de array — GET/SET_INDEX_ARRAY(_NORC) e formas fundidas por slot de local plano e ref, por append (issue #66, item 1)"
+```
+
+---
+
+### Task 3: Handlers no VM, `setIndexGeneric`, `unicizeOwnedSlot`/`unicizeBorrowedSlot`, `goto redispatch`
+
+**Files:**
+- Create: `internal/vm/index_ops.go` (`setIndexGeneric`)
+- Modify: `internal/vm/cow.go` (`unicizeOwnedSlot`, `unicizeBorrowedSlot`)
+- Modify: `internal/vm/executor.go` (rótulo `redispatch`; `case OP_SET_INDEX`, `case OP_GET_LOCAL_MUT`, `case OP_GET_LOCAL_MUT_BORROW` passam a chamar os métodos; seis `case` novos)
+- Create: `internal/vm/typed_index_test.go`
+- Modify: `internal/vm/inline_guard_test.go` (sites de `NeverTracked` em executor.go)
+
+**Interfaces:**
+- Consumes: `value.NeverTracked` (Task 1); opcodes (Task 2); `vm.unicizeThroughRefValue`, `vm.resolveReferenceValue`, `vm.copyValue`, `frame.ownSlot` (existentes).
+- Produces: `func (vm *VM) setIndexGeneric(c *chunk.Chunk, ip int) error` — corpo exato do antigo `case OP_SET_INDEX` (pops val/index/container, array/map/erros, push do val); `func (vm *VM) unicizeOwnedSlot(frame *CallFrame, idx int) value.Value` (corpo de `OP_GET_LOCAL_MUT`); `func (vm *VM) unicizeBorrowedSlot(idx int) value.Value` (corpo de `OP_GET_LOCAL_MUT_BORROW`).
+
+- [ ] **Step 1: Testes de bytecode montado à mão (falham: opcodes não tratados = no-op, pilha errada)**
+
+Criar `internal/vm/typed_index_test.go`:
+
+```go
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: LocalBase = 1, slot local 0 = stack[1]. Os testes deste arquivo
+// montam o bytecode a mao para exercitar cada opcode de indexacao tipada
+// (issue #66, item 1) e o seu fallback, sem depender do compilador; o
+// comportamento ponta a ponta (fonte -> compilador -> VM) e coberto em
+// typed_index_e2e_test.go.
+
+func typedIndexChunk() *chunk.Chunk {
+	code := &chunk.Chunk{}
+	arr := code.AddConstant(value.NewArray([]value.Value{value.NewInt(10), value.NewInt(20), value.NewInt(30)}))
+	code.Write(byte(chunk.OP_CONSTANT), 1) // slot 0 = array
+	code.Write(byte(arr), 1)
+	return code
+}
+
+func writeConstInt(code *chunk.Chunk, n int64) {
+	k := code.AddConstant(value.NewInt(n))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(k), 1)
+}
+
+func TestGetLocalIndexArrayReadsInPlace(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 2)
+	code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1) // slot do array
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[2]; got.Type != value.VAL_INT || got.Int() != 30 {
+		t.Fatalf("esperado 30 no topo, obtido %s", got.String())
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3 (array, elemento), obtido %d", machine.stackTop)
+	}
+}
+
+func TestGetLocalIndexArrayErrorsMatchGeneric(t *testing.T) {
+	cases := []struct {
+		name string
+		idx  value.Value
+		want string
+	}{
+		{"fora da faixa", value.NewInt(3), "array index out of bounds"},
+		{"negativo", value.NewInt(-1), "array index out of bounds"},
+		{"nao inteiro", value.NewString("x"), "array index must be integer"},
+	}
+	for _, tc := range cases {
+		code := typedIndexChunk()
+		k := code.AddConstant(tc.idx)
+		code.Write(byte(chunk.OP_CONSTANT), 1)
+		code.Write(byte(k), 1)
+		code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+		code.Write(0, 1)
+		err := New().Interpret(code)
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: esperava %q, obtido %v", tc.name, tc.want, err)
+		}
+	}
+}
+
+// Container que nao e array (null) cai no OP_GET_INDEX generico via
+// redispatch: a mensagem e a do generico.
+func TestGetLocalIndexArrayFallsBackToGenericForNonArray(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1) // slot 0 = null
+	writeConstInt(code, 0)
+	code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot index non-array/map/bytes") {
+		t.Fatalf("esperava erro do OP_GET_INDEX generico, obtido %v", err)
+	}
+}
+
+func TestGetIndexArrayReadsInPlace(t *testing.T) {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_GET_LOCAL), 1) // empilha o array
+	code.Write(0, 1)
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_GET_INDEX_ARRAY), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[2]; got.Type != value.VAL_INT || got.Int() != 20 {
+		t.Fatalf("esperado 20, obtido %s", got.String())
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3, obtido %d", machine.stackTop)
+	}
+}
+
+// Map no lugar do array: redispatch para o generico, que indexa o map.
+func TestGetIndexArrayFallsBackToGenericMap(t *testing.T) {
+	code := &chunk.Chunk{}
+	m := code.AddConstant(value.NewMapWithData(map[string]value.Value{"k": value.NewInt(7)}))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(m), 1)
+	key := code.AddConstant(value.NewString("k"))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(key), 1)
+	code.Write(byte(chunk.OP_GET_INDEX_ARRAY), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.Int() != 7 {
+		t.Fatalf("esperado 7 (leitura do map pelo generico), obtido %s", got.String())
+	}
+}
+
+func TestSetLocalIndexArrayNorcWritesWithoutPushing(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 1)
+	writeConstInt(code, 99)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	arr := machine.stack[1].Obj.(*value.ObjArray)
+	if arr.Elements[1].Int() != 99 {
+		t.Fatalf("elemento 1 esperado 99, obtido %s", arr.Elements[1].String())
+	}
+	if machine.stackTop != 2 {
+		t.Fatalf("escrita fundida nao deve empilhar: stackTop esperado 2, obtido %d", machine.stackTop)
+	}
+}
+
+// Array compartilhado no slot (Owners > 1): a escrita fundida tem de clonar
+// como OP_GET_LOCAL_MUT faria — o slot passa a guardar o clone (escrito) e o
+// array original fica intacto.
+func TestSetLocalIndexArrayNorcClonesSharedArray(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 5)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	original := code.Constants[0]
+	value.Retain(original)
+	value.Retain(original) // Owners = 2: compartilhado
+	ResetCloneCount()
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+	if original.Obj.(*value.ObjArray).Elements[0].Int() != 10 {
+		t.Fatalf("array compartilhado foi mutado no lugar")
+	}
+	clone := machine.stack[1].Obj.(*value.ObjArray)
+	if clone == original.Obj.(*value.ObjArray) || clone.Elements[0].Int() != 5 {
+		t.Fatalf("slot deveria guardar o clone com a escrita: %v", machine.stack[1].String())
+	}
+}
+
+// Valor composto (vindo por `any`) num NORC: nao pode pular o Retain — cai no
+// generico, e o composto ganha um dono (o elemento do array).
+func TestSetLocalIndexArrayNorcRetainsCompositeValueViaGeneric(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 0)
+	inner := value.NewArray([]value.Value{value.NewInt(1)})
+	k := code.AddConstant(inner)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(k), 1)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	before := value.OwnersCount(inner)
+	if err := New().Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := value.OwnersCount(inner); got != before+1 {
+		t.Fatalf("composto escrito em array deve ganhar 1 dono (generico retem): antes %d, depois %d", before, got)
+	}
+}
+
+func TestSetIndexArrayNorcWritesAndFallsBackForNonArray(t *testing.T) {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_GET_LOCAL), 1)
+	code.Write(0, 1)
+	writeConstInt(code, 2)
+	writeConstInt(code, -7)
+	code.Write(byte(chunk.OP_SET_INDEX_ARRAY_NORC), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray).Elements[2].Int(); got != -7 {
+		t.Fatalf("esperado -7, obtido %d", got)
+	}
+	if machine.stackTop != 2 {
+		t.Fatalf("stackTop esperado 2, obtido %d", machine.stackTop)
+	}
+
+	bad := &chunk.Chunk{}
+	bad.Write(byte(chunk.OP_NULL), 1)
+	writeConstInt(bad, 0)
+	writeConstInt(bad, 1)
+	bad.Write(byte(chunk.OP_SET_INDEX_ARRAY_NORC), 1)
+	err := New().Interpret(bad)
+	if err == nil || !strings.Contains(err.Error(), "cannot set index on non-array/map") {
+		t.Fatalf("esperava erro do OP_SET_INDEX generico, obtido %v", err)
+	}
+}
+
+// Slot 1 = ref (REF_UPVALUE via OP_REF_LOCAL) para o slot 0 (array).
+func refTypedIndexChunk() *chunk.Chunk {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_REF_LOCAL), 1)
+	code.Write(0, 1)
+	return code
+}
+
+func TestGetRefLocalIndexArrayResolvesUpvalueRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_GET_REF_LOCAL_INDEX_ARRAY), 1)
+	code.Write(1, 1) // slot do ref
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[3]; got.Type != value.VAL_INT || got.Int() != 20 {
+		t.Fatalf("esperado 20, obtido %s", got.String())
+	}
+}
+
+// Slot de tipo estatico ref que guarda null (parametro `ref T[]` recebendo
+// null): OP_DEREF passa null adiante e OP_GET_INDEX reclama — a forma fundida
+// tem de produzir a mesma mensagem.
+func TestGetRefLocalIndexArrayNullRefMatchesGeneric(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1) // slot 0 = null
+	writeConstInt(code, 0)
+	code.Write(byte(chunk.OP_GET_REF_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot index non-array/map/bytes") {
+		t.Fatalf("esperava erro do generico para ref null, obtido %v", err)
+	}
+}
+
+func TestSetRefLocalIndexArrayNorcWritesThroughRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 42)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(1, 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray).Elements[0].Int(); got != 42 {
+		t.Fatalf("escrita via ref esperada 42, obtido %d", got)
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3 (array, ref), obtido %d", machine.stackTop)
+	}
+}
+
+// Ref para array compartilhado: clona e grava o clone DE VOLTA pelo ref
+// (unicizeThroughRefValue), como a sequencia GET_LOCAL_MUT_BORROW + DEREF_MUT.
+func TestSetRefLocalIndexArrayNorcClonesSharedThroughRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 42)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(1, 1)
+	original := code.Constants[0]
+	value.Retain(original)
+	value.Retain(original)
+	ResetCloneCount()
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava 1 clone, obtido %d", CloneCountValue())
+	}
+	if original.Obj.(*value.ObjArray).Elements[0].Int() != 10 {
+		t.Fatalf("array compartilhado foi mutado no lugar atraves do ref")
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray); got == original.Obj.(*value.ObjArray) || got.Elements[0].Int() != 42 {
+		t.Fatalf("o slot apontado pelo ref deveria guardar o clone escrito")
+	}
+}
+
+func TestSetRefLocalIndexArrayNorcNullRefMatchesGeneric(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1)
+	writeConstInt(code, 0)
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot set index on non-array/map") {
+		t.Fatalf("esperava erro do generico para ref null, obtido %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `go test ./internal/vm -run 'TypedIndex|LocalIndexArray|IndexArray|RefLocalIndex'`
+Expected: FAIL (opcodes não tratados no `switch` são no-op: valores errados na pilha / sem erro).
+
+- [ ] **Step 3: `setIndexGeneric`**
+
+Criar `internal/vm/index_ops.go` com o corpo EXATO do `case chunk.OP_SET_INDEX` atual (`executor.go`, do `val := vm.pop()` até o `return vm.runtimeError(c, ip, "cannot set index on non-array/map")`), trocando cada `continue` por `return nil`:
+
+```go
+package vm
+
+import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// setIndexGeneric e o corpo de OP_SET_INDEX: desempilha valor, indice e
+// container, escreve em array (guarda de slot ref, retain-antes-de-release)
+// ou map (retain/release so se a chave existia) e EMPILHA o valor (resultado
+// da atribuicao; o compilador emite OP_POP em seguida). Virou metodo na
+// indexacao tipada (issue #66, item 1) para ser o funil unico dos fallbacks
+// dos opcodes *_NORC — que materializam a pilha generica, chamam isto e
+// desempilham o resultado — sem duplicar a logica de erro; o custo e uma
+// chamada a mais por OP_SET_INDEX generico (maps, any, elemento composto),
+// medido em bench_map_churn.
+func (vm *VM) setIndexGeneric(c *chunk.Chunk, ip int) error {
+	val := vm.pop()
+	indexVal := vm.pop()
+	collectionVal := vm.pop() // The array/map itself is on stack (pointer)
+
+	if collectionVal.Type == value.VAL_OBJ {
+		if arr, ok := collectionVal.Obj.(*value.ObjArray); ok {
+			if indexVal.Type != value.VAL_INT {
+				return vm.runtimeError(c, ip, "array index must be integer")
+			}
+			idx := int(indexVal.Int())
+			if idx < 0 || idx >= len(arr.Elements) {
+				return vm.runtimeError(c, ip, "array index out of bounds")
+			}
+			// Guard do slot ref (spec §6.3): elemento `ref T` (tag
+			// RuntimeType) so aceita ref/null; via base tipada o
+			// compilador ja rejeitou. O teste de val.Type vem antes
+			// para o Load() atomico so rodar em escritas nao-ref.
+			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && arrayElementIsRefSlot(arr) {
+				return vm.runtimeError(c, ip, "%s", refSlotWriteError(arr.RuntimeType.Load().Element.String(), val))
+			}
+			// RC: retain-antes-de-release (elemento e dono duravel)
+			old := arr.Elements[idx]
+			value.Retain(val)
+			arr.Elements[idx] = val
+			value.Release(old)
+			vm.push(val) // Assignment expression result
+			return nil
+		} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
+			var key interface{}
+			if indexVal.Type == value.VAL_INT {
+				key = indexVal.Int()
+			} else if indexVal.Type == value.VAL_OBJ {
+				if str, ok := indexVal.Obj.(string); ok {
+					key = str
+				} else {
+					return vm.runtimeError(c, ip, "map key must be int or string")
+				}
+			} else {
+				return vm.runtimeError(c, ip, "map key must be int or string")
+			}
+			// Guard do slot ref (spec §6.3): valor `ref T` (tag
+			// RuntimeType) so aceita ref/null.
+			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && mapValueIsRefSlot(mapObj) {
+				return vm.runtimeError(c, ip, "%s", refSlotWriteError(mapObj.RuntimeType.Load().Value.String(), val))
+			}
+			// RC: so libera o velho se a chave ja existia (dec a
+			// menos e proibido); retain-antes-de-release quando existe.
+			if old, exists := mapObj.Get(key); exists {
+				value.Retain(val)
+				mapObj.Set(key, val)
+				value.Release(old)
+			} else {
+				value.Retain(val)
+				mapObj.Set(key, val)
+			}
+			vm.push(val)
+			return nil
+		}
+	}
+	return vm.runtimeError(c, ip, "cannot set index on non-array/map")
+}
+```
+
+(Conferir linha a linha contra o `case` atual antes de apagar o original — a cópia tem de ser literal.)
+
+Em `executor.go`, o `case chunk.OP_SET_INDEX:` inteiro vira:
+
+```go
+		case chunk.OP_SET_INDEX:
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+```
+
+- [ ] **Step 4: `unicizeOwnedSlot` / `unicizeBorrowedSlot`**
+
+Em `internal/vm/cow.go`, depois de `unicize`:
+
+```go
+// unicizeOwnedSlot e a semantica de OP_GET_LOCAL_MUT para um slot POSSUIDOR:
+// se o composto no slot esta compartilhado, grava um clone no slot (ownSlot
+// mantem o slot registrado em frame.Owned, como OP_SET_LOCAL) e solta o
+// velho; devolve o ocupante (unico) do slot. Metodo para ser o funil comum do
+// case generico e do fallback de OP_SET_LOCAL_INDEX_ARRAY_NORC (issue #66).
+func (vm *VM) unicizeOwnedSlot(frame *CallFrame, idx int) value.Value {
+	v := vm.stack[idx]
+	if value.IsShared(v) {
+		old := v
+		v = vm.copyValue(v)
+		vm.stack[idx] = v
+		// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
+		// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
+		frame.ownSlot(vm, idx)
+		value.Release(old)
+	}
+	return v
+}
+
+// unicizeBorrowedSlot e o gemeo de EMPRESTIMO (OP_GET_LOCAL_MUT_BORROW): slot
+// de tipo `ref T` nao possui o que guarda, entao o clone fica no slot sem
+// retain do novo nem release do velho (soltar o que nunca se reteve e dec a
+// menos). Fallback de OP_SET_REF_LOCAL_INDEX_ARRAY_NORC quando o slot guarda
+// um valor plano (tolerancia herdada do auto-deref antigo).
+func (vm *VM) unicizeBorrowedSlot(idx int) value.Value {
+	v := vm.stack[idx]
+	if value.IsShared(v) {
+		v = vm.copyValue(v)
+		vm.stack[idx] = v
+	}
+	return v
+}
+```
+
+Em `executor.go`, os dois cases passam a:
+
+```go
+		case chunk.OP_GET_LOCAL_MUT:
+			slot := c.Code[ip]
+			ip++
+			vm.push(vm.unicizeOwnedSlot(frame, frame.LocalBase+int(slot)))
+
+		case chunk.OP_GET_LOCAL_MUT_BORROW:
+			slot := c.Code[ip]
+			ip++
+			// RC: gemeo de EMPRESTIMO do acima, emitido quando o tipo declarado
+			// do local e `ref T` — ver unicizeBorrowedSlot (cow.go).
+			vm.push(vm.unicizeBorrowedSlot(frame.LocalBase + int(slot)))
+```
+
+(Mover os comentários longos de RC dos dois cases para os métodos, como acima.)
+
+- [ ] **Step 5: Rótulo `redispatch` e os seis handlers**
+
+Em `run()`, o topo do laço passa a:
+
+```go
+	for {
+		if ip >= len(c.Code) {
+			return nil
+		}
+
+		instruction := chunk.OpCode(c.Code[ip])
+		ip++
+
+		// redispatch: os opcodes de indexacao tipada (issue #66) re-entram aqui
+		// com `instruction` trocada pelo generico quando o container nao e o
+		// array que o tipo estatico prometia (null por `any`, ref de outro
+		// tipo) — depois de materializar na pilha exatamente o que a sequencia
+		// generica teria. Zero custo no caminho comum; so os fallbacks saltam.
+	redispatch:
+		switch instruction {
+```
+
+E, ao fim do `switch` (depois do `case chunk.OP_COPY:`), os seis cases:
+
+```go
+		// perf issue #66 (item 1): indexacao tipada de array. Caminho rapido
+		// grava o resultado NO LUGAR na pilha (sem pop/push); mensagens de erro
+		// identicas as do generico; container inesperado cai no generico.
+		case chunk.OP_GET_INDEX_ARRAY:
+			top := vm.stackTop
+			if arr, ok := vm.stack[top-2].Obj.(*value.ObjArray); ok {
+				indexVal := vm.stack[top-1]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				vm.stack[top-2] = arr.Elements[idx]
+				vm.stack[top-1] = value.Value{}
+				vm.stackTop = top - 1
+				continue
+			}
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_GET_LOCAL_INDEX_ARRAY:
+			slot := c.Code[ip]
+			ip++
+			if arr, ok := vm.stack[frame.LocalBase+int(slot)].Obj.(*value.ObjArray); ok {
+				top := vm.stackTop
+				indexVal := vm.stack[top-1]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				vm.stack[top-1] = arr.Elements[idx]
+				continue
+			}
+			// Fallback: a sequencia generica GET_LOCAL + GET_INDEX.
+			indexVal := vm.pop()
+			vm.push(vm.stack[frame.LocalBase+int(slot)])
+			vm.push(indexVal)
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_GET_REF_LOCAL_INDEX_ARRAY:
+			// O slot guarda o ref de um parametro `ref T[]`. REF_UPVALUE (a
+			// forma que OP_REF_LOCAL cria para todo ref a local) resolve com
+			// uma Load() da caixa em vez de referenceStorage (defer + closure
+			// do setter + reflect). arr != nil espelha o validateReferencedValue
+			// do caminho generico (typed nil cairia no erro de la).
+			slot := c.Code[ip]
+			ip++
+			refVal := vm.stack[frame.LocalBase+int(slot)]
+			if ref, ok := refVal.Obj.(*value.ObjRef); ok && ref.RefType == value.REF_UPVALUE {
+				if stored, ok := ref.Upvalue.Load(); ok {
+					if arr, ok := stored.Obj.(*value.ObjArray); ok && arr != nil {
+						top := vm.stackTop
+						indexVal := vm.stack[top-1]
+						if indexVal.Type != value.VAL_INT {
+							return vm.runtimeError(c, ip, "array index must be integer")
+						}
+						idx := int(indexVal.Int())
+						if idx < 0 || idx >= len(arr.Elements) {
+							return vm.runtimeError(c, ip, "array index out of bounds")
+						}
+						vm.stack[top-1] = arr.Elements[idx]
+						continue
+					}
+				}
+			}
+			// Fallback: GET_LOCAL + OP_DEREF (null e nao-ref passam; ref
+			// resolve) + GET_INDEX.
+			container := refVal
+			if refVal.Type == value.VAL_REF {
+				resolved, err := vm.resolveReferenceValue(refVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				container = resolved
+			}
+			indexVal := vm.pop()
+			vm.push(container)
+			vm.push(indexVal)
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_SET_INDEX_ARRAY_NORC:
+			// [arr, i, v] -> []. Pula Retain/Release SO se valor novo e velho
+			// sao comprovadamente sem contador e o array nao e (ref T)[] —
+			// senao o generico (setIndexGeneric) decide, como OP_SET_INDEX +
+			// OP_POP fariam.
+			top := vm.stackTop
+			if arr, ok := vm.stack[top-3].Obj.(*value.ObjArray); ok {
+				indexVal := vm.stack[top-2]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				val := vm.stack[top-1]
+				if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+					arr.Elements[idx] = val
+					vm.stack[top-1] = value.Value{}
+					vm.stack[top-2] = value.Value{}
+					vm.stack[top-3] = value.Value{}
+					vm.stackTop = top - 3
+					continue
+				}
+			}
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC:
+			// [i, v] -> []; container no slot do local possuidor. Caminho
+			// rapido = array unico (Owners <= 1 e o teste de IsShared, sem a
+			// chamada) + elemento sem contador; senao a sequencia generica
+			// GET_LOCAL_MUT + SET_INDEX + POP (unicizeOwnedSlot clona e
+			// registra posse exatamente como o case generico).
+			slot := c.Code[ip]
+			ip++
+			localIdx := frame.LocalBase + int(slot)
+			top := vm.stackTop
+			if arr, ok := vm.stack[localIdx].Obj.(*value.ObjArray); ok && arr.Owners.Load() <= 1 {
+				indexVal := vm.stack[top-2]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				val := vm.stack[top-1]
+				if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+					arr.Elements[idx] = val
+					vm.stack[top-1] = value.Value{}
+					vm.stack[top-2] = value.Value{}
+					vm.stackTop = top - 2
+					continue
+				}
+			}
+			val := vm.pop()
+			indexVal := vm.pop()
+			vm.push(vm.unicizeOwnedSlot(frame, localIdx))
+			vm.push(indexVal)
+			vm.push(val)
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+			// [i, v] -> []; o slot guarda o ref de um parametro `ref T[]`
+			// (slot de emprestimo). Caminho rapido = REF_UPVALUE cujo array e
+			// unico + elemento sem contador; senao GET_LOCAL_MUT_BORROW +
+			// DEREF_MUT (unicizeThroughRefValue clona e grava de volta pelo
+			// setter do ref) + SET_INDEX + POP.
+			slot := c.Code[ip]
+			ip++
+			localIdx := frame.LocalBase + int(slot)
+			refVal := vm.stack[localIdx]
+			top := vm.stackTop
+			if ref, ok := refVal.Obj.(*value.ObjRef); ok && ref.RefType == value.REF_UPVALUE {
+				if stored, ok := ref.Upvalue.Load(); ok {
+					if arr, ok := stored.Obj.(*value.ObjArray); ok && arr != nil && arr.Owners.Load() <= 1 {
+						indexVal := vm.stack[top-2]
+						if indexVal.Type != value.VAL_INT {
+							return vm.runtimeError(c, ip, "array index must be integer")
+						}
+						idx := int(indexVal.Int())
+						if idx < 0 || idx >= len(arr.Elements) {
+							return vm.runtimeError(c, ip, "array index out of bounds")
+						}
+						val := vm.stack[top-1]
+						if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+							arr.Elements[idx] = val
+							vm.stack[top-1] = value.Value{}
+							vm.stack[top-2] = value.Value{}
+							vm.stackTop = top - 2
+							continue
+						}
+					}
+				}
+			}
+			val := vm.pop()
+			indexVal := vm.pop()
+			var container value.Value
+			if refVal.Type == value.VAL_REF {
+				uniq, err := vm.unicizeThroughRefValue(refVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				container = uniq
+			} else {
+				container = vm.unicizeBorrowedSlot(localIdx)
+			}
+			vm.push(container)
+			vm.push(indexVal)
+			vm.push(val)
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+```
+
+E em `internal/vm/ref_slots.go`, ao lado de `arrayElementIsRefSlot`, a forma por tag (barata o bastante para inline em `run()`):
+
+```go
+// arrayTagIsRefSlot e arrayElementIsRefSlot sobre a tag ja carregada — a
+// forma que os opcodes NORC da indexacao tipada usam no caminho quente
+// (uma Load() feita pelo chamador, sem a chamada).
+func arrayTagIsRefSlot(tag *value.RuntimeTypeInfo) bool {
+	return tag != nil && tag.Kind == value.TYPE_ARRAY && tag.Element != nil && tag.Element.Kind == value.TYPE_REF
+}
+```
+
+- [ ] **Step 6: Rodar os testes novos e os guards**
+
+Run: `go test ./internal/vm -run 'TypedIndex|LocalIndexArray|IndexArray|RefLocalIndex|Inline'`
+Expected: PASS. Conferir no relatório do inliner que o caminho quente só chama `Upvalue.Load`, `NeverTracked` (inline), `arrayTagIsRefSlot` (inline, custo ≤ 20 — se não inlinar, escrever a condição inline no handler):
+
+```bash
+go build -gcflags=-m=2 ./internal/vm 2>&1 | grep -E "can inline (arrayTagIsRefSlot|\(\*VM\)\.(push|pop))|inlining call to value.NeverTracked" | sort | uniq -c | head
+```
+
+- [ ] **Step 7: Guard de sites de `NeverTracked`**
+
+Em `TestPushStaysInlinedInsideRun` (`inline_guard_test.go`), depois do bloco de `pop`:
+
+```go
+	// NeverTracked e chamada no caminho quente dos tres opcodes NORC (issue
+	// #66); se sair do inline, cada escrita tipada paga uma chamada.
+	neverTrackedInlined := 0
+	for _, line := range strings.Split(report, "\n") {
+		if strings.Contains(line, "executor.go") && strings.Contains(line, "inlining call to value.NeverTracked") {
+			neverTrackedInlined++
+		}
+	}
+	if neverTrackedInlined < 6 {
+		t.Errorf("value.NeverTracked foi inlinada em %d sites de executor.go, esperado >= 6 (dois por opcode NORC)", neverTrackedInlined)
+	}
+```
+
+Run: `go test ./internal/vm -run Inline` → PASS.
+
+- [ ] **Step 8: Suíte inteira do vm e gofmt/vet**
+
+Run: `gofmt -l internal/vm internal/value; go vet ./internal/vm ./internal/value; go test ./internal/vm ./internal/value`
+Expected: sem arquivos listados, vet limpo, PASS.
+
+- [ ] **Step 9: Commit e binário de estágio s0**
+
+```bash
+git add internal/vm/index_ops.go internal/vm/cow.go internal/vm/executor.go internal/vm/ref_slots.go internal/vm/typed_index_test.go internal/vm/inline_guard_test.go
+git commit -m "perf(vm): handlers da indexacao tipada de array — caminho rapido no lugar, fallback exato por redispatch (leitura) e setIndexGeneric (escrita), unicizeOwnedSlot/BorrowedSlot (issue #66, item 1)"
+go build -o "$S/bench/noxy_s0.exe" ./cmd/noxy
+```
+
+(`$S` = scratchpad, ver Global Constraints.) Nenhum bytecode novo é emitido ainda: `noxy_s0.exe` mede só o custo dos refactors (`setIndexGeneric` como chamada; `unicize*Slot`).
+
+---
+
+### Task 4: Compilador — formas genéricas `OP_GET_INDEX_ARRAY` / `OP_SET_INDEX_ARRAY_NORC`
+
+**Files:**
+- Create: `internal/compiler/typed_index.go` (`isUntrackedElementType`, `arrayTypeOf`; `isSideEffectFree` entra na Task 5)
+- Modify: `internal/compiler/compiler.go` (`case *ast.IndexExpression:` ~l.1090; atribuição a `IndexExpression` ~l.772)
+- Create: `internal/compiler/typed_index_compile_test.go`
+- Create: `internal/vm/typed_index_e2e_test.go`
+
+**Interfaces:**
+- Produces: `func isUntrackedElementType(t ast.NoxyType) bool` (PrimitiveType com Name em int/float/bool/string/bytes); `func arrayTypeOf(t ast.NoxyType) (*ast.ArrayType, bool)` (desembrulha um nível de `RefType`).
+- Test helper (pacote compiler): `func opcodeNames(t *testing.T, code *chunk.Chunk) []string` — nomes dos opcodes na ordem, lidos do disassembler.
+
+- [ ] **Step 1: Testes de bytecode (falham: genéricos emitidos)**
+
+Criar `internal/compiler/typed_index_compile_test.go`:
+
+```go
+package compiler
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+var opNamePattern = regexp.MustCompile(`\bOP_[A-Z_]+\b`)
+
+// opcodeNames devolve os nomes dos opcodes de um chunk NA ORDEM, lidos da
+// saida do disassembler (que conhece a largura de cada instrucao) —
+// containsOpcode varre bytes e confundiria um operando com um opcode.
+func opcodeNames(t *testing.T, code *chunk.Chunk) []string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan string)
+	go func() {
+		out, _ := io.ReadAll(reader)
+		done <- string(out)
+	}()
+	previous := os.Stdout
+	os.Stdout = writer
+	code.Disassemble("t")
+	_ = writer.Close()
+	os.Stdout = previous
+	return opNamePattern.FindAllString(<-done, -1)
+}
+
+func functionOpcodes(t *testing.T, source, name string) []string {
+	t.Helper()
+	fn := compiledFunction(t, source, name)
+	return opcodeNames(t, fn.Chunk.(*chunk.Chunk))
+}
+
+func topLevelOpcodes(t *testing.T, source string) []string {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return opcodeNames(t, code)
+}
+
+func assertHas(t *testing.T, ops []string, want string) {
+	t.Helper()
+	if !slices.Contains(ops, want) {
+		t.Fatalf("esperava %s no bytecode, obtido: %s", want, strings.Join(ops, " "))
+	}
+}
+
+func assertLacks(t *testing.T, ops []string, unwanted string) {
+	t.Helper()
+	if slices.Contains(ops, unwanted) {
+		t.Fatalf("nao esperava %s no bytecode, obtido: %s", unwanted, strings.Join(ops, " "))
+	}
+}
+
+// Base T[] em posicao generica (global): leitura tipada, escrita NORC sem OP_POP.
+func TestGlobalArrayUsesTypedIndexOpcodes(t *testing.T) {
+	ops := topLevelOpcodes(t, "let xs: int[] = [1, 2]\nlet i: int = 0\nxs[i] = xs[i] + 1\n")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX")
+	// O OP_POP que seguia OP_SET_INDEX nao existe mais: o unico OP_POP
+	// restante e de outra statement, nao o da atribuicao indexada.
+	for k, op := range ops {
+		if op == "OP_SET_INDEX_ARRAY_NORC" && k+1 < len(ops) && ops[k+1] == "OP_POP" {
+			t.Fatalf("OP_SET_INDEX_ARRAY_NORC seguido de OP_POP: a forma NORC nao empilha")
+		}
+	}
+}
+
+// Nested: o nivel de fora e MUT generico, o de dentro e tipado.
+func TestNestedArrayWriteUsesTypedInnerOpcode(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(g: int[][]) -> int
+    g[0][1] = g[1][0] + 1
+    return g[0][1]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX_MUT")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX")
+}
+
+// Elemento composto: escrita segue OP_SET_INDEX (RC do generico); leitura e tipada.
+func TestCompositeElementKeepsGenericSetIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f(ps: P[][]) -> P
+    ps[0][0] = P(1)
+    return ps[0][0]
+end
+`, "f")
+	assertHas(t, ops, "OP_SET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+}
+
+// Map e any: tudo generico.
+func TestMapAndAnyKeepGenericIndexOpcodes(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(m: map[string, int], a: any) -> int
+    m["k"] = a[0]
+    return m["k"]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX")
+	assertHas(t, ops, "OP_SET_INDEX")
+	assertLacks(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+}
+
+// Upvalue de tipo T[] (closure): forma generica tipada, nunca a fundida por slot.
+func TestUpvalueArrayUsesGenericTypedOpcodes(t *testing.T) {
+	ops := functionOpcodes(t, `
+func outer() -> int
+    let xs: int[] = [1, 2]
+    func inner() -> int
+        xs[0] = 5
+        return xs[1]
+    end
+    return inner()
+end
+`, "inner")
+	assertHas(t, ops, "OP_GET_UPVALUE_MUT")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+}
+```
+
+Run: `go test ./internal/compiler -run 'TypedIndex|GlobalArray|NestedArray|CompositeElement|MapAndAny|UpvalueArray'`
+Expected: FAIL (OP_GET_INDEX/OP_SET_INDEX genéricos).
+
+- [ ] **Step 2: Helpers do compilador**
+
+Criar `internal/compiler/typed_index.go`:
+
+```go
+package compiler
+
+import "noxy-vm/internal/ast"
+
+// Indexacao tipada de array (issue #66, item 1): o compilador sabe quando a
+// base e T[] e emite os opcodes especializados de internal/chunk. Este arquivo
+// reune os predicados da decisao; a emissao mora em compiler.go (leitura em
+// `case *ast.IndexExpression`, escrita na atribuicao a IndexExpression e no
+// for-each).
+
+// isUntrackedElementType responde se um ELEMENTO desse tipo estatico nunca
+// tem contador RC — os unicos casos em que a escrita pode usar a forma NORC.
+// Lista fechada por nome: struct tambem e PrimitiveType (pelo nome da
+// declaracao) e `any` pode guardar composto, entao ambos respondem false.
+func isUntrackedElementType(t ast.NoxyType) bool {
+	prim, ok := t.(*ast.PrimitiveType)
+	if !ok {
+		return false
+	}
+	switch prim.Name {
+	case "int", "float", "bool", "string", "bytes":
+		return true
+	}
+	return false
+}
+
+// arrayTypeOf desembrulha um nivel de `ref` e devolve o ArrayType da base,
+// se for um — o tipo que decide entre OP_GET_INDEX_ARRAY e OP_GET_INDEX.
+func arrayTypeOf(t ast.NoxyType) (*ast.ArrayType, bool) {
+	if ref, ok := t.(*ast.RefType); ok {
+		t = ref.ElementType
+	}
+	arr, ok := t.(*ast.ArrayType)
+	return arr, ok
+}
+```
+
+- [ ] **Step 3: Emissão na leitura**
+
+Em `compiler.go`, `case *ast.IndexExpression:`, trocar
+
+```go
+		c.emitByte(byte(chunk.OP_GET_INDEX))
+```
+
+por
+
+```go
+		// perf #66: base estaticamente T[] (ou ref T[], ja dereferenciada
+		// acima) indexa sem despacho dinamico; o VM cai no OP_GET_INDEX
+		// generico se o container em runtime nao for array.
+		if _, isArray := arrayTypeOf(leftType); isArray {
+			c.emitByte(byte(chunk.OP_GET_INDEX_ARRAY))
+		} else {
+			c.emitByte(byte(chunk.OP_GET_INDEX))
+		}
+```
+
+(`leftType` ali ainda é o tipo antes do desembrulho feito logo abaixo — `arrayTypeOf` desembrulha.)
+
+- [ ] **Step 4: Emissão na escrita**
+
+Na atribuição a `IndexExpression` (~l.772), trocar
+
+```go
+			c.emitByte(byte(chunk.OP_SET_INDEX))
+			c.emitByte(byte(chunk.OP_POP))
+```
+
+por
+
+```go
+			// perf #66: elemento sem contador RC em base T[] escreve pela forma
+			// NORC, que e statement (nao empilha; sem OP_POP). O VM confere em
+			// runtime antes de pular Retain/Release.
+			if arrType, isArray := leftType.(*ast.ArrayType); isArray && isUntrackedElementType(arrType.ElementType) {
+				c.emitByte(byte(chunk.OP_SET_INDEX_ARRAY_NORC))
+			} else {
+				c.emitByte(byte(chunk.OP_SET_INDEX))
+				c.emitByte(byte(chunk.OP_POP))
+			}
+```
+
+(`leftType` nesse ponto já foi desembrulhado de `ref` pelo código existente.)
+
+- [ ] **Step 5: Rodar os testes de bytecode**
+
+Run: `go test ./internal/compiler -run 'TypedIndex|GlobalArray|NestedArray|CompositeElement|MapAndAny|UpvalueArray'`
+Expected: PASS.
+
+- [ ] **Step 6: Testes ponta a ponta (comportamento e erros idênticos)**
+
+Criar `internal/vm/typed_index_e2e_test.go`:
+
+```go
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Ponta a ponta (fonte -> compilador -> VM) da indexacao tipada de array
+// (issue #66, item 1): mesmo resultado, mesma semantica CoW/RC e mesmas
+// mensagens de erro do caminho generico. Cada caso "tipado" tem o gemeo
+// "any" (base dinamica), que continua no generico: os dois tem de concordar.
+
+func TestTypedIndexGlobalArrayReadWrite(t *testing.T) {
+	got := captureVMSource(t, `
+let xs: int[] = [1, 2, 3]
+let i: int = 1
+xs[i] = xs[i] * 10
+xs[0] = xs[2]
+test_report(xs)
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 3 || arr.Elements[1].Int() != 20 || arr.Elements[2].Int() != 3 {
+		t.Fatalf("esperado [3, 20, 3], obtido %s", got.String())
+	}
+}
+
+func TestTypedIndexNestedAndStringElements(t *testing.T) {
+	got := captureVMSource(t, `
+func f() -> string
+    let g: string[][] = [["a", "b"], ["c", "d"]]
+    g[0][1] = g[1][0] + "!"
+    return g[0][1] + g[1][1]
+end
+test_report(f())
+`)
+	if s, ok := got.Obj.(string); !ok || s != "c!d" {
+		t.Fatalf("esperado \"c!d\", obtido %s", got.String())
+	}
+}
+
+// Elemento composto vindo por `any` numa base int[]: o NORC ve que o valor e
+// rastreado e cai no generico, que retem — o composto ganha o dono do
+// elemento, como no caminho generico.
+func TestTypedIndexNorcRetainsCompositeFromAny(t *testing.T) {
+	got := captureVMSource(t, `
+let inner: int[] = [7]
+let xs: int[] = [1, 2]
+let v: any = inner
+xs[0] = v
+test_report(xs)
+`)
+	outer := got.Obj.(*value.ObjArray)
+	if value.OwnersCount(outer.Elements[0]) < 2 {
+		t.Fatalf("composto escrito via any deve ter o dono do elemento alem do global: owners=%d", value.OwnersCount(outer.Elements[0]))
+	}
+}
+
+func TestTypedIndexErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa", "let a: int[] = [1]\nlet i: int = 5\nprint(a[i])\n", "let a: any = [1]\nlet i: int = 5\nprint(a[i])\n", "array index out of bounds"},
+		{"escrita fora da faixa", "let a: int[] = [1]\nlet i: int = 5\na[i] = 2\n", "let a: any = [1]\nlet i: int = 5\na[i] = 2\n", "array index out of bounds"},
+		{"indice nao inteiro via any", "let a: int[] = [1]\nlet i: any = \"x\"\nprint(a[i])\n", "let a: any = [1]\nlet i: any = \"x\"\nprint(a[i])\n", "array index must be integer"},
+		{"escrita com indice nao inteiro via any", "let a: int[] = [1]\nlet i: any = \"x\"\na[i] = 2\n", "let a: any = [1]\nlet i: any = \"x\"\na[i] = 2\n", "array index must be integer"},
+		{"nested fora da faixa", "let a: int[][] = [[1]]\nlet i: int = 5\na[0][i] = 1\n", "let a: any = [[1]]\nlet i: int = 5\na[0][i] = 1\n", "array index out of bounds"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}
+```
+
+Run: `go test ./internal/vm -run TypedIndex`
+Expected: PASS.
+
+- [ ] **Step 7: Suíte e commit; binário s1**
+
+Run: `gofmt -l internal/compiler internal/vm; go vet ./internal/compiler ./internal/vm; go test ./internal/compiler ./internal/vm ./internal/chunk`
+Expected: PASS.
+
+```bash
+git add internal/compiler/typed_index.go internal/compiler/compiler.go internal/compiler/typed_index_compile_test.go internal/vm/typed_index_e2e_test.go
+git commit -m "perf(compiler): emite OP_GET_INDEX_ARRAY / OP_SET_INDEX_ARRAY_NORC quando a base e estaticamente T[] e o elemento nao tem contador RC (issue #66, item 1, estagio 1)"
+go build -o "$S/bench/noxy_s1.exe" ./cmd/noxy
+```
+
+---
+
+### Task 5: Compilador — formas fundidas por slot de local plano e for-each
+
+**Files:**
+- Modify: `internal/compiler/typed_index.go` (`isSideEffectFree`, `fusedLocalIndexRead`, `tryFuseLocalIndexAssign`)
+- Modify: `internal/compiler/compiler.go` (`case *ast.IndexExpression:` início; atribuição a `IndexExpression` início; for-each ~l.1657)
+- Modify: `internal/compiler/typed_index_compile_test.go`
+- Modify: `internal/vm/typed_index_e2e_test.go`
+
+**Interfaces:**
+- Produces: `func isSideEffectFree(expr ast.Expression) bool`; `func (c *Compiler) fusedLocalIndexRead(n *ast.IndexExpression) (op chunk.OpCode, slot int, elem ast.NoxyType, ok bool)`; `func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExpr ast.Expression) (bool, error)`. Nesta task só o ramo `ArrayType` dos dois; a Task 6 acrescenta o ramo `RefType{ArrayType}`.
+
+- [ ] **Step 1: Testes de bytecode (falham)**
+
+Acrescentar a `typed_index_compile_test.go`:
+
+```go
+// Local plano T[] com indice puro: forma fundida por slot, sem GET_LOCAL do
+// array e sem OP_POP depois da escrita.
+func TestLocalArrayFusesIndexIntoSlotForm(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    let i: int = 1
+    xs[i + 1] = xs[i] + xs[0]
+    return xs[2]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_LOCAL_MUT")
+	for k, op := range ops {
+		if op == "OP_SET_LOCAL_INDEX_ARRAY_NORC" && k+1 < len(ops) && ops[k+1] == "OP_POP" {
+			t.Fatalf("forma fundida seguida de OP_POP")
+		}
+	}
+}
+
+// Indice ou valor com chamada: a forma fundida NAO sai (le o slot depois de
+// avaliar os operandos; uma chamada poderia rebindar o local via closure ou
+// ref). Fica a forma generica tipada, com o container avaliado primeiro.
+func TestLocalArrayDoesNotFuseWhenOperandHasCall(t *testing.T) {
+	ops := functionOpcodes(t, `
+func idx() -> int
+    return 0
+end
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    xs[idx()] = 5
+    xs[0] = idx()
+    return xs[idx()]
+end
+`, "f")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_LOCAL_MUT")
+}
+
+// Parametro T[] (sem ref) e local possuidor: funde.
+func TestArrayParameterFusesIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+func sum(data: int[]) -> int
+    let s: int = 0
+    let i: int = 0
+    while i < 3 do
+        s = s + data[i]
+        i = i + 1
+    end
+    data[0] = s
+    return s
+end
+`, "sum")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+}
+
+// for-each sobre array: o item e lido pela forma fundida no slot $collection.
+func TestForEachOverArrayUsesFusedRead(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(xs: int[]) -> int
+    let s: int = 0
+    for x in xs do
+        s = s + x
+    end
+    return s
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_GET_INDEX")
+}
+
+// for-each sobre map continua generico (a colecao iterada e o array de chaves
+// sem tipo estatico).
+func TestForEachOverMapKeepsGenericRead(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(m: map[string, int]) -> int
+    let n: int = 0
+    for k in m do
+        n = n + 1
+    end
+    return n
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+}
+
+// Elemento composto em local: leitura funde (leitura nao tem RC), escrita nao.
+func TestLocalCompositeArrayFusesReadOnly(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f() -> P
+    let ps: P[] = [P(1), P(2)]
+    ps[0] = ps[1]
+    return ps[0]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_SET_INDEX")
+}
+```
+
+Run: `go test ./internal/compiler -run 'LocalArray|ArrayParameter|ForEachOver|LocalComposite'`
+Expected: FAIL.
+
+- [ ] **Step 2: Predicado e decisões**
+
+Acrescentar a `internal/compiler/typed_index.go` (imports passam a incluir `"fmt"` e `"noxy-vm/internal/chunk"`):
+
+```go
+// isSideEffectFree e o predicado sintatico que libera as formas FUNDIDAS por
+// slot (spec §3.3): elas leem o slot do local DEPOIS de avaliar indice (e
+// valor), entao so valem quando nada ali pode rodar codigo — chamada
+// (inclusive builtin e f-string, que viram chamadas), closure, `ref`, literal
+// composto, zeros — que rebindasse ou compartilhasse o local no meio da
+// statement. Com operandos assim, a ordem observavel e a da sequencia
+// generica. Conservador: o que nao esta na lista e impuro.
+func isSideEffectFree(expr ast.Expression) bool {
+	switch n := expr.(type) {
+	case *ast.Identifier, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral,
+		*ast.BytesLiteral, *ast.Boolean, *ast.NullLiteral:
+		return true
+	case *ast.PrefixExpression:
+		switch n.Operator {
+		case "-", "!", "~", "*":
+			return isSideEffectFree(n.Right)
+		}
+		return false
+	case *ast.InfixExpression:
+		return isSideEffectFree(n.Left) && isSideEffectFree(n.Right)
+	case *ast.IndexExpression:
+		return isSideEffectFree(n.Left) && isSideEffectFree(n.Index)
+	case *ast.MemberAccessExpression:
+		return isSideEffectFree(n.Left)
+	}
+	return false
+}
+
+// fusedLocalIndexRead decide se `n` (X[i]) pode ser lida pela forma fundida
+// por slot: X e identificador resolvido a local (slot <= 255) de tipo T[]
+// (OP_GET_LOCAL_INDEX_ARRAY) e i e livre de efeito colateral. Devolve o
+// opcode, o slot e o tipo do elemento.
+func (c *Compiler) fusedLocalIndexRead(n *ast.IndexExpression) (chunk.OpCode, int, ast.NoxyType, bool) {
+	ident, ok := n.Left.(*ast.Identifier)
+	if !ok {
+		return 0, 0, nil, false
+	}
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 || !isSideEffectFree(n.Index) {
+		return 0, 0, nil, false
+	}
+	if arr, ok := localType.(*ast.ArrayType); ok {
+		return chunk.OP_GET_LOCAL_INDEX_ARRAY, arg, arr.ElementType, true
+	}
+	return 0, 0, nil, false
+}
+
+// tryFuseLocalIndexAssign funde `x[i] = v` quando x e local T[] POSSUIDOR
+// (OP_SET_LOCAL_INDEX_ARRAY_NORC), T sem contador RC, e i e v sao livres de
+// efeito colateral. Devolve (true, nil) se emitiu; (true, err) num erro de
+// compilacao — as MESMAS checagens e mensagens do ramo ArrayType do caminho
+// generico, so que sem compileLValueBase antes (para identificador local ele
+// nunca erra: so emitiria o GET_LOCAL_MUT que a forma fundida substitui);
+// (false, nil) para seguir o caminho generico. Owns continua a fonte de
+// verdade (spec CoW-RC §4.2): slot T[] nao-possuidor vai pelo generico.
+func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExpr ast.Expression) (bool, error) {
+	ident, ok := target.Left.(*ast.Identifier)
+	if !ok {
+		return false, nil
+	}
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 {
+		return false, nil
+	}
+	var op chunk.OpCode
+	var arrType *ast.ArrayType
+	switch t := localType.(type) {
+	case *ast.ArrayType:
+		if !c.localOwns(arg) {
+			return false, nil
+		}
+		op, arrType = chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC, t
+	default:
+		return false, nil
+	}
+	if !isUntrackedElementType(arrType.ElementType) || !isSideEffectFree(target.Index) || !isSideEffectFree(valueExpr) {
+		return false, nil
+	}
+	_, idxType, err := c.Compile(target.Index)
+	if err != nil {
+		return true, err
+	}
+	if _, isRef := idxType.(*ast.RefType); isRef {
+		c.emitByte(byte(chunk.OP_DEREF))
+	}
+	_, valType, err := c.Compile(valueExpr)
+	if err != nil {
+		return true, err
+	}
+	if ref, isRef := idxType.(*ast.RefType); isRef {
+		idxType = ref.ElementType
+	}
+	if idxType != nil && idxType.String() != "int" {
+		return true, fmt.Errorf("[line %d] array index must be int, got %s", c.currentLine, idxType.String())
+	}
+	if !c.areTypesCompatible(arrType.ElementType, valType) {
+		return true, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s%s", c.currentLine, arrType.ElementType.String(), valType.String(), c.derefReadHint(arrType.ElementType, valType, valueExpr))
+	}
+	if err := c.emitRuntimeValueType(arrType.ElementType); err != nil {
+		return true, err
+	}
+	c.emitBytes(byte(op), byte(arg))
+	return true, nil
+}
+```
+
+- [ ] **Step 3: Ligar no compilador**
+
+Em `compiler.go`, início de `case *ast.IndexExpression:` (antes de `_, leftType, err := c.Compile(n.Left)`):
+
+```go
+	case *ast.IndexExpression:
+		// perf #66: local T[] (ou ref T[]) com indice puro le pela forma
+		// fundida por slot — sem empilhar o Value do array.
+		if op, slot, elem, ok := c.fusedLocalIndexRead(n); ok {
+			_, idxType, err := c.Compile(n.Index)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, isRef := idxType.(*ast.RefType); isRef {
+				c.emitByte(byte(chunk.OP_DEREF))
+			}
+			c.emitBytes(byte(op), byte(slot))
+			return c.currentChunk, elem, nil
+		}
+```
+
+Na atribuição, logo depois de `} else if indexExp, ok := n.Target.(*ast.IndexExpression); ok {` e antes do comentário "Array/Map Assignment":
+
+```go
+			// perf #66: `x[i] = v` com x local T[] (ou ref T[]), elemento sem
+			// contador RC e operandos puros — forma fundida por slot, statement.
+			if fused, err := c.tryFuseLocalIndexAssign(indexExp, n.Value); fused {
+				if err != nil {
+					return nil, nil, err
+				}
+				return c.currentChunk, nil, nil
+			}
+```
+
+No for-each (~l.1657), trocar
+
+```go
+		c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-3)) // $collection
+		c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2)) // $index
+		c.emitByte(byte(chunk.OP_GET_INDEX))
+```
+
+por
+
+```go
+		if _, isArray := colType.(*ast.ArrayType); isArray {
+			// perf #66: leitura fundida — o indice vai para a pilha e o array
+			// vem do slot $collection, sem empilhar o seu Value.
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2))             // $index
+			c.emitBytes(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), byte(len(c.locals)-3)) // $collection
+		} else {
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-3)) // $collection
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2)) // $index
+			c.emitByte(byte(chunk.OP_GET_INDEX))
+		}
+```
+
+- [ ] **Step 4: Rodar os testes de bytecode**
+
+Run: `go test ./internal/compiler`
+Expected: PASS (inclusive os testes existentes de CoW/bytecode).
+
+- [ ] **Step 5: Testes ponta a ponta**
+
+Acrescentar a `internal/vm/typed_index_e2e_test.go`:
+
+```go
+func TestTypedIndexLocalBubbleSortByValue(t *testing.T) {
+	got := captureVMSource(t, `
+func sorted() -> int[]
+    let data: int[] = [5, 1, 4, 2, 3]
+    let n: int = length(data)
+    let i: int = 0
+    while i < n do
+        let j: int = 0
+        while j < n - i - 1 do
+            if data[j] > data[j + 1] then
+                let tmp: int = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            end
+            j = j + 1
+        end
+        i = i + 1
+    end
+    return data
+end
+test_report(sorted())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	for k := range 5 {
+		if arr.Elements[k].Int() != int64(k+1) {
+			t.Fatalf("esperado [1..5], obtido %s", got.String())
+		}
+	}
+}
+
+// CoW: escrita fundida num local cujo array esta compartilhado clona — a copia
+// nao ve a mutacao e o clone e exatamente um.
+func TestTypedIndexLocalWriteClonesSharedArray(t *testing.T) {
+	ResetCloneCount()
+	got := captureVMSource(t, `
+func f() -> int[]
+    let a: int[] = [1, 2, 3]
+    let b: int[] = a
+    a[0] = 99
+    return [a[0], b[0]]
+end
+test_report(f())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 99 || arr.Elements[1].Int() != 1 {
+		t.Fatalf("esperado [99, 1] (b intacto), obtido %s", got.String())
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+}
+
+// for-each sobre array com mutacao durante a iteracao: o comportamento de hoje
+// (a iteracao continua no mesmo array e ve a escrita) e preservado.
+func TestTypedIndexForEachSeesMutationDuringIteration(t *testing.T) {
+	got := captureVMSource(t, `
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    let s: int = 0
+    for x in xs do
+        if x == 1 then
+            xs[2] = 30
+        end
+        s = s + x
+    end
+    return s
+end
+test_report(f())
+`)
+	if got.Int() != 33 {
+		t.Fatalf("esperado 33 (1 + 2 + 30), obtido %s", got.String())
+	}
+}
+
+func TestTypedIndexLocalErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa", "func f() -> int\n    let a: int[] = [1]\n    let i: int = 5\n    return a[i]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: int = 5\n    return a[i]\nend\nprint(f())\n", "array index out of bounds"},
+		{"escrita fora da faixa", "func f() -> int\n    let a: int[] = [1]\n    let i: int = 5\n    a[i] = 2\n    return a[0]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: int = 5\n    a[i] = 2\n    return a[0]\nend\nprint(f())\n", "array index out of bounds"},
+		{"indice nao inteiro via any", "func f() -> int\n    let a: int[] = [1]\n    let i: any = \"x\"\n    return a[i]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: any = \"x\"\n    return a[i]\nend\nprint(f())\n", "array index must be integer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}
+```
+
+Run: `go test ./internal/vm -run TypedIndex`
+Expected: PASS.
+
+- [ ] **Step 6: Suíte, commit e binário s2**
+
+Run: `gofmt -l internal/compiler internal/vm; go vet ./internal/compiler ./internal/vm; go test ./internal/compiler ./internal/vm ./internal/chunk`
+Expected: PASS.
+
+```bash
+git add internal/compiler/typed_index.go internal/compiler/compiler.go internal/compiler/typed_index_compile_test.go internal/vm/typed_index_e2e_test.go
+git commit -m "perf(compiler): formas fundidas por slot para local T[] — OP_GET_LOCAL_INDEX_ARRAY (inclusive for-each) e OP_SET_LOCAL_INDEX_ARRAY_NORC, so com operandos sem efeito colateral (issue #66, item 1, estagio 2)"
+go build -o "$S/bench/noxy_s2.exe" ./cmd/noxy
+```
+
+---
+
+### Task 6: Compilador — formas fundidas para local `ref T[]`
+
+**Files:**
+- Modify: `internal/compiler/typed_index.go` (`fusedLocalIndexRead`, `tryFuseLocalIndexAssign`: ramo `RefType`)
+- Modify: `internal/compiler/typed_index_compile_test.go`
+- Modify: `internal/vm/typed_index_e2e_test.go`
+
+**Interfaces:**
+- Consumes: tudo das Tasks 3–5.
+
+- [ ] **Step 1: Testes de bytecode (falham)**
+
+Acrescentar a `typed_index_compile_test.go`:
+
+```go
+// Parametro `ref T[]`: leitura e escrita pela forma fundida de ref — sem
+// OP_DEREF/OP_DEREF_MUT (o opcode resolve a caixa), sem OP_POP.
+func TestRefArrayParameterFusesIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+func bubble(data: ref int[]) -> void
+    let j: int = 0
+    if data[j] > data[j + 1] then
+        let tmp: int = data[j]
+        data[j] = data[j + 1]
+        data[j + 1] = tmp
+    end
+end
+`, "bubble")
+	assertHas(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_DEREF")
+	assertLacks(t, ops, "OP_DEREF_MUT")
+	assertLacks(t, ops, "OP_GET_LOCAL_MUT_BORROW")
+	assertLacks(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX")
+	for k, op := range ops {
+		if op == "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC" && k+1 < len(ops) && ops[k+1] == "OP_POP" {
+			t.Fatalf("forma fundida de ref seguida de OP_POP")
+		}
+	}
+}
+
+// Com chamada no operando, o ref segue o caminho de hoje (DEREF / DEREF_MUT)
+// com os opcodes tipados genericos.
+func TestRefArrayParameterDoesNotFuseWithCall(t *testing.T) {
+	ops := functionOpcodes(t, `
+func g() -> int
+    return 0
+end
+func f(data: ref int[]) -> int
+    data[g()] = 1
+    return data[g()]
+end
+`, "f")
+	assertLacks(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_DEREF")
+	assertHas(t, ops, "OP_DEREF_MUT")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+}
+
+// `ref P[]` (elemento composto): leitura funde, escrita fica no generico.
+func TestRefCompositeArrayFusesReadOnly(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f(ps: ref P[]) -> P
+    ps[0] = ps[1]
+    return ps[0]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_SET_INDEX")
+}
+```
+
+Run: `go test ./internal/compiler -run 'RefArrayParameter|RefComposite'`
+Expected: FAIL.
+
+- [ ] **Step 2: Ramo `RefType`**
+
+Em `fusedLocalIndexRead`, antes do `return 0, 0, nil, false` final:
+
+```go
+	if ref, ok := localType.(*ast.RefType); ok {
+		if arr, ok := ref.ElementType.(*ast.ArrayType); ok {
+			return chunk.OP_GET_REF_LOCAL_INDEX_ARRAY, arg, arr.ElementType, true
+		}
+	}
+```
+
+Em `tryFuseLocalIndexAssign`, no `switch t := localType.(type)`, acrescentar:
+
+```go
+	case *ast.RefType:
+		// Slot `ref T[]` EMPRESTA (spec CoW-RC §4.2): a forma fundida de ref
+		// reproduz GET_LOCAL_MUT_BORROW + DEREF_MUT. Um slot ref possuidor
+		// seria estado inesperado — vai pelo generico.
+		inner, isArr := t.ElementType.(*ast.ArrayType)
+		if !isArr || c.localOwns(arg) {
+			return false, nil
+		}
+		op, arrType = chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC, inner
+```
+
+Atualizar os comentários de `fusedLocalIndexRead`/`tryFuseLocalIndexAssign` para mencionar o ramo `ref T[]`.
+
+- [ ] **Step 3: Rodar os testes de bytecode**
+
+Run: `go test ./internal/compiler`
+Expected: PASS.
+
+- [ ] **Step 4: Testes ponta a ponta**
+
+Acrescentar a `internal/vm/typed_index_e2e_test.go`:
+
+```go
+func TestTypedIndexRefBubbleSortMutatesCaller(t *testing.T) {
+	got := captureVMSource(t, `
+func bubble(data: ref int[]) -> void
+    let n: int = length(data)
+    let i: int = 0
+    while i < n do
+        let j: int = 0
+        while j < n - i - 1 do
+            if data[j] > data[j + 1] then
+                let tmp: int = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            end
+            j = j + 1
+        end
+        i = i + 1
+    end
+end
+func main() -> int[]
+    let data: int[] = [5, 1, 4, 2, 3]
+    bubble(ref data)
+    return data
+end
+test_report(main())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	for k := range 5 {
+		if arr.Elements[k].Int() != int64(k+1) {
+			t.Fatalf("esperado [1..5] no chamador, obtido %s", got.String())
+		}
+	}
+}
+
+// CoW atraves do ref: o array apontado esta compartilhado com `copy`; a
+// escrita fundida clona, grava o clone de volta no slot do chamador (o ref
+// continua valido) e `copy` fica intacta. Exatamente 1 clone.
+func TestTypedIndexRefWriteClonesSharedTarget(t *testing.T) {
+	ResetCloneCount()
+	got := captureVMSource(t, `
+func set0(data: ref int[]) -> void
+    data[0] = 99
+end
+func main() -> int[]
+    let data: int[] = [1, 2]
+    let copy: int[] = data
+    set0(ref data)
+    return [data[0], copy[0]]
+end
+test_report(main())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 99 || arr.Elements[1].Int() != 1 {
+		t.Fatalf("esperado [99, 1], obtido %s", got.String())
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+}
+
+func TestTypedIndexRefErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa via ref", "func f(d: ref int[]) -> int\n    let i: int = 5\n    return d[i]\nend\nlet a: int[] = [1]\nprint(f(ref a))\n", "func f(d: any) -> any\n    let i: int = 5\n    return d[i]\nend\nlet a: any = [1]\nprint(f(a))\n", "array index out of bounds"},
+		{"escrita fora da faixa via ref", "func f(d: ref int[]) -> void\n    let i: int = 5\n    d[i] = 2\nend\nlet a: int[] = [1]\nf(ref a)\n", "func f(d: any) -> void\n    let i: int = 5\n    d[i] = 2\nend\nlet a: any = [1]\nf(a)\n", "array index out of bounds"},
+		{"ref null leitura", "func f(d: ref int[]) -> int\n    let i: int = 0\n    return d[i]\nend\nprint(f(null))\n", "func f(d: any) -> any\n    let i: int = 0\n    return d[i]\nend\nprint(f(null))\n", "cannot index non-array/map/bytes"},
+		{"ref null escrita", "func f(d: ref int[]) -> void\n    let i: int = 0\n    d[i] = 1\nend\nf(null)\n", "func f(d: any) -> void\n    let i: int = 0\n    d[i] = 1\nend\nf(null)\n", "cannot set index on non-array/map"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}
+```
+
+Run: `go test ./internal/vm -run TypedIndex`
+Expected: PASS.
+
+- [ ] **Step 5: Suíte completa, race, corpus, commit e binário s3 (head)**
+
+```bash
+gofmt -l internal; go vet ./internal/... && go test ./... 2>&1 | tail -15
+go test -race ./internal/value ./internal/vm 2>&1 | tail -3
+go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx 2>&1 | tail -5
+```
+
+Expected: tudo verde; corpus 0 falhas.
+
+```bash
+git add internal/compiler/typed_index.go internal/compiler/typed_index_compile_test.go internal/vm/typed_index_e2e_test.go
+git commit -m "perf(compiler): formas fundidas para parametro ref T[] — OP_GET_REF_LOCAL_INDEX_ARRAY / OP_SET_REF_LOCAL_INDEX_ARRAY_NORC resolvem a caixa com uma Load(), sem referenceStorage (issue #66, item 1, estagio 3)"
+go build -o "$S/bench/noxy_s3.exe" ./cmd/noxy
+```
+
+---
+
+### Task 7: Medição
+
+**Files:**
+- Create (scratch, não commitado): `$S/bench/stages.ps1`
+- Create: `benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md`
+- Modify: `benchmarks/RESULTS.md` (nova seção no topo), `benchmarks/cross_runtime/results/cross_runtime.md` (sobrescrito pelo script)
+
+- [ ] **Step 1: Checar carga e diff de saída do corpus**
+
+```powershell
+Get-Counter '\Processor(_Total)\% Processor Time' -SampleInterval 1 -MaxSamples 3 | % { $_.CounterSamples.CookedValue }
+powershell -File benchmarks/compare_examples.ps1 -Baseline $S\bench\noxy_base.exe -Candidate $S\bench\noxy_s3.exe
+```
+
+Expected: CPU < ~20 %; "N iguais, 0 divergentes".
+
+- [ ] **Step 2: Headline intercalado base × head**
+
+```powershell
+powershell -File benchmarks/interleaved_compare.ps1 -Baseline $S\bench\noxy_base.exe -Candidate $S\bench\noxy_s3.exe -BaselineLabel v0143 -CandidateLabel typed -Runs 9
+```
+
+Guardar a tabela (`benchmarks/results/interleaved.md`) para o raw.
+
+- [ ] **Step 3: Por estágio (cinco binários na mesma janela)**
+
+`$S/bench/stages.ps1`:
+
+```powershell
+param([int]$Runs = 5)
+$S = "C:\Users\estev\AppData\Local\Temp\claude\D--OneDrive-Documentos-go-projects-noxy\ead4c52f-5869-403e-a45b-22421c6f07b9\scratchpad\bench"
+$bins = [ordered]@{ base = "$S\noxy_base.exe"; s0 = "$S\noxy_s0.exe"; s1 = "$S\noxy_s1.exe"; s2 = "$S\noxy_s2.exe"; s3 = "$S\noxy_s3.exe" }
+$root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$benches = Get-ChildItem "$root\benchmarks" -Filter "bench_*.nx" | Sort-Object Name
+$local = "$S\nx"; New-Item -ItemType Directory -Force $local | Out-Null
+$benches | % { Copy-Item $_.FullName $local -Force }
+"| bench | " + (($bins.Keys | % { "$($_)_ms" }) -join " | ") + " |"
+"|---|" + (($bins.Keys | % { "---" }) -join "|") + "|"
+foreach ($b in $benches) {
+    $times = @{}; $bins.Keys | % { $times[$_] = @() }
+    for ($r = 0; $r -lt $Runs; $r++) {
+        foreach ($k in $bins.Keys) {
+            $sw = [Diagnostics.Stopwatch]::StartNew()
+            & $bins[$k] "$local\$($b.Name)" *> $null
+            $sw.Stop(); $times[$k] += $sw.Elapsed.TotalMilliseconds
+        }
+    }
+    $cells = $bins.Keys | % { $s = $times[$_] | Sort-Object; "{0:N1}" -f $s[[int]($s.Count / 2)] }
+    "| $($b.BaseName) | " + ($cells -join " | ") + " |"
+}
+```
+
+Copiar para `$S/bench/stages.ps1` (o `$root` acima assume o script em `<repo>/x/y/`; mais simples: rodar com cwd na raiz do worktree e trocar `$root` por `(Get-Location).Path`). Run: `powershell -File $S/bench/stages.ps1 -Runs 5` a partir da raiz do worktree. Guardar a tabela.
+
+- [ ] **Step 4: Cross-runtime**
+
+```powershell
+powershell -File benchmarks/cross_runtime/run_cross_runtime.ps1 -Noxy $S\bench\noxy_s3.exe -NoxyBaseline $S\bench\noxy_base.exe -BaselineLabel v0143
+```
+
+Saída em `benchmarks/cross_runtime/results/cross_runtime.md` (commitar).
+
+- [ ] **Step 5: Perfil de bubblesort base × head**
+
+```bash
+cd $S/bench && ./noxy_base.exe --cpuprofile bubble_base.prof bubblesort.nx && go tool pprof -top -nodecount=12 noxy_base.exe bubble_base.prof | sed -n 6,20p
+./noxy_s3.exe --cpuprofile bubble_head.prof bubblesort.nx && go tool pprof -top -nodecount=12 noxy_s3.exe bubble_head.prof | sed -n 6,20p
+```
+
+(`bubblesort.nx` = cópia de `benchmarks/cross_runtime/bubblesort.nx` já em `$S/bench`.) Registrar os shares de `referenceStorage`, `Upvalue.Load`, `mallocgc`.
+
+- [ ] **Step 6: Raw + seção em RESULTS.md**
+
+Criar `benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md` com: binários (commit de cada estágio), carga, tabela headline, tabela por estágio, cross-runtime, perfis, e o script `stages.ps1`. Escrever a nova seção no topo de `benchmarks/RESULTS.md` no mesmo formato da seção da fase 2 (cabeçalho `## v0.14.3 (7eed082) × indexação tipada de array (perf/issue-66-typed-array-index, <sha>)`, verificação completa, headline, por estágio, cross-runtime, leitura, gates). Os números são os medidos — inclusive se algum gate falhar ou a meta não se confirmar.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add benchmarks/RESULTS.md benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md benchmarks/cross_runtime/results/cross_runtime.md
+git commit -m "docs(bench): indexacao tipada de array medida por estagio contra v0.14.3 — opcodes tipados, formas fundidas por slot e ref (issue #66, item 1)"
+```
+
+---
+
+### Task 8: Versão v0.14.4, CHANGELOG, docs
+
+**Files:**
+- Modify: `internal/version/version.go` (`const Version = "v0.14.4"`), `CHANGELOG.md` (nova entrada `## [0.14.4] - 2026-08-22`), `README.md:1` (badge) e `:108` (banner REPL), `AGENTS.md:414`, `docs/NOXY_LANGUAGE_SPEC.md` (linha do `sys.version`), `docs/index.html:58` (hero badge) e `:385` (`print(sys.version)`).
+
+- [ ] **Step 1: Bump nos seis pontos**
+
+`grep -rn "0\.14\.3" README.md AGENTS.md internal/version/version.go docs/index.html docs/NOXY_LANGUAGE_SPEC.md` → trocar cada ocorrência por `0.14.4` (Edit tool, CRLF preservado). Conferir com o mesmo grep que não sobrou nenhuma, e `go test ./internal/vm -run Version`.
+
+- [ ] **Step 2: CHANGELOG**
+
+Entrada no topo, no formato da 0.14.3: parágrafo de contexto (item 1 da #66; nenhuma mudança de sintaxe/semântica/saída/erro; corpus e diff de saída), subseção `### Performance` com: os seis opcodes e quando saem; o que o caminho rápido pula e o que confere em runtime; o caso `ref T[]` (sem `referenceStorage`); `setIndexGeneric`; números headline (bubblesort, call_readonly, cross-runtime ÷ CPython antes → depois) apontando para `benchmarks/RESULTS.md`; follow-ups observados (`length()` como chamada nativa; `Upvalue.Load` com RWMutex como custo restante do ref).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/version/version.go CHANGELOG.md README.md AGENTS.md docs/NOXY_LANGUAGE_SPEC.md docs/index.html
+git commit -m "chore(version): noxy v0.14.4 — CHANGELOG (indexacao tipada de array, issue #66 item 1), README, AGENTS, spec, site, version.go"
+```
+
+---
+
+### Task 9: Finalização — branch, PR, comentário na issue
+
+- [ ] **Step 1: Verificação final (superpowers:verification-before-completion)**
+
+```bash
+go test ./... 2>&1 | tail -15
+go test -race ./internal/value ./internal/vm 2>&1 | tail -3
+go run ./cmd/noxy noxy_examples/run_all_tests_concurrent.nx 2>&1 | tail -3
+git status --short; git log --oneline origin/develop..HEAD
+```
+
+- [ ] **Step 2: superpowers:finishing-a-development-branch → PR**
+
+Push `perf/issue-66-typed-array-index`; PR base `develop`, título `perf/issue-66-typed-array-index - Indexação tipada de array (issue #66, item 1)`, label `not available to review`, `--assignee @me`, body Summary / Components / Test Plan com checkboxes, `Refs #66`, sem reviewers/Jira (memória `noxy-pr-conventions`).
+
+- [ ] **Step 3: Comentário na #66** com a tabela headline + cross-runtime, a leitura (o que se confirmou da hipótese e o que não), e os follow-ups (`length()` → `OP_LEN`; `Upvalue.Load`). Não fechar a issue.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §3.1 opcodes → Task 2; §3.2 handlers/fallbacks/`setIndexGeneric`/`unicize*Slot`/redispatch → Task 3; §3.3 predicado, leitura, escrita, for-each → Tasks 4–6; §3.4 `NeverTracked` → Task 1; §4 guards (sentinela, disassembler, bytecode, comportamento, erros, inline, race, corpus, diff de saída) → Tasks 1–7; §5 medição por estágio/cross/perfil/gates/RESULTS → Task 7; decisões 5 (versão) → Task 8.
+- **Placeholders:** nenhum "TBD"; cada step de código traz o código.
+- **Type consistency:** `setIndexGeneric(c *chunk.Chunk, ip int) error`, `unicizeOwnedSlot(frame *CallFrame, idx int) value.Value`, `unicizeBorrowedSlot(idx int) value.Value`, `arrayTagIsRefSlot(tag *value.RuntimeTypeInfo) bool`, `value.NeverTracked(v Value) bool`, `isUntrackedElementType(ast.NoxyType) bool`, `arrayTypeOf(ast.NoxyType) (*ast.ArrayType, bool)`, `isSideEffectFree(ast.Expression) bool`, `fusedLocalIndexRead(*ast.IndexExpression) (chunk.OpCode, int, ast.NoxyType, bool)`, `tryFuseLocalIndexAssign(*ast.IndexExpression, ast.Expression) (bool, error)` — usados com essas assinaturas em todas as tasks.

--- a/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md
@@ -1,0 +1,221 @@
+# VM Perf — Indexação tipada de array (issue #66, item 1)
+
+**Data:** 2026-08-22 · **Issue:** [#66](https://github.com/estevaofon/noxy/issues/66) item 1 · **Branch:** `perf/issue-66-typed-array-index` · **Base:** `develop` (7eed082, v0.14.3)
+
+## 1. Contexto (medido nesta sessão, binário de 7eed082)
+
+**`cross_runtime/bubblesort.nx`** (`data: ref int[]`, 5,5x do CPython): o perfil
+mostra `run` com 25 % flat e **`resolveReferenceValue`/`referenceStorage` com
+42 % cumulativo**, `mallocgc` 15 %, `ObjUpvalue.Load` 10,6 %,
+`unicizeThroughRefValue` 10,6 %. Cada `data[j]` é `OP_GET_LOCAL` + `OP_DEREF` →
+`referenceStorage` (um `defer`, a closure do setter alocada no heap a cada
+chamada, `validateReferencedValue` com `reflect`) + `OP_GET_INDEX`; cada
+`data[j] = x` é `OP_GET_LOCAL_MUT_BORROW` + `OP_DEREF_MUT` (a mesma maquinaria
+via `unicizeThroughRefValue`) + `OP_SET_INDEX` (guarda de slot ref, `Retain` e
+`Release` — duas chamadas reais que são no-op para `int`) + `OP_POP`. Os anchors
+da issue descrevem o local plano `arr: int[]`; o bench que ela cita passa por
+`ref`, e ali o custo dominante é a resolução do ref, não o despacho do índice.
+
+**Local plano `arr: int[]`** (`bench_call_readonly`, `s = s + data[i]`): leitura
+= `OP_GET_LOCAL` (push do `Value` de 32 B do array) + `OP_GET_INDEX` (dois
+pops, teste `VAL_OBJ`, assertion); escrita = `OP_GET_LOCAL_MUT` (`IsShared` —
+custo 55, chamada real dentro de `run()`) + índice + valor + `OP_SET_INDEX` +
+`OP_POP`. Achado colateral: 37 % desse bench é `callNative` — o `length(data)`
+da condição do `while` é chamada de builtin genérica, não indexação (fora do
+escopo; follow-up).
+
+## 2. Objetivo e não-objetivos
+
+**Objetivo:** quando o compilador sabe que a base é `T[]` (ou que um local é
+`ref T[]`), indexar sem despacho dinâmico, sem empilhar o `Value` do array, sem
+`IsShared`/`Retain`/`Release` para elemento sem contador RC, e — no caso
+`ref T[]` — sem `referenceStorage`. Semântica, saída, mensagens de erro, linhas
+de erro e contagem RC **idênticas**; opcodes só por append.
+
+**Não-objetivos:** `length()` → `OP_LEN`; variante tipada de `OP_GET_INDEX_MUT`
+(nível de fora de `a[i][j] = v` segue genérico); forma fundida para elemento
+composto (`nodes[i] = n` segue `OP_SET_INDEX`); deref de upvalue sem o
+`RWMutex`; strings (item 2); maps/structs (item 4).
+
+## 3. Desenho
+
+### 3.1 Opcodes (append ao fim de `internal/chunk/chunk.go`)
+
+| opcode | operando | pilha | emitido quando |
+|---|---|---|---|
+| `OP_GET_INDEX_ARRAY` | – | `[arr, i] → [elem]` | base estática `T[]` em posição genérica (global, upvalue, `a[i][j]`, retorno de chamada, índice impuro) |
+| `OP_SET_INDEX_ARRAY_NORC` | – | `[arr, i, v] → []` | idem, em escrita, com elemento `int/float/bool/string/bytes` |
+| `OP_GET_LOCAL_INDEX_ARRAY` | `[slot]` | `[i] → [elem]` | base é local `T[]` com índice puro (§3.3); também o `$collection[$index]` do for-each sobre array |
+| `OP_SET_LOCAL_INDEX_ARRAY_NORC` | `[slot]` | `[i, v] → []` | local `T[]` possuidor, elemento sem RC, índice e valor puros |
+| `OP_GET_REF_LOCAL_INDEX_ARRAY` | `[slot]` | `[i] → [elem]` | base é local `ref T[]` (parâmetro `ref`), índice puro |
+| `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC` | `[slot]` | `[i, v] → []` | local `ref T[]` (não-possuidor), elemento sem RC, índice e valor puros |
+
+Os de escrita **não empilham** resultado (atribuição é statement, como
+`OP_INC_LOCAL_INT`) e o compilador não emite `OP_POP` depois deles. `NORC` =
+"sem Retain/Release": o compilador só os emite para elemento estático sem
+contador, e o VM **confere em runtime** (§3.2) antes de pular o RC.
+
+### 3.2 VM — caminho rápido e fallback exato
+
+**Leituras.** Caminho rápido: container é `*ObjArray` (uma assertion — com
+`Obj` sendo `*ObjArray` o `Type` é `VAL_OBJ` por construção, como em
+`ownersOf`), índice `VAL_INT` ("array index must be integer"), bounds ("array
+index out of bounds"), resultado gravado **no lugar** na pilha — sobre o slot
+do operando mais fundo (`[arr, i] → [elem]` escreve onde estava `arr`; `[i] →
+[elem]` onde estava `i`), sem pop/push. `OP_GET_REF_LOCAL_INDEX_ARRAY` resolve só `REF_UPVALUE` (a forma que
+`OP_REF_LOCAL` cria para todo `ref` a local) via `ref.Upvalue.Load()` — uma
+chamada com o `RWMutex`, em vez de `referenceStorage`. Fallback (container
+não é array, ref de outro tipo, nulo, slot com valor plano pela tolerância
+herdada): materializa a pilha do caminho genérico (`[container, i]`; para o
+ref, com a semântica exata de `OP_DEREF`: nulo e não-ref passam, ref resolve
+por `resolveReferenceValue`) e **re-despacha** `instruction = OP_GET_INDEX`
+com `goto redispatch` (rótulo logo antes do `switch` de `run()`). Zero custo
+no caminho genérico, zero duplicação, mesmas mensagens e mesma linha (`Lines`
+da mesma statement).
+
+**Escritas NORC.** Caminho rápido exige **todas**: container é `*ObjArray`;
+(formas com slot) `arr.Owners.Load() <= 1` — o mesmo teste de `IsShared`, sem
+a chamada; índice `VAL_INT` e em bounds; a tag do array **não** é `(ref T)[]`
+(a guarda de slot ref do `OP_SET_INDEX`, com o mesmo `RuntimeType.Load()`);
+`value.NeverTracked(val) && value.NeverTracked(old)` (§3.4) — só então
+`arr.Elements[i] = val` sem `Retain`/`Release`. Qualquer condição falha →
+fallback com a semântica exata da sequência genérica:
+
+- `OP_SET_LOCAL_INDEX_ARRAY_NORC`: `vm.unicizeOwnedSlot(frame, idx)` (o corpo
+  de `OP_GET_LOCAL_MUT` extraído em método; o `case` genérico passa a chamá-lo
+  — mesma contagem de chamadas, pois `IsShared` já era chamada real), depois
+  `push(arr, i, v)` e `vm.setIndexGeneric(c, ip)`, depois `LastPopped = pop()`
+  (o `OP_POP` da sequência genérica).
+- `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC`: semântica de `OP_GET_LOCAL_MUT_BORROW`
+  (slot não-ref: `IsShared` → clone gravado no slot sem RC) + `OP_DEREF_MUT`
+  (ref → `unicizeThroughRefValue`, que clona e grava de volta pelo setter se
+  compartilhado; não-ref passa), depois `setIndexGeneric` + `pop`.
+- `OP_SET_INDEX_ARRAY_NORC`: `setIndexGeneric` + `pop`.
+
+`setIndexGeneric(c, ip) error` é o corpo de `OP_SET_INDEX` extraído em método
+(pops, lógica array/map/erros, push do valor); o `case OP_SET_INDEX` passa a
+ser `if err := vm.setIndexGeneric(c, ip); err != nil { return err }`. Custo:
+**uma chamada a mais em cada `OP_SET_INDEX` genérico** (maps, `any`, elemento
+composto) — medido em `bench_map_churn`; a alternativa (duplicar ~45 linhas de
+lógica de erro nos três fallbacks) foi rejeitada em favor do funil único.
+
+**Por que o fallback das escritas é alcançável:** `let a: int[] = x` com
+`x: any` compila (`areTypesCompatible` aceita `any`) e o marcador
+`OP_MARK_RUNTIME_VALUE_TYPE` recusa nulo e não-array no bind — então um slot
+`T[]` plano guarda sempre array; mas parâmetro `ref T[]` aceita `null`
+(`bubble(null)` → "cannot set index on non-array/map" / "cannot index
+non-array/map/bytes"), `a[i] = v` com `v: any` pode trazer composto (o
+genérico retém; o NORC vê `NeverTracked(val)` falso e cai no genérico), e o
+array compartilhado (`let b = a` antes de `a[0] = 9`) tem de clonar.
+
+### 3.3 Compilador
+
+**Predicado `isSideEffectFree(expr)`** (decide a forma fundida): `Identifier`,
+literais `Integer/Float/String/Bytes/Boolean/Null`, `PrefixExpression` com
+`-`, `!`, `~`, `*` sobre operando puro, `InfixExpression` com ambos os lados
+puros, `IndexExpression` e `MemberAccessExpression` com partes puras. Tudo o
+mais (chamadas — inclusive builtins e f-strings que viram chamadas —,
+literais de array/map, closures, `ref`, `zeros`) → impuro → forma não fundida.
+Motivo: a forma fundida lê o slot **depois** de avaliar índice (e valor); com
+operandos sem efeito colateral nenhum código roda no meio que possa rebindar
+o local (closure, `ref`) ou compartilhá-lo, e a ordem observável é a mesma da
+sequência genérica. Exceção teórica documentada: falha dupla com um `ref`
+**obsoleto** como base (`REF_INDEX` para array que encolheu) **e** índice/valor
+puro que também falha (`a[i / 0]`) — o genérico reporta o erro do ref, a forma
+fundida o do índice; não há `ref` obsoleto no corpus.
+
+**Leitura `X[i]`** (`case *ast.IndexExpression` em `Compile`): se `X` é
+`Identifier` resolvido a local (slot ≤ 255) de tipo `ArrayType` e `i` é puro →
+compila `i` (com o `OP_DEREF` de índice ref, como hoje) e emite
+`OP_GET_LOCAL_INDEX_ARRAY slot`; se o tipo é `RefType{ArrayType}` e `i` puro →
+`OP_GET_REF_LOCAL_INDEX_ARRAY slot`. Senão, o caminho de hoje (`Compile(X)`,
+`OP_DEREF` se ref, índice) e `OP_GET_INDEX_ARRAY` quando o tipo de `X`
+desembrulhado é `ArrayType`, `OP_GET_INDEX` caso contrário. O for-each sobre
+`ArrayType` troca `GET_LOCAL $collection; GET_LOCAL $index; GET_INDEX` por
+`GET_LOCAL $index; OP_GET_LOCAL_INDEX_ARRAY $collection`. Tipo do resultado e
+checagens de compilação inalterados.
+
+**Escrita `X[i] = v`** (alvo `IndexExpression` em `AssignStmt`): se `X` é local
+`ArrayType` com elemento `int/float/bool/string/bytes`, `c.localOwns(slot)`, e
+`i` e `v` puros → **não** chama `compileLValueBase`; compila `i` (+`OP_DEREF`
+se ref), compila `v`, roda exatamente as checagens de tipo de hoje (mesmas
+mensagens, mesma ordem — `compileLValueBase` nunca erra para identificador),
+`emitRuntimeValueType(elem)` (no-op para esses tipos), emite
+`OP_SET_LOCAL_INDEX_ARRAY_NORC slot`, sem `OP_POP`. Se `X` é local
+`RefType{ArrayType}` com elemento sem RC, `!c.localOwns(slot)` e operandos
+puros → `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC slot`. Senão, o caminho de hoje
+(`compileLValueBase` etc.) e `OP_SET_INDEX_ARRAY_NORC` (sem `OP_POP`) quando o
+tipo desembrulhado é `ArrayType` com elemento sem RC; `OP_SET_INDEX` + `OP_POP`
+caso contrário. `Owns` continua a fonte de verdade (spec CoW-RC §4.2): flag
+em estado inesperado → genérico.
+
+### 3.4 `value.NeverTracked`
+
+```go
+// NeverTracked: v certamente nao tem contador RC (escalar, ou VAL_OBJ
+// carimbado como sem dono — string/struct/RTI). Conservador: VAL_OBJ sem
+// carimbo (kind zero) responde false e o chamador cai no caminho generico.
+func NeverTracked(v Value) bool { return v.Type != VAL_OBJ || v.kind == objKindNoOwners }
+```
+
+Chamada de dentro de `run()` → precisa caber em 20 no inliner; guard em
+`inline_guard_test.go`.
+
+## 4. Invariantes e guards executáveis
+
+- Opcodes só por append; sentinela de `TestEveryOpcodeHasASymbolicNameWithoutGaps`
+  atualizada para o último; `disassemblyProgram` ganha leituras/escritas
+  tipadas (local plano, `ref`, nested) para `TestDisassemblerDecodesEveryEmittedInstruction`.
+- Bytecode (testes no pacote `compiler`, via disassembler capturado, não por
+  varredura de bytes): cada regra de §3.3 com caso positivo e negativo
+  (índice com chamada → não fundido; upvalue → `OP_GET_INDEX_ARRAY`; elemento
+  composto → `OP_SET_INDEX`; map/`any` → genérico; `OP_POP` ausente após fundido).
+- Comportamento (pacote `vm`): bubblesort via `ref` e via local; CoW — `let b =
+  a; a[0] = 9` (b intacto, `CloneCountValue() == 1`), `ref` a array compartilhado
+  (clone gravado de volta, chamador vê a mutação, cópia intacta); RC — elemento
+  composto via `any` (`OwnersCount` do composto sobe 1 como no genérico);
+  `string[]` escrita; tabela de erros idênticos (OOB leitura/escrita por local,
+  por `ref`, `null` em parâmetro `ref`, índice não-int via `any`) comparando o
+  texto com o mesmo programa de base `any`; for-each sobre array com mutação
+  durante a iteração (comportamento de hoje preservado).
+- Guards de inline: `push` ≥ 100 / `pop` ≥ 70 sites (novos sites só somam);
+  `NeverTracked` ≤ 20; `Retain`/`Release` ≤ 80 inalterados.
+- `go test ./...`, `go test -race ./internal/value ./internal/vm`, corpus
+  `run_all_tests_concurrent.nx` 0 falhas, `compare_examples.ps1` 0 divergentes.
+
+## 5. Medição (protocolo de `benchmarks/RESULTS.md`)
+
+Binários em disco local (scratchpad): `noxy_base.exe` (7eed082), `noxy_s1.exe`
+(opcodes não fundidos), `noxy_s2.exe` (+ fundidos de local plano e for-each),
+`noxy_s3.exe` = head (+ fundidos `ref`). Máquina sem `go test` concorrente.
+
+1. `interleaved_compare.ps1 -Runs 9` base × head (headline) e uma intercalação
+   dos quatro na mesma janela (por estágio).
+2. `cross_runtime/run_cross_runtime.ps1 -NoxyBaseline` base × head (mínimo de 9).
+3. Perfil de `bubblesort` base × head (share de `referenceStorage`/`Load`).
+4. Gates CoW ≤ +5 % (`bench_typed_call_map`, `bench_share_mutate`,
+   `bench_call_light`, `bench_conway`); `bench_map_churn` citado (custo do
+   `setIndexGeneric`).
+5. Nova seção no topo de `RESULTS.md` + `results/2026-08-22-issue-66-typed-arrays-raw.md`.
+
+## 6. Riscos
+
+| risco | mitigação |
+|---|---|
+| forma fundida muda ordem de avaliação | só com índice/valor sem efeito colateral (§3.3); teste de closure/`ref` no índice → não fundido |
+| NORC pular RC de um composto vindo por `any` | `NeverTracked(val) && NeverTracked(old)` em runtime; teste com oráculo `OwnersCount` |
+| fallback divergir do genérico | leitura re-despacha o próprio `OP_GET_INDEX`; escrita chama o mesmo `setIndexGeneric`; tabela de erros idênticos |
+| `setIndexGeneric` regredir map | medido em `bench_map_churn`; se > ruído, reverter para duplicação no fallback |
+| ganho não se materializar | hipótese; números publicados como estão |
+
+## 7. Decisões tomadas sem consulta (para a review)
+
+1. **Escopo inclui o local `ref T[]`** — o bench da issue passa por `ref` e o
+   perfil põe a resolução do ref como custo dominante; é a mesma família de
+   opcodes, sem tocar `referenceStorage`/RWMutex.
+2. Elemento composto não ganha opcode fundido; `OP_SET_INDEX` genérico vira
+   chamada a `setIndexGeneric` (funil único), custo medido.
+3. Formas fundidas exigem operandos sem efeito colateral (predicado sintático,
+   como `tryFuseLocalIntIncrement`), com a exceção teórica da falha dupla.
+4. `length()` → `OP_LEN` fica como follow-up (call_readonly 37 % em `callNative`).
+5. Versão **v0.14.4** (patch: perf interna).

--- a/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md
@@ -68,10 +68,18 @@ chamada com o `RWMutex`, em vez de `referenceStorage`. Fallback (container
 não é array, ref de outro tipo, nulo, slot com valor plano pela tolerância
 herdada): materializa a pilha do caminho genérico (`[container, i]`; para o
 ref, com a semântica exata de `OP_DEREF`: nulo e não-ref passam, ref resolve
-por `resolveReferenceValue`) e **re-despacha** `instruction = OP_GET_INDEX`
-com `goto redispatch` (rótulo logo antes do `switch` de `run()`). Zero custo
-no caminho genérico, zero duplicação, mesmas mensagens e mesma linha (`Lines`
-da mesma statement).
+por `resolveReferenceValue`) e chama `vm.getIndexGeneric(c, ip)` — o corpo de
+`OP_GET_INDEX` extraído em método, exatamente como `setIndexGeneric` para as
+escritas; o `case OP_GET_INDEX` genérico passa a chamá-lo. Zero duplicação,
+mesmas mensagens e mesma linha (`Lines` da mesma statement); custo: uma
+chamada a mais por `OP_GET_INDEX` genérico (maps, strings, `any`).
+*Medido e descartado:* a primeira forma — re-despachar o `case` genérico com
+`instruction = OP_GET_INDEX; goto redispatch` (rótulo antes do `switch`),
+"zero custo no genérico" — custou **+10–14 % no despacho genérico**
+(`bench_generic_vs_hand`, laço sem indexação nenhuma, relógio interno: base
+623 ms, com goto 714 ms, com método 631 ms): o rótulo/phi e o corpo extra em
+`run()` mudaram o codegen do laço inteiro. A chamada no fallback não aparece
+no mesmo bench.
 
 **Escritas NORC.** Caminho rápido exige **todas**: container é `*ObjArray`;
 (formas com slot) `arr.Owners.Load() <= 1` — o mesmo teste de `IsShared`, sem
@@ -204,8 +212,9 @@ Binários em disco local (scratchpad): `noxy_base.exe` (7eed082), `noxy_s1.exe`
 |---|---|
 | forma fundida muda ordem de avaliação | só com índice/valor sem efeito colateral (§3.3); teste de closure/`ref` no índice → não fundido |
 | NORC pular RC de um composto vindo por `any` | `NeverTracked(val) && NeverTracked(old)` em runtime; teste com oráculo `OwnersCount` |
-| fallback divergir do genérico | leitura re-despacha o próprio `OP_GET_INDEX`; escrita chama o mesmo `setIndexGeneric`; tabela de erros idênticos |
-| `setIndexGeneric` regredir map | medido em `bench_map_churn`; se > ruído, reverter para duplicação no fallback |
+| fallback divergir do genérico | leitura chama o mesmo `getIndexGeneric` e escrita o mesmo `setIndexGeneric` que os cases genéricos; tabela de erros idênticos |
+| `getIndexGeneric`/`setIndexGeneric` regredirem map | medido em `bench_map_churn`; se > ruído, reverter para duplicação no fallback |
+| mexer em `run()` regredir o despacho genérico | `bench_generic_vs_hand` (laço sem indexação) como sentinela: foi ele que pegou o `goto` (+10–14 %) |
 | ganho não se materializar | hipótese; números publicados como estão |
 
 ## 7. Decisões tomadas sem consulta (para a review)
@@ -218,4 +227,4 @@ Binários em disco local (scratchpad): `noxy_base.exe` (7eed082), `noxy_s1.exe`
 3. Formas fundidas exigem operandos sem efeito colateral (predicado sintático,
    como `tryFuseLocalIntIncrement`), com a exceção teórica da falha dupla.
 4. `length()` → `OP_LEN` fica como follow-up (call_readonly 37 % em `callNative`).
-5. Versão **v0.14.4** (patch: perf interna).
+5. Versão **v0.15.0** — o plano original dizia v0.14.4 (patch: perf interna); o usuário decidiu minor para esta melhoria (2026-08-22).

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -140,6 +140,21 @@ const (
 	OP_DIV_FLOAT
 	OP_LESS_FLOAT
 	OP_GREATER_FLOAT
+	// perf issue #66 (item 1): indexacao tipada de array. Emitidos so quando o
+	// compilador sabe que a base e T[] (ou que o local e `ref T[]`). Semantica
+	// e mensagens de erro identicas as dos genericos; container que nao e
+	// array em runtime cai no caminho generico (leituras re-despacham
+	// OP_GET_INDEX; escritas chamam setIndexGeneric). NORC = elemento
+	// estaticamente sem contador RC (int/float/bool/string/bytes): o VM confere
+	// em runtime (value.NeverTracked do valor novo e do velho, tag do array nao
+	// e (ref T)[]) antes de pular Retain/Release. Os de escrita NAO empilham
+	// resultado (atribuicao e statement; o compilador nao emite OP_POP depois).
+	OP_GET_INDEX_ARRAY                // pops index, container; push elemento
+	OP_SET_INDEX_ARRAY_NORC           // pops val, index, container
+	OP_GET_LOCAL_INDEX_ARRAY          // [slot]; pops index; container = local T[]
+	OP_SET_LOCAL_INDEX_ARRAY_NORC     // [slot]; pops val, index; local T[] possuidor (Owners<=1, senao uniciza como GET_LOCAL_MUT)
+	OP_GET_REF_LOCAL_INDEX_ARRAY      // [slot]; pops index; local `ref T[]` (REF_UPVALUE resolvido com uma Load(); outros refs pelo caminho de OP_DEREF)
+	OP_SET_REF_LOCAL_INDEX_ARRAY_NORC // [slot]; pops val, index; local `ref T[]` (Owners<=1, senao unicizeThroughRefValue)
 )
 
 func (op OpCode) String() string {
@@ -238,6 +253,18 @@ func (op OpCode) String() string {
 		return "OP_LESS_FLOAT"
 	case OP_GREATER_FLOAT:
 		return "OP_GREATER_FLOAT"
+	case OP_GET_INDEX_ARRAY:
+		return "OP_GET_INDEX_ARRAY"
+	case OP_SET_INDEX_ARRAY_NORC:
+		return "OP_SET_INDEX_ARRAY_NORC"
+	case OP_GET_LOCAL_INDEX_ARRAY:
+		return "OP_GET_LOCAL_INDEX_ARRAY"
+	case OP_SET_LOCAL_INDEX_ARRAY_NORC:
+		return "OP_SET_LOCAL_INDEX_ARRAY_NORC"
+	case OP_GET_REF_LOCAL_INDEX_ARRAY:
+		return "OP_GET_REF_LOCAL_INDEX_ARRAY"
+	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+		return "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -559,6 +586,18 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.simpleInstruction("OP_LESS_FLOAT", offset)
 	case OP_GREATER_FLOAT:
 		return c.simpleInstruction("OP_GREATER_FLOAT", offset)
+	case OP_GET_INDEX_ARRAY:
+		return c.simpleInstruction("OP_GET_INDEX_ARRAY", offset)
+	case OP_SET_INDEX_ARRAY_NORC:
+		return c.simpleInstruction("OP_SET_INDEX_ARRAY_NORC", offset)
+	case OP_GET_LOCAL_INDEX_ARRAY:
+		return c.byteInstruction("OP_GET_LOCAL_INDEX_ARRAY", offset)
+	case OP_SET_LOCAL_INDEX_ARRAY_NORC:
+		return c.byteInstruction("OP_SET_LOCAL_INDEX_ARRAY_NORC", offset)
+	case OP_GET_REF_LOCAL_INDEX_ARRAY:
+		return c.byteInstruction("OP_GET_REF_LOCAL_INDEX_ARRAY", offset)
+	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+		return c.byteInstruction("OP_SET_REF_LOCAL_INDEX_ARRAY_NORC", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:

--- a/internal/chunk/chunk_test.go
+++ b/internal/chunk/chunk_test.go
@@ -45,7 +45,7 @@ func TestEveryOpcodeHasASymbolicNameWithoutGaps(t *testing.T) {
 	}
 	// Sentinela: o último opcode declarado em chunk.go precisa estar nomeado.
 	// Se você acrescentou um opcode depois dele, atualize aqui também.
-	if last := int(chunk.OP_GREATER_FLOAT); firstUnnamed >= 0 && firstUnnamed <= last {
+	if last := int(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC); firstUnnamed >= 0 && firstUnnamed <= last {
 		t.Fatalf("opcode %d está abaixo do último declarado (%d) e não tem nome em String()", firstUnnamed, last)
 	}
 }
@@ -179,6 +179,12 @@ func muta(valores: ref int[]) -> void
     incr()
     let rl: ref int[] = ref local
     rl[0] = 3
+    // indexacao tipada (issue #66): leitura fundida de local e de ref local,
+    // leitura/escrita tipadas genericas no nivel de dentro de um nested.
+    print(local[0] + rl[0])
+    let g: int[][] = [[1, 2], [3, 4]]
+    g[0][1] = g[1][0]
+    print(g[0][1])
     let pt: Point = Point(1, 2)
     let rp: ref Point = ref pt
     rp.x = 5

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -690,6 +690,14 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				c.emitByte(byte(chunk.OP_POP))
 			}
 		} else if indexExp, ok := n.Target.(*ast.IndexExpression); ok {
+			// perf #66: `x[i] = v` com x local T[] (ou ref T[]), elemento sem
+			// contador RC e operandos puros — forma fundida por slot, statement.
+			if fused, err := c.tryFuseLocalIndexAssign(indexExp, n.Value); fused {
+				if err != nil {
+					return nil, nil, err
+				}
+				return c.currentChunk, nil, nil
+			}
 			// Array/Map Assignment: arr[i] = val
 			// IndexExpression assignment is REBINDING the slot in the container.
 			// If the container holds References, we are rebinding that slot.
@@ -1058,6 +1066,20 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		return c.currentChunk, &ast.MapType{KeyType: keyType, ValueType: valType}, nil
 
 	case *ast.IndexExpression:
+		// perf #66: local T[] (ou ref T[]) com indice puro le pela forma
+		// fundida por slot — sem empilhar o Value do array.
+		if op, slot, elem, ok := c.fusedLocalIndexRead(n); ok {
+			_, idxType, err := c.Compile(n.Index)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, isRef := idxType.(*ast.RefType); isRef {
+				c.emitByte(byte(chunk.OP_DEREF))
+			}
+			c.emitBytes(byte(op), byte(slot))
+			return c.currentChunk, elem, nil
+		}
+
 		_, leftType, err := c.Compile(n.Left)
 		if err != nil {
 			return nil, nil, err
@@ -1668,9 +1690,16 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		c.emitByte(byte(chunk.OP_POP)) // Pop condition
 
 		// 8. Get Item -> User Variable
-		c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-3)) // $collection
-		c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2)) // $index
-		c.emitByte(byte(chunk.OP_GET_INDEX))
+		if _, isArray := colType.(*ast.ArrayType); isArray {
+			// perf #66: leitura fundida — o indice vai para a pilha e o array
+			// vem do slot $collection, sem empilhar o seu Value.
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2))             // $index
+			c.emitBytes(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), byte(len(c.locals)-3)) // $collection
+		} else {
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-3)) // $collection
+			c.emitBytes(byte(chunk.OP_GET_LOCAL), byte(len(c.locals)-2)) // $index
+			c.emitByte(byte(chunk.OP_GET_INDEX))
+		}
 
 		// Body Scope
 		c.beginScope()

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -769,8 +769,15 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				return nil, nil, err
 			}
 
-			c.emitByte(byte(chunk.OP_SET_INDEX))
-			c.emitByte(byte(chunk.OP_POP))
+			// perf #66: elemento sem contador RC em base T[] escreve pela forma
+			// NORC, que e statement (nao empilha; sem OP_POP). O VM confere em
+			// runtime antes de pular Retain/Release.
+			if arrType, isArray := leftType.(*ast.ArrayType); isArray && isUntrackedElementType(arrType.ElementType) {
+				c.emitByte(byte(chunk.OP_SET_INDEX_ARRAY_NORC))
+			} else {
+				c.emitByte(byte(chunk.OP_SET_INDEX))
+				c.emitByte(byte(chunk.OP_POP))
+			}
 
 		} else if memberExp, ok := n.Target.(*ast.MemberAccessExpression); ok {
 			// Struct Field Assignment: obj.field = val
@@ -1087,7 +1094,14 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			// return nil, nil, fmt.Errorf("index must be int, got %s", idxType)
 		}
 
-		c.emitByte(byte(chunk.OP_GET_INDEX))
+		// perf #66: base estaticamente T[] (ou ref T[], ja dereferenciada
+		// acima) indexa sem despacho dinamico; o VM cai no OP_GET_INDEX
+		// generico se o container em runtime nao for array.
+		if _, isArray := arrayTypeOf(leftType); isArray {
+			c.emitByte(byte(chunk.OP_GET_INDEX_ARRAY))
+		} else {
+			c.emitByte(byte(chunk.OP_GET_INDEX))
+		}
 
 		// Result Type: Element type of array
 		// Unwrap RefType (getting index from ref array)

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -84,13 +84,33 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 }
 
 func TestLoweringLocalIndexAssignment(t *testing.T) {
+	// Indexacao tipada (issue #66): `a[0] = 9` com a local int[] e operandos
+	// puros sai pela forma fundida OP_SET_LOCAL_INDEX_ARRAY_NORC, que carrega
+	// a unicizacao do slot dentro do opcode (unicizeOwnedSlot, a mesma de
+	// OP_GET_LOCAL_MUT) — a cadeia MUT explicita nao aparece.
 	code := compileSource(t, `func f()
     let a: int[] = [1, 2]
     a[0] = 9
 end`)
 	ops := collectOpcodes(t, code)
+	if ops[chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC] == 0 {
+		t.Fatal("a[0] = 9 com a local int[] deve emitir OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	}
+	if ops[chunk.OP_GET_LOCAL_MUT] != 0 {
+		t.Fatal("a forma fundida substitui a cadeia OP_GET_LOCAL_MUT")
+	}
+	// Com operando impuro (chamada), a forma fundida nao sai e a cadeia MUT
+	// continua unicizando o local antes da escrita.
+	code = compileSource(t, `func g() -> int
+    return 9
+end
+func f()
+    let a: int[] = [1, 2]
+    a[0] = g()
+end`)
+	ops = collectOpcodes(t, code)
 	if ops[chunk.OP_GET_LOCAL_MUT] == 0 {
-		t.Fatal("a[0] = 9 com a local deve emitir OP_GET_LOCAL_MUT")
+		t.Fatal("a[0] = g() com a local deve emitir OP_GET_LOCAL_MUT")
 	}
 }
 

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -145,12 +145,32 @@ a[0].x = 9`)
 }
 
 func TestLoweringRefParamIndexAssignment(t *testing.T) {
+	// Indexacao tipada (issue #66): `a[0] = 9` com a parametro `ref int[]` e
+	// operandos puros sai pela forma fundida OP_SET_REF_LOCAL_INDEX_ARRAY_NORC,
+	// que carrega a semantica de GET_LOCAL_MUT_BORROW + DEREF_MUT dentro do
+	// opcode (unicizeThroughRefValue no fallback) — a cadeia explicita nao
+	// aparece.
 	code := compileSource(t, `func f(a: ref int[])
     a[0] = 9
 end`)
 	ops := collectOpcodes(t, code)
+	if ops[chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC] == 0 {
+		t.Fatal("a[0] = 9 com a ref int[] deve emitir OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	}
+	if ops[chunk.OP_DEREF_MUT] != 0 {
+		t.Fatal("a forma fundida de ref substitui a cadeia OP_DEREF_MUT")
+	}
+	// Com operando impuro (chamada), a cadeia MUT continua unicizando atraves
+	// do ref antes da escrita.
+	code = compileSource(t, `func g() -> int
+    return 9
+end
+func f(a: ref int[])
+    a[0] = g()
+end`)
+	ops = collectOpcodes(t, code)
 	if ops[chunk.OP_DEREF_MUT] == 0 {
-		t.Fatal("a[0] = 9 com a ref deve emitir OP_DEREF_MUT")
+		t.Fatal("a[0] = g() com a ref deve emitir OP_DEREF_MUT")
 	}
 }
 

--- a/internal/compiler/typed_index.go
+++ b/internal/compiler/typed_index.go
@@ -1,0 +1,35 @@
+package compiler
+
+import "noxy-vm/internal/ast"
+
+// Indexacao tipada de array (issue #66, item 1): o compilador sabe quando a
+// base e T[] e emite os opcodes especializados de internal/chunk. Este arquivo
+// reune os predicados da decisao; a emissao mora em compiler.go (leitura em
+// `case *ast.IndexExpression`, escrita na atribuicao a IndexExpression e no
+// for-each).
+
+// isUntrackedElementType responde se um ELEMENTO desse tipo estatico nunca
+// tem contador RC — os unicos casos em que a escrita pode usar a forma NORC.
+// Lista fechada por nome: struct tambem e PrimitiveType (pelo nome da
+// declaracao) e `any` pode guardar composto, entao ambos respondem false.
+func isUntrackedElementType(t ast.NoxyType) bool {
+	prim, ok := t.(*ast.PrimitiveType)
+	if !ok {
+		return false
+	}
+	switch prim.Name {
+	case "int", "float", "bool", "string", "bytes":
+		return true
+	}
+	return false
+}
+
+// arrayTypeOf desembrulha um nivel de `ref` e devolve o ArrayType da base,
+// se for um — o tipo que decide entre OP_GET_INDEX_ARRAY e OP_GET_INDEX.
+func arrayTypeOf(t ast.NoxyType) (*ast.ArrayType, bool) {
+	if ref, ok := t.(*ast.RefType); ok {
+		t = ref.ElementType
+	}
+	arr, ok := t.(*ast.ArrayType)
+	return arr, ok
+}

--- a/internal/compiler/typed_index.go
+++ b/internal/compiler/typed_index.go
@@ -70,8 +70,9 @@ func isSideEffectFree(expr ast.Expression) bool {
 
 // fusedLocalIndexRead decide se `n` (X[i]) pode ser lida pela forma fundida
 // por slot: X e identificador resolvido a local (slot <= 255) de tipo T[]
-// (OP_GET_LOCAL_INDEX_ARRAY) e i e livre de efeito colateral. Devolve o
-// opcode, o slot e o tipo do elemento.
+// (OP_GET_LOCAL_INDEX_ARRAY) ou `ref T[]` (OP_GET_REF_LOCAL_INDEX_ARRAY, que
+// resolve a caixa do ref dentro do opcode — sem OP_DEREF) e i e livre de
+// efeito colateral. Devolve o opcode, o slot e o tipo do elemento.
 func (c *Compiler) fusedLocalIndexRead(n *ast.IndexExpression) (chunk.OpCode, int, ast.NoxyType, bool) {
 	ident, ok := n.Left.(*ast.Identifier)
 	if !ok {
@@ -84,17 +85,25 @@ func (c *Compiler) fusedLocalIndexRead(n *ast.IndexExpression) (chunk.OpCode, in
 	if arr, ok := localType.(*ast.ArrayType); ok {
 		return chunk.OP_GET_LOCAL_INDEX_ARRAY, arg, arr.ElementType, true
 	}
+	if ref, ok := localType.(*ast.RefType); ok {
+		if arr, ok := ref.ElementType.(*ast.ArrayType); ok {
+			return chunk.OP_GET_REF_LOCAL_INDEX_ARRAY, arg, arr.ElementType, true
+		}
+	}
 	return 0, 0, nil, false
 }
 
 // tryFuseLocalIndexAssign funde `x[i] = v` quando x e local T[] POSSUIDOR
-// (OP_SET_LOCAL_INDEX_ARRAY_NORC), T sem contador RC, e i e v sao livres de
+// (OP_SET_LOCAL_INDEX_ARRAY_NORC) ou local `ref T[]` NAO-possuidor
+// (OP_SET_REF_LOCAL_INDEX_ARRAY_NORC — a semantica de GET_LOCAL_MUT_BORROW +
+// DEREF_MUT dentro do opcode), T sem contador RC, e i e v sao livres de
 // efeito colateral. Devolve (true, nil) se emitiu; (true, err) num erro de
 // compilacao — as MESMAS checagens e mensagens do ramo ArrayType do caminho
 // generico, so que sem compileLValueBase antes (para identificador local ele
-// nunca erra: so emitiria o GET_LOCAL_MUT que a forma fundida substitui);
+// nunca erra: so emitiria a cadeia MUT que a forma fundida substitui);
 // (false, nil) para seguir o caminho generico. Owns continua a fonte de
-// verdade (spec CoW-RC §4.2): slot T[] nao-possuidor vai pelo generico.
+// verdade (spec CoW-RC §4.2): slot T[] nao-possuidor ou slot ref possuidor
+// seriam estado inesperado e vao pelo generico.
 func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExpr ast.Expression) (bool, error) {
 	ident, ok := target.Left.(*ast.Identifier)
 	if !ok {
@@ -112,6 +121,14 @@ func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExp
 			return false, nil
 		}
 		op, arrType = chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC, t
+	case *ast.RefType:
+		// Slot `ref T[]` EMPRESTA (spec CoW-RC §4.2): a forma fundida de ref
+		// reproduz GET_LOCAL_MUT_BORROW + DEREF_MUT.
+		inner, isArr := t.ElementType.(*ast.ArrayType)
+		if !isArr || c.localOwns(arg) {
+			return false, nil
+		}
+		op, arrType = chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC, inner
 	default:
 		return false, nil
 	}

--- a/internal/compiler/typed_index.go
+++ b/internal/compiler/typed_index.go
@@ -1,12 +1,18 @@
 package compiler
 
-import "noxy-vm/internal/ast"
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+)
 
 // Indexacao tipada de array (issue #66, item 1): o compilador sabe quando a
 // base e T[] e emite os opcodes especializados de internal/chunk. Este arquivo
-// reune os predicados da decisao; a emissao mora em compiler.go (leitura em
-// `case *ast.IndexExpression`, escrita na atribuicao a IndexExpression e no
-// for-each).
+// reune os predicados e as decisoes; a emissao das formas genericas tipadas
+// mora em compiler.go (leitura em `case *ast.IndexExpression`, escrita na
+// atribuicao a IndexExpression e no for-each), e as formas fundidas por slot
+// sao emitidas por tryFuseLocalIndexAssign / fusedLocalIndexRead abaixo.
 
 // isUntrackedElementType responde se um ELEMENTO desse tipo estatico nunca
 // tem contador RC — os unicos casos em que a escrita pode usar a forma NORC.
@@ -32,4 +38,109 @@ func arrayTypeOf(t ast.NoxyType) (*ast.ArrayType, bool) {
 	}
 	arr, ok := t.(*ast.ArrayType)
 	return arr, ok
+}
+
+// isSideEffectFree e o predicado sintatico que libera as formas FUNDIDAS por
+// slot (spec §3.3): elas leem o slot do local DEPOIS de avaliar indice (e
+// valor), entao so valem quando nada ali pode rodar codigo — chamada
+// (inclusive builtin e f-string, que viram chamadas), closure, `ref`, literal
+// composto, zeros — que rebindasse ou compartilhasse o local no meio da
+// statement. Com operandos assim, a ordem observavel e a da sequencia
+// generica. Conservador: o que nao esta na lista e impuro.
+func isSideEffectFree(expr ast.Expression) bool {
+	switch n := expr.(type) {
+	case *ast.Identifier, *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral,
+		*ast.BytesLiteral, *ast.Boolean, *ast.NullLiteral:
+		return true
+	case *ast.PrefixExpression:
+		switch n.Operator {
+		case "-", "!", "~", "*":
+			return isSideEffectFree(n.Right)
+		}
+		return false
+	case *ast.InfixExpression:
+		return isSideEffectFree(n.Left) && isSideEffectFree(n.Right)
+	case *ast.IndexExpression:
+		return isSideEffectFree(n.Left) && isSideEffectFree(n.Index)
+	case *ast.MemberAccessExpression:
+		return isSideEffectFree(n.Left)
+	}
+	return false
+}
+
+// fusedLocalIndexRead decide se `n` (X[i]) pode ser lida pela forma fundida
+// por slot: X e identificador resolvido a local (slot <= 255) de tipo T[]
+// (OP_GET_LOCAL_INDEX_ARRAY) e i e livre de efeito colateral. Devolve o
+// opcode, o slot e o tipo do elemento.
+func (c *Compiler) fusedLocalIndexRead(n *ast.IndexExpression) (chunk.OpCode, int, ast.NoxyType, bool) {
+	ident, ok := n.Left.(*ast.Identifier)
+	if !ok {
+		return 0, 0, nil, false
+	}
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 || !isSideEffectFree(n.Index) {
+		return 0, 0, nil, false
+	}
+	if arr, ok := localType.(*ast.ArrayType); ok {
+		return chunk.OP_GET_LOCAL_INDEX_ARRAY, arg, arr.ElementType, true
+	}
+	return 0, 0, nil, false
+}
+
+// tryFuseLocalIndexAssign funde `x[i] = v` quando x e local T[] POSSUIDOR
+// (OP_SET_LOCAL_INDEX_ARRAY_NORC), T sem contador RC, e i e v sao livres de
+// efeito colateral. Devolve (true, nil) se emitiu; (true, err) num erro de
+// compilacao — as MESMAS checagens e mensagens do ramo ArrayType do caminho
+// generico, so que sem compileLValueBase antes (para identificador local ele
+// nunca erra: so emitiria o GET_LOCAL_MUT que a forma fundida substitui);
+// (false, nil) para seguir o caminho generico. Owns continua a fonte de
+// verdade (spec CoW-RC §4.2): slot T[] nao-possuidor vai pelo generico.
+func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExpr ast.Expression) (bool, error) {
+	ident, ok := target.Left.(*ast.Identifier)
+	if !ok {
+		return false, nil
+	}
+	arg, localType := c.resolveLocal(ident.Value)
+	if arg == -1 || arg > 255 {
+		return false, nil
+	}
+	var op chunk.OpCode
+	var arrType *ast.ArrayType
+	switch t := localType.(type) {
+	case *ast.ArrayType:
+		if !c.localOwns(arg) {
+			return false, nil
+		}
+		op, arrType = chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC, t
+	default:
+		return false, nil
+	}
+	if !isUntrackedElementType(arrType.ElementType) || !isSideEffectFree(target.Index) || !isSideEffectFree(valueExpr) {
+		return false, nil
+	}
+	_, idxType, err := c.Compile(target.Index)
+	if err != nil {
+		return true, err
+	}
+	if _, isRef := idxType.(*ast.RefType); isRef {
+		c.emitByte(byte(chunk.OP_DEREF))
+	}
+	_, valType, err := c.Compile(valueExpr)
+	if err != nil {
+		return true, err
+	}
+	if ref, isRef := idxType.(*ast.RefType); isRef {
+		idxType = ref.ElementType
+	}
+	if idxType != nil && idxType.String() != "int" {
+		return true, fmt.Errorf("[line %d] array index must be int, got %s", c.currentLine, idxType.String())
+	}
+	if !c.areTypesCompatible(arrType.ElementType, valType) {
+		return true, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s%s", c.currentLine, arrType.ElementType.String(), valType.String(), c.derefReadHint(arrType.ElementType, valType, valueExpr))
+	}
+	if err := c.emitRuntimeValueType(arrType.ElementType); err != nil {
+		return true, err
+	}
+	c.emitBytes(byte(op), byte(arg))
+	return true, nil
 }

--- a/internal/compiler/typed_index_compile_test.go
+++ b/internal/compiler/typed_index_compile_test.go
@@ -1,0 +1,178 @@
+package compiler
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+var opNamePattern = regexp.MustCompile(`\bOP_[A-Z_]+\b`)
+
+// opcodeNames devolve os nomes dos opcodes de um chunk NA ORDEM, lidos da
+// saida do disassembler (que conhece a largura de cada instrucao) —
+// containsOpcode varre bytes e confundiria um operando com um opcode.
+func opcodeNames(t *testing.T, code *chunk.Chunk) []string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan string)
+	go func() {
+		out, _ := io.ReadAll(reader)
+		done <- string(out)
+	}()
+	previous := os.Stdout
+	os.Stdout = writer
+	code.Disassemble("t")
+	_ = writer.Close()
+	os.Stdout = previous
+	return opNamePattern.FindAllString(<-done, -1)
+}
+
+// findFunctionChunk procura a funcao pelo nome em toda a arvore de constantes
+// (compiledFunction so olha o nivel de cima; closures aninhadas — `inner`
+// dentro de `outer` — moram no chunk da funcao que as declara).
+func findFunctionChunk(code *chunk.Chunk, name string) *chunk.Chunk {
+	for _, constant := range code.Constants {
+		if constant.Type != value.VAL_FUNCTION {
+			continue
+		}
+		fn := constant.Obj.(*value.ObjFunction)
+		child := fn.Chunk.(*chunk.Chunk)
+		if fn.Name == name {
+			return child
+		}
+		if found := findFunctionChunk(child, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func functionOpcodes(t *testing.T, source, name string) []string {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fnChunk := findFunctionChunk(code, name)
+	if fnChunk == nil {
+		t.Fatalf("function %q not found", name)
+	}
+	return opcodeNames(t, fnChunk)
+}
+
+func topLevelOpcodes(t *testing.T, source string) []string {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return opcodeNames(t, code)
+}
+
+func assertHas(t *testing.T, ops []string, want string) {
+	t.Helper()
+	if !slices.Contains(ops, want) {
+		t.Fatalf("esperava %s no bytecode, obtido: %s", want, strings.Join(ops, " "))
+	}
+}
+
+func assertLacks(t *testing.T, ops []string, unwanted string) {
+	t.Helper()
+	if slices.Contains(ops, unwanted) {
+		t.Fatalf("nao esperava %s no bytecode, obtido: %s", unwanted, strings.Join(ops, " "))
+	}
+}
+
+// assertNotFollowedByPop: as formas de escrita tipadas sao statement (nao
+// empilham), entao o compilador nao pode emitir o OP_POP da sequencia
+// generica depois delas.
+func assertNotFollowedByPop(t *testing.T, ops []string, op string) {
+	t.Helper()
+	for k, name := range ops {
+		if name == op && k+1 < len(ops) && ops[k+1] == "OP_POP" {
+			t.Fatalf("%s seguido de OP_POP: a forma tipada de escrita nao empilha", op)
+		}
+	}
+}
+
+// Base T[] em posicao generica (global): leitura tipada, escrita NORC sem OP_POP.
+func TestGlobalArrayUsesTypedIndexOpcodes(t *testing.T) {
+	ops := topLevelOpcodes(t, "let xs: int[] = [1, 2]\nlet i: int = 0\nxs[i] = xs[i] + 1\n")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX")
+	assertNotFollowedByPop(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+}
+
+// Nested: o nivel de fora e MUT generico, o de dentro e tipado.
+func TestNestedArrayWriteUsesTypedInnerOpcode(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(g: int[][]) -> int
+    g[0][1] = g[1][0] + 1
+    return g[0][1]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX_MUT")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX")
+}
+
+// Elemento composto: escrita segue OP_SET_INDEX (RC do generico); leitura e tipada.
+func TestCompositeElementKeepsGenericSetIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f(ps: P[][]) -> P
+    ps[0][0] = P(1)
+    return ps[0][0]
+end
+`, "f")
+	assertHas(t, ops, "OP_SET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+}
+
+// Map e any: tudo generico.
+func TestMapAndAnyKeepGenericIndexOpcodes(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(m: map[string, int], a: any) -> int
+    m["k"] = a[0]
+    return m["k"]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX")
+	assertHas(t, ops, "OP_SET_INDEX")
+	assertLacks(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+}
+
+// Upvalue de tipo T[] (closure): forma generica tipada, nunca a fundida por slot.
+func TestUpvalueArrayUsesGenericTypedOpcodes(t *testing.T) {
+	ops := functionOpcodes(t, `
+func outer() -> int
+    let xs: int[] = [1, 2]
+    func inner() -> int
+        xs[0] = 5
+        return xs[1]
+    end
+    return inner()
+end
+`, "inner")
+	assertHas(t, ops, "OP_GET_UPVALUE_MUT")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+}

--- a/internal/compiler/typed_index_compile_test.go
+++ b/internal/compiler/typed_index_compile_test.go
@@ -283,3 +283,66 @@ end
 	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
 	assertHas(t, ops, "OP_SET_INDEX")
 }
+
+// Parametro `ref T[]`: leitura e escrita pela forma fundida de ref — sem
+// OP_DEREF/OP_DEREF_MUT (o opcode resolve a caixa), sem OP_POP.
+func TestRefArrayParameterFusesIndex(t *testing.T) {
+	// (as escritas vem ANTES do `if` de proposito: no fim de um bloco o
+	// compilador emite OP_POP para os locais do bloco, e assertNotFollowedByPop
+	// confundiria esse pop de escopo com o pop da atribuicao.)
+	ops := functionOpcodes(t, `
+func bubble(data: ref int[]) -> void
+    let j: int = 0
+    let tmp: int = data[j]
+    data[j] = data[j + 1]
+    data[j + 1] = tmp
+    if data[j] > data[j + 1] then
+        j = j + 1
+    end
+end
+`, "bubble")
+	assertHas(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_DEREF")
+	assertLacks(t, ops, "OP_DEREF_MUT")
+	assertLacks(t, ops, "OP_GET_LOCAL_MUT_BORROW")
+	assertLacks(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_SET_INDEX")
+	assertNotFollowedByPop(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+}
+
+// Com chamada no operando, o ref segue o caminho de hoje (DEREF / DEREF_MUT)
+// com os opcodes tipados genericos.
+func TestRefArrayParameterDoesNotFuseWithCall(t *testing.T) {
+	ops := functionOpcodes(t, `
+func g() -> int
+    return 0
+end
+func f(data: ref int[]) -> int
+    data[g()] = 1
+    return data[g()]
+end
+`, "f")
+	assertLacks(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_DEREF")
+	assertHas(t, ops, "OP_DEREF_MUT")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+}
+
+// `ref P[]` (elemento composto): leitura funde, escrita fica no generico.
+func TestRefCompositeArrayFusesReadOnly(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f(ps: ref P[]) -> P
+    ps[0] = ps[1]
+    return ps[0]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_REF_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_SET_INDEX")
+}

--- a/internal/compiler/typed_index_compile_test.go
+++ b/internal/compiler/typed_index_compile_test.go
@@ -176,3 +176,110 @@ end
 	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
 	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
 }
+
+// Local plano T[] com indice puro: forma fundida por slot, sem GET_LOCAL do
+// array e sem OP_POP depois da escrita.
+func TestLocalArrayFusesIndexIntoSlotForm(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    let i: int = 1
+    xs[i + 1] = xs[i] + xs[0]
+    return xs[2]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertLacks(t, ops, "OP_GET_LOCAL_MUT")
+	assertNotFollowedByPop(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+}
+
+// Indice ou valor com chamada: a forma fundida NAO sai (le o slot depois de
+// avaliar os operandos; uma chamada poderia rebindar o local via closure ou
+// ref). Fica a forma generica tipada, com o container avaliado primeiro.
+func TestLocalArrayDoesNotFuseWhenOperandHasCall(t *testing.T) {
+	ops := functionOpcodes(t, `
+func idx() -> int
+    return 0
+end
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    xs[idx()] = 5
+    xs[0] = idx()
+    return xs[idx()]
+end
+`, "f")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_GET_LOCAL_MUT")
+}
+
+// Parametro T[] (sem ref) e local possuidor: funde.
+func TestArrayParameterFusesIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+func sum(data: int[]) -> int
+    let s: int = 0
+    let i: int = 0
+    while i < 3 do
+        s = s + data[i]
+        i = i + 1
+    end
+    data[0] = s
+    return s
+end
+`, "sum")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertHas(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+}
+
+// for-each sobre array: o item e lido pela forma fundida no slot $collection.
+func TestForEachOverArrayUsesFusedRead(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(xs: int[]) -> int
+    let s: int = 0
+    for x in xs do
+        s = s + x
+    end
+    return s
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_GET_INDEX")
+}
+
+// for-each sobre map continua generico (a colecao iterada e o array de chaves
+// sem tipo estatico).
+func TestForEachOverMapKeepsGenericRead(t *testing.T) {
+	ops := functionOpcodes(t, `
+func f(m: map[string, int]) -> int
+    let n: int = 0
+    for k in m do
+        n = n + 1
+    end
+    return n
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_INDEX")
+	assertLacks(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+}
+
+// Elemento composto em local: leitura funde (leitura nao tem RC), escrita nao.
+func TestLocalCompositeArrayFusesReadOnly(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct P
+    x: int
+end
+func f() -> P
+    let ps: P[] = [P(1), P(2)]
+    ps[0] = ps[1]
+    return ps[0]
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_LOCAL_INDEX_ARRAY")
+	assertLacks(t, ops, "OP_SET_LOCAL_INDEX_ARRAY_NORC")
+	assertHas(t, ops, "OP_SET_INDEX")
+}

--- a/internal/value/cow.go
+++ b/internal/value/cow.go
@@ -14,6 +14,19 @@ func IsShared(v Value) bool {
 	return owners != nil && owners.Load() > 1
 }
 
+// NeverTracked responde se v CERTAMENTE nao tem contador RC: escalares
+// (Type != VAL_OBJ) e os VAL_OBJ que os construtores carimbaram como sem dono
+// (string, *ObjStruct, *RuntimeTypeInfo). E a conferencia que as escritas NORC
+// da indexacao tipada (issue #66, item 1) fazem antes de pular Retain/Release:
+// se o valor novo ou o velho nao for comprovadamente sem contador (composto,
+// ou VAL_OBJ sem carimbo — kind zero), o chamador cai no caminho generico, que
+// retem. Conservador por construcao: nunca devolve true para um composto.
+// Chamada de dentro de run(): tem de caber em 20 no inliner
+// (inline_guard_test.go).
+func NeverTracked(v Value) bool {
+	return v.Type != VAL_OBJ || v.kind == objKindNoOwners
+}
+
 // ownersSaturation impede overflow do contador; acima disso o valor se
 // comporta como permanentemente compartilhado (equivalente ao sticky).
 const ownersSaturation = math.MaxInt32 / 2

--- a/internal/value/never_tracked_test.go
+++ b/internal/value/never_tracked_test.go
@@ -1,0 +1,36 @@
+package value
+
+import "testing"
+
+// NeverTracked e o teste que as escritas NORC da indexacao tipada fazem em
+// runtime antes de pular Retain/Release (issue #66, item 1): so pode dizer
+// "true" para o que o RC comprovadamente nao rastreia. A direcao segura e
+// "false" — o chamador cai no caminho generico, que retem.
+func TestNeverTrackedIsTrueOnlyForValuesWithoutOwners(t *testing.T) {
+	inst := NewInstanceWith(&ObjStruct{Name: "P"}, map[string]Value{})
+	cases := []struct {
+		name string
+		v    Value
+		want bool
+	}{
+		{"int", NewInt(1), true},
+		{"float", NewFloat(1.5), true},
+		{"bool", NewBool(true), true},
+		{"null", NewNull(), true},
+		{"string (carimbada)", NewString("x"), true},
+		{"bytes", Value{Type: VAL_BYTES, Obj: "ab"}, true},
+		{"ref", Value{Type: VAL_REF, Obj: &ObjRef{}}, true},
+		{"array", NewArray(nil), false},
+		{"map", NewMap(), false},
+		{"instance", inst, false},
+		// VAL_OBJ montado fora dos construtores (kind zero): nao se sabe,
+		// entao false — o caminho generico decide por ownersOf.
+		{"string sem carimbo", Value{Type: VAL_OBJ, Obj: "x"}, false},
+		{"array sem carimbo", Value{Type: VAL_OBJ, Obj: &ObjArray{}}, false},
+	}
+	for _, tc := range cases {
+		if got := NeverTracked(tc.v); got != tc.want {
+			t.Errorf("%s: NeverTracked = %v, esperado %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.14.3"
+const Version = "v0.15.0"

--- a/internal/vm/cow.go
+++ b/internal/vm/cow.go
@@ -22,6 +22,41 @@ func (vm *VM) unicize(v value.Value) (value.Value, bool) {
 	return vm.copyValue(v), true
 }
 
+// unicizeOwnedSlot e a semantica de OP_GET_LOCAL_MUT para um slot POSSUIDOR:
+// se o composto no slot esta compartilhado, grava um clone no slot (ownSlot
+// mantem o slot registrado em frame.Owned, como OP_SET_LOCAL) e solta o
+// velho; devolve o ocupante (unico) do slot. Metodo para ser o funil comum do
+// case generico e do fallback de OP_SET_LOCAL_INDEX_ARRAY_NORC (issue #66).
+func (vm *VM) unicizeOwnedSlot(frame *CallFrame, idx int) value.Value {
+	v := vm.stack[idx]
+	if value.IsShared(v) {
+		old := v
+		v = vm.copyValue(v)
+		vm.stack[idx] = v
+		// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
+		// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
+		frame.ownSlot(vm, idx)
+		value.Release(old)
+	}
+	return v
+}
+
+// unicizeBorrowedSlot e o gemeo de EMPRESTIMO (OP_GET_LOCAL_MUT_BORROW): slot
+// de tipo `ref T` nao possui o que guarda, entao o clone fica no slot sem
+// retain do novo nem release do velho (soltar o que nunca se reteve e dec a
+// menos, e faria o objeto compartilhado parecer unico). A mutacao adiante
+// vai para o clone, exatamente como no comportamento pre-RC. Tambem e o
+// fallback de OP_SET_REF_LOCAL_INDEX_ARRAY_NORC quando o slot guarda um valor
+// plano (tolerancia herdada do auto-deref antigo).
+func (vm *VM) unicizeBorrowedSlot(idx int) value.Value {
+	v := vm.stack[idx]
+	if value.IsShared(v) {
+		v = vm.copyValue(v)
+		vm.stack[idx] = v
+	}
+	return v
+}
+
 // unicizeThroughRefValue resolve um valor VAL_REF (slot: variável, campo,
 // índice…), garante posse exclusiva do composto armazenado e grava o clone
 // de volta no slot pelo setter quando clona. Devolve o valor único.

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -78,6 +78,12 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		instruction := chunk.OpCode(c.Code[ip])
 		ip++
 
+		// redispatch: os opcodes de indexacao tipada (issue #66) re-entram aqui
+		// com `instruction` trocada pelo generico quando o container nao e o
+		// array que o tipo estatico prometia (null por `any`, ref de outro
+		// tipo) — depois de materializar na pilha exatamente o que a sequencia
+		// generica teria. Zero custo no caminho comum; so os fallbacks saltam.
+	redispatch:
 		switch instruction {
 		case chunk.OP_CONSTANT:
 			// Read constant
@@ -1437,66 +1443,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			return vm.runtimeError(c, ip, "cannot index non-array/map/bytes")
 
 		case chunk.OP_SET_INDEX:
-			val := vm.pop()
-			indexVal := vm.pop()
-			collectionVal := vm.pop() // The array/map itself is on stack (pointer)
-
-			if collectionVal.Type == value.VAL_OBJ {
-				if arr, ok := collectionVal.Obj.(*value.ObjArray); ok {
-					if indexVal.Type != value.VAL_INT {
-						return vm.runtimeError(c, ip, "array index must be integer")
-					}
-					idx := int(indexVal.Int())
-					if idx < 0 || idx >= len(arr.Elements) {
-						return vm.runtimeError(c, ip, "array index out of bounds")
-					}
-					// Guard do slot ref (spec §6.3): elemento `ref T` (tag
-					// RuntimeType) so aceita ref/null; via base tipada o
-					// compilador ja rejeitou. O teste de val.Type vem antes
-					// para o Load() atomico so rodar em escritas nao-ref.
-					if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && arrayElementIsRefSlot(arr) {
-						return vm.runtimeError(c, ip, "%s", refSlotWriteError(arr.RuntimeType.Load().Element.String(), val))
-					}
-					// RC: retain-antes-de-release (elemento e dono duravel)
-					old := arr.Elements[idx]
-					value.Retain(val)
-					arr.Elements[idx] = val
-					value.Release(old)
-					vm.push(val) // Assignment expression result
-					continue
-				} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
-					var key interface{}
-					if indexVal.Type == value.VAL_INT {
-						key = indexVal.Int()
-					} else if indexVal.Type == value.VAL_OBJ {
-						if str, ok := indexVal.Obj.(string); ok {
-							key = str
-						} else {
-							return vm.runtimeError(c, ip, "map key must be int or string")
-						}
-					} else {
-						return vm.runtimeError(c, ip, "map key must be int or string")
-					}
-					// Guard do slot ref (spec §6.3): valor `ref T` (tag
-					// RuntimeType) so aceita ref/null.
-					if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && mapValueIsRefSlot(mapObj) {
-						return vm.runtimeError(c, ip, "%s", refSlotWriteError(mapObj.RuntimeType.Load().Value.String(), val))
-					}
-					// RC: so libera o velho se a chave ja existia (dec a
-					// menos e proibido); retain-antes-de-release quando existe.
-					if old, exists := mapObj.Get(key); exists {
-						value.Retain(val)
-						mapObj.Set(key, val)
-						value.Release(old)
-					} else {
-						value.Retain(val)
-						mapObj.Set(key, val)
-					}
-					vm.push(val)
-					continue
-				}
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
 			}
-			return vm.runtimeError(c, ip, "cannot set index on non-array/map")
 
 		case chunk.OP_GET_PROPERTY:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
@@ -1633,35 +1582,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		case chunk.OP_GET_LOCAL_MUT:
 			slot := c.Code[ip]
 			ip++
-			idx := frame.LocalBase + int(slot)
-			v := vm.stack[idx]
-			if value.IsShared(v) {
-				old := v
-				v = vm.copyValue(v)
-				vm.stack[idx] = v
-				// RC: usa ownSlot (mantem o slot registrado em frame.Owned)
-				// em vez de Retain cru — mesmo padrao do OP_SET_LOCAL.
-				frame.ownSlot(vm, idx)
-				value.Release(old)
-			}
-			vm.push(v)
+			vm.push(vm.unicizeOwnedSlot(frame, frame.LocalBase+int(slot)))
 
 		case chunk.OP_GET_LOCAL_MUT_BORROW:
 			slot := c.Code[ip]
 			ip++
 			// RC: gemeo de EMPRESTIMO do acima, emitido quando o tipo declarado
-			// do local e `ref T`. O slot nao possui o que guarda: nao pode
-			// reter o clone nem soltar o velho (soltar o que nunca se reteve e
-			// dec a menos, e faria o objeto compartilhado parecer unico). O
-			// clone fica no slot emprestado sem dono — a mutacao adiante vai
-			// para o clone, exatamente como no comportamento pre-RC.
-			idx := frame.LocalBase + int(slot)
-			v := vm.stack[idx]
-			if value.IsShared(v) {
-				v = vm.copyValue(v)
-				vm.stack[idx] = v
-			}
-			vm.push(v)
+			// do local e `ref T` — ver unicizeBorrowedSlot (cow.go).
+			vm.push(vm.unicizeBorrowedSlot(frame.LocalBase + int(slot)))
 
 		case chunk.OP_GET_GLOBAL_MUT:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
@@ -1840,6 +1768,214 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// copiar; unicidade e decidida por Owners (RC), nao por marcacao.
 			val := vm.pop()
 			vm.push(val)
+
+		// perf issue #66 (item 1): indexacao tipada de array. Caminho rapido
+		// grava o resultado NO LUGAR na pilha (sem pop/push); mensagens de erro
+		// identicas as do generico; container inesperado cai no generico.
+		case chunk.OP_GET_INDEX_ARRAY:
+			top := vm.stackTop
+			if arr, ok := vm.stack[top-2].Obj.(*value.ObjArray); ok {
+				indexVal := vm.stack[top-1]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				vm.stack[top-2] = arr.Elements[idx]
+				vm.stack[top-1] = value.Value{}
+				vm.stackTop = top - 1
+				continue
+			}
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_GET_LOCAL_INDEX_ARRAY:
+			slot := c.Code[ip]
+			ip++
+			if arr, ok := vm.stack[frame.LocalBase+int(slot)].Obj.(*value.ObjArray); ok {
+				top := vm.stackTop
+				indexVal := vm.stack[top-1]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				vm.stack[top-1] = arr.Elements[idx]
+				continue
+			}
+			// Fallback: a sequencia generica GET_LOCAL + GET_INDEX.
+			indexVal := vm.pop()
+			vm.push(vm.stack[frame.LocalBase+int(slot)])
+			vm.push(indexVal)
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_GET_REF_LOCAL_INDEX_ARRAY:
+			// O slot guarda o ref de um parametro `ref T[]`. REF_UPVALUE (a
+			// forma que OP_REF_LOCAL cria para todo ref a local) resolve com
+			// uma Load() da caixa em vez de referenceStorage (defer + closure
+			// do setter + reflect). arr != nil espelha o validateReferencedValue
+			// do caminho generico (typed nil cairia no erro de la).
+			slot := c.Code[ip]
+			ip++
+			refVal := vm.stack[frame.LocalBase+int(slot)]
+			if ref, ok := refVal.Obj.(*value.ObjRef); ok && ref.RefType == value.REF_UPVALUE {
+				if stored, ok := ref.Upvalue.Load(); ok {
+					if arr, ok := stored.Obj.(*value.ObjArray); ok && arr != nil {
+						top := vm.stackTop
+						indexVal := vm.stack[top-1]
+						if indexVal.Type != value.VAL_INT {
+							return vm.runtimeError(c, ip, "array index must be integer")
+						}
+						idx := int(indexVal.Int())
+						if idx < 0 || idx >= len(arr.Elements) {
+							return vm.runtimeError(c, ip, "array index out of bounds")
+						}
+						vm.stack[top-1] = arr.Elements[idx]
+						continue
+					}
+				}
+			}
+			// Fallback: GET_LOCAL + OP_DEREF (null e nao-ref passam; ref
+			// resolve) + GET_INDEX.
+			container := refVal
+			if refVal.Type == value.VAL_REF {
+				resolved, err := vm.resolveReferenceValue(refVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				container = resolved
+			}
+			indexVal := vm.pop()
+			vm.push(container)
+			vm.push(indexVal)
+			instruction = chunk.OP_GET_INDEX
+			goto redispatch
+
+		case chunk.OP_SET_INDEX_ARRAY_NORC:
+			// [arr, i, v] -> []. Pula Retain/Release SO se valor novo e velho
+			// sao comprovadamente sem contador e o array nao e (ref T)[] —
+			// senao o generico (setIndexGeneric) decide, como OP_SET_INDEX +
+			// OP_POP fariam.
+			top := vm.stackTop
+			if arr, ok := vm.stack[top-3].Obj.(*value.ObjArray); ok {
+				indexVal := vm.stack[top-2]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				val := vm.stack[top-1]
+				if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+					arr.Elements[idx] = val
+					vm.stack[top-1] = value.Value{}
+					vm.stack[top-2] = value.Value{}
+					vm.stack[top-3] = value.Value{}
+					vm.stackTop = top - 3
+					continue
+				}
+			}
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC:
+			// [i, v] -> []; container no slot do local possuidor. Caminho
+			// rapido = array unico (Owners <= 1 e o teste de IsShared, sem a
+			// chamada) + elemento sem contador; senao a sequencia generica
+			// GET_LOCAL_MUT + SET_INDEX + POP (unicizeOwnedSlot clona e
+			// registra posse exatamente como o case generico).
+			slot := c.Code[ip]
+			ip++
+			localIdx := frame.LocalBase + int(slot)
+			top := vm.stackTop
+			if arr, ok := vm.stack[localIdx].Obj.(*value.ObjArray); ok && arr.Owners.Load() <= 1 {
+				indexVal := vm.stack[top-2]
+				if indexVal.Type != value.VAL_INT {
+					return vm.runtimeError(c, ip, "array index must be integer")
+				}
+				idx := int(indexVal.Int())
+				if idx < 0 || idx >= len(arr.Elements) {
+					return vm.runtimeError(c, ip, "array index out of bounds")
+				}
+				val := vm.stack[top-1]
+				if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+					arr.Elements[idx] = val
+					vm.stack[top-1] = value.Value{}
+					vm.stack[top-2] = value.Value{}
+					vm.stackTop = top - 2
+					continue
+				}
+			}
+			val := vm.pop()
+			indexVal := vm.pop()
+			vm.push(vm.unicizeOwnedSlot(frame, localIdx))
+			vm.push(indexVal)
+			vm.push(val)
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
+			// [i, v] -> []; o slot guarda o ref de um parametro `ref T[]`
+			// (slot de emprestimo). Caminho rapido = REF_UPVALUE cujo array e
+			// unico + elemento sem contador; senao GET_LOCAL_MUT_BORROW +
+			// DEREF_MUT (unicizeThroughRefValue clona e grava de volta pelo
+			// setter do ref) + SET_INDEX + POP.
+			slot := c.Code[ip]
+			ip++
+			localIdx := frame.LocalBase + int(slot)
+			refVal := vm.stack[localIdx]
+			top := vm.stackTop
+			if ref, ok := refVal.Obj.(*value.ObjRef); ok && ref.RefType == value.REF_UPVALUE {
+				if stored, ok := ref.Upvalue.Load(); ok {
+					if arr, ok := stored.Obj.(*value.ObjArray); ok && arr != nil && arr.Owners.Load() <= 1 {
+						indexVal := vm.stack[top-2]
+						if indexVal.Type != value.VAL_INT {
+							return vm.runtimeError(c, ip, "array index must be integer")
+						}
+						idx := int(indexVal.Int())
+						if idx < 0 || idx >= len(arr.Elements) {
+							return vm.runtimeError(c, ip, "array index out of bounds")
+						}
+						val := vm.stack[top-1]
+						if value.NeverTracked(val) && value.NeverTracked(arr.Elements[idx]) && !arrayTagIsRefSlot(arr.RuntimeType.Load()) {
+							arr.Elements[idx] = val
+							vm.stack[top-1] = value.Value{}
+							vm.stack[top-2] = value.Value{}
+							vm.stackTop = top - 2
+							continue
+						}
+					}
+				}
+			}
+			val := vm.pop()
+			indexVal := vm.pop()
+			var container value.Value
+			if refVal.Type == value.VAL_REF {
+				uniq, err := vm.unicizeThroughRefValue(refVal)
+				if err != nil {
+					return vm.runtimeError(c, ip, "%s", err)
+				}
+				container = uniq
+			} else {
+				container = vm.unicizeBorrowedSlot(localIdx)
+			}
+			vm.push(container)
+			vm.push(indexVal)
+			vm.push(val)
+			if err := vm.setIndexGeneric(c, ip); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
 		}
 	}
 }

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -78,12 +78,6 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 		instruction := chunk.OpCode(c.Code[ip])
 		ip++
 
-		// redispatch: os opcodes de indexacao tipada (issue #66) re-entram aqui
-		// com `instruction` trocada pelo generico quando o container nao e o
-		// array que o tipo estatico prometia (null por `any`, ref de outro
-		// tipo) — depois de materializar na pilha exatamente o que a sequencia
-		// generica teria. Zero custo no caminho comum; so os fallbacks saltam.
-	redispatch:
 		switch instruction {
 		case chunk.OP_CONSTANT:
 			// Read constant
@@ -1378,69 +1372,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			}
 
 		case chunk.OP_GET_INDEX:
-			indexVal := vm.pop()
-			collectionVal := vm.pop()
-
-			if collectionVal.Type == value.VAL_OBJ {
-				if arr, ok := collectionVal.Obj.(*value.ObjArray); ok {
-					if indexVal.Type != value.VAL_INT {
-						return vm.runtimeError(c, ip, "array index must be integer")
-					}
-					idx := int(indexVal.Int())
-					if idx < 0 || idx >= len(arr.Elements) {
-						return vm.runtimeError(c, ip, "array index out of bounds")
-					}
-					vm.push(arr.Elements[idx])
-					continue
-				} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
-					var key interface{}
-					if indexVal.Type == value.VAL_INT {
-						key = indexVal.Int()
-					} else if indexVal.Type == value.VAL_OBJ {
-						if str, ok := indexVal.Obj.(string); ok {
-							key = str
-						} else {
-							return vm.runtimeError(c, ip, "map key must be int or string")
-						}
-					} else {
-						return vm.runtimeError(c, ip, "map key must be int or string")
-					}
-
-					val, ok := mapObj.Get(key)
-					if !ok {
-						vm.push(value.NewNull())
-					} else {
-						vm.push(val)
-					}
-					continue
-				} else if str, ok := collectionVal.Obj.(string); ok {
-					// String indexing
-					if indexVal.Type != value.VAL_INT {
-						return vm.runtimeError(c, ip, "string index must be integer")
-					}
-					idx := int(indexVal.Int())
-					runes := []rune(str) // Expensive but correct for now
-					if idx < 0 || idx >= len(runes) {
-						return vm.runtimeError(c, ip, "string index out of bounds")
-					}
-					vm.push(value.NewString(string(runes[idx])))
-					continue
-				}
+			if err := vm.getIndexGeneric(c, ip); err != nil {
+				return err
 			}
-			// Check if it's a bytes value
-			if collectionVal.Type == value.VAL_BYTES {
-				str := collectionVal.Obj.(string)
-				if indexVal.Type != value.VAL_INT {
-					return vm.runtimeError(c, ip, "bytes index must be integer")
-				}
-				idx := int(indexVal.Int())
-				if idx < 0 || idx >= len(str) {
-					return vm.runtimeError(c, ip, "bytes index out of bounds")
-				}
-				vm.push(value.NewInt(int64(str[idx])))
-				continue
-			}
-			return vm.runtimeError(c, ip, "cannot index non-array/map/bytes")
 
 		case chunk.OP_SET_INDEX:
 			if err := vm.setIndexGeneric(c, ip); err != nil {
@@ -1788,8 +1722,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				vm.stackTop = top - 1
 				continue
 			}
-			instruction = chunk.OP_GET_INDEX
-			goto redispatch
+			if err := vm.getIndexGeneric(c, ip); err != nil {
+				return err
+			}
 
 		case chunk.OP_GET_LOCAL_INDEX_ARRAY:
 			slot := c.Code[ip]
@@ -1811,8 +1746,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			indexVal := vm.pop()
 			vm.push(vm.stack[frame.LocalBase+int(slot)])
 			vm.push(indexVal)
-			instruction = chunk.OP_GET_INDEX
-			goto redispatch
+			if err := vm.getIndexGeneric(c, ip); err != nil {
+				return err
+			}
 
 		case chunk.OP_GET_REF_LOCAL_INDEX_ARRAY:
 			// O slot guarda o ref de um parametro `ref T[]`. REF_UPVALUE (a
@@ -1853,8 +1789,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			indexVal := vm.pop()
 			vm.push(container)
 			vm.push(indexVal)
-			instruction = chunk.OP_GET_INDEX
-			goto redispatch
+			if err := vm.getIndexGeneric(c, ip); err != nil {
+				return err
+			}
 
 		case chunk.OP_SET_INDEX_ARRAY_NORC:
 			// [arr, i, v] -> []. Pula Retain/Release SO se valor novo e velho

--- a/internal/vm/index_ops.go
+++ b/internal/vm/index_ops.go
@@ -76,3 +76,77 @@ func (vm *VM) setIndexGeneric(c *chunk.Chunk, ip int) error {
 	}
 	return vm.runtimeError(c, ip, "cannot set index on non-array/map")
 }
+
+// getIndexGeneric e o corpo de OP_GET_INDEX: desempilha indice e container,
+// indexa array / map / string / bytes (mesmas mensagens de erro) e empilha o
+// resultado. Virou metodo na indexacao tipada (issue #66, item 1) para ser o
+// funil unico dos fallbacks de OP_GET_INDEX_ARRAY / OP_GET_LOCAL_INDEX_ARRAY /
+// OP_GET_REF_LOCAL_INDEX_ARRAY, que materializam a pilha generica e chamam
+// isto, sem duplicar a logica. (A primeira forma, re-despachar o case
+// generico por `goto` dentro de run(), custou ~10 % no despacho generico:
+// o rotulo/phi e o corpo extra em run() mudaram o codegen do laco.)
+func (vm *VM) getIndexGeneric(c *chunk.Chunk, ip int) error {
+	indexVal := vm.pop()
+	collectionVal := vm.pop()
+
+	if collectionVal.Type == value.VAL_OBJ {
+		if arr, ok := collectionVal.Obj.(*value.ObjArray); ok {
+			if indexVal.Type != value.VAL_INT {
+				return vm.runtimeError(c, ip, "array index must be integer")
+			}
+			idx := int(indexVal.Int())
+			if idx < 0 || idx >= len(arr.Elements) {
+				return vm.runtimeError(c, ip, "array index out of bounds")
+			}
+			vm.push(arr.Elements[idx])
+			return nil
+		} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
+			var key interface{}
+			if indexVal.Type == value.VAL_INT {
+				key = indexVal.Int()
+			} else if indexVal.Type == value.VAL_OBJ {
+				if str, ok := indexVal.Obj.(string); ok {
+					key = str
+				} else {
+					return vm.runtimeError(c, ip, "map key must be int or string")
+				}
+			} else {
+				return vm.runtimeError(c, ip, "map key must be int or string")
+			}
+
+			val, ok := mapObj.Get(key)
+			if !ok {
+				vm.push(value.NewNull())
+			} else {
+				vm.push(val)
+			}
+			return nil
+		} else if str, ok := collectionVal.Obj.(string); ok {
+			// String indexing
+			if indexVal.Type != value.VAL_INT {
+				return vm.runtimeError(c, ip, "string index must be integer")
+			}
+			idx := int(indexVal.Int())
+			runes := []rune(str) // Expensive but correct for now
+			if idx < 0 || idx >= len(runes) {
+				return vm.runtimeError(c, ip, "string index out of bounds")
+			}
+			vm.push(value.NewString(string(runes[idx])))
+			return nil
+		}
+	}
+	// Check if it's a bytes value
+	if collectionVal.Type == value.VAL_BYTES {
+		str := collectionVal.Obj.(string)
+		if indexVal.Type != value.VAL_INT {
+			return vm.runtimeError(c, ip, "bytes index must be integer")
+		}
+		idx := int(indexVal.Int())
+		if idx < 0 || idx >= len(str) {
+			return vm.runtimeError(c, ip, "bytes index out of bounds")
+		}
+		vm.push(value.NewInt(int64(str[idx])))
+		return nil
+	}
+	return vm.runtimeError(c, ip, "cannot index non-array/map/bytes")
+}

--- a/internal/vm/index_ops.go
+++ b/internal/vm/index_ops.go
@@ -1,0 +1,78 @@
+package vm
+
+import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// setIndexGeneric e o corpo de OP_SET_INDEX: desempilha valor, indice e
+// container, escreve em array (guarda de slot ref, retain-antes-de-release)
+// ou map (retain/release so se a chave existia) e EMPILHA o valor (resultado
+// da atribuicao; o compilador emite OP_POP em seguida). Virou metodo na
+// indexacao tipada (issue #66, item 1) para ser o funil unico dos fallbacks
+// dos opcodes *_NORC — que materializam a pilha generica, chamam isto e
+// desempilham o resultado — sem duplicar a logica de erro; o custo e uma
+// chamada a mais por OP_SET_INDEX generico (maps, any, elemento composto),
+// medido em bench_map_churn.
+func (vm *VM) setIndexGeneric(c *chunk.Chunk, ip int) error {
+	val := vm.pop()
+	indexVal := vm.pop()
+	collectionVal := vm.pop() // The array/map itself is on stack (pointer)
+
+	if collectionVal.Type == value.VAL_OBJ {
+		if arr, ok := collectionVal.Obj.(*value.ObjArray); ok {
+			if indexVal.Type != value.VAL_INT {
+				return vm.runtimeError(c, ip, "array index must be integer")
+			}
+			idx := int(indexVal.Int())
+			if idx < 0 || idx >= len(arr.Elements) {
+				return vm.runtimeError(c, ip, "array index out of bounds")
+			}
+			// Guard do slot ref (spec §6.3): elemento `ref T` (tag
+			// RuntimeType) so aceita ref/null; via base tipada o
+			// compilador ja rejeitou. O teste de val.Type vem antes
+			// para o Load() atomico so rodar em escritas nao-ref.
+			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && arrayElementIsRefSlot(arr) {
+				return vm.runtimeError(c, ip, "%s", refSlotWriteError(arr.RuntimeType.Load().Element.String(), val))
+			}
+			// RC: retain-antes-de-release (elemento e dono duravel)
+			old := arr.Elements[idx]
+			value.Retain(val)
+			arr.Elements[idx] = val
+			value.Release(old)
+			vm.push(val) // Assignment expression result
+			return nil
+		} else if mapObj, ok := collectionVal.Obj.(*value.ObjMap); ok {
+			var key interface{}
+			if indexVal.Type == value.VAL_INT {
+				key = indexVal.Int()
+			} else if indexVal.Type == value.VAL_OBJ {
+				if str, ok := indexVal.Obj.(string); ok {
+					key = str
+				} else {
+					return vm.runtimeError(c, ip, "map key must be int or string")
+				}
+			} else {
+				return vm.runtimeError(c, ip, "map key must be int or string")
+			}
+			// Guard do slot ref (spec §6.3): valor `ref T` (tag
+			// RuntimeType) so aceita ref/null.
+			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && mapValueIsRefSlot(mapObj) {
+				return vm.runtimeError(c, ip, "%s", refSlotWriteError(mapObj.RuntimeType.Load().Value.String(), val))
+			}
+			// RC: so libera o velho se a chave ja existia (dec a
+			// menos e proibido); retain-antes-de-release quando existe.
+			if old, exists := mapObj.Get(key); exists {
+				value.Retain(val)
+				mapObj.Set(key, val)
+				value.Release(old)
+			} else {
+				value.Retain(val)
+				mapObj.Set(key, val)
+			}
+			vm.push(val)
+			return nil
+		}
+	}
+	return vm.runtimeError(c, ip, "cannot set index on non-array/map")
+}

--- a/internal/vm/inline_guard_test.go
+++ b/internal/vm/inline_guard_test.go
@@ -135,6 +135,21 @@ func TestRetainReleaseStayInlinable(t *testing.T) {
 			t.Errorf("value.%s tem custo de inline %d, maximo %d — enxugue ownersOf (ver cow.go)", name, cost, inlineNormalMaxCost)
 		}
 	}
+
+	// NeverTracked (cow.go) e chamada de DENTRO de run() pelas escritas NORC da
+	// indexacao tipada (issue #66): orcamento de 20, nao 80.
+	neverTrackedPattern := regexp.MustCompile(`can inline NeverTracked with cost (\d+)`)
+	ntMatch := neverTrackedPattern.FindStringSubmatch(report)
+	if ntMatch == nil {
+		t.Fatalf("o compilador nao inlina value.NeverTracked — procure por 'cannot inline NeverTracked' em `go build -gcflags=-m=2 ./internal/value`")
+	}
+	ntCost, ntErr := strconv.Atoi(ntMatch[1])
+	if ntErr != nil {
+		t.Fatalf("custo ilegivel em %q: %v", ntMatch[0], ntErr)
+	}
+	if ntCost > inlineBigFunctionMaxCost {
+		t.Errorf("value.NeverTracked tem custo de inline %d, maximo %d para ser inlinada dentro de run()", ntCost, inlineBigFunctionMaxCost)
+	}
 }
 
 // inlineBigFunctionMaxCost espelha a constante homonima do compilador

--- a/internal/vm/inline_guard_test.go
+++ b/internal/vm/inline_guard_test.go
@@ -77,6 +77,36 @@ func TestPushStaysInlinedInsideRun(t *testing.T) {
 		t.Errorf("pop foi inlinada em %d call sites de executor.go, esperado >= %d (custo reportado: %d)", popInlined, minPopInlineSitesInRun, popCost)
 	}
 
+	// Indexacao tipada (issue #66): value.NeverTracked e arrayTagIsRefSlot
+	// (ref_slots.go) ficam no caminho quente dos tres opcodes NORC; se
+	// sairem do inline, cada escrita tipada paga uma chamada. arrayTagIsRefSlot
+	// custa EXATAMENTE 20 hoje — sem folga.
+	neverTrackedInlined := 0
+	tagInlined := 0
+	for _, line := range strings.Split(report, "\n") {
+		if !strings.Contains(line, "executor.go") {
+			continue
+		}
+		if strings.Contains(line, "inlining call to value.NeverTracked") {
+			neverTrackedInlined++
+		}
+		if strings.Contains(line, "inlining call to arrayTagIsRefSlot") {
+			tagInlined++
+		}
+	}
+	if neverTrackedInlined < 6 {
+		t.Errorf("value.NeverTracked foi inlinada em %d sites de executor.go, esperado >= 6 (dois por opcode NORC)", neverTrackedInlined)
+	}
+	if tagInlined < 3 {
+		t.Errorf("arrayTagIsRefSlot foi inlinada em %d sites de executor.go, esperado >= 3 (um por opcode NORC) — confira o custo em `go build -gcflags=-m=2 ./internal/vm | grep arrayTagIsRefSlot`", tagInlined)
+	}
+	tagCostPattern := regexp.MustCompile(`can inline arrayTagIsRefSlot with cost (\d+)`)
+	if tagMatch := tagCostPattern.FindStringSubmatch(report); tagMatch == nil {
+		t.Errorf("o compilador nao inlina arrayTagIsRefSlot (ref_slots.go)")
+	} else if tagCost, convErr := strconv.Atoi(tagMatch[1]); convErr != nil || tagCost > inlineBigFunctionMaxCost {
+		t.Errorf("arrayTagIsRefSlot tem custo de inline %s, maximo %d para ser inlinada dentro de run()", tagMatch[1], inlineBigFunctionMaxCost)
+	}
+
 	// ensureCallCapacity (calls.go) e chamada em call()/callPreparedClosure, que
 	// NAO sao "big function" (calls.go fica bem abaixo de 5000 nos de AST), entao
 	// o orcamento de inline aqui e o normal (80), nao os 20 de dentro de run().

--- a/internal/vm/ref_slots.go
+++ b/internal/vm/ref_slots.go
@@ -42,7 +42,14 @@ func arrayElementIsRefSlot(array *value.ObjArray) bool {
 	if array == nil {
 		return false
 	}
-	tag := array.RuntimeType.Load()
+	return arrayTagIsRefSlot(array.RuntimeType.Load())
+}
+
+// arrayTagIsRefSlot e arrayElementIsRefSlot sobre a tag ja carregada — a
+// forma que os opcodes NORC da indexacao tipada (issue #66) usam no caminho
+// quente de run(): uma Load() feita pelo chamador e um corpo que cabe no
+// orcamento de inline de 20.
+func arrayTagIsRefSlot(tag *value.RuntimeTypeInfo) bool {
 	return tag != nil && tag.Kind == value.TYPE_ARRAY && tag.Element != nil && tag.Element.Kind == value.TYPE_REF
 }
 

--- a/internal/vm/typed_index_e2e_test.go
+++ b/internal/vm/typed_index_e2e_test.go
@@ -174,3 +174,83 @@ func TestTypedIndexLocalErrorsMatchGenericPath(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedIndexRefBubbleSortMutatesCaller(t *testing.T) {
+	got := captureVMSource(t, `
+func bubble(data: ref int[]) -> void
+    let n: int = length(data)
+    let i: int = 0
+    while i < n do
+        let j: int = 0
+        while j < n - i - 1 do
+            if data[j] > data[j + 1] then
+                let tmp: int = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            end
+            j = j + 1
+        end
+        i = i + 1
+    end
+end
+func main() -> int[]
+    let data: int[] = [5, 1, 4, 2, 3]
+    bubble(ref data)
+    return data
+end
+test_report(main())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	for k := range 5 {
+		if arr.Elements[k].Int() != int64(k+1) {
+			t.Fatalf("esperado [1..5] no chamador, obtido %s", got.String())
+		}
+	}
+}
+
+// CoW atraves do ref: o array apontado esta compartilhado com `copy`; a
+// escrita fundida clona, grava o clone de volta no slot do chamador (o ref
+// continua valido) e `copy` fica intacta. Exatamente 1 clone.
+func TestTypedIndexRefWriteClonesSharedTarget(t *testing.T) {
+	ResetCloneCount()
+	got := captureVMSource(t, `
+func set0(data: ref int[]) -> void
+    data[0] = 99
+end
+func main() -> int[]
+    let data: int[] = [1, 2]
+    let copy: int[] = data
+    set0(ref data)
+    return [data[0], copy[0]]
+end
+test_report(main())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 99 || arr.Elements[1].Int() != 1 {
+		t.Fatalf("esperado [99, 1], obtido %s", got.String())
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+}
+
+func TestTypedIndexRefErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa via ref", "func f(d: ref int[]) -> int\n    let i: int = 5\n    return d[i]\nend\nlet a: int[] = [1]\nprint(f(ref a))\n", "func f(d: any) -> any\n    let i: int = 5\n    return d[i]\nend\nlet a: any = [1]\nprint(f(a))\n", "array index out of bounds"},
+		{"escrita fora da faixa via ref", "func f(d: ref int[]) -> void\n    let i: int = 5\n    d[i] = 2\nend\nlet a: int[] = [1]\nf(ref a)\n", "func f(d: any) -> void\n    let i: int = 5\n    d[i] = 2\nend\nlet a: any = [1]\nf(a)\n", "array index out of bounds"},
+		{"ref null leitura", "func f(d: ref int[]) -> int\n    let i: int = 0\n    return d[i]\nend\nprint(f(null))\n", "func f(d: any) -> any\n    let i: int = 0\n    return d[i]\nend\nprint(f(null))\n", "cannot index non-array/map/bytes"},
+		{"ref null escrita", "func f(d: ref int[]) -> void\n    let i: int = 0\n    d[i] = 1\nend\nf(null)\n", "func f(d: any) -> void\n    let i: int = 0\n    d[i] = 1\nend\nf(null)\n", "cannot set index on non-array/map"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}

--- a/internal/vm/typed_index_e2e_test.go
+++ b/internal/vm/typed_index_e2e_test.go
@@ -80,3 +80,97 @@ func TestTypedIndexErrorsMatchGenericPath(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedIndexLocalBubbleSortByValue(t *testing.T) {
+	got := captureVMSource(t, `
+func sorted() -> int[]
+    let data: int[] = [5, 1, 4, 2, 3]
+    let n: int = length(data)
+    let i: int = 0
+    while i < n do
+        let j: int = 0
+        while j < n - i - 1 do
+            if data[j] > data[j + 1] then
+                let tmp: int = data[j]
+                data[j] = data[j + 1]
+                data[j + 1] = tmp
+            end
+            j = j + 1
+        end
+        i = i + 1
+    end
+    return data
+end
+test_report(sorted())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	for k := range 5 {
+		if arr.Elements[k].Int() != int64(k+1) {
+			t.Fatalf("esperado [1..5], obtido %s", got.String())
+		}
+	}
+}
+
+// CoW: escrita fundida num local cujo array esta compartilhado clona — a copia
+// nao ve a mutacao e o clone e exatamente um.
+func TestTypedIndexLocalWriteClonesSharedArray(t *testing.T) {
+	ResetCloneCount()
+	got := captureVMSource(t, `
+func f() -> int[]
+    let a: int[] = [1, 2, 3]
+    let b: int[] = a
+    a[0] = 99
+    return [a[0], b[0]]
+end
+test_report(f())
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 99 || arr.Elements[1].Int() != 1 {
+		t.Fatalf("esperado [99, 1] (b intacto), obtido %s", got.String())
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+}
+
+// for-each sobre array com mutacao durante a iteracao: o comportamento de hoje
+// (a iteracao continua no mesmo array e ve a escrita) e preservado.
+func TestTypedIndexForEachSeesMutationDuringIteration(t *testing.T) {
+	got := captureVMSource(t, `
+func f() -> int
+    let xs: int[] = [1, 2, 3]
+    let s: int = 0
+    for x in xs do
+        if x == 1 then
+            xs[2] = 30
+        end
+        s = s + x
+    end
+    return s
+end
+test_report(f())
+`)
+	if got.Int() != 33 {
+		t.Fatalf("esperado 33 (1 + 2 + 30), obtido %s", got.String())
+	}
+}
+
+func TestTypedIndexLocalErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa", "func f() -> int\n    let a: int[] = [1]\n    let i: int = 5\n    return a[i]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: int = 5\n    return a[i]\nend\nprint(f())\n", "array index out of bounds"},
+		{"escrita fora da faixa", "func f() -> int\n    let a: int[] = [1]\n    let i: int = 5\n    a[i] = 2\n    return a[0]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: int = 5\n    a[i] = 2\n    return a[0]\nend\nprint(f())\n", "array index out of bounds"},
+		{"indice nao inteiro via any", "func f() -> int\n    let a: int[] = [1]\n    let i: any = \"x\"\n    return a[i]\nend\nprint(f())\n", "func f() -> any\n    let a: any = [1]\n    let i: any = \"x\"\n    return a[i]\nend\nprint(f())\n", "array index must be integer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}

--- a/internal/vm/typed_index_e2e_test.go
+++ b/internal/vm/typed_index_e2e_test.go
@@ -1,0 +1,82 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Ponta a ponta (fonte -> compilador -> VM) da indexacao tipada de array
+// (issue #66, item 1): mesmo resultado, mesma semantica CoW/RC e mesmas
+// mensagens de erro do caminho generico. Cada caso "tipado" tem o gemeo
+// "any" (base dinamica), que continua no generico: os dois tem de concordar.
+
+func TestTypedIndexGlobalArrayReadWrite(t *testing.T) {
+	got := captureVMSource(t, `
+let xs: int[] = [1, 2, 3]
+let i: int = 1
+xs[i] = xs[i] * 10
+xs[0] = xs[2]
+test_report(xs)
+`)
+	arr := got.Obj.(*value.ObjArray)
+	if arr.Elements[0].Int() != 3 || arr.Elements[1].Int() != 20 || arr.Elements[2].Int() != 3 {
+		t.Fatalf("esperado [3, 20, 3], obtido %s", got.String())
+	}
+}
+
+func TestTypedIndexNestedAndStringElements(t *testing.T) {
+	got := captureVMSource(t, `
+func f() -> string
+    let g: string[][] = [["a", "b"], ["c", "d"]]
+    g[0][1] = g[1][0] + "!"
+    return g[0][1] + g[1][1]
+end
+test_report(f())
+`)
+	if s, ok := got.Obj.(string); !ok || s != "c!d" {
+		t.Fatalf("esperado \"c!d\", obtido %s", got.String())
+	}
+}
+
+// Elemento composto vindo por `any` numa base int[]: o NORC ve que o valor e
+// rastreado e cai no generico, que retem — o composto ganha o dono do
+// elemento, como no caminho generico.
+func TestTypedIndexNorcRetainsCompositeFromAny(t *testing.T) {
+	got := captureVMSource(t, `
+let inner: int[] = [7]
+let xs: int[] = [1, 2]
+let v: any = inner
+xs[0] = v
+test_report(xs)
+`)
+	outer := got.Obj.(*value.ObjArray)
+	if value.OwnersCount(outer.Elements[0]) < 2 {
+		t.Fatalf("composto escrito via any deve ter o dono do elemento alem do global: owners=%d", value.OwnersCount(outer.Elements[0]))
+	}
+}
+
+func TestTypedIndexErrorsMatchGenericPath(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"leitura fora da faixa", "let a: int[] = [1]\nlet i: int = 5\nprint(a[i])\n", "let a: any = [1]\nlet i: int = 5\nprint(a[i])\n", "array index out of bounds"},
+		{"escrita fora da faixa", "let a: int[] = [1]\nlet i: int = 5\na[i] = 2\n", "let a: any = [1]\nlet i: int = 5\na[i] = 2\n", "array index out of bounds"},
+		// (a escrita `a[i] = 2` com i: any e erro de COMPILACAO — "array index
+		// must be int, got any" — no caminho generico desde antes; so a leitura
+		// chega ao runtime.)
+		{"indice nao inteiro via any", "let a: int[] = [1]\nlet i: any = \"x\"\nprint(a[i])\n", "let a: any = [1]\nlet i: any = \"x\"\nprint(a[i])\n", "array index must be integer"},
+		{"nested fora da faixa", "let a: int[][] = [[1]]\nlet i: int = 5\na[0][i] = 1\n", "let a: any = [[1]]\nlet i: int = 5\na[0][i] = 1\n", "array index out of bounds"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), tc.typed)
+			dynErr := interpretVMSource(t, New(), tc.dynamic)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("dinamico: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}

--- a/internal/vm/typed_index_test.go
+++ b/internal/vm/typed_index_test.go
@@ -1,0 +1,313 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Frame raiz: LocalBase = 1, slot local 0 = stack[1]. Os testes deste arquivo
+// montam o bytecode a mao para exercitar cada opcode de indexacao tipada
+// (issue #66, item 1) e o seu fallback, sem depender do compilador; o
+// comportamento ponta a ponta (fonte -> compilador -> VM) e coberto em
+// typed_index_e2e_test.go.
+
+func typedIndexChunk() *chunk.Chunk {
+	code := &chunk.Chunk{}
+	arr := code.AddConstant(value.NewArray([]value.Value{value.NewInt(10), value.NewInt(20), value.NewInt(30)}))
+	code.Write(byte(chunk.OP_CONSTANT), 1) // slot 0 = array
+	code.Write(byte(arr), 1)
+	return code
+}
+
+func writeConstInt(code *chunk.Chunk, n int64) {
+	k := code.AddConstant(value.NewInt(n))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(k), 1)
+}
+
+func TestGetLocalIndexArrayReadsInPlace(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 2)
+	code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1) // slot do array
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[2]; got.Type != value.VAL_INT || got.Int() != 30 {
+		t.Fatalf("esperado 30 no topo, obtido %s", got.String())
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3 (array, elemento), obtido %d", machine.stackTop)
+	}
+}
+
+func TestGetLocalIndexArrayErrorsMatchGeneric(t *testing.T) {
+	cases := []struct {
+		name string
+		idx  value.Value
+		want string
+	}{
+		{"fora da faixa", value.NewInt(3), "array index out of bounds"},
+		{"negativo", value.NewInt(-1), "array index out of bounds"},
+		{"nao inteiro", value.NewString("x"), "array index must be integer"},
+	}
+	for _, tc := range cases {
+		code := typedIndexChunk()
+		k := code.AddConstant(tc.idx)
+		code.Write(byte(chunk.OP_CONSTANT), 1)
+		code.Write(byte(k), 1)
+		code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+		code.Write(0, 1)
+		err := New().Interpret(code)
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: esperava %q, obtido %v", tc.name, tc.want, err)
+		}
+	}
+}
+
+// Container que nao e array (null) cai no OP_GET_INDEX generico via
+// redispatch: a mensagem e a do generico.
+func TestGetLocalIndexArrayFallsBackToGenericForNonArray(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1) // slot 0 = null
+	writeConstInt(code, 0)
+	code.Write(byte(chunk.OP_GET_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot index non-array/map/bytes") {
+		t.Fatalf("esperava erro do OP_GET_INDEX generico, obtido %v", err)
+	}
+}
+
+func TestGetIndexArrayReadsInPlace(t *testing.T) {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_GET_LOCAL), 1) // empilha o array
+	code.Write(0, 1)
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_GET_INDEX_ARRAY), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[2]; got.Type != value.VAL_INT || got.Int() != 20 {
+		t.Fatalf("esperado 20, obtido %s", got.String())
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3, obtido %d", machine.stackTop)
+	}
+}
+
+// Map no lugar do array: redispatch para o generico, que indexa o map.
+func TestGetIndexArrayFallsBackToGenericMap(t *testing.T) {
+	code := &chunk.Chunk{}
+	m := code.AddConstant(value.NewMapWithData(map[string]value.Value{"k": value.NewInt(7)}))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(m), 1)
+	key := code.AddConstant(value.NewString("k"))
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(key), 1)
+	code.Write(byte(chunk.OP_GET_INDEX_ARRAY), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1]; got.Type != value.VAL_INT || got.Int() != 7 {
+		t.Fatalf("esperado 7 (leitura do map pelo generico), obtido %s", got.String())
+	}
+}
+
+func TestSetLocalIndexArrayNorcWritesWithoutPushing(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 1)
+	writeConstInt(code, 99)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	arr := machine.stack[1].Obj.(*value.ObjArray)
+	if arr.Elements[1].Int() != 99 {
+		t.Fatalf("elemento 1 esperado 99, obtido %s", arr.Elements[1].String())
+	}
+	if machine.stackTop != 2 {
+		t.Fatalf("escrita fundida nao deve empilhar: stackTop esperado 2, obtido %d", machine.stackTop)
+	}
+}
+
+// Array compartilhado no slot (Owners > 1): a escrita fundida tem de clonar
+// como OP_GET_LOCAL_MUT faria — o slot passa a guardar o clone (escrito) e o
+// array original fica intacto.
+func TestSetLocalIndexArrayNorcClonesSharedArray(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 5)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	original := code.Constants[0]
+	value.Retain(original)
+	value.Retain(original) // Owners = 2: compartilhado
+	ResetCloneCount()
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava exatamente 1 clone CoW, obtido %d", CloneCountValue())
+	}
+	if original.Obj.(*value.ObjArray).Elements[0].Int() != 10 {
+		t.Fatalf("array compartilhado foi mutado no lugar")
+	}
+	clone := machine.stack[1].Obj.(*value.ObjArray)
+	if clone == original.Obj.(*value.ObjArray) || clone.Elements[0].Int() != 5 {
+		t.Fatalf("slot deveria guardar o clone com a escrita: %v", machine.stack[1].String())
+	}
+}
+
+// Valor composto (vindo por `any`) num NORC: nao pode pular o Retain — cai no
+// generico, e o composto ganha um dono (o elemento do array).
+func TestSetLocalIndexArrayNorcRetainsCompositeValueViaGeneric(t *testing.T) {
+	code := typedIndexChunk()
+	writeConstInt(code, 0)
+	inner := value.NewArray([]value.Value{value.NewInt(1)})
+	k := code.AddConstant(inner)
+	code.Write(byte(chunk.OP_CONSTANT), 1)
+	code.Write(byte(k), 1)
+	code.Write(byte(chunk.OP_SET_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	before := value.OwnersCount(inner)
+	if err := New().Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := value.OwnersCount(inner); got != before+1 {
+		t.Fatalf("composto escrito em array deve ganhar 1 dono (generico retem): antes %d, depois %d", before, got)
+	}
+}
+
+func TestSetIndexArrayNorcWritesAndFallsBackForNonArray(t *testing.T) {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_GET_LOCAL), 1)
+	code.Write(0, 1)
+	writeConstInt(code, 2)
+	writeConstInt(code, -7)
+	code.Write(byte(chunk.OP_SET_INDEX_ARRAY_NORC), 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray).Elements[2].Int(); got != -7 {
+		t.Fatalf("esperado -7, obtido %d", got)
+	}
+	if machine.stackTop != 2 {
+		t.Fatalf("stackTop esperado 2, obtido %d", machine.stackTop)
+	}
+
+	bad := &chunk.Chunk{}
+	bad.Write(byte(chunk.OP_NULL), 1)
+	writeConstInt(bad, 0)
+	writeConstInt(bad, 1)
+	bad.Write(byte(chunk.OP_SET_INDEX_ARRAY_NORC), 1)
+	err := New().Interpret(bad)
+	if err == nil || !strings.Contains(err.Error(), "cannot set index on non-array/map") {
+		t.Fatalf("esperava erro do OP_SET_INDEX generico, obtido %v", err)
+	}
+}
+
+// Slot 1 = ref (REF_UPVALUE via OP_REF_LOCAL) para o slot 0 (array).
+func refTypedIndexChunk() *chunk.Chunk {
+	code := typedIndexChunk()
+	code.Write(byte(chunk.OP_REF_LOCAL), 1)
+	code.Write(0, 1)
+	return code
+}
+
+func TestGetRefLocalIndexArrayResolvesUpvalueRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_GET_REF_LOCAL_INDEX_ARRAY), 1)
+	code.Write(1, 1) // slot do ref
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[3]; got.Type != value.VAL_INT || got.Int() != 20 {
+		t.Fatalf("esperado 20, obtido %s", got.String())
+	}
+}
+
+// Slot de tipo estatico ref que guarda null (parametro `ref T[]` recebendo
+// null): OP_DEREF passa null adiante e OP_GET_INDEX reclama — a forma fundida
+// tem de produzir a mesma mensagem.
+func TestGetRefLocalIndexArrayNullRefMatchesGeneric(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1) // slot 0 = null
+	writeConstInt(code, 0)
+	code.Write(byte(chunk.OP_GET_REF_LOCAL_INDEX_ARRAY), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot index non-array/map/bytes") {
+		t.Fatalf("esperava erro do generico para ref null, obtido %v", err)
+	}
+}
+
+func TestSetRefLocalIndexArrayNorcWritesThroughRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 42)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(1, 1)
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray).Elements[0].Int(); got != 42 {
+		t.Fatalf("escrita via ref esperada 42, obtido %d", got)
+	}
+	if machine.stackTop != 3 {
+		t.Fatalf("stackTop esperado 3 (array, ref), obtido %d", machine.stackTop)
+	}
+}
+
+// Ref para array compartilhado: clona e grava o clone DE VOLTA pelo ref
+// (unicizeThroughRefValue), como a sequencia GET_LOCAL_MUT_BORROW + DEREF_MUT.
+func TestSetRefLocalIndexArrayNorcClonesSharedThroughRef(t *testing.T) {
+	code := refTypedIndexChunk()
+	writeConstInt(code, 0)
+	writeConstInt(code, 42)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(1, 1)
+	original := code.Constants[0]
+	value.Retain(original)
+	value.Retain(original)
+	ResetCloneCount()
+	machine := New()
+	if err := machine.Interpret(code); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	if CloneCountValue() != 1 {
+		t.Fatalf("esperava 1 clone, obtido %d", CloneCountValue())
+	}
+	if original.Obj.(*value.ObjArray).Elements[0].Int() != 10 {
+		t.Fatalf("array compartilhado foi mutado no lugar atraves do ref")
+	}
+	if got := machine.stack[1].Obj.(*value.ObjArray); got == original.Obj.(*value.ObjArray) || got.Elements[0].Int() != 42 {
+		t.Fatalf("o slot apontado pelo ref deveria guardar o clone escrito")
+	}
+}
+
+func TestSetRefLocalIndexArrayNorcNullRefMatchesGeneric(t *testing.T) {
+	code := &chunk.Chunk{}
+	code.Write(byte(chunk.OP_NULL), 1)
+	writeConstInt(code, 0)
+	writeConstInt(code, 1)
+	code.Write(byte(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC), 1)
+	code.Write(0, 1)
+	err := New().Interpret(code)
+	if err == nil || !strings.Contains(err.Error(), "cannot set index on non-array/map") {
+		t.Fatalf("esperava erro do generico para ref null, obtido %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Indexação tipada de array — item 1 do roadmap pós-fase 2 (#66). Seis opcodes novos, **por append** ao fim de `internal/chunk/chunk.go`: `OP_GET_INDEX_ARRAY` / `OP_SET_INDEX_ARRAY_NORC` (base estaticamente `T[]` em posição genérica), `OP_GET_LOCAL_INDEX_ARRAY` / `OP_SET_LOCAL_INDEX_ARRAY_NORC` (local `T[]`, inclusive o `$collection` do for-each — o array vem do slot, sem empilhar o `Value`) e `OP_GET_REF_LOCAL_INDEX_ARRAY` / `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC` (parâmetro `ref T[]`, que resolve a caixa do ref com uma `Upvalue.Load()` em vez de `referenceStorage` — `defer` + closure alocada + `reflect` por acesso).
- Semântica, saída, mensagens e linhas de erro e contagem RC **idênticas**: `NORC` só pula `Retain`/`Release` depois de conferir em runtime que valor novo e velho não têm contador (`value.NeverTracked`, guard de inline ≤ 20) e que o array não é `(ref T)[]`; composto vindo por `any`, array compartilhado (CoW clona como antes) e container inesperado caem nos funis genéricos `getIndexGeneric`/`setIndexGeneric` (corpos de `OP_GET_INDEX`/`OP_SET_INDEX` extraídos em método). Formas fundidas por slot só com índice (e valor) sintaticamente sem efeito colateral (`isSideEffectFree`), para a ordem de avaliação ser a da sequência genérica.
- **Resultado** (mediana de 9, intercalado, v0.14.3 × head): `bench_bubblesort` **−64,5 %**, `bench_call_ref` **−43,4 %**, `bench_call_readonly` −12,1 %, `bench_path_update` −9,2 %; gates CoW dentro de ±2 % (rodada focada); cross-runtime `bubblesort` **5,5x → 1,8x do CPython** (430,6 → 153,6 ms líquidos, 0,36x). Hipótese da issue (2–2,5x; ≥ −30 %) confirmada com folga; a meta de `call_readonly ≥ −30 %` não confirma (−12 %): 37 % desse bench é `callNative` (`length(data)`), não indexação — follow-up.
- **Achado da rodada:** o primeiro fallback de leitura (re-despachar o `case` genérico por `goto` dentro de `run()`) custou **+10–14 % no despacho genérico** (`bench_generic_vs_hand`, laço sem indexação); trocado por chamada a `getIndexGeneric` antes do merge (commit d870a02), o bench voltou ao ruído (+0,7 %). Registrado na spec/RESULTS como sentinela para os próximos itens.
- Versão **v0.15.0** (minor, decisão do usuário). Spec e plano em `docs/superpowers/`; números em `benchmarks/RESULTS.md` (seção do topo) e `benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md`.

## Components
- `internal/chunk/chunk.go` — seis opcodes (append), `String()`, disassembler; `chunk_test.go` (sentinela, programa de desmontagem)
- `internal/vm/executor.go` — seis handlers (caminho rápido no lugar + fallback exato); `OP_GET_INDEX`/`OP_SET_INDEX`/`OP_GET_LOCAL_MUT(_BORROW)` passam a chamar os métodos
- `internal/vm/index_ops.go` — `getIndexGeneric`, `setIndexGeneric`; `internal/vm/cow.go` — `unicizeOwnedSlot`, `unicizeBorrowedSlot`; `internal/vm/ref_slots.go` — `arrayTagIsRefSlot`
- `internal/value/cow.go` — `NeverTracked`; `internal/vm/inline_guard_test.go` — guards novos (`NeverTracked` ≤ 20 e ≥ 6 sites, `arrayTagIsRefSlot` ≤ 20 e ≥ 3 sites)
- `internal/compiler/typed_index.go` — `isUntrackedElementType`, `arrayTypeOf`, `isSideEffectFree`, `fusedLocalIndexRead`, `tryFuseLocalIndexAssign`; `compiler.go` — emissão na leitura, na atribuição indexada e no for-each
- Testes: `internal/vm/typed_index_test.go` (bytecode à mão: cada opcode e cada fallback), `internal/vm/typed_index_e2e_test.go` (bubblesort por valor e via ref, CoW/RC, erros idênticos ao caminho `any`), `internal/compiler/typed_index_compile_test.go` (bytecode pelo disassembler), `internal/value/never_tracked_test.go`; `cow_lowering_test.go` atualizado para o novo lowering
- Docs/bench: `docs/superpowers/specs/2026-08-22-vm-perf-issue-66-typed-array-index-design.md`, `docs/superpowers/plans/2026-08-22-vm-perf-issue-66-typed-array-index.md`, `benchmarks/RESULTS.md`, `benchmarks/results/2026-08-22-issue-66-typed-arrays-raw.md`, `benchmarks/cross_runtime/results/cross_runtime.md`, `CHANGELOG.md`, bump v0.15.0 (version.go, README ×2, AGENTS, spec, docs/index.html ×2)

## Test Plan
- [x] `go test ./...` verde (12 pacotes); `go vet ./...` limpo
- [x] `go test -race ./internal/value ./internal/vm` verde
- [x] Corpus `noxy_examples/run_all_tests_concurrent.nx`: 177/177
- [x] Diff de saída base × head (`compare_examples.ps1`): 146 iguais, 0 divergentes
- [x] Guards de inline: `push` 20/121 sites, `pop` 18/85, `Retain` 67, `Release` 80, `NeverTracked` 10, `arrayTagIsRefSlot` 20
- [x] Benchmarks: headline intercalado (9), por estágio (6 binários, 5), cross-runtime (mín. de 9) e A/Bs focados de `generic_vs_hand`, `share_mutate`, `map_churn`, `loop_arith`; gates CoW ≤ +5 %
- [x] Review
- [x] Merge em `develop`

Refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
