### PR TITLE
perf/issue-66-call-protocol - Protocolo de chamada: fast path de retorno e de chamada, ParamsUntracked e superinstruções (issue #66, item 3) — v0.15.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.15.1)
+**Versão**: 1.0 (Noxy VM 0.15.2)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.15.2] - 2026-08-22
+
+Protocolo de chamada (issue #66, item 3 do roadmap pós-fase 2). Nenhuma
+mudança de sintaxe, semântica, saída, mensagem de erro ou contagem RC; dois
+opcodes novos por append ao fim de `internal/chunk/chunk.go`. Corpus 177/177 e
+diff de saída base × head sem divergência. Números em `benchmarks/RESULTS.md`
+(seção do topo) e `benchmarks/results/2026-08-22-issue-66-call-protocol-raw.md`.
+
+### Performance
+
+- **Retorno com fast path** (`OP_RETURN`): frame sem `defer`, sem vínculo RC
+  registrado, sem upvalue aberto e acima do `minFrameCount` do `run()` corrente
+  passa por `popSimpleFrame` (`unwind.go`) — o mesmo teardown terminal, sem a
+  cópia dupla de `frameOutcome` nem a segunda chamada. Era o maior termo do
+  perfil de `fib` (24 %).
+- **Chamada com fast path** (`OP_CALL_STATIC`): callee closure com
+  `ParamsUntracked` (flag nova em `ObjFunction`, calculada pelo compilador —
+  todo parâmetro sem `ref` e de tipo `int/float/bool/string/bytes`) e aridade
+  certa monta o frame inline, sem `callValueStatic`/`callPreparedClosure` nem o
+  laço `ownSlot`; capacidade conferida à mão, `growForCall` continua o único
+  dono das mensagens de overflow. Qualquer outro callee segue o caminho atual.
+- **Superinstruções** emitidas em nível de AST: `OP_GET_LOCAL_ADD_IMM_INT
+  [slot][imm i8]` para `local ± K` como expressão (`fib(n - 1)`) e
+  `OP_GET_LOCAL_2 [a][b]` para `local OP local` (`a + b`, `i < n`, inclusive
+  na condição fundida de `while`); só local plano de tipo primitivo, nunca
+  `ref`/upvalue/global.
+- **Resultado (v0.15.1 × v0.15.2, mesma máquina, intercalado):** cross-runtime
+  `fib` **185,1 → 105,4 ms líquidos (0,57x; ÷ CPython 2,0x → 1,16x; ÷ Lua
+  4,4x → 2,5x)**, `bubblesort` 0,91x (1,7x → 1,55x); `bench_bubblesort` −10,7 %,
+  `bench_spawn_sum` −7,3 %; `BenchmarkNoxyCallOverhead` **−28 %** (meta ≥ −25 %);
+  demais benches ±3 %, gates CoW verdes, sentinela `bench_generic_vs_hand`
+  −1,7 %. Por estágio em `fib`: retorno −21 %, chamada −7 %, superinstruções
+  −18 %.
+
+### Corrigido
+
+- `OP_CLOSURE`/`OP_CONSTANT`/`OP_CONSTANT_LONG` copiam o `ObjFunction` ao
+  vincular ao ambiente e perdiam o flag novo — o fast path de chamada nunca
+  disparava (sem efeito funcional); `TestClosureKeepsParamsUntracked` trava
+  pelo valor da closure.
+
 ## [0.15.1] - 2026-08-22
 
 Strings: fast path ASCII e `to_str(int)` sem `fmt` (issue #66, item 2 do

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.15.1](https://img.shields.io/badge/noxy-0.15.1-blue)](CHANGELOG.md)
+[![noxy 0.15.2](https://img.shields.io/badge/noxy-0.15.2-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.15.1
+Noxy REPL v0.15.2
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,125 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## v0.15.1 (c1cc12a) × protocolo de chamada — v0.15.2 (perf/issue-66-call-protocol, 868d435)
+
+**Data:** 2026-08-22 · Windows 11 · Intel Core 7 150U (mesma máquina do item
+2; só o delta intra-sessão é comparável com as seções de item 1/fase 2) ·
+Python 3.14.7 · Lua 5.4.6 · Go 1.26.6 · pwsh 7.6.5 · protocolo intercalado,
+mediana de 9 (headline), mediana de 11 (A/B por estágio, quatro binários na
+mesma janela), mínimo de 9 no cross-runtime, `-count 8` no bench Go. Máquina
+sem `go test` nem build durante as medições; CPU 0–21 % no início de cada
+passo. Dados brutos, perfis e carga por passo em
+[`results/2026-08-22-issue-66-call-protocol-raw.md`](results/2026-08-22-issue-66-call-protocol-raw.md).
+Spec: `docs/superpowers/specs/2026-08-22-vm-perf-issue-66-call-protocol-design.md`
+(issue #66, item 3).
+
+O que mudou: **(d)** `OP_RETURN` com fast path quando o frame não tem `defer`,
+não tem vínculo RC (`Owned` vazio), não há upvalue aberto e o frame de baixo
+ainda pertence ao `run()` corrente — `popSimpleFrame` em `unwind.go` (o guard
+de arquitetura exige teardown terminal só lá) faz o mesmo teardown sem a
+cópia dupla de `frameOutcome` nem a segunda chamada; **(a)+(b)** `OP_CALL_STATIC`
+com fast path inline quando o callee é closure com `ParamsUntracked` (flag nova
+do `ObjFunction`, calculada pelo compilador: todo parâmetro sem `ref` e de tipo
+`int/float/bool/string/bytes`) e aridade certa — capacidade conferida à mão
+(`ensureCallCapacity` custa 80 e não cabe em `run()`), frame montado sem o
+laço `ownSlot`; **(c)** duas superinstruções por append em `chunk.go`,
+emitidas em nível de AST: `OP_GET_LOCAL_ADD_IMM_INT [slot][imm i8]` (`n - 1`,
+`i + 2` como expressão) e `OP_GET_LOCAL_2 [a][b]` (`a + b`, `i < n` — também
+na condição fundida de `while`). O "(a) literal" da issue (pular o lookup de
+global do callee com operando de constante) ficou de fora: era 1,6 % do perfil
+de base. Caminhos lentos, `OP_CALL`, RC e mensagens de erro intocados.
+
+**Verificação completa:** `go test ./...` verde (12 pacotes); `go test -race
+./internal/value ./internal/vm` verde; **corpus 177/177**; **diff de saída
+base × head: 146 iguais, 0 divergentes**; guards de inline inalterados
+(`popSimpleFrame` custa 60 — uma chamada real, de propósito); guard de
+arquitetura de teardown verde.
+
+### Achado da rodada (custou um commit a mais)
+
+A primeira medição por estágio deu **s1 ≈ s0** apesar de o perfil atribuir
+12 % ao lado da chamada: `OP_CLOSURE`/`OP_CONSTANT`/`OP_CONSTANT_LONG` copiam o
+`ObjFunction` campo a campo e **perderam `ParamsUntracked`** — o fast path
+nunca disparava, e nenhum teste funcional pega isso (o caminho lento é
+correto). Fix em 868d435 com `TestClosureKeepsParamsUntracked`, que pergunta
+ao valor da closure. Lição: flag novo em `ObjFunction` precisa de teste pelo
+**valor em runtime**, não pelo constant do chunk.
+
+### Headline — base × head (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | v0151_ms | call_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_bubblesort | 776,9 | 694,1 | **−10,7 %** | ✅ `OP_GET_LOCAL_2` em `j < n - i - 1`/`a[j] > a[j+1]` |
+| bench_spawn_sum | 398,8 | 369,8 | **−7,3 %** | ✅ chamadas com parâmetro `int` |
+| bench_generic_vs_hand | 456,6 | 448,7 | −1,7 % | ✅ sentinela de `run()`: sem regressão de codegen |
+| bench_call_light | 19,9 | 19,7 | −1,0 % | ➖ piso¹ (gate CoW ok) |
+| bench_typed_call_map | 22,3 | 22,5 | +0,9 % | ➖ piso¹ (gate CoW ok) |
+| bench_path_update | 229,8 | 231,8 | +0,9 % | ➖ ruído |
+| bench_call_readonly | 531,3 | 537,4 | +1,1 % | ➖ parâmetro `int[]` → caminho lento, como desenhado |
+| bench_call_ref | 1137,1 | 1149,9 | +1,1 % | ➖ idem (`ref int[]`) |
+| bench_conway | 1253,2 | 1275,3 | +1,8 % | ✅ gate CoW (≤ +5 %) |
+| bench_share_mutate | 100,6 | 103,3 | +2,7 % | ✅ gate CoW |
+| bench_map_churn | 194,3 | 200,1 | +3,0 % | ➖ ruído (cross `map_churn` +5 %, ver abaixo) |
+| bench_value_call_mutate | 21,1 | 21,2 | +0,5 % | ➖ piso¹ |
+
+¹ ~20 ms com piso de processo ~10 ms: não decidem nada.
+
+### A/B por estágio — quatro binários intercalados (mediana de 11, parede; piso 10 ms)
+
+`s0` = (d) retorno · `s1` = + (a/b) chamada (com o fix do flag) · `call` =
+head (+ (c) superinstruções).
+
+| bench | base | s0 | s1 | head | s0 vs base | s1 vs s0 | head vs s1 | **head vs base** |
+|---|---|---|---|---|---|---|---|---|
+| `cross_runtime/fib` | 203,4 | 161,1 | 149,5 | **122,0** | −20,8 % | −7,2 % | −18,4 % | **−40,0 %** (líquido −42 %) |
+| `cross_runtime/bubblesort` | 133,3 | 132,7 | 133,8 | **118,9** | −0,5 % | +0,8 % | −11,1 % | **−10,8 %** |
+| `cross_runtime/loop_arith` | 213,3 | 214,5 | 220,5 | 216,2 | +0,6 % | +2,8 % | −2,0 % | +1,4 % (ruído) |
+
+### Cross-runtime (mínimo de 9, intercalado com CPython 3.14.7 / Lua 5.4.6 / Go 1.26.6)
+
+Tempo líquido (descontado o piso de `startup`, ~9,5 ms nos dois Noxy); tabela
+completa em [`cross_runtime/results/cross_runtime.md`](cross_runtime/results/cross_runtime.md).
+
+| bench | v0.15.1 | v0.15.2 | v0.15.2 ÷ v0.15.1 | ÷ python (antes → agora, esta máquina) | ÷ lua |
+|---|---|---|---|---|---|
+| `fib` | 185,1 | **105,4** | **0,57x** | 2,0x → **1,16x** | 4,4x → **2,5x** |
+| `bubblesort` | 117,1 | **106,8** | **0,91x** | 1,7x → **1,55x** | – |
+| `string_ops` | 73,7 | 69,0 | 0,94x | 2,3x → 2,2x | – |
+| `loop_arith` | 193,7 | 194,7 | 1,01x | 1,06x → 1,06x | 5,0x |
+| `mandelbrot` | 132,9 | 133,5 | 1,00x | 1,8x → 1,8x | – |
+| `map_churn` | 112,3 | 117,5 | 1,05x | 2,0x → 2,1x | – |
+
+**`BenchmarkNoxyCallOverhead`** (`-count 8`, mediana): 73 762 → **53 076 ns/op
+(−28,0 %)**, 560 B/op e 10 allocs/op nos dois — meta da issue (≥ −25 %) ✅.
+
+### Leitura
+
+**A meta da issue ("`fib` 2,9x → ~2x do CPython; `BenchmarkNoxyCallOverhead`
+≥ −25 %") confirma com folga: `fib` 0,57x de v0.15.1 (−42 % líquido), 1,16x do
+CPython nesta máquina; bench Go −28 %.** A decomposição por estágio diz onde
+estava o custo: o **retorno** (s0: −21 %) era o maior item — `finishFrame` +
+`finalizeCurrentFrame` eram 24 % do perfil por causa da cópia dupla de
+`frameOutcome` e das duas chamadas, não dos laços (vazios em `fib`); a
+**chamada** (s1: −7 %) pagava `callValueStatic` → `callPreparedClosure` →
+`ownSlot` por parâmetro; as **superinstruções** (−18 % sobre s1) tiram 4 dos
+15 despachos por chamada não-folha de `fib` e são o que move `bubblesort`
+(−11 %, `j < n - i - 1`). `loop_arith` não mexe: o laço compara `i < 5000000`
+(literal, sem par de locais) e o corpo já usa `OP_INC_LOCAL_INT`.
+
+**O que resta em `fib` (perfil do head):** despacho puro (`run` 60 % flat,
+11 opcodes por chamada não-folha), `push`/`pop` 17 %, `popSimpleFrame` 6 % e —
+agora visível — o lookup cacheado do callee em `OP_GET_GLOBAL` (`Generation()`
+atômico + compare de entrada, ~12 %). Esse último é exatamente o "(a) literal"
+da issue que ficou de fora por ser 1,6 % na base; com o protocolo cortado
+virou o próximo candidato (callee in-module resolvido em compilação, ou
+`GET_GLOBAL + CALL_STATIC` fundido).
+
+**Gates CoW (≤ +5 %):** `conway` +1,8 %, `share_mutate` +2,7 %,
+`typed_call_map` +0,9 %, `call_light` −1,0 % — verdes. Sentinela
+`bench_generic_vs_hand` −1,7 %: os dois blocos inline novos em `run()` não
+pioraram o codegen do laço (o risco real desta rodada, lição do item 1).
+
 ## v0.15.0 (73cf11a) × strings: fast path ASCII + `to_str(int)` — v0.15.1 (perf/issue-66-string-ascii-fastpath, 0bc9e5d)
 
 **Data:** 2026-08-22 · Windows 11 · **Intel Core 7 150U** (máquina diferente das

--- a/benchmarks/cross_runtime/results/cross_runtime.md
+++ b/benchmarks/cross_runtime/results/cross_runtime.md
@@ -1,47 +1,47 @@
 # Cross-runtime: Noxy x CPython x Lua x Go
 
-- noxy: `C:\Users\sandr\AppData\Local\Temp\claude\C--Users-sandr-Documents-noxy\58670b25-86ee-451c-a716-ecd4cec33bde\scratchpad\bench\noxy_str.exe` (Noxy v0.15.0)
-- v0150: `C:\Users\sandr\AppData\Local\Temp\claude\C--Users-sandr-Documents-noxy\58670b25-86ee-451c-a716-ecd4cec33bde\scratchpad\bench\noxy_base.exe` (Noxy v0.15.0)
+- noxy: `C:\Users\sandr\AppData\Local\Temp\claude\C--Users-sandr-Documents-noxy\58670b25-86ee-451c-a716-ecd4cec33bde\scratchpad\bench\noxy_call.exe` (Noxy v0.15.1)
+- v0151: `C:\Users\sandr\AppData\Local\Temp\claude\C--Users-sandr-Documents-noxy\58670b25-86ee-451c-a716-ecd4cec33bde\scratchpad\bench\noxy_base.exe` (Noxy v0.15.1)
 - python: Python 3.14.7
-- lua: ausente
+- lua: Lua 5.4.6  Copyright (C) 1994-2023 Lua.org, PUC-Rio
 - go: go version go1.26.6 windows/amd64
-- Data: 2026-08-22T20:47:49
+- Data: 2026-08-22T21:40:04
 - Runs por bench: 9, intercalados; **minimo** reportado
 
 ## Tempo total (ms)
 
-| bench | noxy | v0150 | python | go |
-|---|---|---|---|---|
-| `bubblesort` | 140,0 | 137,1 | 91,8 | - |
-| `fib` | 208,5 | 213,5 | 118,5 | 10,4 |
-| `loop_arith` | 209,7 | 213,4 | 212,0 | 15,0 |
-| `mandelbrot` | 149,0 | 146,7 | 96,5 | - |
-| `map_churn` | 126,0 | 143,0 | 78,6 | - |
-| `startup` | 11,0 | 10,7 | 20,6 | 7,2 |
-| `string_ops` | 85,2 | 106,9 | 51,3 | - |
+| bench | noxy | v0151 | python | lua | go |
+|---|---|---|---|---|---|
+| `bubblesort` | 116,4 | 126,4 | 87,6 | - | - |
+| `fib` | 115,0 | 194,4 | 109,4 | 48,8 | 9,7 |
+| `loop_arith` | 204,3 | 203,0 | 202,3 | 45,6 | 13,9 |
+| `mandelbrot` | 143,1 | 142,2 | 93,0 | - | - |
+| `map_churn` | 127,1 | 121,6 | 75,6 | - | - |
+| `startup` | 9,6 | 9,3 | 18,7 | 6,8 | 6,5 |
+| `string_ops` | 78,6 | 83,0 | 50,5 | - | - |
 
 ## Tempo de execucao, descontado o piso de `startup` (ms)
 
-| bench | noxy | v0150 | python | go |
-|---|---|---|---|---|
-| `bubblesort` | 129,0 | 126,4 | 71,2 | - |
-| `fib` | 197,5 | 202,8 | 97,9 | ~0 |
-| `loop_arith` | 198,7 | 202,7 | 191,4 | 7,8 |
-| `mandelbrot` | 138,0 | 136,0 | 75,9 | - |
-| `map_churn` | 115,0 | 132,3 | 58,0 | - |
-| `string_ops` | 74,2 | 96,2 | 30,7 | - |
+| bench | noxy | v0151 | python | lua | go |
+|---|---|---|---|---|---|
+| `bubblesort` | 106,8 | 117,1 | 68,9 | - | - |
+| `fib` | 105,4 | 185,1 | 90,7 | 42,0 | ~0 |
+| `loop_arith` | 194,7 | 193,7 | 183,6 | 38,8 | 7,4 |
+| `mandelbrot` | 133,5 | 132,9 | 74,3 | - | - |
+| `map_churn` | 117,5 | 112,3 | 56,9 | - | - |
+| `string_ops` | 69,0 | 73,7 | 31,8 | - | - |
 
 `~0` = o trabalho cabe dentro do ruido do piso de processo do runtime.
 
 ## Razoes sobre o tempo liquido (noxy / outro)
 
-| bench | / v0150 | / python | / go |
-|---|---|---|---|
-| `bubblesort` | 1,02x | 1,81x | - |
-| `fib` | 0,97x | 2,02x | - |
-| `loop_arith` | 0,98x | 1,04x | 25,47x |
-| `mandelbrot` | 1,01x | 1,82x | - |
-| `map_churn` | 0,87x | 1,98x | - |
-| `string_ops` | 0,77x | 2,42x | - |
+| bench | / v0151 | / python | / lua | / go |
+|---|---|---|---|---|
+| `bubblesort` | 0,91x | 1,55x | - | - |
+| `fib` | 0,57x | 1,16x | 2,51x | - |
+| `loop_arith` | 1,01x | 1,06x | 5,02x | 26,31x |
+| `mandelbrot` | 1,00x | 1,80x | - | - |
+| `map_churn` | 1,05x | 2,07x | - | - |
+| `string_ops` | 0,94x | 2,17x | - | - |
 
 Menor e melhor. `-` = um dos lados cai dentro do ruido do piso e a razao nao tem significado.

--- a/benchmarks/results/2026-08-22-issue-66-call-protocol-raw.md
+++ b/benchmarks/results/2026-08-22-issue-66-call-protocol-raw.md
@@ -1,0 +1,146 @@
+# Dados brutos — issue #66, item 3: protocolo de chamada
+
+**Data:** 2026-08-22 · **Máquina:** Windows 11 · Intel Core 7 150U (mesma do
+item 2; diferente das seções de item 1/fase 2, que rodaram num i7-1165G7 — só
+o delta intra-sessão é comparável) · Python 3.14.7 · Lua 5.4.6 · Go 1.26.6 ·
+pwsh 7.6.5 (scripts de `benchmarks/` direto). Binários em disco local
+(scratchpad), os quatro compilados na mesma sessão:
+
+- `noxy_base.exe` = `develop` c1cc12a (v0.15.1)
+- `noxy_s0.exe` = a4e23e6 (Tasks 1–2: `ParamsUntracked` + `OP_RETURN` fast path / `popSimpleFrame`)
+- `noxy_s1.exe` = 307b276 + 868d435 (s0 + `OP_CALL_STATIC` fast path **com** o fix de propagação do flag — ver §0)
+- `noxy_call.exe` = 868d435 (head: + superinstruções)
+
+Máquina sem `go test`/build durante as medições; CPU média no início de cada
+passo (`Win32_Processor.LoadPercentage`).
+
+## 0. Achado da rodada (custou um commit a mais)
+
+A primeira medição por estágio deu **s1 ≈ s0** (`fib` 166 × 170 ms) apesar de
+o perfil atribuir 12 % ao lado da chamada. O perfil de s1 mostrou
+`callValueStatic`/`callPreparedClosure`/`ownSlot` **ainda presentes**: o fast
+path nunca era tomado. Causa: `OP_CLOSURE`, `OP_CONSTANT` e `OP_CONSTANT_LONG`
+copiam o `ObjFunction` campo a campo ao vincular ao ambiente e **perderam
+`ParamsUntracked`**. Nenhum teste funcional pega isso (o caminho lento é
+correto). Fix em 868d435 + `TestClosureKeepsParamsUntracked`, que pergunta ao
+valor da closure. O `noxy_s1.exe` desta tabela é s1 **com** o fix
+(cherry-pick em worktree destacado).
+
+## 1. Verificação
+
+- `go test ./...` verde (12 pacotes); `go test -race ./internal/value ./internal/vm` verde (2,4 s / 28,9 s)
+- corpus `noxy_examples/run_all_tests_concurrent.nx`: **177/177**
+- `compare_examples.ps1` base × head: **146 iguais, 0 divergentes, 70 excluídos**
+- guards de inline inalterados (`push` 20, `pop` 18, `Retain` 67, `Release` 80, `NeverTracked`, `arrayTagIsRefSlot` 20, `ensureCallCapacity` 80, `isASCII` 23); `popSimpleFrame` custa 60 (chamada real, de propósito — uma, sem `frameOutcome`); guard de arquitetura `TestUnwindArchitectureCentralizesTerminalFrameTeardown` verde (teardown terminal só em `unwind.go`)
+- dois opcodes novos por append (`OP_GET_LOCAL_ADD_IMM_INT`, `OP_GET_LOCAL_2`)
+
+## 2. `interleaved_compare.ps1 -Runs 9` — base × head (CPU 17 % no início)
+
+| bench | v0151_ms | call_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 776.9 | 694.1 | -10.7% |
+| bench_call_light.nx | 19.9 | 19.7 | -1% |
+| bench_call_readonly.nx | 531.3 | 537.4 | 1.1% |
+| bench_call_ref.nx | 1137.1 | 1149.9 | 1.1% |
+| bench_conway.nx | 1253.2 | 1275.3 | 1.8% |
+| bench_generic_vs_hand.nx | 456.6 | 448.7 | -1.7% |
+| bench_map_churn.nx | 194.3 | 200.1 | 3% |
+| bench_path_update.nx | 229.8 | 231.8 | 0.9% |
+| bench_share_mutate.nx | 100.6 | 103.3 | 2.7% |
+| bench_spawn_sum.nx | 398.8 | 369.8 | -7.3% |
+| bench_typed_call_map.nx | 22.3 | 22.5 | 0.9% |
+| bench_value_call_mutate.nx | 21.1 | 21.2 | 0.5% |
+
+`bench_call_readonly`/`bench_call_ref` chamam com parâmetro `int[]`/`ref int[]`
+(`ParamsUntracked` false → caminho lento de chamada) e o laço não é `local OP
+local` — ficam em ±1 %, como esperado.
+
+## 3. A/B por estágio — quatro binários intercalados, 11 execuções, tempo de parede (piso ≈ 10 ms)
+
+`ab_stages.ps1` (scratchpad): warmup + 11 rodadas `base, s0, s1, call` na
+mesma janela; mediana (mínimo).
+
+| bench | base | s0 | s1 | call (head) | s0 vs base | s1 vs s0 | head vs s1 | **head vs base** |
+|---|---|---|---|---|---|---|---|---|
+| `cross_runtime/fib.nx` (CPU 15 %) | 203,4 (196,1) | 161,1 (156,4) | 149,5 (144,1) | **122,0 (117,2)** | −20,8 % | −7,2 % | −18,4 % | **−40,0 %** |
+| `cross_runtime/bubblesort.nx` (CPU 7 %) | 133,3 (127,8) | 132,7 (127,0) | 133,8 (127,8) | **118,9 (114,2)** | −0,5 % | +0,8 % | −11,1 % | **−10,8 %** |
+| `cross_runtime/loop_arith.nx` (CPU 0 %) | 213,3 (209,6) | 214,5 (210,8) | 220,5 (216,3) | 216,2 (212,0) | +0,6 % | +2,8 % | −2,0 % | +1,4 % |
+| `cross_runtime/mandelbrot.nx`¹ (CPU 34 %) | 149,5 (143,8) | 154,9 (147,7) | 152,7 (149,6) | 150,8 (145,1) | +3,6 % | −1,4 % | −1,2 % | +0,9 % |
+
+¹ rodada anterior ao fix do flag (s1 sem o fix); `mandelbrot` não chama função
+no laço nem tem `local OP local` int, então os quatro binários são
+equivalentes ali — a coluna vale como ruído da máquina (±3 %).
+
+Líquido (piso 10 ms): `fib` 193,4 → 112,0 ms (**−42 %**).
+
+## 4. `run_cross_runtime.ps1 -NoxyBaseline` — mínimo de 9, intercalado (CPU 21 % no início)
+
+Líquido (descontado `startup`: 9,6 / 9,3 ms) e razões:
+
+| bench | head | v0151 | python | lua | head ÷ v0151 | head ÷ python | v0151 ÷ python |
+|---|---|---|---|---|---|---|---|
+| `fib` | **105,4** | 185,1 | 90,7 | 42,0 | **0,57x** | **1,16x** | 2,04x |
+| `bubblesort` | **106,8** | 117,1 | 68,9 | – | **0,91x** | **1,55x** | 1,70x |
+| `string_ops` | 69,0 | 73,7 | 31,8 | – | 0,94x | 2,17x | 2,32x |
+| `loop_arith` | 194,7 | 193,7 | 183,6 | 38,8 | 1,01x | 1,06x | 1,06x |
+| `mandelbrot` | 133,5 | 132,9 | 74,3 | – | 1,00x | 1,80x | 1,79x |
+| `map_churn` | 117,5 | 112,3 | 56,9 | – | 1,05x | 2,07x | 1,97x |
+
+Tabela completa em `cross_runtime/results/cross_runtime.md`. `fib` ÷ lua: 2,5x
+(era 4,4x).
+
+## 5. `BenchmarkNoxyCallOverhead` (`go test -bench -count 8`, worktree destacado para a base)
+
+| | ns/op (8 rodadas) | mediana | B/op | allocs/op |
+|---|---|---|---|---|
+| base c1cc12a | 72242 · 73271 · 73627 · 73985 · 74182 · 73897 · 77855 · 73132 | **73 762** | 560 | 10 |
+| head 868d435 | 52976 · 51756 · 53064 · 53053 · 53087 · 53176 · 53422 · 53174 | **53 076** | 560 | 10 |
+
+**−28,0 %** (meta da issue ≥ −25 % ✅). `leaf(i)` tem parâmetro `int` → fast path
+de chamada e de retorno; `acc = leaf(i)`/`i = i + 1` não usam as superinstruções.
+
+## 6. Perfis (`noxy --cpuprofile`, `fib(34)`, amostras de 10 ms, mesma janela)
+
+**Base c1cc12a** — 1,32 s, 1280 ms de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 41,4 % | 96,9 % |
+| `push` / `pop` | 13,3 / 3,9 % | |
+| `finishFrame` + `finalizeCurrentFrame` | 12,5 + 7,8 % | **24,2 %** |
+| `callValueStatic` → `callPreparedClosure` → `ownSlot` | 3,9 / 2,3 / 2,3 % | **12,5 %** |
+
+**s0 a4e23e6** (retorno) — 1,08 s: `run` 46 % flat; `popSimpleFrame` 2,9 %;
+`callValueStatic` 22 % cum (`ownSlot` 11,5 %, `callPreparedClosure` 17 %) —
+o retorno sumiu, a chamada ficou inteira.
+
+**s1 sem o fix** — 1,13 s: `callPreparedClosure` 9,9 %, `ownSlot` 4,5 %,
+`callValueStatic` 10,8 % cum **ainda lá** (ver §0).
+
+**Head 868d435** — 0,80 s, 780 ms de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 60,3 % | 94,9 % |
+| `push` / `pop` | 10,3 / 6,4 % | |
+| `popSimpleFrame` | 6,4 % | 6,4 % |
+| `GlobalCache` + `Generation` + `atomic.Load` | 3,8 + 2,6 + 3,8 % | **~12 %** |
+| `finishFrame` / `finalizeCurrentFrame` / `callValueStatic` / `callPreparedClosure` / `ownSlot` | — | ausentes |
+
+Leitura: o protocolo de chamada/retorno saiu do perfil (36 % → 6,4 % de
+`popSimpleFrame`). O que resta em `fib`: despacho puro (`run` 60 % flat, 11
+opcodes por chamada não-folha), `push`/`pop` 17 % e — agora visível — o
+lookup cacheado de `fib` (`OP_GET_GLOBAL`: `Generation()` atômico + compare,
+~12 %). Esse último é o "(a) literal" da issue, que ficou de fora deste PR por
+ser 1,6 % no perfil de base; com o resto cortado virou o próximo candidato.
+
+## 7. Carga e condições
+
+| passo | CPU no início |
+|---|---|
+| A/B estágios (fib / bubblesort / loop_arith) | 15 / 7 / 0 % |
+| `interleaved_compare` | 17 % |
+| `cross_runtime` | 21 % |
+| `go test -bench` | — (único processo) |
+
+Firefox e o Claude Code abertos; nenhum `go test`/build concorrente.

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,14 +1,14 @@
-| bench | v0150_ms | str_ms | delta |
+| bench | v0151_ms | call_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 862.7 | 878.8 | 1.9% |
-| bench_call_light.nx | 20.3 | 19.8 | -2.5% |
-| bench_call_readonly.nx | 587.7 | 591.6 | 0.7% |
-| bench_call_ref.nx | 1252.2 | 1240.7 | -0.9% |
-| bench_conway.nx | 1348.9 | 1330.3 | -1.4% |
-| bench_generic_vs_hand.nx | 474.4 | 474.8 | 0.1% |
-| bench_map_churn.nx | 230.1 | 203.6 | -11.5% |
-| bench_path_update.nx | 239.1 | 244.6 | 2.3% |
-| bench_share_mutate.nx | 144.4 | 146.5 | 1.5% |
-| bench_spawn_sum.nx | 431.5 | 419.4 | -2.8% |
-| bench_typed_call_map.nx | 22.4 | 21.5 | -4% |
-| bench_value_call_mutate.nx | 20.2 | 20.1 | -0.5% |
+| bench_bubblesort.nx | 776.9 | 694.1 | -10.7% |
+| bench_call_light.nx | 19.9 | 19.7 | -1% |
+| bench_call_readonly.nx | 531.3 | 537.4 | 1.1% |
+| bench_call_ref.nx | 1137.1 | 1149.9 | 1.1% |
+| bench_conway.nx | 1253.2 | 1275.3 | 1.8% |
+| bench_generic_vs_hand.nx | 456.6 | 448.7 | -1.7% |
+| bench_map_churn.nx | 194.3 | 200.1 | 3% |
+| bench_path_update.nx | 229.8 | 231.8 | 0.9% |
+| bench_share_mutate.nx | 100.6 | 103.3 | 2.7% |
+| bench_spawn_sum.nx | 398.8 | 369.8 | -7.3% |
+| bench_typed_call_map.nx | 22.3 | 22.5 | 0.9% |
+| bench_value_call_mutate.nx | 21.1 | 21.2 | 0.5% |

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2104,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.15.1`). It is a module binding, not a
+string `noxy --version` prints (`v0.15.2`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.15.1</span>
+                    <span class="version-badge-tag">v0.15.2</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.15.1
+print(sys.version)           // v0.15.2
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-call-protocol.md
+++ b/docs/superpowers/plans/2026-08-22-vm-perf-issue-66-call-protocol.md
@@ -1,0 +1,381 @@
+# VM Perf — Protocolo de chamada (issue #66, item 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fast path inline de retorno e de chamada para frames simples, flag `ParamsUntracked` no `ObjFunction`, e duas superinstruções (`OP_GET_LOCAL_ADD_IMM_INT`, `OP_GET_LOCAL_2`) — sem mudar semântica, saída, mensagens de erro ou RC — e medir por estágio (issue #66, item 3).
+
+**Architecture:** Três estágios, um commit-binário cada: s0 = `OP_RETURN` com fast path inline quando `Deferred`/`Owned` vazios, sem upvalue aberto e acima de `minFrameCount`; s1 = `OP_CALL_STATIC` com fast path inline (capacidade escrita à mão + frame montado sem `ownSlot`) quando o callee é closure com `ParamsUntracked` e aridade certa; s2 = superinstruções emitidas em nível de AST. Caminhos lentos intocados.
+
+**Tech Stack:** Go 1.26, pwsh 7.6 (`benchmarks/*.ps1` direto), `go build -gcflags=-m=2`, `noxy --cpuprofile`, `go test -bench`.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-vm-perf-issue-66-call-protocol-design.md`
+
+## Global Constraints
+
+- Branch `perf/issue-66-call-protocol`, worktree `.claude/worktrees/perf-issue-66-call-protocol`, base `origin/develop` c1cc12a (v0.15.1). Um commit por task; os commits das Tasks 2, 3 e 4 geram `noxy_s0/s1/s2.exe`.
+- Semântica, saída, mensagens de erro e RC idênticos; corpus 0 falhas; `compare_examples.ps1` 0 divergentes; opcodes só por APPEND em `internal/chunk/chunk.go`.
+- Nenhum helper novo chamado de `run()`; guards de `inline_guard_test.go` verdes.
+- Repo CRLF: Edit tool em arquivos existentes; conferir `git diff --numstat`.
+- Binários em `$S\bench\` (`S = C:\Users\sandr\AppData\Local\Temp\claude\C--Users-sandr-Documents-noxy\58670b25-86ee-451c-a716-ecd4cec33bde\scratchpad`); `noxy_base3.exe` já buildado de c1cc12a — renomear para `noxy_base.exe`. Máquina sem `go test`/build durante medições.
+- cwd = raiz do worktree, Git Bash.
+
+---
+
+### Task 1: `ObjFunction.ParamsUntracked` calculado pelo compilador
+
+**Files:** Modify `internal/value/value.go` (struct `ObjFunction`); Modify `internal/compiler/compiler.go` (`compileFunction`); Create `internal/compiler/params_untracked_test.go`.
+
+**Produces:** `ObjFunction.ParamsUntracked bool`; `func paramsUntracked(params []*ast.Parameter) bool` em compiler.go.
+
+- [ ] **Step 1: Teste** (`params_untracked_test.go`, usa `compiledFunction(t, src, name)` de `inc_local_compile_test.go`):
+
+```go
+package compiler
+
+import "testing"
+
+func TestParamsUntrackedFlag(t *testing.T) {
+	cases := []struct {
+		name, source string
+		want         bool
+	}{
+		{"int", "func f(n: int) -> int\n    return n\nend\n", true},
+		{"scalars and string", "func f(s: string, b: bytes, x: float, ok: bool) -> int\n    return 0\nend\n", true},
+		{"no params", "func f() -> int\n    return 1\nend\n", true},
+		{"array", "func f(a: int[]) -> int\n    return 0\nend\n", false},
+		{"any", "func f(x: any) -> int\n    return 0\nend\n", false},
+		{"ref", "func f(r: ref int) -> int\n    return 0\nend\n", false},
+		{"struct", "struct P\n    x: int\nend\nfunc f(p: P) -> int\n    return 0\nend\n", false},
+		{"func type", "func f(g: func(int) -> int) -> int\n    return 0\nend\n", false},
+		{"mixed", "func f(n: int, a: int[]) -> int\n    return 0\nend\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := compiledFunction(t, tc.source, "f")
+			if fn.ParamsUntracked != tc.want {
+				t.Fatalf("ParamsUntracked = %v, want %v", fn.ParamsUntracked, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2:** `go test ./internal/compiler -run TestParamsUntrackedFlag` → FAIL (campo não existe).
+- [ ] **Step 3:** `value.go`: campo `ParamsUntracked bool` com comentário (perf #66 item 3). `compiler.go` antes de `compileFunction`:
+
+```go
+// paramsUntracked diz se NENHUM parametro pode carregar contador RC: todos sem
+// `ref` e de tipo primitivo escalar/string/bytes (value.Retain e no-op para
+// eles). Com isso o fast path de OP_CALL_STATIC pula o laco ownSlot (issue
+// #66, item 3). Conservador: qualquer outra coisa (any, T[], struct, func,
+// ref) devolve false e a chamada segue por callPreparedClosure.
+func paramsUntracked(params []*ast.Parameter) bool {
+	for _, param := range params {
+		prim, ok := param.Type.(*ast.PrimitiveType)
+		if !ok {
+			return false
+		}
+		switch prim.Name {
+		case "int", "float", "bool", "string", "bytes":
+		default:
+			return false
+		}
+	}
+	return true
+}
+```
+e em `compileFunction`, depois de criar `fnObj`: `fnObj.Obj.(*value.ObjFunction).ParamsUntracked = paramsUntracked(params)`.
+- [ ] **Step 4:** teste → PASS; `go test ./internal/compiler ./internal/value` → PASS.
+- [ ] **Step 5: Commit** `perf(compiler,value): ObjFunction.ParamsUntracked — parametros sem contador RC, calculado em compileFunction (issue #66, item 3)`.
+
+---
+
+### Task 2: `OP_RETURN` fast path (s0)
+
+**Files:** Modify `internal/vm/executor.go` (handler `OP_RETURN`); Create `internal/vm/call_protocol_test.go`.
+
+- [ ] **Step 1: Testes e2e** (`call_protocol_test.go`) — passam no baseline; travam o contrato:
+
+```go
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+func TestCallProtocolFastPathsKeepSemantics(t *testing.T) {
+	src := `
+func fib(n: int) -> int
+    if n <= 1 then
+        return n
+    end
+    return fib(n - 1) + fib(n - 2)
+end
+func withDefer(n: int) -> int
+    let acc: int[] = []
+    defer append(acc, 1)
+    return n + 1
+end
+func makeAdder(base: int) -> func(int) -> int
+    return func(x: int) -> int
+        return base + x
+    end
+end
+func sumArr(a: int[]) -> int
+    let s: int = 0
+    let i: int = 0
+    while i < length(a) do
+        s = s + a[i]
+        i = i + 1
+    end
+    return s
+end
+let arr: int[] = [1, 2, 3]
+let total: int = sumArr(arr)
+append(arr, 4)
+let add5: func(int) -> int = makeAdder(5)
+test_report([fib(20), fib(1), fib(0), withDefer(41), add5(10), total, length(arr)])
+`
+	got := semArray(t, captureVMSource(t, src))
+	want := []int64{6765, 1, 0, 42, 15, 6, 4}
+	for i, w := range want {
+		if got[i].Type != value.VAL_INT || got[i].Int() != w {
+			t.Fatalf("celula %d: got %s, want %d", i, got[i].String(), w)
+		}
+	}
+}
+
+func TestCallProtocolErrorsUnchanged(t *testing.T) {
+	cases := []struct{ name, source, want string }{
+		{"deep recursion", "func down(n: int) -> int\n    return down(n + 1)\nend\ndown(0)\n", "stack overflow: call depth exceeds"},
+		{"arity via any", "func f(a: int, b: int) -> int\n    return a + b\nend\nlet g: any = f\ng(1)\n", "expected 2 arguments but got 1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := interpretVMSource(t, New(), tc.source)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want contendo %q", err, tc.want)
+			}
+		})
+	}
+}
+```
+- [ ] **Step 2:** `go test ./internal/vm -run TestCallProtocol` → PASS (baseline).
+- [ ] **Step 3: Implementar** o fast path no handler `OP_RETURN` (código da spec §3.1, antes de `result := vm.pop()` atual; o caminho lento fica igual).
+- [ ] **Step 4:** `go test ./internal/vm` → PASS; `go vet ./internal/vm`; guards de inline verdes (`-run 'StaysInlin'`).
+- [ ] **Step 5: Commit** `perf(vm): OP_RETURN com fast path inline para frame sem defer/Owned/upvalue aberto (issue #66, item 3, s0)`.
+
+---
+
+### Task 3: `OP_CALL_STATIC` fast path (s1)
+
+**Files:** Modify `internal/vm/executor.go` (handler `OP_CALL_STATIC`); Modify `internal/vm/call_protocol_test.go`.
+
+- [ ] **Step 1: Teste adicional** — parâmetro composto segue caminho lento e retém (CoW intacto):
+
+```go
+func TestCallWithCompositeParamStillRetains(t *testing.T) {
+	src := `
+func touch(a: int[]) -> int
+    a[0] = 99
+    return a[0]
+end
+let base: int[] = [1, 2]
+let r: int = touch(base)
+test_report([r, base[0]])
+`
+	got := semArray(t, captureVMSource(t, src))
+	if got[0].Int() != 99 || got[1].Int() != 1 {
+		t.Fatalf("got %s/%s, want 99/1 (CoW: base nao muda)", got[0].String(), got[1].String())
+	}
+}
+```
+- [ ] **Step 2:** PASS no baseline.
+- [ ] **Step 3: Implementar** (spec §3.2) no handler `OP_CALL_STATIC` antes de `frame.IP = ip` atual.
+- [ ] **Step 4:** `go test ./internal/vm` + `go test -race ./internal/vm -run 'TestCallProtocol|TestParamRetain|TestSpawn|TestDefer'` → PASS; guards.
+- [ ] **Step 5: Commit** `perf(vm): OP_CALL_STATIC com fast path inline (capacidade a mao, frame sem ownSlot) para closure ParamsUntracked (issue #66, item 3, s1)`.
+
+---
+
+### Task 4: Superinstruções `OP_GET_LOCAL_ADD_IMM_INT` e `OP_GET_LOCAL_2` (s2)
+
+**Files:** Modify `internal/chunk/chunk.go` (append + `String()` + disassembler); Modify `internal/vm/executor.go` (2 handlers); Modify `internal/compiler/compiler.go` (helpers + 2 sites); Create `internal/compiler/superinstr_compile_test.go`; Modify `internal/vm/call_protocol_test.go` (e2e + emissão via `chunkTreeEmits`).
+
+- [ ] **Step 1: Testes de emissão** (`superinstr_compile_test.go`):
+
+```go
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+func TestLocalAddImmFuses(t *testing.T) {
+	fn := compiledFunction(t, "func f(n: int) -> int\n    return n - 1 + (n + 2)\nend\n", "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_GET_LOCAL_ADD_IMM_INT) {
+		t.Fatalf("n - 1 / n + 2 nao fundiram")
+	}
+	if containsOpcode(code, chunk.OP_SUB_INT) {
+		t.Fatalf("OP_SUB_INT presente: n - 1 caiu no generico")
+	}
+}
+
+func TestLocalAddImmDoesNotFuse(t *testing.T) {
+	cases := map[string]string{
+		"global":      "let x: int = 0\nfunc f() -> int\n    return x + 1\nend\n",
+		"float":       "func f(x: float) -> float\n    return x + 1.0\nend\n",
+		"big imm":     "func f(n: int) -> int\n    return n + 1000\nend\n",
+		"literal left": "func f(n: int) -> int\n    return 1 + n\nend\n",
+		"ref":         "func f(r: ref int) -> int\n    return *r + 1\nend\n",
+		"upvalue":     "func f(n: int) -> func() -> int\n    return func() -> int\n        return n + 1\n    end\nend\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := compiledFunction(t, src, "f")
+			if containsOpcodeTree(fn, chunk.OP_GET_LOCAL_ADD_IMM_INT) {
+				t.Fatalf("%s fundiu indevidamente", name)
+			}
+		})
+	}
+}
+
+func TestLocalPairFuses(t *testing.T) {
+	fn := compiledFunction(t, "func f(a: int, b: int) -> int\n    let i: int = 0\n    while i < b do\n        i = i + 1\n    end\n    return a + b\nend\n", "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_GET_LOCAL_2) {
+		t.Fatalf("a + b / i < b nao fundiram em OP_GET_LOCAL_2")
+	}
+}
+
+func TestLocalPairDoesNotFuseForRefOrGlobal(t *testing.T) {
+	cases := map[string]string{
+		"global": "let g: int = 1\nfunc f(a: int) -> int\n    return a + g\nend\n",
+		"ref":    "func f(a: int, r: ref int) -> bool\n    return r == null\nend\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := compiledFunction(t, src, "f")
+			if containsOpcodeTree(fn, chunk.OP_GET_LOCAL_2) {
+				t.Fatalf("%s fundiu indevidamente", name)
+			}
+		})
+	}
+}
+```
+(`containsOpcodeTree` = variante recursiva de `containsOpcode` sobre constantes função; criar no mesmo arquivo se não existir.)
+
+- [ ] **Step 2:** FAIL (opcodes não existem).
+- [ ] **Step 3: `chunk.go`** — append após `OP_SET_REF_LOCAL_INDEX_ARRAY_NORC`:
+
+```go
+	// perf issue #66 (item 3): superinstrucoes emitidas em nivel de AST.
+	OP_GET_LOCAL_ADD_IMM_INT // [slot u8][imm i8]; push local(int)+imm (== GET_LOCAL+CONSTANT+ADD_INT/SUB_INT; wrappa como OP_ADD_INT)
+	OP_GET_LOCAL_2           // [a u8][b u8]; push local a, push local b (== GET_LOCAL a + GET_LOCAL b)
+```
+`String()`: dois cases. Disassembler: `OP_GET_LOCAL_ADD_IMM_INT` → `slotDeltaInstruction`; `OP_GET_LOCAL_2` → novo `twoByteInstruction(name, offset)` imprimindo os dois slots (modelar em `byteInstruction`).
+- [ ] **Step 4: VM** (`executor.go`, perto de `OP_INC_LOCAL_INT`):
+
+```go
+		case chunk.OP_GET_LOCAL_ADD_IMM_INT:
+			slot := c.Code[ip]
+			imm := int8(c.Code[ip+1])
+			ip += 2
+			vm.push(value.NewInt(vm.stack[frame.LocalBase+int(slot)].Int() + int64(imm)))
+
+		case chunk.OP_GET_LOCAL_2:
+			a := c.Code[ip]
+			b := c.Code[ip+1]
+			ip += 2
+			vm.push(vm.stack[frame.LocalBase+int(a)])
+			vm.push(vm.stack[frame.LocalBase+int(b)])
+```
+- [ ] **Step 5: Compilador** — helpers perto de `tryFuseLocalIntIncrement`:
+
+```go
+// tryEmitLocalAddImm funde `local ± K` (local PLANO de tipo int — resolveLocal,
+// nunca upvalue/global/ref; K literal int com o sinal aplicado em [-128,127])
+// em OP_GET_LOCAL_ADD_IMM_INT. Devolve true se emitiu (o resultado e int).
+func (c *Compiler) tryEmitLocalAddImm(infix *ast.InfixExpression) bool {
+	if infix.Operator != "+" && infix.Operator != "-" {
+		return false
+	}
+	ident, ok := infix.Left.(*ast.Identifier)
+	if !ok {
+		return false
+	}
+	lit, ok := infix.Right.(*ast.IntegerLiteral)
+	if !ok {
+		return false
+	}
+	slot, localType := c.resolveLocal(ident.Value)
+	if slot == -1 || slot > 255 {
+		return false
+	}
+	prim, ok := localType.(*ast.PrimitiveType)
+	if !ok || prim.Name != "int" {
+		return false
+	}
+	imm := lit.Value
+	if infix.Operator == "-" {
+		imm = -imm
+	}
+	if imm < -128 || imm > 127 {
+		return false
+	}
+	c.emitBytes(byte(chunk.OP_GET_LOCAL_ADD_IMM_INT), byte(slot))
+	c.emitByte(byte(int8(imm)))
+	return true
+}
+
+// tryEmitLocalPair funde dois operandos que sao locais PLANOS de tipo primitivo
+// (sem ref: o site do infix emite OP_DEREF para RefType e isso tem de
+// continuar acontecendo pelo caminho normal) em OP_GET_LOCAL_2. Devolve os
+// tipos como resolveLocal os da, para o chamador seguir igual.
+func (c *Compiler) tryEmitLocalPair(left, right ast.Expression) (ast.NoxyType, ast.NoxyType, bool) {
+	li, ok := left.(*ast.Identifier)
+	if !ok {
+		return nil, nil, false
+	}
+	ri, ok := right.(*ast.Identifier)
+	if !ok {
+		return nil, nil, false
+	}
+	ls, lt := c.resolveLocal(li.Value)
+	rs, rt := c.resolveLocal(ri.Value)
+	if ls == -1 || rs == -1 || ls > 255 || rs > 255 {
+		return nil, nil, false
+	}
+	if _, ok := lt.(*ast.PrimitiveType); !ok {
+		return nil, nil, false
+	}
+	if _, ok := rt.(*ast.PrimitiveType); !ok {
+		return nil, nil, false
+	}
+	c.emitBytes(byte(chunk.OP_GET_LOCAL_2), byte(ls))
+	c.emitByte(byte(rs))
+	return lt, rt, true
+}
+```
+Sites: (i) no `case *ast.InfixExpression` genérico, logo antes de `_, leftType, err := c.Compile(n.Left)`: `if c.tryEmitLocalAddImm(n) { return c.currentChunk, &ast.PrimitiveType{Name: "int"}, nil }` e em seguida `var leftType, rightType ast.NoxyType; if lt, rt, ok := c.tryEmitLocalPair(n.Left, n.Right); ok { leftType, rightType = lt, rt } else { ...compila os dois como hoje, com os dois OP_DEREF... }` — o resto do case segue inalterado usando `leftType`/`rightType`. (ii) em `tryCompileFusedCondition`, depois de obter `jumpOp`: `if lt, rt, ok := c.tryEmitLocalPair(infix.Left, infix.Right); ok { if lt.String()=="int" && rt.String()=="int" { return jumpOp, true, nil }; c.currentChunk.TruncateTo(checkpoint); /* segue generico */ }` — o checkpoint já existe antes.
+- [ ] **Step 6:** testes do compilador PASS; `go test ./internal/vm ./internal/compiler ./internal/chunk`; e2e em `call_protocol_test.go` (TestCallProtocolFastPathsKeepSemantics já cobre `fib`, `i < length(a)`, `s + a[i]`); `noxy --disassembly` de `fib.nx` mostra os opcodes novos; corpus.
+- [ ] **Step 7: Commit** `perf(compiler,vm): superinstrucoes OP_GET_LOCAL_ADD_IMM_INT e OP_GET_LOCAL_2 emitidas em nivel de AST (issue #66, item 3, s2)`.
+
+---
+
+### Task 5: Verificação + medição + relatório
+
+- [ ] `go test ./...`; `go test -race ./internal/value ./internal/vm`; corpus; `compare_examples.ps1` base × head = 0 divergentes; guards.
+- [ ] Binários: `noxy_base.exe` (c1cc12a, = `noxy_base3.exe`), `noxy_s0.exe` (Task 2), `noxy_s1.exe` (Task 3), `noxy_s2.exe` = head (Task 4) — via `git worktree add --detach $S/wt_sN <commit>`.
+- [ ] `pwsh -NoProfile -File benchmarks/interleaved_compare.ps1 -Baseline base -Candidate head -Runs 9`; A/B por estágio (4 binários × 11) em `fib.nx` e `loop_arith.nx` (+ `bubblesort.nx`); `run_cross_runtime.ps1 -NoxyBaseline`; `go test ./internal/vm -run xxx -bench BenchmarkNoxyCallOverhead -count 10` base × head (base via worktree detach); perfil `fib(34)` head.
+- [ ] `benchmarks/results/2026-08-22-issue-66-call-protocol-raw.md` + seção nova no topo de `RESULTS.md`.
+- [ ] Commit `docs(bench): protocolo de chamada medido contra v0.15.1 ... (issue #66, item 3)`.
+
+### Task 6: Bump v0.15.2 (7 pontos) + CHANGELOG — mesmo procedimento do item 2.
+
+### Task 7: finishing-a-development-branch — push, PR base develop (título `perf/issue-66-call-protocol - ...`, label "not available to review", assignee @me, Refs #66), comentário na #66; depois seguir para o item 4 conforme combinado (opção A).

--- a/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-call-protocol-design.md
+++ b/docs/superpowers/specs/2026-08-22-vm-perf-issue-66-call-protocol-design.md
@@ -1,0 +1,110 @@
+# VM Perf — Protocolo de chamada (issue #66, item 3)
+
+**Data:** 2026-08-22 · **Issue:** [#66](https://github.com/estevaofon/noxy/issues/66) item 3 · **Branch:** `perf/issue-66-call-protocol` · **Base:** `develop` (c1cc12a, v0.15.1)
+
+## 1. Contexto (medido nesta sessão, binário de c1cc12a, `fib(34)`, 1,25 s de amostras)
+
+| componente | flat | cum | o que é |
+|---|---|---|---|
+| `(*VM).run` | 40,8 % | 99 % | despacho: 15 opcodes por chamada não-folha de `fib` |
+| `finishFrame` + `finalizeCurrentFrame` | 15,2 + 10,4 % | **26,4 %** | o retorno: `frameOutcome` (48 B) copiado na ida e na volta, laço de `Deferred`, guard de upvalues, laço de `Owned`, zerar slots, `push` — em `fib` **tudo vazio** |
+| `callValueStatic` → `callPreparedClosure` → `ownSlot` | 4,8 + 2,4 + 3,2 % | **12,0 %** | a chamada: duas chamadas Go reais + `ownSlot` por parâmetro (para `int`, só descobre que não há o que reter) |
+| `push` / `pop` | 15,2 / 4,0 % | | |
+| `GlobalCache` | 1,6 % | | lookup de `fib` já cacheado — barato |
+| `ensureCallCapacity` | 0,8 % | | inlinado (custo 80 exato) |
+
+Bytecode de `fib` (não-folha): `GET_LOCAL 1 · CONSTANT 1 · JUMP_IF_GT_INT · GET_GLOBAL fib · GET_LOCAL 1 · CONSTANT 1 · SUB_INT · CALL_STATIC 1 · GET_GLOBAL fib · GET_LOCAL 1 · CONSTANT 2 · SUB_INT · CALL_STATIC 1 · ADD_INT · RETURN`.
+
+## 2. Objetivo e não-objetivos
+
+**Objetivo:** tirar do caminho quente de chamada/retorno de funções com frame "simples" (sem `defer`, sem upvalue aberto, sem vínculo RC) as duas chamadas Go, a cópia de `frameOutcome` e o laço `ownSlot`; e reduzir o número de despachos das expressões que todo laço/chamada tem (`local ± K`, `local OP local`). Semântica, saída, mensagens de erro, linhas de erro e contagem RC **idênticas**; opcodes só por append.
+
+**Não-objetivos:** pular o lookup de global do callee com operando de constante (o "(a) literal" da issue — `GlobalCache` é 1,6 % e exigiria o callee embaixo dos args ou mudar o layout do frame); fusão `GET_LOCAL+CONST+JUMP_IF_*` (follow-up se o número pedir); mexer em `OP_CALL` genérico, natives, struct constructors, `defer`, `spawn`; `Owned` ou RC.
+
+## 3. Desenho
+
+### 3.1 (d) `OP_RETURN` escalar — fast path inline no handler
+
+No handler de `OP_RETURN`, **antes** de `finishFrame`:
+
+```
+if len(frame.Deferred) == 0 && len(frame.Owned) == 0 && vm.openUpvalues == nil && vm.frameCount-1 >= minFrameCount {
+    result := vm.pop()
+    for i := frame.StackBase; i < vm.stackTop; i++ { vm.stack[i] = value.Value{} }
+    frame.Closure = nil; frame.Environment = nil
+    vm.frameCount--
+    vm.stackTop = frame.StackBase
+    vm.currentFrame = &vm.frames[vm.frameCount-1]
+    vm.push(result)
+    frame = vm.currentFrame; c = ...; gcache = ...; ip = frame.IP
+    continue
+}
+```
+
+É exatamente o que `finalizeCurrentFrame` faria com esses quatro guardas verdadeiros (os três laços vazios/pulados, o `if frameCount == 0` impossível porque `frameCount-1 >= minFrameCount >= 1`), sem a cópia dupla de `frameOutcome` e sem as duas chamadas. `vm.openUpvalues == nil` é conservador (qualquer upvalue aberto em qualquer frame → caminho lento). Nenhum opcode novo.
+
+### 3.2 (a)+(b) `OP_CALL_STATIC` — fast path inline + `ParamsUntracked`
+
+**Flag no `ObjFunction`:** `ParamsUntracked bool`, calculada em `compileFunction`: verdadeira sse todo parâmetro é sem `ref` e de tipo `int`, `float`, `bool`, `string` ou `bytes` (valores que nunca têm contador RC — `Retain` é no-op; ver `value.NeverTracked`). Cache de módulos é em memória (`moduleCache`), sem serialização — campo novo não muda formato nenhum.
+
+**Handler de `OP_CALL_STATIC`**, antes de `callValueStatic`:
+
+```
+callee := vm.stack[vm.stackTop-argCount-1]
+if callee.Type == value.VAL_FUNCTION {
+    if closure, ok := callee.Obj.(*value.ObjClosure); ok && closure.Function.ParamsUntracked && argCount == closure.Function.Arity {
+        if vm.frameCount == len(vm.frames) || len(vm.stack)-vm.stackTop < stackReserve {   // = ensureCallCapacity, escrito a mao
+            if err := vm.growForCall(c, ip); err != nil { return err }
+        }
+        frame.IP = ip
+        nf := &vm.frames[vm.frameCount]
+        nf.Closure = closure; nf.IP = 0; nf.StackBase = vm.stackTop-argCount-1; nf.LocalBase = nf.StackBase
+        nf.Environment = closure.Environment; nf.Deferred = nf.Deferred[:0]; nf.Owned = nf.Owned[:0]
+        vm.frameCount++; vm.currentFrame = nf
+        frame = nf; c = ...; gcache = ...; ip = 0
+        continue
+    }
+}
+// caminho atual: frame.IP = ip; callValueStatic(...)
+```
+
+Igual a `callPreparedClosure` menos o laço `ownSlot` — que com `ParamsUntracked` só faria `Retain` no-op em cada argumento (e, como `Owned` está vazio e o ocupante não é retível, nem entrada removeria). Aridade errada, native, struct, `any` → caminho atual, mesmas mensagens. `ensureCallCapacity` custa 80 e não cabe em `run()` (orçamento 20) — por isso a condição é copiada; `growForCall` continua `//go:noinline` e é o único dono das mensagens de overflow.
+
+### 3.3 (c) Superinstruções (append ao fim de `internal/chunk/chunk.go`)
+
+| opcode | operandos | pilha | emitido quando |
+|---|---|---|---|
+| `OP_GET_LOCAL_ADD_IMM_INT` | `[slot u8][imm i8]` | `[] → [local+imm]` | infix `+`/`-` com **esquerda** identificador resolvido por `resolveLocal` de tipo `PrimitiveType int` e **direita** `IntegerLiteral` com `±K ∈ [-128,127]` (sinal já aplicado) |
+| `OP_GET_LOCAL_2` | `[a u8][b u8]` | `[] → [local a, local b]` | os dois operandos de um infix (ou da condição fundida de `tryCompileFusedCondition`) são identificadores resolvidos por `resolveLocal`, ambos de tipo `PrimitiveType` (nunca `ref`, nunca upvalue/global) |
+
+Emissão **em nível de AST** (helpers `tryEmitLocalAddImm` / `tryEmitLocalPair`, sem emissão especulativa nem peephole — não existe alvo de salto no meio de uma expressão). Depois de `OP_GET_LOCAL_2` o compilador segue exatamente como se tivesse compilado os dois operandos (tipos de `resolveLocal`), emitindo o operador de sempre. Overflow de `local+imm` wrappa como `OP_ADD_INT`. Semântica idêntica: os dois são apenas `OP_GET_LOCAL`(+`OP_CONSTANT`+`OP_ADD_INT`) fundidos.
+
+### 3.4 O que NÃO muda
+
+`callValue`/`callValueStatic`/`callPreparedClosure`/`finishFrame`/`finalizeCurrentFrame` (continuam sendo os caminhos lentos e os únicos com `defer`/upvalue/`Owned`); `OP_CALL`; RC (`Owned` vazio ⇒ nada a soltar; `ParamsUntracked` ⇒ nada a reter); mensagens de erro (aridade, overflow de frames/operandos, "can only call functions"); `OP_INC_LOCAL_INT`; layout do frame.
+
+## 4. Invariantes e guards executáveis
+
+- **Nenhum helper novo chamado de `run()`**; tudo é código inline de handler. Guards existentes (`push` 20, `pop` 18, `Retain` 67, `Release` 80, `NeverTracked`, `arrayTagIsRefSlot` 20, `ensureCallCapacity` 80, `isASCII` 23) continuam verdes.
+- Compilador: `ParamsUntracked` true para `(n: int)`, `(s: string, b: bytes, f: float, ok: bool)`; false para `(a: int[])`, `(x: any)`, `(r: ref int)`, `(p: Ponto)`, `(f: func(int) -> int)`; zero params → true.
+- Emissão: `OP_GET_LOCAL_ADD_IMM_INT` presente em `n - 1`/`i + 2` (local int), **ausente** para global, upvalue, `ref int`, float, `K` fora de i8, `1 + n` (literal à esquerda); `OP_GET_LOCAL_2` presente em `a + b`/`i < n` (dois locais int) e na condição de `while`, ausente com upvalue/global/`ref`.
+- E2E: `fib(20)` = 6765, `fib(1)`, função com `defer` retornando, closure capturando local (upvalue aberto no retorno), função com parâmetro `int[]` mutado depois da chamada (CoW intacto — caminho lento de chamada), recursão profunda → mesma mensagem `stack overflow: call depth exceeds N frames`, aridade errada via `any` → mesma mensagem; testes de RC existentes (`TestParamRetainReleasedAfterReturn`, etc.).
+- `go test ./...`, `-race` value/vm, corpus 0 falhas, `compare_examples.ps1` 0 divergentes, gates CoW ≤ +5 %, sentinela `bench_generic_vs_hand`.
+
+## 5. Medição (protocolo de `benchmarks/RESULTS.md`)
+
+Binários em disco local: `noxy_base.exe` (c1cc12a) · `s0` = +3.1 (return) · `s1` = +3.2 (call) · `s2` = +3.3 (superinstruções) = head. `interleaved_compare.ps1 -Runs 9` base × head; A/B por estágio (4 binários, 11 intercaladas) em `cross_runtime/fib.nx` e `loop_arith.nx`; `run_cross_runtime.ps1 -NoxyBaseline` (mín. de 9); `BenchmarkNoxyCallOverhead` base × head (`go test -bench`, `-count=10`); perfil de `fib(34)` antes/depois. pwsh 7 instalado (7.6.5): scripts rodam direto.
+
+**Meta (hipótese):** `fib` 2,0x → ~1,5x do CPython nesta máquina; `BenchmarkNoxyCallOverhead` ≥ −25 %.
+
+## 6. Riscos
+
+- **Codegen de `run()`** (lição do item 1: +12 % num bench sem relação): cada estágio é medido contra o sentinela; estágio que regrida o sentinela é desfeito e registrado.
+- Fast path de retorno e `minFrameCount`: um native que reentra a VM (`invokePreparedCall`, `spawn`) roda `run(minFrameCount=k)` — o guard `frameCount-1 >= minFrameCount` garante que o retorno que encerra esse `run` continua pelo caminho lento, que é quem devolve `terminalResult`.
+- `ParamsUntracked` e fronteira dinâmica: se um valor composto chegar num parâmetro `int` (impossível com o checker; via `any` o tipo do param seria `any` → flag false), o `Retain` pulado seria um vazamento, não corrupção — e `callValueStatic` já pulava `validateParameterModes` com a mesma confiança no checker.
+
+## 7. Decisões tomadas sem consulta (para a review)
+
+- Ordem dos estágios: (d) → (a/b) → (c), pelo tamanho no perfil.
+- `OP_GET_LOCAL_2` também na condição fundida (`while i < n`) — é onde `loop_arith`/`bubblesort` passam.
+- Imediato i8 (não índice de constante) em `OP_GET_LOCAL_ADD_IMM_INT`, espelhando `OP_INC_LOCAL_INT`.

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -155,6 +155,11 @@ const (
 	OP_SET_LOCAL_INDEX_ARRAY_NORC     // [slot]; pops val, index; local T[] possuidor (Owners<=1, senao uniciza como GET_LOCAL_MUT)
 	OP_GET_REF_LOCAL_INDEX_ARRAY      // [slot]; pops index; local `ref T[]` (REF_UPVALUE resolvido com uma Load(); outros refs pelo caminho de OP_DEREF)
 	OP_SET_REF_LOCAL_INDEX_ARRAY_NORC // [slot]; pops val, index; local `ref T[]` (Owners<=1, senao unicizeThroughRefValue)
+	// perf issue #66 (item 3): superinstrucoes emitidas em nivel de AST (sem
+	// peephole — nao existe alvo de salto no meio de uma expressao). Sao so
+	// GET_LOCAL(+CONSTANT+ADD_INT) fundidos; semantica identica.
+	OP_GET_LOCAL_ADD_IMM_INT // [slot u8][imm i8]; push local(int)+imm (wrappa como OP_ADD_INT)
+	OP_GET_LOCAL_2           // [a u8][b u8]; push local a, push local b
 )
 
 func (op OpCode) String() string {
@@ -265,6 +270,10 @@ func (op OpCode) String() string {
 		return "OP_GET_REF_LOCAL_INDEX_ARRAY"
 	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
 		return "OP_SET_REF_LOCAL_INDEX_ARRAY_NORC"
+	case OP_GET_LOCAL_ADD_IMM_INT:
+		return "OP_GET_LOCAL_ADD_IMM_INT"
+	case OP_GET_LOCAL_2:
+		return "OP_GET_LOCAL_2"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -598,6 +607,10 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.byteInstruction("OP_GET_REF_LOCAL_INDEX_ARRAY", offset)
 	case OP_SET_REF_LOCAL_INDEX_ARRAY_NORC:
 		return c.byteInstruction("OP_SET_REF_LOCAL_INDEX_ARRAY_NORC", offset)
+	case OP_GET_LOCAL_ADD_IMM_INT:
+		return c.slotDeltaInstruction("OP_GET_LOCAL_ADD_IMM_INT", offset)
+	case OP_GET_LOCAL_2:
+		return c.twoSlotInstruction("OP_GET_LOCAL_2", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:
@@ -713,6 +726,14 @@ func (c *Chunk) slotDeltaInstruction(name string, offset int) int {
 	slot := c.Code[offset+1]
 	delta := int8(c.Code[offset+2])
 	fmt.Printf("%-16s %4d %4d\n", name, slot, delta)
+	return offset + 3
+}
+
+// twoSlotInstruction imprime os dois slots (u8) de OP_GET_LOCAL_2.
+func (c *Chunk) twoSlotInstruction(name string, offset int) int {
+	a := c.Code[offset+1]
+	b := c.Code[offset+2]
+	fmt.Printf("%-16s %4d %4d\n", name, a, b)
 	return offset + 3
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -3335,6 +3335,26 @@ func (c *Compiler) emitClosureUpvalues(fnCompiler *Compiler) {
 	}
 }
 
+// paramsUntracked diz se NENHUM parametro pode carregar contador RC: todos sem
+// `ref` e de tipo primitivo escalar/string/bytes (value.Retain e no-op para
+// eles). Com isso o fast path de OP_CALL_STATIC pula o laco ownSlot (issue
+// #66, item 3). Conservador: qualquer outra coisa (any, T[], struct, func,
+// ref, generico) devolve false e a chamada segue por callPreparedClosure.
+func paramsUntracked(params []*ast.Parameter) bool {
+	for _, param := range params {
+		prim, ok := param.Type.(*ast.PrimitiveType)
+		if !ok {
+			return false
+		}
+		switch prim.Name {
+		case "int", "float", "bool", "string", "bytes":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *ast.BlockStatement, returnType ast.NoxyType) (value.Value, *Compiler, error) {
 	restoreBindings := c.applyProgramBindings()
 	defer restoreBindings()
@@ -3385,6 +3405,7 @@ func (c *Compiler) compileFunction(name string, params []*ast.Parameter, body *a
 	upvalueCount := len(fnCompiler.upvalues)
 	fnObj := value.NewFunction(name, len(params), upvalueCount, paramsInfo, fnCompiler.currentChunk, nil)
 	fnObj.Obj.(*value.ObjFunction).RuntimeType = c.runtimeTypeInfo(newFunctionType(params, declaredReturn))
+	fnObj.Obj.(*value.ObjFunction).ParamsUntracked = paramsUntracked(params)
 
 	return fnObj, fnCompiler, nil
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1232,30 +1232,43 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// seguem dereferenciando neste ponto.
 		identityComparison := n.Operator == "==" || n.Operator == "!="
 
-		_, leftType, err := c.Compile(n.Left)
-		if err != nil {
-			return nil, nil, err
+		// Superinstrucoes (issue #66, item 3): `local ± K` (resultado int,
+		// nada mais a checar: int com int) e `local OP local` (os dois
+		// operandos num despacho; o resto do case segue com os tipos que
+		// resolveLocal da, sem OP_DEREF porque ref nunca funde).
+		if c.tryEmitLocalAddImm(n) {
+			return c.currentChunk, &ast.PrimitiveType{Name: "int"}, nil
 		}
-
-		if _, ok := leftType.(*ast.RefType); ok && !identityComparison {
-			// Always deref ref types before comparison (including null comparison)
-			// This ensures 'ref Node == null' compares the pointed-to value, not the ref itself
-			c.emitByte(byte(chunk.OP_DEREF))
-			if ref, ok := leftType.(*ast.RefType); ok {
-				leftType = ref.ElementType
+		var leftType, rightType ast.NoxyType
+		if pairLeft, pairRight, fused := c.tryEmitLocalPair(n.Left, n.Right); fused {
+			leftType, rightType = pairLeft, pairRight
+		} else {
+			var err error
+			_, leftType, err = c.Compile(n.Left)
+			if err != nil {
+				return nil, nil, err
 			}
-		}
 
-		_, rightType, err := c.Compile(n.Right)
-		if err != nil {
-			return nil, nil, err
-		}
+			if _, ok := leftType.(*ast.RefType); ok && !identityComparison {
+				// Always deref ref types before comparison (including null comparison)
+				// This ensures 'ref Node == null' compares the pointed-to value, not the ref itself
+				c.emitByte(byte(chunk.OP_DEREF))
+				if ref, ok := leftType.(*ast.RefType); ok {
+					leftType = ref.ElementType
+				}
+			}
 
-		if _, ok := rightType.(*ast.RefType); ok && !identityComparison {
-			// Always deref ref types before comparison (including null comparison)
-			c.emitByte(byte(chunk.OP_DEREF))
-			if ref, ok := rightType.(*ast.RefType); ok {
-				rightType = ref.ElementType
+			_, rightType, err = c.Compile(n.Right)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if _, ok := rightType.(*ast.RefType); ok && !identityComparison {
+				// Always deref ref types before comparison (including null comparison)
+				c.emitByte(byte(chunk.OP_DEREF))
+				if ref, ok := rightType.(*ast.RefType); ok {
+					rightType = ref.ElementType
+				}
 			}
 		}
 
@@ -2722,6 +2735,15 @@ func (c *Compiler) tryCompileFusedCondition(cond ast.Expression) (chunk.OpCode, 
 		return 0, false, nil
 	}
 	checkpoint := len(c.currentChunk.Code)
+	// Superinstrucao (issue #66, item 3): `i < n` com dois locais int vira
+	// OP_GET_LOCAL_2 + salto fundido. Par de locais que nao sao ambos int e
+	// desfeito como qualquer outra especulacao daqui.
+	if pairLeft, pairRight, fused := c.tryEmitLocalPair(infix.Left, infix.Right); fused {
+		if pairLeft.String() == "int" && pairRight.String() == "int" {
+			return jumpOp, true, nil
+		}
+		c.currentChunk.TruncateTo(checkpoint)
+	}
 	_, leftType, err := c.Compile(infix.Left)
 	if err != nil {
 		// Sem TruncateTo aqui: um erro aborta a compilacao inteira (o
@@ -2855,6 +2877,72 @@ func (c *Compiler) localOwns(index int) bool {
 		return false
 	}
 	return c.locals[index].Owns
+}
+
+// tryEmitLocalAddImm funde a EXPRESSAO `local ± K` (local PLANO de tipo int —
+// resolveLocal, nunca upvalue/global/ref; K literal int com o sinal aplicado em
+// [-128,127]) em OP_GET_LOCAL_ADD_IMM_INT (issue #66, item 3). Devolve true se
+// emitiu; o resultado e int. Irmao de expressao do tryFuseLocalIntIncrement.
+func (c *Compiler) tryEmitLocalAddImm(infix *ast.InfixExpression) bool {
+	if infix.Operator != "+" && infix.Operator != "-" {
+		return false
+	}
+	ident, ok := infix.Left.(*ast.Identifier)
+	if !ok {
+		return false
+	}
+	lit, ok := infix.Right.(*ast.IntegerLiteral)
+	if !ok {
+		return false
+	}
+	slot, localType := c.resolveLocal(ident.Value)
+	if slot == -1 || slot > 255 {
+		return false
+	}
+	prim, ok := localType.(*ast.PrimitiveType)
+	if !ok || prim.Name != "int" {
+		return false
+	}
+	imm := lit.Value
+	if infix.Operator == "-" {
+		imm = -imm
+	}
+	if imm < -128 || imm > 127 {
+		return false
+	}
+	c.emitBytes(byte(chunk.OP_GET_LOCAL_ADD_IMM_INT), byte(slot))
+	c.emitByte(byte(int8(imm)))
+	return true
+}
+
+// tryEmitLocalPair funde dois operandos que sao locais PLANOS de tipo
+// primitivo em OP_GET_LOCAL_2 (issue #66, item 3). Sem ref: o site do infix
+// emite OP_DEREF para RefType e isso tem de continuar acontecendo pelo caminho
+// normal. Devolve os tipos como resolveLocal os da, para o chamador seguir
+// exatamente como se tivesse compilado os dois operandos.
+func (c *Compiler) tryEmitLocalPair(left, right ast.Expression) (ast.NoxyType, ast.NoxyType, bool) {
+	leftIdent, ok := left.(*ast.Identifier)
+	if !ok {
+		return nil, nil, false
+	}
+	rightIdent, ok := right.(*ast.Identifier)
+	if !ok {
+		return nil, nil, false
+	}
+	leftSlot, leftType := c.resolveLocal(leftIdent.Value)
+	rightSlot, rightType := c.resolveLocal(rightIdent.Value)
+	if leftSlot == -1 || rightSlot == -1 || leftSlot > 255 || rightSlot > 255 {
+		return nil, nil, false
+	}
+	if _, ok := leftType.(*ast.PrimitiveType); !ok {
+		return nil, nil, false
+	}
+	if _, ok := rightType.(*ast.PrimitiveType); !ok {
+		return nil, nil, false
+	}
+	c.emitBytes(byte(chunk.OP_GET_LOCAL_2), byte(leftSlot))
+	c.emitByte(byte(rightSlot))
+	return leftType, rightType, true
 }
 
 // tryFuseLocalIntIncrement funde `i = i + K` / `i = i - K` (i local int

--- a/internal/compiler/params_untracked_test.go
+++ b/internal/compiler/params_untracked_test.go
@@ -1,0 +1,32 @@
+package compiler
+
+import "testing"
+
+// ParamsUntracked (issue #66, item 3) e o que autoriza o fast path de
+// OP_CALL_STATIC a pular o laco ownSlot: so pode ser true quando NENHUM
+// parametro pode carregar contador RC. Conservador para tudo que nao e
+// primitivo escalar/string/bytes sem ref.
+func TestParamsUntrackedFlag(t *testing.T) {
+	cases := []struct {
+		name, source string
+		want         bool
+	}{
+		{"int", "func f(n: int) -> int\n    return n\nend\n", true},
+		{"scalars and string", "func f(s: string, b: bytes, x: float, ok: bool) -> int\n    return 0\nend\n", true},
+		{"no params", "func f() -> int\n    return 1\nend\n", true},
+		{"array", "func f(a: int[]) -> int\n    return 0\nend\n", false},
+		{"any", "func f(x: any) -> int\n    return 0\nend\n", false},
+		{"ref", "func f(r: ref int) -> int\n    return 0\nend\n", false},
+		{"struct", "struct P\n    x: int\nend\nfunc f(p: P) -> int\n    return 0\nend\n", false},
+		{"func type", "func f(g: func(int) -> int) -> int\n    return 0\nend\n", false},
+		{"mixed", "func f(n: int, a: int[]) -> int\n    return 0\nend\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := compiledFunction(t, tc.source, "f")
+			if fn.ParamsUntracked != tc.want {
+				t.Fatalf("ParamsUntracked = %v, want %v", fn.ParamsUntracked, tc.want)
+			}
+		})
+	}
+}

--- a/internal/compiler/superinstr_compile_test.go
+++ b/internal/compiler/superinstr_compile_test.go
@@ -1,0 +1,84 @@
+package compiler
+
+import (
+	"testing"
+
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// containsOpcodeTree e containsOpcode sobre a funcao E toda funcao constante
+// aninhada (closures), para provar que a fusao NAO dispara dentro de um corpo
+// interno que so enxerga a variavel como upvalue.
+func containsOpcodeTree(fn *value.ObjFunction, opcode chunk.OpCode) bool {
+	body := fn.Chunk.(*chunk.Chunk)
+	if containsOpcode(body.Code, opcode) {
+		return true
+	}
+	for _, constant := range body.Constants {
+		if constant.Type != value.VAL_FUNCTION {
+			continue
+		}
+		if inner, ok := constant.Obj.(*value.ObjFunction); ok && inner != nil && containsOpcodeTree(inner, opcode) {
+			return true
+		}
+	}
+	return false
+}
+
+// Superinstrucoes (issue #66, item 3): `local ± K` com local PLANO int e K em
+// i8 vira OP_GET_LOCAL_ADD_IMM_INT; dois operandos locais primitivos viram
+// OP_GET_LOCAL_2. Tudo em nivel de AST — sem peephole.
+func TestLocalAddImmFuses(t *testing.T) {
+	fn := compiledFunction(t, "func f(n: int) -> int\n    return n - 1 + (n + 2)\nend\n", "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_GET_LOCAL_ADD_IMM_INT) {
+		t.Fatalf("n - 1 / n + 2 nao fundiram em OP_GET_LOCAL_ADD_IMM_INT")
+	}
+	if containsOpcode(code, chunk.OP_SUB_INT) {
+		t.Fatalf("OP_SUB_INT presente: n - 1 caiu no caminho generico")
+	}
+}
+
+func TestLocalAddImmDoesNotFuse(t *testing.T) {
+	cases := map[string]string{
+		"global":       "let x: int = 0\nfunc f() -> int\n    return x + 1\nend\n",
+		"float":        "func f(x: float) -> float\n    return x + 1.0\nend\n",
+		"big imm":      "func f(n: int) -> int\n    return n + 1000\nend\n",
+		"literal left": "func f(n: int) -> int\n    return 1 + n\nend\n",
+		"ref":          "func f(r: ref int) -> int\n    return *r + 1\nend\n",
+		"upvalue":      "func f(n: int) -> func() -> int\n    return func() -> int\n        return n + 1\n    end\nend\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := compiledFunction(t, src, "f")
+			if containsOpcodeTree(fn, chunk.OP_GET_LOCAL_ADD_IMM_INT) {
+				t.Fatalf("%s fundiu indevidamente em OP_GET_LOCAL_ADD_IMM_INT", name)
+			}
+		})
+	}
+}
+
+func TestLocalPairFuses(t *testing.T) {
+	fn := compiledFunction(t, "func f(a: int, b: int) -> int\n    let i: int = 0\n    while i < b do\n        i = i + 1\n    end\n    return a + b\nend\n", "f")
+	code := fn.Chunk.(*chunk.Chunk).Code
+	if !containsOpcode(code, chunk.OP_GET_LOCAL_2) {
+		t.Fatalf("a + b / i < b nao fundiram em OP_GET_LOCAL_2")
+	}
+}
+
+func TestLocalPairDoesNotFuseForRefOrGlobal(t *testing.T) {
+	cases := map[string]string{
+		"global":  "let g: int = 1\nfunc f(a: int) -> int\n    return a + g\nend\n",
+		"ref":     "func f(a: int, r: ref int) -> bool\n    return r == null\nend\n",
+		"upvalue": "func f(a: int, b: int) -> func() -> int\n    return func() -> int\n        return a + b\n    end\nend\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := compiledFunction(t, src, "f")
+			if containsOpcodeTree(fn, chunk.OP_GET_LOCAL_2) {
+				t.Fatalf("%s fundiu indevidamente em OP_GET_LOCAL_2", name)
+			}
+		})
+	}
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -179,6 +179,11 @@ type ObjFunction struct {
 	Chunk        interface{}
 	Environment  *GlobalEnvironment
 	RuntimeType  *RuntimeTypeInfo
+	// ParamsUntracked: nenhum parametro pode carregar contador RC (todos sem
+	// `ref` e de tipo int/float/bool/string/bytes — Retain e no-op para eles).
+	// Calculado pelo compilador; autoriza o fast path de OP_CALL_STATIC a
+	// montar o frame sem o laco ownSlot (perf issue #66, item 3).
+	ParamsUntracked bool
 }
 
 type ObjUpvalue struct {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.15.1"
+const Version = "v0.15.2"

--- a/internal/vm/call_protocol_test.go
+++ b/internal/vm/call_protocol_test.go
@@ -75,6 +75,32 @@ test_report([r, base[0]])
 	}
 }
 
+// OP_CLOSURE (e os sites que vinculam um function constant ao ambiente) copiam
+// o ObjFunction campo a campo; se esquecerem ParamsUntracked o fast path de
+// OP_CALL_STATIC nunca e tomado — silenciosamente, sem erro funcional. Este
+// teste pergunta ao proprio valor de closure.
+func TestClosureKeepsParamsUntracked(t *testing.T) {
+	cases := []struct {
+		name, source string
+		want         bool
+	}{
+		{"int param", "func f(n: int) -> int\n    return n\nend\ntest_report(f)\n", true},
+		{"array param", "func f(a: int[]) -> int\n    return 0\nend\ntest_report(f)\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureVMSource(t, tc.source)
+			closure, ok := got.Obj.(*value.ObjClosure)
+			if got.Type != value.VAL_FUNCTION || !ok {
+				t.Fatalf("test_report recebeu %s, esperava closure", got.String())
+			}
+			if closure.Function.ParamsUntracked != tc.want {
+				t.Fatalf("closure.Function.ParamsUntracked = %v, want %v (copia de ObjFunction perdeu o flag?)", closure.Function.ParamsUntracked, tc.want)
+			}
+		})
+	}
+}
+
 // As mensagens de erro do protocolo de chamada nao mudam: overflow de frames
 // (growForCall continua o unico dono da mensagem) e aridade errada pela
 // fronteira dinamica (callValue, caminho lento).

--- a/internal/vm/call_protocol_test.go
+++ b/internal/vm/call_protocol_test.go
@@ -1,0 +1,94 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Os fast paths de OP_RETURN e OP_CALL_STATIC (issue #66, item 3) so podem
+// existir se o resultado for byte a byte o mesmo dos caminhos lentos: retorno
+// com defer, closure com upvalue aberto no retorno, parametro composto por
+// valor (CoW) e recursao continuam corretos.
+func TestCallProtocolFastPathsKeepSemantics(t *testing.T) {
+	src := `
+func fib(n: int) -> int
+    if n <= 1 then
+        return n
+    end
+    return fib(n - 1) + fib(n - 2)
+end
+func withDefer(n: int) -> int
+    let acc: int[] = []
+    defer append(acc, 1)
+    return n + 1
+end
+func makeAdder(base: int) -> func(int) -> int
+    return func(x: int) -> int
+        return base + x
+    end
+end
+func sumArr(a: int[]) -> int
+    let s: int = 0
+    let i: int = 0
+    while i < length(a) do
+        s = s + a[i]
+        i = i + 1
+    end
+    return s
+end
+let arr: int[] = [1, 2, 3]
+let total: int = sumArr(arr)
+append(arr, 4)
+let add5: func(int) -> int = makeAdder(5)
+test_report([fib(20), fib(1), fib(0), withDefer(41), add5(10), total, length(arr)])
+`
+	got := semArray(t, captureVMSource(t, src))
+	want := []int64{6765, 1, 0, 42, 15, 6, 4}
+	if len(got) != len(want) {
+		t.Fatalf("got %d celulas, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Type != value.VAL_INT || got[i].Int() != w {
+			t.Fatalf("celula %d: got %s, want %d", i, got[i].String(), w)
+		}
+	}
+}
+
+// Parametro composto por valor nao passa pelo fast path (ParamsUntracked e
+// false): o frame retem o argumento e a mutacao dentro da funcao clona (CoW),
+// deixando o array do chamador intacto.
+func TestCallWithCompositeParamStillRetains(t *testing.T) {
+	src := `
+func touch(a: int[]) -> int
+    a[0] = 99
+    return a[0]
+end
+let base: int[] = [1, 2]
+let r: int = touch(base)
+test_report([r, base[0]])
+`
+	got := semArray(t, captureVMSource(t, src))
+	if got[0].Int() != 99 || got[1].Int() != 1 {
+		t.Fatalf("got %s/%s, want 99/1 (CoW: base nao muda)", got[0].String(), got[1].String())
+	}
+}
+
+// As mensagens de erro do protocolo de chamada nao mudam: overflow de frames
+// (growForCall continua o unico dono da mensagem) e aridade errada pela
+// fronteira dinamica (callValue, caminho lento).
+func TestCallProtocolErrorsUnchanged(t *testing.T) {
+	cases := []struct{ name, source, want string }{
+		{"deep recursion", "func down(n: int) -> int\n    return down(n + 1)\nend\ndown(0)\n", "stack overflow: call depth exceeds"},
+		{"arity via any", "func f(a: int, b: int) -> int\n    return a + b\nend\nlet g: any = f\ng(1)\n", "expected 2 arguments but got 1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := interpretVMSource(t, New(), tc.source)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want contendo %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1141,6 +1141,42 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			argCount := int(c.Code[ip])
 			ip++
 
+			// Fast path (perf issue #66, item 3): callee e closure com
+			// ParamsUntracked (nenhum parametro pode carregar contador RC —
+			// o laco ownSlot de callPreparedClosure so faria Retain no-op) e
+			// aridade certa. E callPreparedClosure escrito aqui, menos o
+			// laco: a condicao de capacidade e a de ensureCallCapacity (que
+			// custa 80 e nao cabe no orcamento de 20 de run()), com
+			// growForCall continuando o unico dono das mensagens de overflow.
+			// Qualquer outra coisa (aridade errada, native, struct, any,
+			// parametro composto) segue por callValueStatic, mesmas mensagens.
+			if callee := vm.stack[vm.stackTop-argCount-1]; callee.Type == value.VAL_FUNCTION {
+				if closure, ok := callee.Obj.(*value.ObjClosure); ok && closure.Function.ParamsUntracked && argCount == closure.Function.Arity {
+					if vm.frameCount == len(vm.frames) || len(vm.stack)-vm.stackTop < stackReserve {
+						frame.IP = ip
+						if err := vm.growForCall(c, ip); err != nil {
+							return err
+						}
+					}
+					frame.IP = ip
+					callFrame := &vm.frames[vm.frameCount]
+					callFrame.Closure = closure
+					callFrame.IP = 0
+					callFrame.StackBase = vm.stackTop - argCount - 1
+					callFrame.LocalBase = callFrame.StackBase
+					callFrame.Environment = closure.Environment
+					callFrame.Deferred = callFrame.Deferred[:0]
+					callFrame.Owned = callFrame.Owned[:0]
+					vm.frameCount++
+					vm.currentFrame = callFrame
+					frame = callFrame
+					c = closure.Function.Chunk.(*chunk.Chunk)
+					gcache = c.GlobalCache()
+					ip = 0
+					continue
+				}
+			}
+
 			frame.IP = ip // Save current instruction pointer to the frame before call
 
 			if ok, err := vm.callValueStatic(vm.peek(argCount), argCount, c, ip); !ok {

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -221,6 +221,22 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			slotValue := &vm.stack[frame.LocalBase+int(slot)]
 			slotValue.SetInt(slotValue.Int() + int64(delta))
 
+		case chunk.OP_GET_LOCAL_ADD_IMM_INT:
+			// perf issue #66 (item 3): GET_LOCAL + CONSTANT + ADD_INT/SUB_INT
+			// num despacho so; o compilador garante local int e imediato i8.
+			slot := c.Code[ip]
+			imm := int8(c.Code[ip+1])
+			ip += 2
+			vm.push(value.NewInt(vm.stack[frame.LocalBase+int(slot)].Int() + int64(imm)))
+
+		case chunk.OP_GET_LOCAL_2:
+			// perf issue #66 (item 3): dois GET_LOCAL num despacho so.
+			slotA := c.Code[ip]
+			slotB := c.Code[ip+1]
+			ip += 2
+			vm.push(vm.stack[frame.LocalBase+int(slotA)])
+			vm.push(vm.stack[frame.LocalBase+int(slotB)])
+
 		case chunk.OP_TRUE:
 			vm.push(value.NewBool(true))
 		case chunk.OP_FALSE:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1273,6 +1273,24 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			vm.pop()
 
 		case chunk.OP_RETURN:
+			// Fast path (perf issue #66, item 3): frame sem defer, sem vinculo
+			// RC registrado e sem upvalue aberto em lugar nenhum, retornando
+			// para um frame que ainda pertence a este run() — popSimpleFrame
+			// (unwind.go) faz so o teardown terminal, sem a copia dupla de
+			// frameOutcome nem a segunda chamada. Nada de RC: Owned vazio =
+			// nada a soltar; push nao retem. O caso terminal (frameCount-1 <
+			// minFrameCount) e quem devolve terminalResult e fica no caminho
+			// lento.
+			if len(frame.Deferred) == 0 && len(frame.Owned) == 0 && vm.openUpvalues == nil && vm.frameCount-1 >= minFrameCount {
+				result := vm.pop()
+				vm.popSimpleFrame()
+				vm.push(result)
+				frame = vm.currentFrame
+				c = frame.Closure.Function.Chunk.(*chunk.Chunk)
+				gcache = c.GlobalCache()
+				ip = frame.IP
+				continue
+			}
 			result := vm.pop()
 			frame.IP = ip
 			outcome := vm.finishFrame(frameOutcome{Result: result})

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -90,13 +90,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				fn := constant.Obj.(*value.ObjFunction)
 				// Clone so compiler constants remain unbound and reusable.
 				boundFn := &value.ObjFunction{
-					Name:         fn.Name,
-					Arity:        fn.Arity,
-					UpvalueCount: fn.UpvalueCount,
-					Params:       fn.Params,
-					Chunk:        fn.Chunk,
-					Environment:  frame.Environment,
-					RuntimeType:  fn.RuntimeType,
+					Name:            fn.Name,
+					Arity:           fn.Arity,
+					UpvalueCount:    fn.UpvalueCount,
+					Params:          fn.Params,
+					Chunk:           fn.Chunk,
+					Environment:     frame.Environment,
+					RuntimeType:     fn.RuntimeType,
+					ParamsUntracked: fn.ParamsUntracked, // issue #66 item 3: sem isto o fast path de OP_CALL_STATIC nunca dispara
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
 			} else {
@@ -111,13 +112,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			if constant.Type == value.VAL_FUNCTION {
 				fn := constant.Obj.(*value.ObjFunction)
 				boundFn := &value.ObjFunction{
-					Name:         fn.Name,
-					Arity:        fn.Arity,
-					UpvalueCount: fn.UpvalueCount,
-					Params:       fn.Params,
-					Chunk:        fn.Chunk,
-					Environment:  frame.Environment,
-					RuntimeType:  fn.RuntimeType,
+					Name:            fn.Name,
+					Arity:           fn.Arity,
+					UpvalueCount:    fn.UpvalueCount,
+					Params:          fn.Params,
+					Chunk:           fn.Chunk,
+					Environment:     frame.Environment,
+					RuntimeType:     fn.RuntimeType,
+					ParamsUntracked: fn.ParamsUntracked, // issue #66 item 3: sem isto o fast path de OP_CALL_STATIC nunca dispara
 				}
 				vm.push(value.Value{Type: value.VAL_FUNCTION, Obj: boundFn})
 			} else {
@@ -1235,13 +1237,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			fnVal := c.Constants[idx]
 			fn := fnVal.Obj.(*value.ObjFunction)
 			boundFn := &value.ObjFunction{
-				Name:         fn.Name,
-				Arity:        fn.Arity,
-				UpvalueCount: fn.UpvalueCount,
-				Params:       fn.Params,
-				Chunk:        fn.Chunk,
-				Environment:  frame.Environment,
-				RuntimeType:  fn.RuntimeType,
+				Name:            fn.Name,
+				Arity:           fn.Arity,
+				UpvalueCount:    fn.UpvalueCount,
+				Params:          fn.Params,
+				Chunk:           fn.Chunk,
+				Environment:     frame.Environment,
+				RuntimeType:     fn.RuntimeType,
+				ParamsUntracked: fn.ParamsUntracked, // issue #66 item 3: sem isto o fast path de OP_CALL_STATIC nunca dispara
 			}
 
 			closure := &value.ObjClosure{

--- a/internal/vm/unwind.go
+++ b/internal/vm/unwind.go
@@ -11,6 +11,27 @@ func (vm *VM) finishFrame(outcome frameOutcome) frameOutcome {
 	return vm.finalizeCurrentFrame(outcome)
 }
 
+// popSimpleFrame e o caminho RAPIDO de OP_RETURN (perf issue #66, item 3). So
+// e chamado quando o frame corrente nao tem Deferred, nao tem Owned, nao ha
+// upvalue aberto em lugar nenhum e o frame de baixo ainda pertence ao run()
+// corrente — exatamente o subconjunto de finalizeCurrentFrame cujos tres
+// lacos sao vazios ou pulados. Faz o MESMO teardown terminal (zerar slots a
+// partir de StackBase, soltar Closure/Environment, frameCount--, stackTop =
+// StackBase, currentFrame), sem frameOutcome na ida e na volta. Mora aqui, e
+// nao inline no handler, por causa do guard de arquitetura: teardown terminal
+// de frame so existe em unwind.go.
+func (vm *VM) popSimpleFrame() {
+	frame := &vm.frames[vm.frameCount-1]
+	for i := frame.StackBase; i < vm.stackTop; i++ {
+		vm.stack[i] = value.Value{}
+	}
+	frame.Closure = nil
+	frame.Environment = nil
+	vm.frameCount--
+	vm.stackTop = frame.StackBase
+	vm.currentFrame = &vm.frames[vm.frameCount-1]
+}
+
 func (vm *VM) unwindTo(targetFrameCount int, outcome frameOutcome) frameOutcome {
 	for vm.frameCount > targetFrameCount {
 		outcome = vm.finalizeCurrentFrame(outcome)


### PR DESCRIPTION
## Summary

Item 3 da #66 (roadmap pós-fase 2): **protocolo de chamada**. Nenhuma mudança de sintaxe, semântica, saída, mensagem de erro ou contagem RC; dois opcodes novos por append. Bump **v0.15.2**.

Perfil de `fib(34)` no `develop`: `finishFrame`+`finalizeCurrentFrame` **24 %** (cópia dupla de `frameOutcome` + duas chamadas, com laços vazios), `callValueStatic`→`callPreparedClosure`→`ownSlot` **12 %**. Três estágios, um binário cada:

- **s0 — (d) `OP_RETURN` fast path:** frame sem `defer`/`Owned`/upvalue aberto e acima do `minFrameCount` → `popSimpleFrame` (`unwind.go`, onde o guard de arquitetura exige o teardown terminal), sem `frameOutcome`.
- **s1 — (a)+(b) `OP_CALL_STATIC` fast path:** callee closure com `ParamsUntracked` (flag nova no `ObjFunction`, calculada pelo compilador: todo parâmetro sem `ref` e de tipo `int/float/bool/string/bytes`) e aridade certa → frame montado inline, sem o laço `ownSlot`; capacidade conferida à mão, `growForCall` continua dono das mensagens de overflow.
- **s2 — (c) superinstruções** em nível de AST: `OP_GET_LOCAL_ADD_IMM_INT [slot][imm i8]` (`n - 1`) e `OP_GET_LOCAL_2 [a][b]` (`a + b`, `i < n`, inclusive na condição fundida de `while`).

O "(a) literal" da issue (pular o lookup de global do callee) ficou de fora: 1,6 % do perfil de base — mas com o resto cortado virou ~12 % do perfil do head e é o próximo candidato.

**Resultado (v0.15.1 × v0.15.2, mesma máquina, intercalado — só o delta intra-sessão é comparável):**

| bench | v0.15.1 | v0.15.2 | ÷ base | ÷ CPython (antes → agora) |
|---|---|---|---|---|
| cross `fib` (líquido, mín. de 9) | 185,1 ms | **105,4 ms** | **0,57x** | 2,0x → **1,16x** (÷ Lua 4,4x → 2,5x) |
| cross `bubblesort` (líquido) | 117,1 ms | **106,8 ms** | **0,91x** | 1,7x → **1,55x** |
| `BenchmarkNoxyCallOverhead` (mediana de 8) | 73 762 ns/op | **53 076 ns/op** | **−28 %** (meta ≥ −25 %) | |
| `bench_bubblesort` / `bench_spawn_sum` (mediana de 9) | 776,9 / 398,8 | 694,1 / 369,8 | **−10,7 % / −7,3 %** | |
| demais benches | | | ±3 % | |

Por estágio (A/B de 11, 4 binários) em `fib`: retorno **−21 %**, chamada **−7 %**, superinstruções **−18 %** (−40 % de parede, −42 % líquido). Gates CoW verdes (`conway` +1,8 %, `share_mutate` +2,7 %, `typed_call_map` +0,9 %, `call_light` −1,0 %); sentinela `bench_generic_vs_hand` −1,7 % (os dois blocos inline novos em `run()` não pioraram o codegen).

**Achado da rodada:** a primeira medição deu s1 ≈ s0 — `OP_CLOSURE`/`OP_CONSTANT`/`OP_CONSTANT_LONG` copiam o `ObjFunction` e perdiam `ParamsUntracked`; o fast path nunca disparava e nenhum teste funcional pega isso. Fix em 868d435 + `TestClosureKeepsParamsUntracked` (pergunta ao valor da closure).

## Components

- `internal/value/value.go`: `ObjFunction.ParamsUntracked`; `internal/compiler/compiler.go`: `paramsUntracked`, `tryEmitLocalAddImm`, `tryEmitLocalPair` (infix genérico + `tryCompileFusedCondition`).
- `internal/vm/unwind.go`: `popSimpleFrame`; `internal/vm/executor.go`: fast paths em `OP_RETURN` e `OP_CALL_STATIC`, handlers das duas superinstruções, propagação do flag nas três cópias de `ObjFunction`.
- `internal/chunk/chunk.go`: `OP_GET_LOCAL_ADD_IMM_INT`, `OP_GET_LOCAL_2` (append), `String()`, disassembler (`twoSlotInstruction`).
- Testes: `compiler/params_untracked_test.go`, `compiler/superinstr_compile_test.go` (emite / não emite para global, upvalue, ref, float, imm fora de i8, literal à esquerda), `vm/call_protocol_test.go` (e2e fib/defer/closure/CoW, mensagens de erro, flag pelo valor da closure).
- `benchmarks/RESULTS.md` (seção nova), `benchmarks/results/2026-08-22-issue-66-call-protocol-raw.md`, `cross_runtime/results/cross_runtime.md`; spec + plano em `docs/superpowers/`.
- Bump v0.15.2 nos 7 pontos + CHANGELOG.

## Test Plan

- [x] `go test ./...` verde (12 pacotes); `go test -race ./internal/value ./internal/vm` verde
- [x] corpus `run_all_tests_concurrent.nx` 177/177; `compare_examples.ps1` base × head 146 iguais / 0 divergentes
- [x] guards de inline inalterados; guard de arquitetura de teardown (`unwind.go`) verde
- [x] gates CoW ≤ +5 %; sentinela `bench_generic_vs_hand`
- [x] `interleaved_compare.ps1 -Runs 9`, A/B por estágio (4 binários × 11), `run_cross_runtime.ps1 -NoxyBaseline`, `BenchmarkNoxyCallOverhead -count 8`
- [x] opcodes só por append; `OP_CALL`, caminhos lentos, RC e mensagens intocados
- [ ] revisão humana das condições do fast path de `OP_RETURN` (`Deferred`/`Owned`/`openUpvalues`/`minFrameCount`) e de `paramsUntracked`

Refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
