### PR TITLE
feat/let-type-inference - Inferência local de tipo em `let x = expr` (issue #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ Noxy é **estaticamente tipada** - nunca quebre a verificação de tipos:
 let x: int = 42
 x = 100       // ✓ OK
 x = 3.14      // ✗ ERRO
+let y = 42    // tipo inferido do RHS (int) — igualmente estável (spec §3, issue #41)
+y = "a"       // ✗ ERRO
 ```
 
 ### 2. Pipeline de Compilação

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Inferência local de tipo em `let`** (issue #41): `let x = expr` sem
+  anotação é aceito, com o tipo declarado **inferido do tipo estático do
+  lado direito** — a variável continua type-stable (`let x = 10` seguido de
+  `x = "a"` é erro de compilação), exatamente como se o tipo tivesse sido
+  escrito. Inferência unidirecional (RHS → binding) e só em `let`: nada de
+  Hindley-Milner, parâmetros, retornos e campos de struct continuam
+  anotados. Superset puro — todo código anotado segue válido e idêntico.
+  - O tipo inferido é o do binding, não o do literal: `[1, 2, 3]` infere
+    `int[]` (dinâmico), não `int[3]`; `ref n` infere `ref int` (empréstimo,
+    como com anotação); chamada genérica infere a instância primeiro
+    (`let y = id(5)` → `int`).
+  - Continuam exigindo anotação, com erro `cannot infer type for 'x' from
+    its initializer: ...` + hint da forma anotada: literal vazio (`[]`, `{}`,
+    também aninhado), `null`, expressão de tipo `any` no topo (fronteira
+    dinâmica explícita; `any` aninhado como `map[string, any]` é inferido
+    fielmente) e nome cujo tipo ainda não é conhecido (`let a = b` com `b`
+    declarado depois).
+  - `let x` sem tipo nem valor vira `SyntaxError: missing type annotation or
+    initializer for 'x'` (hint: `let x: <type>` ou `let x = <value>`);
+    `let x int = 1` mantém o `expected ':'` genérico.
+  - Globais de topo inferidos entram na pré-declaração (corpo de função
+    declarado antes do `let` já enxerga o tipo certo), módulos exportam o
+    tipo inferido e o REPL infere linha a linha.
+  - Spec §3 (nova subseção *Local type inference*) e §6.2, README, exemplo
+    `noxy_examples/let_inference.nx` no runner; `test_let_error.nx` passa a
+    demonstrar o `let x` nu.
+
 ## [0.16.0] - 2026-08-22
 
 Versão de marco: nenhuma mudança de código, sintaxe, semântica, saída ou

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@
   - `let x` sem tipo nem valor vira `SyntaxError: missing type annotation or
     initializer for 'x'` (hint: `let x: <type>` ou `let x = <value>`);
     `let x int = 1` mantém o `expected ':'` genérico.
+  - **Builtins centrais com tipo de retorno estático** (`length`, `to_str`,
+    `to_int`, `to_float`, `to_bytes`, `type`, `input`, `fmt`, `hex`,
+    `hex_encode`, `hex_decode`, `ord`, `contains`, `has_key`, `json_dumps`,
+    `keys(map[K, V]) -> K[]`, `slice`): antes compilavam como global
+    desconhecido (tipo nil, só o runtime conferia); agora `let n =
+    length(xs)` infere `int` e a checagem vale em toda posição — `let s:
+    string = length(xs)` passa a ser erro de compilação, não de runtime.
+    `func length(...)` declarado pelo programa continua sombreando o
+    builtin. Membro de namespace (`m.x`, `m.f()`) e builtins de fronteira
+    dinâmica (`json_parse`, `task_await`, ...) continuam sem tipo estático:
+    `let` sobre eles pede anotação (ou `use m select f`).
+  - Consequência: `~` em `bytes` passa no checador estático (`operand of
+    '~' must be int or bytes, got bool`) — a VM sempre aceitou (`~` inverte
+    cada byte, `test_bytes_full.nx`), mas nenhum valor de tipo estático
+    `bytes` chegava ao check antes de `hex_decode`/`to_bytes` terem tipo.
+    Spec §8 corrigida.
   - Globais de topo inferidos entram na pré-declaração (corpo de função
     declarado antes do `let` já enxerga o tipo certo), módulos exportam o
     tipo inferido e o REPL infere linha a linha.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ nothing at runtime.
 let n: int = 42
 n = "text"                    // compile error: expected int, got string
 
+let m = 42                    // same thing, type inferred from the value: m is int
+m = "text"                    // compile error — inference is local, not dynamic
+
 let loose: any = 42           // the dynamic hole is spelled out...
 loose = "now a string"        // ...and only there does the type move
 
@@ -137,6 +140,7 @@ Fixing beats staying compatible, until 1.0 says otherwise.
 - ✅ Bytecode compiler
 - ✅ High-performance stack-based VM
 - ✅ Primitive types: `int`, `float`, `string`, `bool`, `bytes`
+- ✅ Local type inference in `let` (`let x = 10` binds `x: int`; annotations stay mandatory in signatures and struct fields)
 - ✅ Structs with typed fields (global and local scope)
 - ✅ Dynamic arrays with `append`, `pop`, `contains`
 - ✅ Maps (hashmaps) with literals `{key: value}`
@@ -323,6 +327,11 @@ let pi: float = 3.14159
 let name: string = "Noxy"
 let active: bool = true
 let data: bytes = b"hello"
+
+// The annotation can be omitted when the initializer has a single static
+// type — the variable is still type-stable (x is int, for good):
+let total = x + 8          // total: int
+let label = "v" + name     // label: string
 ```
 
 ### Dynamic Arrays

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -509,9 +509,51 @@ end
 
 ```noxy
 let name: type = value
+let name = value          // type inferred from the initializer
 ```
 
 Variables can be reassigned, but the new value **MUST** be of the same type as declared.
+
+### Local type inference
+
+When the annotation is omitted, the variable's declared type is the **static
+type of the initializer**, fixed at the declaration exactly as if it had been
+written. Inference is local and one-directional — from the right-hand side to
+the binding, only in `let` — and it does not make the variable dynamic: the
+type-stability rules of §2.0 apply unchanged.
+
+```noxy
+let n = 42                 // n: int
+let name = "Noxy"          // name: string
+let xs = [1, 2, 3]         // xs: int[]   (a dynamic array, not int[3])
+let m = {"a": 1}           // m: map[string, int]
+let p = Point(1, 2)        // p: Point
+let r = ref n              // r: ref int (a borrow, like `let r: ref int = ref n`)
+let y = id(5)              // y: int — the generic instance is inferred first (§6.2)
+
+n = "text"                 // ERROR: type mismatch — n is int
+```
+
+Annotations stay mandatory where they are contract documentation — function
+parameters and return types, struct fields — and where the initializer does
+not have a single type of its own. Each of these is a compile-time error
+(`cannot infer type for 'x' from its initializer: ...`) with a hint showing the
+annotated form:
+
+| Initializer | Why | Write instead |
+|-------------|-----|---------------|
+| `[]`, `{}` (also nested: `[[]]`, `{"a": []}`) | empty literal, no element/key/value type | `let xs: int[] = []`, `let m: map[string, int] = {}` |
+| `null` (also `[null]`) | `null` is a value of the nullable types, not a type | `let p: Point = null` |
+| a call to a `void` function | there is no value to bind | return a value, or annotate |
+| an expression of type `any` | the dynamic boundary must be spelled out (`any` *nested* in a type, such as `map[string, any]`, is an ordinary type and is inferred faithfully) | `let v: any = parse(s)` |
+| a name whose type is not known yet (`let a = b` with `b` declared later) | no static type at that point | annotate, or reorder |
+
+`let x` with neither annotation nor initializer is a syntax error (there is
+nothing to infer); `let x: T` without an initializer keeps the default-value
+rule below. Inferred declarations are ordinary declarations in every other
+respect: a top-level `let x = 10` is visible, typed `int`, to every function in
+the file (including ones declared before it), is exported by the module with
+that type, and the REPL infers line by line (`>>> let x = 10`).
 
 ### Declaration without an initializer
 
@@ -863,9 +905,11 @@ push(ref ints, 20)
 print(peek(ints)) // 20
 ```
 
-This works because every `let` in Noxy already requires a type annotation —
-the language already forces the caller to write the information inference
-needs.
+This is the one place where an annotated `let` carries information the
+arguments do not: with an inferred `let` (§3, `let ints = Stack([])`) there
+is nothing to unify `T` against, and the call is rejected with the usual
+"could not infer T — annotate the type" error. Once the arguments pin `T`
+(`let ints = Stack([1, 2])`), the inferred `let` works like any other.
 
 The declared return type of the enclosing function is the same kind of
 anchor: a generic call in `return` position unifies its return type against

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -546,7 +546,21 @@ annotated form:
 | `null` (also `[null]`) | `null` is a value of the nullable types, not a type | `let p: Point = null` |
 | a call to a `void` function | there is no value to bind | return a value, or annotate |
 | an expression of type `any` | the dynamic boundary must be spelled out (`any` *nested* in a type, such as `map[string, any]`, is an ordinary type and is inferred faithfully) | `let v: any = parse(s)` |
-| a name whose type is not known yet (`let a = b` with `b` declared later) | no static type at that point | annotate, or reorder |
+| a name whose type is not known yet (`let a = b` with `b` declared later; also a later un-annotated global read inside the body of a generic function that a top-level `let y = id(...)` instantiates) | no static type at that point — top-level inferred `let`s are typed in file order | annotate, or reorder |
+| a namespace member — `m.x`, `m.f(...)` after `use m` | member access through a namespace carries no static type today | `use m select f` (imported names keep their declared type), or annotate |
+| a builtin outside the typed core set (§10) — `json_parse`, `task_await`, `make_chan`, ... | its result is `any` or has no static type | annotate (`let v: any = json_parse(s)`) |
+
+The core builtins whose result type never varies — `length`, `to_str`,
+`to_int`, `to_float`, `to_bytes`, `type`, `input`, `fmt`, `hex`,
+`hex_encode`, `hex_decode`, `ord`, `contains`, `has_key`, `json_dumps`,
+plus `keys(map[K, V]) -> K[]` and `slice` (same type as its first argument)
+— have a static return type (§10), so `let n = length(xs)` binds `n: int`.
+That type is checked in every position, not only in `let`: `let s: string =
+length(xs)` is a compile-time error.
+
+A `ref` initializer binds a **borrow**, exactly as the annotated form does:
+`let v = r` with `r: ref T` gives `v: ref T` (the same slot, no copy). To copy
+the value out of a reference, annotate — `let v: T = r` auto-dereferences.
 
 `let x` with neither annotation nor initializer is a syntax error (there is
 nothing to infer); `let x: T` without an initializer keeps the default-value
@@ -1699,10 +1713,10 @@ boolean operands, got int and bool`); an `any` operand is checked at runtime.
 
 The bitwise operators are strictly bitwise: they are never a substitute for
 `&&`/`||`. `&`, `|` and `^` accept two `int` or two `bytes` of the same length;
