### PR TITLE
chore/version-0.17.0 - Bump v0.17.0: inferência local de tipo em let (issue #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.16.0)
+**Versão**: 1.0 (Noxy VM 0.17.0)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [Unreleased]
+## [0.17.0] - 2026-08-23
+
+Inferência local de tipo em `let` (issue #41, PR #73): `let x = expr` sem
+anotação, com o tipo do binding inferido do tipo estático do RHS — type-stable
+como sempre. Minor porque é sintaxe nova aceita; superset puro de 0.16.0 (todo
+código anotado continua válido, com o mesmo bytecode). Junto, os builtins
+centrais ganharam tipo de retorno estático e `~` passou a aceitar `bytes` no
+checador (a VM já aceitava). Corpus 178/178.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.16.0](https://img.shields.io/badge/noxy-0.16.0-blue)](CHANGELOG.md)
+[![noxy 0.17.0](https://img.shields.io/badge/noxy-0.17.0-blue)](CHANGELOG.md)
 
 # Noxy
 
@@ -200,7 +200,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.16.0
+Noxy REPL v0.17.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2173,7 +2173,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.16.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.17.0`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.16.0</span>
+                    <span class="version-badge-tag">v0.17.0</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.16.0
+print(sys.version)           // v0.17.0
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.16.0"
+const Version = "v0.17.0"


### PR DESCRIPTION
Bump de versão após o merge do #73 (issue #41). Sem mudança de código além de `internal/version/version.go`: CHANGELOG (`[Unreleased]` → `[0.17.0] - 2026-08-23`, com parágrafo de abertura), badge/REPL do README, AGENTS, spec (`sys.version`), site.

Minor (0.16.0 → 0.17.0) porque `let x = expr` é sintaxe nova aceita; superset puro de 0.16.0.

`noxy --version` → `Noxy v0.17.0`; testes de versão (vm, cmd) verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)