### PR TITLE
chore/version-0.16.0 - Bump v0.16.0: versão de marco (ciclo #66 fechado, sem mudança de código sobre 0.15.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.15.2)
+**Versão**: 1.0 (Noxy VM 0.16.0)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.16.0] - 2026-08-22
+
+Versão de marco: nenhuma mudança de código, sintaxe, semântica, saída ou
+mensagem de erro em relação a 0.15.2 — quem está em 0.15.2 não precisa migrar
+nada. O minor fecha o ciclo de performance pós-fase 2 (issue #66, itens 1–3,
+entregues como 0.15.0–0.15.2: indexação tipada de array, fast path ASCII de
+strings e protocolo de chamada) e marca o quanto a linguagem acumulou desde
+0.7.0: genéricos por monomorfização, `call_result`, `type` e target typing em
+`return`, `let` sem redeclaração, invariante do slot `ref T` com contêineres
+donos dos filhos, os 16 achados do K&R em Noxy, `io` com cursor e campo
+`m.T`, checagem estática de membro de `m.T` e de tipo desconhecido, `range`
+builtin e `sys.version`, REPL com editor de linha em tty POSIX, layout de
+`Value` em 32 B. Cross-runtime ao fim do ciclo (tempo líquido ÷ CPython, cada
+par medido intercalado na própria rodada): `bubblesort` 5,5x → 1,8x (0.15.0),
+`string_ops` 3,1x → 2,4x e `map_churn` 2,3x → 2,0x (0.15.1), `fib` 2,0x →
+1,16x (0.15.2). O detalhe de cada entrega está nas seções abaixo; números em
+`benchmarks/RESULTS.md`.
+
 ## [0.15.2] - 2026-08-22
 
 Protocolo de chamada (issue #66, item 3 do roadmap pós-fase 2). Nenhuma

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.15.2](https://img.shields.io/badge/noxy-0.15.2-blue)](CHANGELOG.md)
+[![noxy 0.16.0](https://img.shields.io/badge/noxy-0.16.0-blue)](CHANGELOG.md)
 
 # Noxy VM 🚀
 
@@ -105,7 +105,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.15.2
+Noxy REPL v0.16.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2104,7 +2104,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.15.2`). It is a module binding, not a
+string `noxy --version` prints (`v0.16.0`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.15.2</span>
+                    <span class="version-badge-tag">v0.16.0</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.15.2
+print(sys.version)           // v0.16.0
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.15.2"
+const Version = "v0.16.0"


### PR DESCRIPTION
## Summary

- Bump **v0.15.2 → v0.16.0** como **versão de marco**: nenhuma mudança de código, sintaxe, semântica, saída ou mensagem de erro em relação a 0.15.2 — quem está em 0.15.2 não precisa migrar nada.
- O minor fecha o ciclo de performance pós-fase 2 (issue #66, itens 1–3, entregues como 0.15.0–0.15.2: indexação tipada de array, fast path ASCII de strings, protocolo de chamada) e marca o acumulado da linguagem desde 0.7.0 (genéricos, `call_result`, `type` + target typing em `return`, `let` sem redeclaração, invariante do slot `ref T` com contêineres donos dos filhos, os 16 achados do K&R, `io` com cursor e campo `m.T`, checagem estática de membro de `m.T` e tipo desconhecido, `range` builtin + `sys.version`, REPL com editor de linha POSIX, `Value` em 32 B).
- Seção nova `## [0.16.0] - 2026-08-22` no topo do CHANGELOG com esse resumo e os números cross-runtime de cada rodada (`bubblesort` 5,5x → 1,8x ÷ CPython em 0.15.0; `string_ops` 3,1x → 2,4x e `map_churn` 2,3x → 2,0x em 0.15.1; `fib` 2,0x → 1,16x em 0.15.2). Seções antigas intocadas (a 0.15.2 já estava mergeada em `develop`/`main`, por isso não foi renomeada).

## Components

- `internal/version/version.go`: `Version = "v0.16.0"` (fonte de `noxy --version` e `sys.version`).
- `CHANGELOG.md`: seção `[0.16.0]` inserida no topo.
- `README.md`: badge da linha 1 (2 ocorrências) e banner `Noxy REPL v0.16.0`.
- `AGENTS.md`: linha "Versão: 1.0 (Noxy VM 0.16.0)".
- `docs/NOXY_LANGUAGE_SPEC.md`: exemplo de `sys.version` na seção System.
- `docs/index.html`: badge do hero (`version-badge-tag`) e `print(sys.version)` do exemplo.

## Test Plan

- [x] `go build ./...` ok
- [x] `go test ./internal/vm -run 'SysVersion|Version'` verde (testes comparam com `version.Version`, sem literal)
- [x] `go run ./cmd/noxy --version` → `Noxy v0.16.0`; `use sys` + `print(sys.version)` → `v0.16.0`
- [x] `git diff --numstat` mínimo (25 ins / 7 del em 6 arquivos) — CRLF preservado, nenhuma ocorrência de `0.15.2` restante fora do CHANGELOG e do plano histórico em `docs/superpowers/plans/`
- [ ] revisão humana do texto da seção `[0.16.0]` (recorte do resumo acumulado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