-`<<` and `>>` accept `int` only; `~` accepts `int` only. Wrong static types are
-compile-time errors with the same text as the runtime check
-(`[line N] operands for & must be integers or bytes, got int and bool`,
-`operand of '~' must be int, got bool`).
+`<<` and `>>` accept `int` only; `~` accepts `int` or `bytes` (every byte is
+inverted). Wrong static types are compile-time errors with the same text as
+the runtime check (`[line N] operands for & must be integers or bytes, got int
+and bool`, `operand of '~' must be int or bytes, got bool`).
 
 Unary `*` is the dereference operator and applies only to a `ref`. With a known
 non-`ref` static type it is a compile-time error, so `2 ** 3` (there is no
@@ -1815,8 +1829,19 @@ Validar antes de converter não é uma alternativa correta: `is_digit` aceita
 `"9999999999999999999"`, que estoura `int64`, e não há como checar o intervalo
 sem converter. Não existe `is_float`.
 
+The core builtins have static return types where the result never varies —
+`length`, `to_str`, `to_int`, `to_float`, `to_bytes`, `type`, `input`, `fmt`,
+`hex`, `hex_encode`, `hex_decode`, `ord`, `contains`, `has_key`, `json_dumps`,
+`keys(map[K, V]) -> K[]`, `slice` (same type as its first argument) — so a
+value of theirs is checked like any other expression (`let s: string =
+length(xs)` is a compile error) and can initialize an inferred `let` (§3).
+The others (`json_parse`, `task_await`, `call_result`, `make_chan`, ...) are
+dynamic-boundary builtins: their result is `any` or untyped and needs an
+annotation. A function the program declares with a builtin's name shadows the
+builtin, static type included.
+
 ### Collections
-- `length(arr_or_map)`
+- `length(arr_or_map) -> int`
 - `append(arr, val)`
 - `pop(arr)`
 - `keys(map)`: Returns array of keys.

--- a/internal/compiler/builtin_return_types.go
+++ b/internal/compiler/builtin_return_types.go
@@ -1,0 +1,71 @@
+package compiler
+
+import "noxy-vm/internal/ast"
+
+// Tipo de retorno estatico dos builtins CENTRAIS (os que existem sem `use`:
+// registrados pela VM em defineNatives, sem wrapper tipado na stdlib). Ate a
+// issue #41 eles compilavam como global desconhecido — tipo nil, que o
+// checador aceita em qualquer posicao e so o runtime confere. A inferencia
+// de `let` (`let n = length(xs)`) precisa do tipo estatico, e a checagem
+// ganha junto em toda posicao: `let s: string = length(xs)` passa a ser erro
+// de compilacao, nao de runtime.
+//
+// So entram aqui builtins cujo tipo de retorno NAO depende dos argumentos
+// (ou depende de forma trivial, como keys/slice, tratados em
+// builtinReturnType). Os que devolvem `any` (json_parse, task_await...) ou
+// estruturas da stdlib ficam de fora: continuam nil, e um `let` sem
+// anotacao sobre eles pede a anotacao.
+//
+// Um `func length(...)` declarado pelo programa sombreia o builtin (spec
+// §10, regra do `range`): o chamador so consulta esta tabela quando o nome
+// NAO resolve para local, upvalue ou global declarado.
+var coreBuiltinReturnTypes = map[string]string{
+	"length":     "int",
+	"to_str":     "string",
+	"to_int":     "int",
+	"to_float":   "float",
+	"to_bytes":   "bytes",
+	"type":       "string",
+	"input":      "string",
+	"fmt":        "string",
+	"hex":        "string",
+	"hex_encode": "string",
+	"hex_decode": "bytes",
+	"ord":        "int",
+	"contains":   "bool",
+	"has_key":    "bool",
+	"json_dumps": "string",
+}
+
+// builtinReturnType devolve o tipo estatico de `name(args...)` para um
+// builtin central, ou nil quando o nome nao e um builtin tipado aqui (ou o
+// tipo depende de um argumento cujo tipo estatico nao se conhece).
+func builtinReturnType(name string, argTypes []ast.NoxyType) ast.NoxyType {
+	if primitive, ok := coreBuiltinReturnTypes[name]; ok {
+		return &ast.PrimitiveType{Name: primitive}
+	}
+	switch name {
+	case "keys":
+		// keys(map[K, V]) -> K[]
+		if len(argTypes) == 1 {
+			if mapType, ok := argTypes[0].(*ast.MapType); ok && mapType.KeyType != nil {
+				return &ast.ArrayType{ElementType: mapType.KeyType}
+			}
+		}
+	case "slice":
+		// slice(T[], ...) -> T[]; slice(string, ...) -> string
+		if len(argTypes) >= 1 {
+			switch typed := argTypes[0].(type) {
+			case *ast.ArrayType:
+				if typed.ElementType != nil {
+					return &ast.ArrayType{ElementType: typed.ElementType}
+				}
+			case *ast.PrimitiveType:
+				if typed.Name == "string" {
+					return typed
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -388,6 +388,18 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				return nil, nil, err
 			}
 			valType = t
+			// Inferencia local (issue #41, spec §3): sem anotacao, o tipo
+			// estatico do RHS vira o tipo declarado — gravado in-place, entao
+			// daqui em diante o caminho e o mesmo de um `let` anotado
+			// (globais de topo ja chegam aqui inferidos por
+			// inferGlobalLetTypes; este ramo cobre os locais e e idempotente).
+			if n.Type == nil {
+				inferred, err := inferLetType(n.Name.Value, valType, n.Token.Line)
+				if err != nil {
+					return nil, nil, err
+				}
+				n.Type = inferred
+			}
 		} else {
 			// Default value — so para tipos que TEM um (issue #61 item 1):
 			// chan e func nao tem, e o null que saia daqui era o unico

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1499,8 +1499,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			c.emitByte(byte(chunk.OP_NOT))
 			return c.currentChunk, &ast.PrimitiveType{Name: "bool"}, nil
 		} else if n.Operator == "~" {
-			if rightType != nil && !isAny(rightType) && rightType.String() != "int" {
-				return nil, nil, fmt.Errorf("[line %d] operand of '~' must be int, got %s", c.currentLine, rightType.String())
+			// A VM aceita int e bytes em OP_BIT_NOT (inverte cada byte);
+			// o checador tem de aceitar os mesmos dois.
+			if rightType != nil && !isAny(rightType) && rightType.String() != "int" && rightType.String() != "bytes" {
+				return nil, nil, fmt.Errorf("[line %d] operand of '~' must be int or bytes, got %s", c.currentLine, rightType.String())
 			}
 			c.emitByte(byte(chunk.OP_BIT_NOT))
 			return c.currentChunk, rightType, nil
@@ -2443,6 +2445,9 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 	// OP_CALL_STATIC; nesse caso caímos para OP_CALL, que ainda roda
 	// validateParameterModes em tempo de execução.
 	modesProven := isExact
+	// Tipos dos argumentos, para o tipo de retorno dos builtins centrais
+	// cujo retorno depende do argumento (keys, slice — builtin_return_types.go).
+	argTypes := make([]ast.NoxyType, 0, len(call.Arguments))
 	for i, arg := range call.Arguments {
 		if isExact {
 			if expectedRef, ok := funcType.Params[i].(*ast.RefType); ok {
@@ -2497,6 +2502,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 			c.emitByte(byte(chunk.OP_DEREF))
 			argType = ref.ElementType
 		}
+		argTypes = append(argTypes, argType)
 		if isExact {
 			if _, stillRef := argType.(*ast.RefType); stillRef {
 				if _, expectedIsRef := funcType.Params[i].(*ast.RefType); !expectedIsRef {
@@ -2523,6 +2529,14 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 		return c.currentChunk, funcType.Return, nil
 	}
 	if fnType == nil {
+		// Builtin central (length, to_str, type...): nao e global declarado
+		// nem local/upvalue — e o nome que a VM resolve em runtime. O tipo de
+		// retorno estatico vem da tabela (issue #41); nil para os demais.
+		if ident, ok := call.Function.(*ast.Identifier); ok && !c.isShadowedByLocal(ident.Value) {
+			if _, declared := c.globals[ident.Value]; !declared {
+				return c.currentChunk, builtinReturnType(ident.Value, argTypes), nil
+			}
+		}
 		return c.currentChunk, nil, nil
 	}
 	return c.currentChunk, &ast.PrimitiveType{Name: "any"}, nil

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -66,11 +66,20 @@ func TestAssignmentTypeErrorReportsAssignmentLine(t *testing.T) {
 	}
 }
 
+// `~` aceita bytes alem de int (a VM sempre aceitou: OP_BIT_NOT inverte cada
+// byte); o checador estatico so rejeitava porque nenhum valor de tipo
+// estatico bytes chegava nele — hex_decode/to_bytes ganharam tipo na #41.
+func TestBitNotAcceptsBytesStatically(t *testing.T) {
+	if _, _, err := New().Compile(parse("let b: bytes = hex_decode(\"00ff\")\nlet n: bytes = ~b\nlet m: bytes = ~hex_decode(\"00\")\n")); err != nil {
+		t.Fatalf("~ em bytes deveria compilar: %v", err)
+	}
+}
+
 func TestStaticOperandChecksForUnaryAndBitwise(t *testing.T) {
 	cases := []struct{ source, want string }{
 		{"print(2 ** 3)\n", "cannot dereference non-reference value of type int"},
 		{"print(!0)\n", "operand of '!' must be bool, got int"},
-		{"print(~true)\n", "operand of '~' must be int, got bool"},
+		{"print(~true)\n", "operand of '~' must be int or bytes, got bool"},
 		{"print(1 & 3 == 1)\n", "operands for & must be integers or bytes, got int and bool"},
 		{"print(\"a\" << 1)\n", "operands for << must be integers, got string and int"},
 	}

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -332,7 +332,10 @@ func (c *Compiler) predeclareGlobalBindings(statements []ast.Statement) error {
 			c.globals[declaration.Name] = newStructFunctionType(declaration.Name, params)
 		}
 	}
-	return nil
+	// Segunda varredura: `let` de topo SEM anotacao (issue #41) — infere o
+	// tipo do RHS agora que funcoes, structs e lets anotados ja estao em
+	// c.globals (ver let_inference.go).
+	return c.inferGlobalLetTypes(statements)
 }
 
 func newStructFunctionType(name string, params []ast.NoxyType) *ast.FunctionType {

--- a/internal/compiler/generics.go
+++ b/internal/compiler/generics.go
@@ -668,9 +668,12 @@ func (c *Compiler) compileInstanceBody(instance *ast.FunctionStatement) error {
 // compilada FORA DE ORDEM (antes do callee) e o caminho normal a compila de
 // novo logo depois.
 //
-// Como isso so roda no pass 1, cujo bytecode inteiro e descartado, eventuais
-// efeitos colaterais no compilador (constantes orfas, upvalues abertos duas
-// vezes — addUpvalue deduplica) nao alcancam o bytecode final do pass 2.
+// Nasceu para o pass 1 (bytecode inteiro descartado); desde a inferencia de
+// `let` (issue #41, inferGlobalLetTypes) roda tambem no compilador real, em
+// qualquer passe. O invariante que sustenta os dois usos: a emissao vai
+// INTEIRA para o chunk descartavel (constantes inclusive), addUpvalue
+// deduplica, c.warn deduplica — nenhum efeito colateral alcanca o bytecode
+// final (guardado por TestInferredLetEmitsSameBytecodeAsAnnotated).
 func (c *Compiler) typeOfDiscardedExpression(expr ast.Expression) (ast.NoxyType, error) {
 	savedChunk := c.currentChunk
 	savedLine := c.currentLine

--- a/internal/compiler/let_inference.go
+++ b/internal/compiler/let_inference.go
@@ -1,0 +1,150 @@
+package compiler
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// Inferencia local de tipo em `let` (issue #41, spec §3): `let x = expr` sem
+// anotacao binda o tipo ESTATICO do RHS, como se ele tivesse sido escrito. A
+// inferencia e unidirecional (RHS -> binding) e so acontece em `let` — nada
+// de Hindley-Milner, parametros ou retornos continuam anotados.
+//
+// O tipo inferido e gravado in-place em LetStmt.Type (mesmo mecanismo das
+// anotacoes resolvidas de genericos), entao TODO o resto do caminho — checagem
+// de type-stability, RC/borrow de `ref T`, registro de globais, exports de
+// modulo — e identico ao de um `let` anotado.
+
+// inferLetType valida o tipo estatico do inicializador de `let name` e
+// devolve o tipo a bindar. Recusa, com hint, o que nao tem tipo unico:
+// literal vazio (`[]`, `{}`), `null`, tipo desconhecido (global ainda nao
+// declarado) e `any` no TOPO — fronteira dinamica, que a spec quer explicita
+// na anotacao. `any` aninhado (`map[string, any]`) e um tipo declaravel comum
+// e e inferido fielmente.
+func inferLetType(name string, valType ast.NoxyType, line int) (ast.NoxyType, error) {
+	fail := func(reason, hint string) error {
+		return fmt.Errorf("[line %d] cannot infer type for '%s' from its initializer: %s\n  hint: use 'let %s: %s'",
+			line, name, reason, name, hint)
+	}
+	if valType == nil {
+		return nil, fail("its type is not known here", "<type> = ...")
+	}
+	if isNullType(valType) {
+		return nil, fail("'null' has no type of its own", "<type> = null")
+	}
+	if valType.String() == "void" {
+		return nil, fail("the initializer does not return a value (void)", "<type> = ...")
+	}
+	if isAny(valType) {
+		return nil, fail("the initializer's type is 'any'", "any = ...")
+	}
+	switch typed := valType.(type) {
+	case *ast.ArrayType:
+		if typed.ElementType == nil {
+			return nil, fail("an empty array literal has no element type", "<type>[] = []")
+		}
+	case *ast.MapType:
+		if typed.KeyType == nil || typed.ValueType == nil {
+			return nil, fail("an empty map literal has no key/value types", "map[<key>, <value>] = {}")
+		}
+	}
+	if reason := incompleteTypeReason(valType); reason != "" {
+		return nil, fail(reason, "<type> = ...")
+	}
+	return normalizeInferredType(valType), nil
+}
+
+// incompleteTypeReason procura, em qualquer profundidade, um componente sem
+// tipo unico: elemento/chave/valor nil (`[[]]`, `{"a": []}`) ou `null`
+// (`[null]`). Devolve "" quando o tipo e totalmente determinado.
+func incompleteTypeReason(t ast.NoxyType) string {
+	switch typed := t.(type) {
+	case nil:
+		return "part of its type is not known"
+	case *ast.ArrayType:
+		if typed.ElementType == nil {
+			return "an empty array literal inside it has no element type"
+		}
+		if isNullType(typed.ElementType) {
+			return "'null' has no type of its own"
+		}
+		return incompleteTypeReason(typed.ElementType)
+	case *ast.MapType:
+		if typed.KeyType == nil || typed.ValueType == nil {
+			return "an empty map literal inside it has no key/value types"
+		}
+		if isNullType(typed.KeyType) || isNullType(typed.ValueType) {
+			return "'null' has no type of its own"
+		}
+		if reason := incompleteTypeReason(typed.KeyType); reason != "" {
+			return reason
+		}
+		return incompleteTypeReason(typed.ValueType)
+	case *ast.RefType:
+		if typed.ElementType == nil {
+			return "part of its type is not known"
+		}
+		return incompleteTypeReason(typed.ElementType)
+	case *ast.ChanType:
+		if typed.ElementType == nil {
+			return "part of its type is not known"
+		}
+		return incompleteTypeReason(typed.ElementType)
+	}
+	return ""
+}
+
+// normalizeInferredType transforma o tipo de um LITERAL no tipo de um
+// BINDING: `[1, 2, 3]` e int[3] como valor, mas a variavel que o recebe e
+// int[] — fixar o tamanho surpreenderia (push, reatribuicao com outro
+// tamanho) e nenhuma anotacao escrita a mao diria `int[3]` para isso. A
+// normalizacao e profunda (`[[1, 2], [3, 4]]` -> int[][]) e so reconstroi os
+// containers; tipos folha (primitivos, structs, funcoes) sao compartilhados.
+func normalizeInferredType(t ast.NoxyType) ast.NoxyType {
+	switch typed := t.(type) {
+	case *ast.ArrayType:
+		return &ast.ArrayType{ElementType: normalizeInferredType(typed.ElementType)}
+	case *ast.MapType:
+		return &ast.MapType{KeyType: normalizeInferredType(typed.KeyType), ValueType: normalizeInferredType(typed.ValueType)}
+	case *ast.RefType:
+		return &ast.RefType{ElementType: normalizeInferredType(typed.ElementType)}
+	case *ast.ChanType:
+		return &ast.ChanType{ElementType: normalizeInferredType(typed.ElementType)}
+	}
+	return t
+}
+
+// inferGlobalLetTypes e a segunda varredura de predeclareGlobalBindings:
+// `let` de topo SEM anotacao precisa do tipo ja na pre-declaracao, porque
+// corpos de funcao declarados antes do `let` leem o global por
+// programBindings — sem isso o global cairia em "tipo desconhecido" e uma
+// atribuicao errada dentro da funcao passaria em silencio.
+//
+// Roda DEPOIS da varredura principal (funcoes, structs, lets anotados ja em
+// c.globals), na ordem do programa, compilando cada RHS num chunk descartavel
+// (typeOfDiscardedExpression) so para ler o tipo. O tipo vai in-place para
+// declaration.Type, entao quando o LetStmt compilar de verdade ele segue o
+// caminho anotado — e a segunda compilacao do RHS e a unica, no bytecode
+// final. Um RHS que nao tem tipo aqui (`let a = b` com `b` declarado depois)
+// e erro de inferencia: em runtime seria leitura de global indefinido.
+func (c *Compiler) inferGlobalLetTypes(statements []ast.Statement) error {
+	for _, statement := range statements {
+		declaration, ok := statement.(*ast.LetStmt)
+		if !ok || declaration.Type != nil || declaration.Value == nil {
+			continue
+		}
+		c.setLine(declaration.Token.Line)
+		valType, err := c.typeOfDiscardedExpression(declaration.Value)
+		if err != nil {
+			return err
+		}
+		inferred, err := inferLetType(declaration.Name.Value, valType, declaration.Token.Line)
+		if err != nil {
+			return err
+		}
+		declaration.Type = inferred
+		c.globals[declaration.Name.Value] = inferred
+	}
+	return nil
+}

--- a/internal/compiler/let_inference.go
+++ b/internal/compiler/let_inference.go
@@ -28,7 +28,10 @@ func inferLetType(name string, valType ast.NoxyType, line int) (ast.NoxyType, er
 			line, name, reason, name, hint)
 	}
 	if valType == nil {
-		return nil, fail("its type is not known here", "<type> = ...")
+		// Fontes usuais de tipo desconhecido: global declarado mais adiante,
+		// membro acessado por namespace (`m.x`, `m.f()`), builtin sem tipo
+		// de retorno estatico (ver builtin_return_types.go).
+		return nil, fail("its type is not known here (a global declared later, a namespace member 'm.x', or a builtin without a static return type)", "<type> = ...")
 	}
 	if isNullType(valType) {
 		return nil, fail("'null' has no type of its own", "<type> = null")
@@ -50,7 +53,14 @@ func inferLetType(name string, valType ast.NoxyType, line int) (ast.NoxyType, er
 		}
 	}
 	if reason := incompleteTypeReason(valType); reason != "" {
-		return nil, fail(reason, "<type> = ...")
+		hint := "<type> = ..."
+		switch valType.(type) {
+		case *ast.ArrayType:
+			hint = "<type>[] = ..."
+		case *ast.MapType:
+			hint = "map[<key>, <value>] = ..."
+		}
+		return nil, fail(reason, hint)
 	}
 	return normalizeInferredType(valType), nil
 }
@@ -135,7 +145,7 @@ func (c *Compiler) inferGlobalLetTypes(statements []ast.Statement) error {
 			continue
 		}
 		c.setLine(declaration.Token.Line)
-		valType, err := c.typeOfDiscardedExpression(declaration.Value)
+		valType, err := c.typeOfGlobalInitializer(declaration.Value)
 		if err != nil {
 			return err
 		}
@@ -147,4 +157,21 @@ func (c *Compiler) inferGlobalLetTypes(statements []ast.Statement) error {
 		c.globals[declaration.Name.Value] = inferred
 	}
 	return nil
+}
+
+// typeOfGlobalInitializer e o leitor de tipo da varredura de globais. Um
+// literal de funcao tem o tipo escrito na propria assinatura: le-la direto
+// (resolvendo anotacoes de struct generico, como o compile faria) evita
+// compilar o CORPO fora de ordem — o corpo pode ler um global inferido
+// declarado DEPOIS (`let f = func() ... counter ... end` / `let counter =
+// 10`), que nesta altura ainda nao tem tipo. Qualquer outra expressao passa
+// por typeOfDiscardedExpression.
+func (c *Compiler) typeOfGlobalInitializer(expr ast.Expression) (ast.NoxyType, error) {
+	if literal, ok := expr.(*ast.FunctionLiteral); ok {
+		if err := c.resolveSignatureAnnotations(literal.Parameters, &literal.ReturnType, literal.Token.Line); err != nil {
+			return nil, err
+		}
+		return newFunctionType(literal.Parameters, literal.ReturnType), nil
+	}
+	return c.typeOfDiscardedExpression(expr)
 }

--- a/internal/compiler/let_inference_test.go
+++ b/internal/compiler/let_inference_test.go
@@ -7,6 +7,7 @@ package compiler
 // topo (fronteira dinamica pede anotacao explicita).
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,4 +199,117 @@ func TestLetInferenceRejectsVoidCall(t *testing.T) {
 end
 let v = f()
 `, cannotInferText+" 'v'", "does not return a value")
+}
+
+// Builtins centrais (sem `use`) nao tem assinatura estatica no compilador —
+// eram compilados como global desconhecido (tipo nil). Para a inferencia ser
+// util no codigo de todo dia (`let n = length(xs)`), os de tipo de retorno
+// INVARIANTE ganham tipo estatico (builtin_return_types.go); a checagem vale
+// em toda posicao, nao so no `let`.
+func TestLetInfersCoreBuiltinReturnTypes(t *testing.T) {
+	src := `let xs: int[] = [1, 2]
+let m: map[string, int] = {"a": 1}
+let n = length(xs)
+let s = to_str(5)
+let i = to_int("5")
+let fl = to_float(1)
+let by = to_bytes("a")
+let ty = type(xs)
+let f = fmt("%d", 1)
+let c = contains(xs, 1)
+let h = has_key(m, "a")
+let ks = keys(m)
+let sl = slice(xs, 0, 1)
+let sub = slice("abc", 0, 1)
+let he = hex_encode(by)
+let hd = hex_decode(he)
+let o = ord("a")
+let js = json_dumps(m)
+`
+	for name, want := range map[string]string{
+		"n": "int", "s": "string", "i": "int", "fl": "float", "by": "bytes",
+		"ty": "string", "f": "string", "c": "bool", "h": "bool", "ks": "string[]",
+		"sl": "int[]", "sub": "string", "he": "string", "hd": "bytes", "o": "int",
+		"js": "string",
+	} {
+		if got := inferredLetType(t, src, name); got != want {
+			t.Errorf("let %s: want %s, got %s", name, want, got)
+		}
+	}
+}
+
+func TestCoreBuiltinReturnTypeIsCheckedStatically(t *testing.T) {
+	requireCompileError(t, "let xs: int[] = [1]\nlet s: string = length(xs)\n",
+		"type mismatch in 's' declaration: expected string, got int")
+}
+
+func TestUserFunctionShadowsBuiltinReturnType(t *testing.T) {
+	if got := inferredLetType(t, `func length(x: int) -> string
+    return "n"
+end
+let v = length(1)
+`, "v"); got != "string" {
+		t.Errorf("v: want string (funcao do usuario), got %s", got)
+	}
+}
+
+func TestTopLevelFunctionLiteralInfersFromSignatureWithoutCompilingBody(t *testing.T) {
+	// O corpo le um global inferido declarado DEPOIS: a pre-declaracao nao
+	// pode compilar o corpo para descobrir o tipo — a assinatura ja o diz.
+	src := `let f = func() -> int
+    let total = counter + 1
+    return total
+end
+let counter = 10
+`
+	if got := inferredLetType(t, src, "f"); got != "func() -> int" {
+		t.Errorf("f: want func() -> int, got %s", got)
+	}
+}
+
+func TestInferredLetEmitsSameBytecodeAsAnnotated(t *testing.T) {
+	// Guarda do design de dupla compilacao do RHS na pre-declaracao: o chunk
+	// final tem de ser identico ao do programa anotado.
+	inferred, _, err := New().Compile(parse("let xs = [1, 2]\nlet f = func(a: int) -> int\n    return a + length(xs)\nend\nprint(f(1))\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	annotated, _, err := New().Compile(parse("let xs: int[] = [1, 2]\nlet f: func(int) -> int = func(a: int) -> int\n    return a + length(xs)\nend\nprint(f(1))\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(inferred.Code, annotated.Code) {
+		t.Fatalf("bytecode diverge:\ninferido:  %v\nanotado:   %v", inferred.Code, annotated.Code)
+	}
+	if len(inferred.Constants) != len(annotated.Constants) {
+		t.Fatalf("pool de constantes diverge: %d vs %d", len(inferred.Constants), len(annotated.Constants))
+	}
+}
+
+func TestLetInferenceNestedEmptyLiteralHintKeepsShape(t *testing.T) {
+	requireCompileError(t, "let xs = [[]]\n", cannotInferText+" 'xs'", "hint: use 'let xs: <type>[] = ...'")
+	requireCompileError(t, "let m = {\"a\": []}\n", cannotInferText+" 'm'", "hint: use 'let m: map[<key>, <value>] = ...'")
+}
+
+func TestInferredLetInsideGenericTemplateBodyInstantiatedTwice(t *testing.T) {
+	// O corpo do template e clonado por instancia; o tipo inferido gravado
+	// in-place no pass 1 tem de valer para cada clone (int e string) e o
+	// pass 2 tem de aceita-lo como anotacao ja resolvida.
+	requireCompiles(t, `func first<T>(xs: T[]) -> T
+    let head = xs[0]
+    let copy = head
+    return copy
+end
+let a = first([1, 2])
+let b = first(["x", "y"])
+print(a + 1)
+print(b + "!")
+`)
+	requireCompileError(t, `func first<T>(xs: T[]) -> T
+    let head = xs[0]
+    head = "s"
+    return head
+end
+let a = first([1, 2])
+`, "type mismatch in assignment to 'head'")
 }

--- a/internal/compiler/let_inference_test.go
+++ b/internal/compiler/let_inference_test.go
@@ -1,0 +1,201 @@
+package compiler
+
+// Inferencia local de tipo em `let` (issue #41, spec §3): `let x = expr` binda
+// o tipo ESTATICO do RHS como se tivesse sido anotado — a variavel continua
+// type-stable. Inferencia e unidirecional (RHS -> binding) e so em `let`; o
+// tipo inferido tem de ser totalmente determinado e nao pode ser `any` no
+// topo (fronteira dinamica pede anotacao explicita).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+const cannotInferText = "cannot infer type for"
+
+func requireCompileError(t *testing.T, src string, wants ...string) {
+	t.Helper()
+	_, _, err := New().Compile(parse(src))
+	if err == nil {
+		t.Fatalf("programa deveria falhar na compilacao:\n%s", src)
+	}
+	for _, want := range wants {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("erro deveria conter %q: %v", want, err)
+		}
+	}
+}
+
+// inferredLetType compila src e devolve o tipo gravado no `let` de topo
+// chamado name (o compilador escreve o tipo inferido in-place no AST, como ja
+// faz com anotacoes resolvidas).
+func inferredLetType(t *testing.T, src, name string) string {
+	t.Helper()
+	program := parse(src)
+	if _, _, err := New().Compile(program); err != nil {
+		t.Fatalf("programa valido nao deveria falhar: %v", err)
+	}
+	for _, stmt := range program.Statements {
+		if let, ok := stmt.(*ast.LetStmt); ok && let.Name.Value == name {
+			if let.Type == nil {
+				t.Fatalf("let %s: tipo inferido nao foi gravado no AST", name)
+			}
+			return let.Type.String()
+		}
+	}
+	t.Fatalf("let %s nao encontrado", name)
+	return ""
+}
+
+func TestLetInfersPrimitiveTypes(t *testing.T) {
+	src := `let i = 10
+let f = 1.5
+let s = "a" + "b"
+let b = 1 < 2
+`
+	for name, want := range map[string]string{"i": "int", "f": "float", "s": "string", "b": "bool"} {
+		if got := inferredLetType(t, src, name); got != want {
+			t.Errorf("let %s: want %s, got %s", name, want, got)
+		}
+	}
+}
+
+func TestInferredLetIsTypeStable(t *testing.T) {
+	// Global
+	requireCompileError(t, "let x = 10\nx = \"a\"\n", "type mismatch in assignment to global 'x'", "expected int, got string")
+	// Local
+	requireCompileError(t, `func f()
+    let x = 10
+    x = "a"
+end`, "type mismatch in assignment to 'x'", "expected int, got string")
+}
+
+func TestInferredLetCompatibleReassignmentCompiles(t *testing.T) {
+	requireCompiles(t, "let x = 10\nx = 20\nlet s = \"a\"\ns = \"b\"\n")
+}
+
+func TestLetInfersArrayLiteralAsDynamicArray(t *testing.T) {
+	// `[1, 2, 3]` e int[3] como literal, mas o binding inferido e int[]:
+	// fixar o tamanho surpreenderia (push, reatribuir com outro tamanho).
+	src := "let xs = [1, 2, 3]\nxs = [4]\nlet grid = [[1, 2], [3, 4]]\n"
+	if got := inferredLetType(t, src, "xs"); got != "int[]" {
+		t.Errorf("xs: want int[], got %s", got)
+	}
+	if got := inferredLetType(t, src, "grid"); got != "int[][]" {
+		t.Errorf("grid: want int[][], got %s", got)
+	}
+}
+
+func TestLetInfersMapStructFunctionAndRef(t *testing.T) {
+	src := `struct P
+    x: int
+end
+let m = {"a": 1}
+let p = P(1)
+let f = func(a: int) -> int
+    return a
+end
+let n = 5
+let r = ref n
+`
+	for name, want := range map[string]string{
+		"m": "map[string, int]",
+		"p": "P",
+		"f": "func(int) -> int",
+		"r": "ref int",
+	} {
+		if got := inferredLetType(t, src, name); got != want {
+			t.Errorf("let %s: want %s, got %s", name, want, got)
+		}
+	}
+}
+
+func TestLetInferenceRejectsEmptyLiterals(t *testing.T) {
+	requireCompileError(t, "let xs = []\n", cannotInferText+" 'xs'", "hint: use 'let xs: <type>[] = []'")
+	requireCompileError(t, "let m = {}\n", cannotInferText+" 'm'", "hint: use 'let m: map[<key>, <value>] = {}'")
+	requireCompileError(t, "let n = null\n", cannotInferText+" 'n'", "hint: use 'let n: <type> = null'")
+}
+
+func TestLetInferenceRejectsTopLevelAny(t *testing.T) {
+	// `any` no topo e fronteira dinamica: a anotacao torna a escolha explicita.
+	requireCompileError(t, `func dyn() -> any
+    return 1
+end
+let v = dyn()
+`, cannotInferText+" 'v'", "is 'any'", "hint: use 'let v: any = ...'")
+	// `any` ANINHADO e um tipo declaravel comum e e inferido fielmente.
+	if got := inferredLetType(t, "let m = {\"a\": 1, \"b\": \"s\"}\n", "m"); got != "map[string, any]" {
+		t.Errorf("m: want map[string, any], got %s", got)
+	}
+}
+
+func TestLetInferenceRejectsUnknownGlobal(t *testing.T) {
+	// `b` e declarado depois: na posicao do `let a` nao ha tipo estatico
+	// (e em runtime seria leitura de global indefinido).
+	requireCompileError(t, "let a = b\nlet b = 1\n", cannotInferText+" 'a'")
+}
+
+func TestInferredGlobalIsVisibleToEarlierFunctionBodies(t *testing.T) {
+	// Corpo de funcao declarado ANTES do `let` de topo: a pre-declaracao de
+	// globais ja precisa do tipo inferido — senao o global cairia em "tipo
+	// desconhecido" e a atribuicao errada passaria em silencio.
+	requireCompileError(t, `func bad()
+    x = "a"
+end
+let x = 10
+`, "type mismatch in assignment to global 'x'", "expected int, got string")
+	requireCompiles(t, `func ok() -> int
+    return x + 1
+end
+let x = 10
+`)
+}
+
+func TestLetInfersFromGenericCall(t *testing.T) {
+	src := `func id<T>(v: T) -> T
+    return v
+end
+let y = id(5)
+let z = id("s")
+func use_it() -> int
+    let w = id(1)
+    return w + y
+end
+`
+	if got := inferredLetType(t, src, "y"); got != "int" {
+		t.Errorf("y: want int, got %s", got)
+	}
+	if got := inferredLetType(t, src, "z"); got != "string" {
+		t.Errorf("z: want string, got %s", got)
+	}
+}
+
+func TestInferredModuleLetExportsItsType(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "cfg.nx"), []byte("let limit = 10\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(root, "main.nx")
+	program := parse("use cfg select limit\nlimit = \"a\"\n")
+	_, _, err := NewWithState(make(map[string]ast.NoxyType), make(map[string]*ast.StructStatement), mainPath).Compile(program)
+	if err == nil {
+		t.Fatal("atribuicao de string a global int importado (tipo inferido no modulo) deveria falhar")
+	}
+	if !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("erro deveria citar o tipo inferido no modulo: %v", err)
+	}
+}
+
+func TestLetInferenceRejectsVoidCall(t *testing.T) {
+	// Chamada a funcao void nao produz valor: nao ha tipo para bindar (com
+	// anotacao o mesmo programa ja era "expected int, got void").
+	requireCompileError(t, `func f()
+    print(1)
+end
+let v = f()
+`, cannotInferText+" 'v'", "does not return a value")
+}

--- a/internal/parser/let_inference_test.go
+++ b/internal/parser/let_inference_test.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/lexer"
+)
+
+// Issue #41: `let x = expr` e aceito sem anotacao — o tipo fica para o
+// compilador inferir do RHS. O parser so precisa devolver Type == nil com o
+// valor parseado.
+func TestLetWithoutAnnotationParses(t *testing.T) {
+	p := New(lexer.New("let x = 5\nlet s = \"a\" + \"b\"\n"))
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	if len(program.Statements) != 2 {
+		t.Fatalf("want 2 statements, got %d", len(program.Statements))
+	}
+	for i, name := range []string{"x", "s"} {
+		let, ok := program.Statements[i].(*ast.LetStmt)
+		if !ok {
+			t.Fatalf("stmt %d: want *ast.LetStmt, got %T", i, program.Statements[i])
+		}
+		if let.Name.Value != name {
+			t.Errorf("stmt %d: want name %q, got %q", i, name, let.Name.Value)
+		}
+		if let.Type != nil {
+			t.Errorf("stmt %d: want Type nil (inferred), got %s", i, let.Type.String())
+		}
+		if let.Value == nil {
+			t.Errorf("stmt %d: want Value parsed, got nil", i)
+		}
+	}
+	if _, ok := program.Statements[0].(*ast.LetStmt).Value.(*ast.IntegerLiteral); !ok {
+		t.Errorf("x: want IntegerLiteral value, got %T", program.Statements[0].(*ast.LetStmt).Value)
+	}
+}
+
+// `let x` sem tipo NEM valor nao tem o que inferir: erro didatico com as duas
+// formas validas no hint.
+func TestLetWithoutAnnotationOrInitializerIsSyntaxError(t *testing.T) {
+	p := New(lexer.New("let x\n"))
+	p.ParseProgram()
+	errs := strings.Join(p.Errors(), "\n")
+	for _, want := range []string{
+		"SyntaxError: missing type annotation or initializer for 'x'",
+		"hint: use 'let x: <type>' or 'let x = <value>'",
+	} {
+		if !strings.Contains(errs, want) {
+			t.Errorf("errors %q missing %q", errs, want)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -275,11 +275,22 @@ func (p *Parser) parseLetStatement() *ast.LetStmt {
 
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 
-	// Specific check for missing type: let x = ...
+	// Inferencia local (issue #41, spec §3): `let x = expr` sem anotacao —
+	// Type fica nil e o compilador binda o tipo estatico do RHS. `let` ja
+	// marca declaracao, entao nao ha ambiguidade com atribuicao.
 	if p.peekTokenIs(token.ASSIGN) {
-		msg := fmt.Sprintf("[%d:%d] SyntaxError: missing type annotation for '%s'\n  hint: use 'let %s: <type> = ...'",
+		p.nextToken() // Eat ASSIGN
+		p.nextToken() // Start expression
+		stmt.Value = p.parseExpression(LOWEST)
+		return stmt
+	}
+
+	// `let x` sozinho: sem tipo nem valor, nao ha o que inferir. (`let x int`
+	// cai no "expected ':'" generico, que aponta o que falta.)
+	if p.peekTokenIs(token.NEWLINE) || p.peekTokenIs(token.EOF) {
+		msg := fmt.Sprintf("[%d:%d] SyntaxError: missing type annotation or initializer for '%s'\n  hint: use 'let %s: <type>' or 'let %s = <value>'",
 			p.peekToken.Line, p.peekToken.Column,
-			stmt.Name.Value, stmt.Name.Value)
+			stmt.Name.Value, stmt.Name.Value, stmt.Name.Value)
 		p.errors = append(p.errors, msg)
 
 		// Advance to avoid subsequent errors

--- a/internal/parser/syntax_errors_test.go
+++ b/internal/parser/syntax_errors_test.go
@@ -24,9 +24,9 @@ func TestSyntaxErrorMessages(t *testing.T) {
 			want:   []string{"SyntaxError: missing 'let' keyword for variable declaration", "hint: use 'let x: ...'"},
 		},
 		{
-			name:   "missing type annotation in let",
-			source: "let x = 5\n",
-			want:   []string{"SyntaxError: missing type annotation for 'x'", "hint: use 'let x: <type> = ...'"},
+			name:   "let without type or initializer",
+			source: "let x\n",
+			want:   []string{"SyntaxError: missing type annotation or initializer for 'x'", "hint: use 'let x: <type>' or 'let x = <value>'"},
 		},
 		{
 			name:   "if without end",
@@ -109,7 +109,7 @@ func TestSyntaxErrorMessages(t *testing.T) {
 // Cada diagnóstico carrega a posição [linha:coluna] do ponto do erro — é o
 // que o usuário usa para achar a linha; garante que a linha não é sempre 1.
 func TestSyntaxErrorsCarryLineAndColumn(t *testing.T) {
-	p := New(lexer.New("let a: int = 1\nlet b: int = 2\nlet x = 5\n"))
+	p := New(lexer.New("let a: int = 1\nlet b: int = 2\nlet x\n"))
 	_ = p.ParseProgram()
 	joined := strings.Join(p.Errors(), "\n")
 	if !strings.HasPrefix(joined, "[3:") {

--- a/noxy_examples/let_inference.nx
+++ b/noxy_examples/let_inference.nx
@@ -1,0 +1,93 @@
+// Inferencia local de tipo em `let` (issue #41, spec §3):
+// `let x = expr` binda o tipo estatico do RHS — a variavel continua
+// type-stable, como se o tipo tivesse sido escrito.
+
+use sys select exit
+
+func assert(condition: bool, message: string) -> void
+    if !condition then
+        print("let inference: FAIL - " + message)
+        exit(1)
+    end
+end
+
+struct Point
+    x: int
+    y: int
+end
+
+func id<T>(v: T) -> T
+    return v
+end
+
+// Globais inferidos (visiveis em funcoes declaradas antes ou depois)
+let counter = 0
+let greeting = "hello"
+let ratio = 2.5
+let flags = [true, false]
+let scores = {"ana": 10, "bia": 20}
+
+func bump() -> void
+    counter = counter + 1
+end
+
+func main()
+    // Primitivos
+    let i = 10
+    let f = 1.5
+    let s = "a" + "b"
+    let b = i < 20
+    assert(i == 10, "int inferido")
+    assert(f == 1.5, "float inferido")
+    assert(s == "ab", "string inferida")
+    assert(b, "bool inferido")
+    assert(type(i) == "int", "type int")
+    assert(type(s) == "string", "type string")
+
+    // Reatribuicao compativel continua OK (type-stable)
+    i = 20
+    s = "c"
+    assert(i == 20 && s == "c", "reatribuicao")
+
+    // Array literal infere T[] dinamico (nao int[3]): push e reatribuir
+    let xs = [1, 2, 3]
+    append(xs, 4)
+    assert(length(xs) == 4, "append em array inferido")
+    xs = [9]
+    assert(length(xs) == 1, "reatribuicao com outro tamanho")
+
+    // Map, struct, funcao, ref, generico
+    let m = {"k": 1}
+    m["z"] = 2
+    assert(length(m) == 2, "map inferido")
+    let p = Point(1, 2)
+    assert(p.x + p.y == 3, "struct inferido")
+    let double = func(n: int) -> int
+        return n * 2
+    end
+    assert(double(21) == 42, "funcao inferida")
+    let n = 5
+    let r = ref n
+    *r = 6
+    assert(n == 6, "ref inferido escreve no alvo")
+    let g = id(7)
+    assert(g + 1 == 8, "generico inferido")
+
+    // Globais
+    bump()
+    bump()
+    assert(counter == 2, "global inferido atualizado por funcao")
+    assert(greeting == "hello" && ratio == 2.5, "globais inferidos")
+    assert(length(flags) == 2 && scores["bia"] == 20, "globais compostos")
+
+    // Escopo interno sombreando com tipo diferente, como antes
+    if i > 0 then
+        let i = "inner"
+        assert(i == "inner", "shadow")
+    end
+    assert(i == 20, "outer intacto")
+
+    print("OK let inference")
+end
+
+main()

--- a/noxy_examples/let_inference.nx
+++ b/noxy_examples/let_inference.nx
@@ -20,15 +20,20 @@ func id<T>(v: T) -> T
     return v
 end
 
+// Funcao declarada ANTES do global inferido que ela usa: a pre-declaracao
+// ja conhece o tipo de `counter` (int).
+func bump() -> void
+    counter = counter + 1
+end
+
 // Globais inferidos (visiveis em funcoes declaradas antes ou depois)
 let counter = 0
 let greeting = "hello"
 let ratio = 2.5
 let flags = [true, false]
 let scores = {"ana": 10, "bia": 20}
-
-func bump() -> void
-    counter = counter + 1
+let handler = func(n: int) -> int
+    return n + counter
 end
 
 func main()
@@ -52,7 +57,11 @@ func main()
     // Array literal infere T[] dinamico (nao int[3]): push e reatribuir
     let xs = [1, 2, 3]
     append(xs, 4)
-    assert(length(xs) == 4, "append em array inferido")
+    let n_items = length(xs)          // builtin central: int
+    let label = to_str(n_items)       // builtin central: string
+    assert(n_items == 4 && label == "4", "append em array inferido + builtins tipados")
+    let ks = keys(scores)             // keys(map[string, int]) -> string[]
+    assert(length(ks) == 2, "keys inferido")
     xs = [9]
     assert(length(xs) == 1, "reatribuicao com outro tamanho")
 
@@ -77,6 +86,7 @@ func main()
     bump()
     bump()
     assert(counter == 2, "global inferido atualizado por funcao")
+    assert(handler(40) == 42, "function literal global inferido pela assinatura")
     assert(greeting == "hello" && ratio == 2.5, "globais inferidos")
     assert(length(flags) == 2 && scores["bia"] == 20, "globais compostos")
 

--- a/noxy_examples/test_let_error.nx
+++ b/noxy_examples/test_let_error.nx
@@ -1,6 +1,8 @@
+// Erro intencional (excluido do runner): `let` sem tipo NEM valor nao tem o
+// que inferir. `let a = 10` (sem anotacao) e valido desde a inferencia local
+// da issue #41 — ver let_inference.nx.
 func main()
-    let a = 10
-    let b = 20
-    print(a + b)
+    let a
+    print(a)
 end
 main()

--- a/tests/test_errors/test_case_3.nx
+++ b/tests/test_errors/test_case_3.nx
@@ -1,4 +1,3 @@
-
 func main()
-    let x = 10
+    let x
 end


### PR DESCRIPTION
Fecha #41.

## Resumo

`let x = expr` sem anotação passa a ser aceito: o tipo declarado é o **tipo estático do lado direito**, fixado na declaração como se tivesse sido escrito — a variável continua type-stable (`let x = 10` seguido de `x = "a"` é erro de compilação). Inferência unidirecional (RHS → binding), só em `let`; parâmetros, retornos e campos de struct continuam anotados. Superset puro: todo código anotado segue válido e com o mesmo bytecode.

- **Parser**: `let x = expr` (Type nil); `let x` nu → `SyntaxError: missing type annotation or initializer for 'x'` (hint com as duas formas); `let x int = 1` mantém o `expected ':'`.
- **Compilador**: `inferLetType` valida o tipo do RHS e grava in-place em `LetStmt.Type` — o resto do caminho (type-stability, RC/borrow de `ref`, globais, exports de módulo, REPL) fica idêntico ao anotado. Literal de array normaliza para `T[]` (não `int[3]`). Exigem anotação, com erro `cannot infer type for 'x' from its initializer: ...` + hint: literal vazio (também aninhado), `null`, chamada void, `any` no topo (`any` aninhado, ex. `map[string, any]`, é inferido fielmente — decisão de design da issue), e tipo ainda desconhecido (global declarado depois, membro de namespace `m.x`, builtin sem tipo estático).
- **Globais de topo sem anotação** entram na pré-declaração (segunda varredura via `typeOfDiscardedExpression`; function literal via assinatura, sem compilar o corpo), para que funções declaradas antes do `let` enxerguem o tipo certo.
- **Builtins centrais com tipo de retorno estático** (`length`, `to_str`, `to_int`, `to_float`, `to_bytes`, `type`, `input`, `fmt`, `hex`, `hex_encode`, `hex_decode`, `ord`, `contains`, `has_key`, `json_dumps`, `keys(map[K,V]) -> K[]`, `slice`): antes compilavam como global desconhecido (tipo nil); sem isso `let n = length(xs)` pedia anotação. A checagem vale em toda posição (`let s: string = length(xs)` vira erro de compilação). Função do programa com o mesmo nome continua sombreando o builtin.
- Consequência: `~` em `bytes` passa no checador estático (a VM sempre aceitou; `test_bytes_full.nx` dependia disso via `hex_decode`). Spec §8 corrigida.

## Docs / testes

- Spec §3 (nova subseção *Local type inference*, tabela dos casos que exigem anotação), §6.2, §8, §10; README; CHANGELOG `[Unreleased]`; AGENTS.
- Testes: parser (`let_inference_test.go`), compiler (`let_inference_test.go`: inferência de primitivos/array/map/struct/func/ref/genérico, type-stability, erros com hint, global visível a função anterior, export de módulo, builtins, bytecode inferido == anotado, corpo genérico instanciado 2x, `~` em bytes); exemplo `noxy_examples/let_inference.nx` no runner; `test_let_error.nx` e `tests/test_errors/test_case_3.nx` viram `let x` nu.
- `go test ./...` limpo; `run_all_tests_concurrent.nx` 178/178.

## Limitação documentada

Membro de namespace (`use m` + `m.x`/`m.f()`) e builtins de fronteira dinâmica (`json_parse`, `task_await`, ...) não têm tipo estático: `let` sobre eles pede anotação (ou `use m select f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
