### PR TITLE
docs(readme): vende a linguagem pela tese, não pela VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,115 @@
 [![noxy 0.16.0](https://img.shields.io/badge/noxy-0.16.0-blue)](CHANGELOG.md)
 
-# Noxy VM 🚀
+# Noxy
 
-A complete bytecode virtual machine for the **Noxy** programming language, written in Go. [Official Website.](https://noxylang.com/)
-
-For a complete guide, consult the [NOXY_LANGUAGE_SPEC.md](docs/NOXY_LANGUAGE_SPEC.md).
-For real projects built with the language, see the [Showcase](docs/SHOWCASE.md).
+**A statically typed scripting language where values are copies, sharing is
+explicit, and errors are data.**
 
 <p align="center">
 <img width="200" height="200" alt="noxy" src="https://github.com/user-attachments/assets/acfc226e-f129-43ed-97df-25dda7c97fcf" />
 </p>
 
-## What is Noxy VM?
+Most scripting languages make you guess: did that function mutate my list?
+Is this variable a copy or an alias? Can this call throw? Noxy answers all
+three at the type level — and the compiler speaks first.
 
-Noxy VM is a bytecode compiler and virtual machine for the Noxy language created by Estêvão Fonseca. This implementation compiles source code into bytecode and executes it on a stack-based VM, offering high performance.
+```noxy
+struct Cart
+    items: string[]
+end
 
-Noxy is statically typed, with explicit dynamic boundaries through `any`, bare
-`func`, untyped native primitives, and plugins without signatures. Its
-variables are type-stable: the declared type does not change, while values may
-be mutable.
+func add_free_gift(c: Cart) -> Cart      // c is a copy: the caller's cart is safe
+    append(c.items, "gift")
+    return c
+end
+
+func checkout(c: ref Cart) -> void       // ref: the ONLY way to mutate the caller's value
+    append(c.items, "receipt")
+end
+
+let mine: Cart = Cart(["book"])
+let yours: Cart = mine                   // a copy, not an alias
+append(yours.items, "pen")
+
+let promo: Cart = add_free_gift(mine)    // mine untouched
+checkout(mine)                           // mine changes — and the signature says so
+
+print(mine.items)    // [book, receipt]
+print(yours.items)   // [book, pen]
+print(promo.items)   // [book, gift]
+```
+
+No hidden aliasing, no defensive `.copy()`, no action at a distance. Copies
+are cheap: composites are copy-on-write, so a "copy" costs nothing until
+someone actually writes to it.
+
+[Language spec](docs/NOXY_LANGUAGE_SPEC.md) ·
+[Showcase](docs/SHOWCASE.md) ·
+[Website](https://noxylang.com/)
+
+## Three rules
+
+**1. Variables are values.** Assigning, passing, or returning a struct, array
+or map gives you an independent value — at any depth. `ref` is the single,
+visible mechanism for sharing, and it is part of the type.
+
+```noxy
+func push(xs: int[])       // cannot touch the caller's array
+func push(xs: ref int[])   // can — and the signature says so
+```
+
+**2. Errors are values, not exceptions.** A failure that indicates a bug
+raises and stops the program. A failure that is *expected* — bad input, wire
+data — is data you branch on. Nothing flies past you silently.
+
+```noxy
+use errors select *
+
+let r: CallResult = call_result(to_int, input)
+if r.ok then
+    print(r.value)
+else
+    print("bad input: " + r.failure.message)
+end
+```
+
+**3. Dynamic is explicit.** Static typing everywhere; when you need a dynamic
+hole — `any`, a bare `func`, a plugin — you write it down. Generics are
+monomorphized at compile time and always inferred, so the type system costs
+nothing at runtime.
+
+```noxy
+let n: int = 42
+n = "text"                    // compile error: expected int, got string
+
+let loose: any = 42           // the dynamic hole is spelled out...
+loose = "now a string"        // ...and only there does the type move
+
+func first<T>(arr: T[]) -> T
+    return arr[0]
+end
+print(first([3, 1, 2]))       // first<int>, resolved at compile time
+print(first(["b", "a"]))      // first<string> — no runtime dispatch
+```
+
+## What this buys you
+
+- **Concurrency without data races by construction** — data handed to a
+  routine by argument or channel is an independent value. Only `ref` and
+  globals need coordination, and both are visible in the code.
+  ([docs/CONCURRENCY.md](docs/CONCURRENCY.md))
+- **Refactoring you can trust** — a function's signature tells you exactly
+  what it can mutate and how it can fail.
+- **One rule, everywhere** — file, module, and REPL behave the same.
+
+Noxy compiles to bytecode and runs on a stack-based VM written in Go. The
+core is deliberately small — structs, arrays, maps, closures, generics,
+routines and channels, `defer` — and the standard library covers the usual
+scripting ground (io, net, http, sqlite, json, strings, crypto, time) plus a
+[package manager](docs/PACKAGE_MANAGER.md). Performance today sits around
+CPython for call-heavy code and is
+[measured against every release](benchmarks/RESULTS.md) — without changing
+semantics.
 
 ### The Zen of Noxy
 
@@ -43,27 +134,26 @@ Fixing beats staying compatible, until 1.0 says otherwise.
 
 ### Features
 
-- ✅ Bytecode compiler
-- ✅ High-performance stack-based VM
-- ✅ Primitive types: `int`, `float`, `string`, `bool`, `bytes`
-- ✅ Structs with typed fields (global and local scope)
-- ✅ Dynamic arrays with `append`, `pop`, `contains`
-- ✅ Maps (hashmaps) with literals `{key: value}`
-- ✅ Functions with recursion
-- ✅ Reference system (`ref`)
-- ✅ F-strings with interpolation
-- ✅ Single and double quote support
-- ✅ Line tracking for debugging
-- ✅ SQLite database support (Thread-safe)
-- ✅ HTTP server support
-- ✅ Value semantics with copy-on-write (composites are independent values; `ref` is the only sharing mechanism)
-- ✅ First-class functions
-- ✅ Closures
-- ✅ Generics with zero runtime cost (monomorphization: `func first<T>(arr: T[]) -> T`, `struct Stack<T>`, always inferred from usage)
-- ✅ Concurrency (noxy routines) [docs/CONCURRENCY.md](docs/CONCURRENCY.md)
-- ✅ Garbage collection
-- ✅ Built-in modules (io, net, http, sqlite)
-- ✅ Package manager (see [docs/PACKAGE_MANAGER.md](docs/PACKAGE_MANAGER.md))
+**Language**
+
+- Primitive types `int`, `float`, `string`, `bool`, `bytes`; structs with typed fields
+- Dynamic arrays and maps with literals (`[1, 2]`, `{key: value}`)
+- Value semantics with copy-on-write; `ref` as the only sharing mechanism
+- First-class functions, closures, recursion
+- Generics with zero runtime cost (monomorphization, always inferred from usage)
+- F-strings, `defer`, `call_result` error boundary
+- Concurrency: routines, channels, supervised tasks ([docs/CONCURRENCY.md](docs/CONCURRENCY.md))
+
+**Runtime**
+
+- Bytecode compiler and stack-based VM with garbage collection
+- REPL with the same rules as files and modules
+- Diagnostics to stderr with line tracking and hints
+
+**Ecosystem**
+
+- Built-in modules: io, net, http, sqlite (thread-safe), json, strings, crypto, time, errors
+- Package manager ([docs/PACKAGE_MANAGER.md](docs/PACKAGE_MANAGER.md))
 
 ## Installation
 
@@ -341,10 +431,11 @@ The compiler generates bytecode that can be visualized:
 
 ## Performance
 
-The bytecode VM offers high performance, especially for:
-- Intensive loops
-- Recursive function calls
-- Operations with large arrays
+Measured, not promised: every release is benchmarked against the previous
+one and against CPython, Lua and Go on the same machine, with an interleaved
+protocol — see [benchmarks/RESULTS.md](benchmarks/RESULTS.md). As of 0.16.0,
+call-heavy code (`fib`) runs at about 1.2x CPython and arithmetic loops at
+about 1.06x; performance work never changes language semantics.
 
 ## License
 
@@ -352,4 +443,4 @@ MIT License
 
 ---
 
-*Bytecode implementation of the Noxy language in Go.*
+*Noxy — values are copies, sharing is `ref`, errors are data. Implemented in Go.*

--- a/README.md
+++ b/README.md
@@ -134,26 +134,27 @@ Fixing beats staying compatible, until 1.0 says otherwise.
 
 ### Features
 
-**Language**
-
-- Primitive types `int`, `float`, `string`, `bool`, `bytes`; structs with typed fields
-- Dynamic arrays and maps with literals (`[1, 2]`, `{key: value}`)
-- Value semantics with copy-on-write; `ref` as the only sharing mechanism
-- First-class functions, closures, recursion
-- Generics with zero runtime cost (monomorphization, always inferred from usage)
-- F-strings, `defer`, `call_result` error boundary
-- Concurrency: routines, channels, supervised tasks ([docs/CONCURRENCY.md](docs/CONCURRENCY.md))
-
-**Runtime**
-
-- Bytecode compiler and stack-based VM with garbage collection
-- REPL with the same rules as files and modules
-- Diagnostics to stderr with line tracking and hints
-
-**Ecosystem**
-
-- Built-in modules: io, net, http, sqlite (thread-safe), json, strings, crypto, time, errors
-- Package manager ([docs/PACKAGE_MANAGER.md](docs/PACKAGE_MANAGER.md))
+- ✅ Bytecode compiler
+- ✅ High-performance stack-based VM
+- ✅ Primitive types: `int`, `float`, `string`, `bool`, `bytes`
+- ✅ Structs with typed fields (global and local scope)
+- ✅ Dynamic arrays with `append`, `pop`, `contains`
+- ✅ Maps (hashmaps) with literals `{key: value}`
+- ✅ Functions with recursion
+- ✅ Reference system (`ref`)
+- ✅ F-strings with interpolation
+- ✅ Single and double quote support
+- ✅ Line tracking for debugging
+- ✅ SQLite database support (Thread-safe)
+- ✅ HTTP server support
+- ✅ Value semantics with copy-on-write (composites are independent values; `ref` is the only sharing mechanism)
+- ✅ First-class functions
+- ✅ Closures
+- ✅ Generics with zero runtime cost (monomorphization: `func first<T>(arr: T[]) -> T`, `struct Stack<T>`, always inferred from usage)
+- ✅ Concurrency (noxy routines) [docs/CONCURRENCY.md](docs/CONCURRENCY.md)
+- ✅ Garbage collection
+- ✅ Built-in modules (io, net, http, sqlite)
+- ✅ Package manager (see [docs/PACKAGE_MANAGER.md](docs/PACKAGE_MANAGER.md))
 
 ## Installation
 


### PR DESCRIPTION
## O quê

Reescreve o topo do `README.md` para apresentar a **linguagem** pela sua tese, em vez de apresentar a **VM** por uma lista de features.

- Título passa de "Noxy VM" para "Noxy"; tagline: *values are copies, sharing is explicit, errors are data*.
- Exemplo de abertura mostra semântica de valor, `ref` na assinatura e `call_result` — em vez de hello world.
- Novas seções **Three rules** (valor / erro como dado / dinâmico explícito, cada uma com trecho de código) e **What this buys you** (concorrência sem race por construção, refactor confiável, uma regra em todo lugar).
- Zen of Noxy e Features ficam *depois* do exemplo de abertura; a lista de Features é a original, intacta (com ✅).
- Seção **Performance** troca "high performance" por números medidos (~1,2x CPython em `fib`, ~1,06x em loop aritmético) com link para `benchmarks/RESULTS.md`.
- O restante (Installation, REPL, Architecture, Data Types, Opcodes…) inalterado.

## Por quê

A linguagem tem uma tese forte (CoW + `ref` único + erro como valor) e o README atual a apresenta como "mais uma linguagem com structs, maps e goroutines". A primeira tela deve responder *por que isto existe*, não *o que isto tem*.

## Verificação

Todos os trechos novos foram executados no `noxy.exe` 0.16.0 e produzem a saída comentada. Uma versão inicial usava `let loose: any = first` (genérico para `any`), que a spec §6.3 proíbe — o compilador rejeitou e o exemplo foi trocado.

## Observação

Ao testar o exemplo de `call_result`, a mensagem capturada de um native vem com prefixo `[?:line 0]` (`[?:line 0] native 'to_int' failed: ...`). Não mexi nisso aqui, mas como é a primeira coisa que um leitor verá sair do modelo de erros, vale uma issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)