### PR TITLE
fix/issue-75-arith-operand-checks - Checagem estática de operandos aritméticos e de comparação (issue #75) — v0.17.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.17.0)
+**Versão**: 1.0 (Noxy VM 0.17.1)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
   bytecode de programa válido idêntico (hash dos chunks de 354 arquivos do
   corpus antes × depois sem diferença; o único que muda é
   `noxy_examples/error_type.nx`, erro intencional que agora falha em
-  compile-time). Spec §8 ganha a tabela.
+  compile-time). Como toda checagem estática, também rejeita código morto
+  (`if false then print(1 + "a") end`). Spec §8 ganha a subseção *Static
+  operand checks*.
 
 ## [0.17.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Checagem estática de operandos aritméticos e de comparação** (issue
+  #75): `int + string`, `bool * int`, `string - string`, `float % int`,
+  `bytes < bytes`, `string < int`... passam a ser erro de **compilação**,
+  com o texto do runtime mais os dois tipos (`[line N] operands must be
+  numbers or strings or bytes, got int and string`; `operands must be
+  numbers, got bool and int`; `operands for % must be integers, got float
+  and int`; `operands must be numbers or strings, got bytes and bytes`) —
+  mesmo padrão do #56 para `!`, `~` e bitwise. Antes o compilador emitia o
+  opcode genérico e só a VM reclamava; valia para anotado (`let x: int`) e
+  inferido (`let x = 10`, #41). `any`/tipo desconhecido continuam no caminho
+  genérico com checagem em runtime; `ref T` é lido como `T`; `==`/`!=` têm
+  regra própria e não mudam. Zero custo em runtime: a checagem lê os tipos
+  que o compilador já calcula para escolher `OP_ADD_INT`/`OP_ADD_FLOAT` —
+  bytecode de programa válido idêntico (hash dos chunks de 354 arquivos do
+  corpus antes × depois sem diferença; o único que muda é
+  `noxy_examples/error_type.nx`, erro intencional que agora falha em
+  compile-time). Spec §8 ganha a tabela.
+
 ## [0.17.0] - 2026-08-23
 
 Inferência local de tipo em `let` (issue #41, PR #73): `let x = expr` sem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [0.17.1] - 2026-08-23
+
+Patch de checagem estática (issue #75, PR #76): operandos aritméticos e de
+comparação de tipo incompatível viram erro de compilação, não de runtime.
+Nenhuma sintaxe nova, nenhum opcode novo, bytecode de programa válido
+idêntico ao de 0.17.0 (só programas que já falhariam em runtime deixam de
+compilar). Corpus 179/179.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.17.0](https://img.shields.io/badge/noxy-0.17.0-blue)](CHANGELOG.md)
+[![noxy 0.17.1](https://img.shields.io/badge/noxy-0.17.1-blue)](CHANGELOG.md)
 
 # Noxy
 
@@ -200,7 +200,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.17.0
+Noxy REPL v0.17.1
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1718,6 +1718,30 @@ inverted). Wrong static types are compile-time errors with the same text as
 the runtime check (`[line N] operands for & must be integers or bytes, got int
 and bool`, `operand of '~' must be int or bytes, got bool`).
 
+The arithmetic and ordering operators are checked the same way. When both
+operands have a known static type (anything but `any` or an untyped dynamic
+value), the compiler applies the runtime rules up front and rejects a
+mismatch with the runtime message plus the two types:
+
+| Operator | Accepts | Compile-time error text |
+|----------|---------|-------------------------|
+| `+` | `int`/`float` (mixed promotes), `string + string`, `bytes + bytes` | `operands must be numbers or strings or bytes, got int and string` |
+| `-`, `*`, `/` | `int`/`float` | `operands must be numbers, got bool and int` |
+| `%` | `int % int` | `operands for % must be integers, got float and int` |
+| `<`, `>`, `<=`, `>=` | `int`/`float`, or `string` with `string` | `operands must be numbers or strings, got bytes and bytes` |
+
+`==`/`!=` keep their own rules (§2.3). A `ref T` operand is read as `T`
+(auto-dereference). `any` and untyped values stay on the generic opcode and are
+checked at runtime, so the dynamic boundary is unchanged; the bytecode of a
+valid program is identical with or without the check.
+
+```noxy
+let x: int = 10
+print(x + "ola")    // ERROR: [line 2] operands must be numbers or strings or bytes, got int and string
+let v: any = 10
+print(v + "ola")    // compiles; fails at runtime with the same message
+```
+
 Unary `*` is the dereference operator and applies only to a `ref`. With a known
 non-`ref` static type it is a compile-time error, so `2 ** 3` (there is no
 exponentiation operator in Noxy) reports

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2206,7 +2206,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.17.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.17.1`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -1688,8 +1688,10 @@ Ordering (`>`, `<`, `>=`, `<=`) is defined for **numbers** (with the usual
 int/float promotion) and for **strings**. String ordering is lexicographic
 and byte-exact — for valid UTF-8, which every Noxy string is by invariant,
 this is identical to code-point order, mirroring Python. Ordering any other
-operand pair, including `bytes`, is a runtime error (`operands must be
-numbers or strings`); bridge bytes through `to_str` first. Equality
+operand pair, including `bytes`, is an error (`operands must be numbers or
+strings` — at compile time when both static types are known, see *Static
+operand checks* below; at runtime otherwise); bridge bytes through `to_str`
+first. Equality
 (`==`, `!=`) is structural for every type (§2.2, rule 7).
 
 ### Logical
@@ -1718,8 +1720,10 @@ inverted). Wrong static types are compile-time errors with the same text as
 the runtime check (`[line N] operands for & must be integers or bytes, got int
 and bool`, `operand of '~' must be int or bytes, got bool`).
 
-The arithmetic and ordering operators are checked the same way. When both
-operands have a known static type (anything but `any` or an untyped dynamic
+### Static operand checks
+
+The arithmetic and ordering operators are checked the same way as the bitwise
+ones. When both operands have a known static type (anything but `any` or an untyped dynamic
 value), the compiler applies the runtime rules up front and rejects a
 mismatch with the runtime message plus the two types:
 
@@ -1733,7 +1737,12 @@ mismatch with the runtime message plus the two types:
 `==`/`!=` keep their own rules (§2.3). A `ref T` operand is read as `T`
 (auto-dereference). `any` and untyped values stay on the generic opcode and are
 checked at runtime, so the dynamic boundary is unchanged; the bytecode of a
-valid program is identical with or without the check.
+valid program is identical with or without the check. Inside a generic
+function the check runs per instance, so `soma(true, false)` on
+`func soma<T>(a: T, b: T)` reports `em soma<bool> (instanciado na linha N):
+operands must be numbers or strings or bytes, got bool and bool`. Like every
+static check, it also rejects a mismatch in code that would never run
+(`if false then print(1 + "a") end`).
 
 ```noxy
 let x: int = 10

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.17.0</span>
+                    <span class="version-badge-tag">v0.17.1</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.17.0
+print(sys.version)           // v0.17.1
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/chunk/chunk_test.go
+++ b/internal/chunk/chunk_test.go
@@ -159,7 +159,8 @@ let fdiv: float = fa / fb
 let fless: bool = fa < fb
 let cmp: bool = sa > "b" || sa < "c" || sa == "a" || fa >= fb || fa <= fb || !ok || false
 let bits: int = (6 & 3) | (6 ^ 3) | (~5) | (1 << 2) | (8 >> 1) | (7 % 3) | -(2)
-let fm: float = fa % fb
+let va: any = 7
+let fm: any = va % 3    // OP_MODULO generico: float % float e erro de compilacao (#75)
 let ge: bool = 1 >= 2
 if 1 == 1 then print("eq") end
 if 1 > 0 then print("gt") end

--- a/internal/compiler/arith_operand_checks.go
+++ b/internal/compiler/arith_operand_checks.go
@@ -1,0 +1,58 @@
+package compiler
+
+import (
+	"fmt"
+
+	"noxy-vm/internal/ast"
+)
+
+// Checagem estatica dos operandos de `+ - * / %` e `< > <= >=` (issue #75):
+// espelha em tempo de compilacao as regras que a VM aplica em runtime
+// (executor.go, OP_ADD/OP_SUBTRACT/.../OP_GREATER), com o MESMO texto de erro
+// mais "got A and B" — o padrao do #56 para `!`, `~` e bitwise. So le os tipos
+// estaticos que o compilador ja calcula para escolher OP_ADD_INT/OP_ADD_FLOAT,
+// e roda antes de qualquer emissao: o bytecode de programa valido nao muda.
+//
+// Fronteira dinamica: `any` e tipo desconhecido (nil) passam e ficam para o
+// runtime, como em checkBitwiseOperands. `ref T` ja chega aqui desembrulhado
+// (auto-deref do caminho infixo). `==`/`!=` tem regra propria (§2.3) e nao
+// entram. Struct como operando e recusado antes, por structOperandName.
+//
+// Regras (as do runtime): `+` aceita numeros (int/float, misto promove),
+// string+string e bytes+bytes; `-`, `*`, `/` aceitam numeros; `%` aceita
+// int e int; `<`, `>`, `<=`, `>=` aceitam numeros ou string com string.
+func checkArithmeticOperands(operator string, left, right ast.NoxyType) error {
+	var message string
+	var ok func(l, r string) bool
+	switch operator {
+	case "+":
+		message = "operands must be numbers or strings or bytes"
+		ok = func(l, r string) bool {
+			return (isNumericName(l) && isNumericName(r)) || (l == "string" && r == "string") || (l == "bytes" && r == "bytes")
+		}
+	case "-", "*", "/":
+		message = "operands must be numbers"
+		ok = func(l, r string) bool { return isNumericName(l) && isNumericName(r) }
+	case "%":
+		message = "operands for % must be integers"
+		ok = func(l, r string) bool { return l == "int" && r == "int" }
+	case "<", ">", "<=", ">=":
+		message = "operands must be numbers or strings"
+		ok = func(l, r string) bool {
+			return (isNumericName(l) && isNumericName(r)) || (l == "string" && r == "string")
+		}
+	default:
+		return nil
+	}
+	if left == nil || right == nil || isAny(left) || isAny(right) {
+		return nil
+	}
+	if ok(left.String(), right.String()) {
+		return nil
+	}
+	return fmt.Errorf("%s, got %s and %s", message, left.String(), right.String())
+}
+
+func isNumericName(name string) bool {
+	return name == "int" || name == "float"
+}

--- a/internal/compiler/arith_operand_checks.go
+++ b/internal/compiler/arith_operand_checks.go
@@ -17,6 +17,9 @@ import (
 // runtime, como em checkBitwiseOperands. `ref T` ja chega aqui desembrulhado
 // (auto-deref do caminho infixo). `==`/`!=` tem regra propria (§2.3) e nao
 // entram. Struct como operando e recusado antes, por structOperandName.
+// (Unica variante textual do runtime nao reproduzida: OP_ADD com dois
+// objetos nao-string — array+array, map+map — diz "numbers, strings or
+// bytes" com virgula; aqui sai sempre a forma com "or".)
 //
 // Regras (as do runtime): `+` aceita numeros (int/float, misto promove),
 // string+string e bytes+bytes; `-`, `*`, `/` aceitam numeros; `%` aceita

--- a/internal/compiler/arith_operand_checks_test.go
+++ b/internal/compiler/arith_operand_checks_test.go
@@ -28,6 +28,9 @@ func TestArithmeticOperandMismatchIsCompileError(t *testing.T) {
 		{"print(true > false)\n", "[line 1] operands must be numbers or strings, got bool and bool"},
 		{"print(b\"a\" + \"b\")\n", "[line 1] operands must be numbers or strings or bytes, got bytes and string"},
 		{"let xs: int[] = [1]\nprint(xs + 1)\n", "[line 2] operands must be numbers or strings or bytes, got int[] and int"},
+		{"print(1 + null)\n", "[line 1] operands must be numbers or strings or bytes, got int and null"},
+		// Dentro de generico a checagem roda por instancia, na cadeia do §9.
+		{"func soma<T>(a: T, b: T) -> T\n    return a + b\nend\nprint(soma(true, false))\n", "em soma<bool> (instanciado na linha 4): operands must be numbers or strings or bytes, got bool and bool"},
 	}
 	for _, tc := range cases {
 		_, _, err := New().Compile(parse(tc.source))
@@ -44,7 +47,10 @@ func TestArithmeticOperandsCompatibleStillCompile(t *testing.T) {
 		"print(\"a\" + \"b\")\n",
 		"print(b\"a\" + b\"b\")\n",
 		"print(\"a\" < \"b\")\n",
+		"print(\"a\" <= \"b\", \"a\" >= \"b\")\n",
 		"print(1 < 2.5)\n",
+		"print(2.5 >= 1, 1 <= 2.5)\n",
+		"func soma<T>(a: T, b: T) -> T\n    return a + b\nend\nprint(soma(1, 2), soma(\"a\", \"b\"), soma(1.5, 2.5))\n",
 		"print(7 % 2)\n",
 		// Fronteira dinamica: any e tipo desconhecido ficam para o runtime.
 		"let v: any = 1\nprint(v + \"x\")\nprint(v < 2)\nprint(v % 2)\n",

--- a/internal/compiler/arith_operand_checks_test.go
+++ b/internal/compiler/arith_operand_checks_test.go
@@ -1,0 +1,90 @@
+package compiler
+
+// Issue #75: operandos aritmeticos/de comparacao de tipo estatico
+// incompativel sao erro de COMPILACAO, com o texto do runtime + "got A and
+// B" — mesmo padrao do #56 para `!`, `~` e bitwise. `any`, tipo desconhecido
+// (nil) e `ref` (auto-deref) continuam no caminho generico com checagem em
+// runtime. Bytecode de programa valido nao muda (a checagem so le os tipos
+// que o compilador ja calcula para escolher OP_ADD_INT/OP_ADD_FLOAT).
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/ast"
+)
+
+func TestArithmeticOperandMismatchIsCompileError(t *testing.T) {
+	cases := []struct{ source, want string }{
+		{"let x: int = 10\nprint(x + \"ola\")\n", "[line 2] operands must be numbers or strings or bytes, got int and string"},
+		{"let x = 10\nprint(x + \"ola\")\n", "[line 2] operands must be numbers or strings or bytes, got int and string"},
+		{"print(true * 2)\n", "[line 1] operands must be numbers, got bool and int"},
+		{"print(\"a\" - \"b\")\n", "[line 1] operands must be numbers, got string and string"},
+		{"print(\"a\" / 2)\n", "[line 1] operands must be numbers, got string and int"},
+		{"print(1.5 % 2)\n", "[line 1] operands for % must be integers, got float and int"},
+		{"print(b\"a\" < b\"b\")\n", "[line 1] operands must be numbers or strings, got bytes and bytes"},
+		{"print(\"a\" < 1)\n", "[line 1] operands must be numbers or strings, got string and int"},
+		{"print(1 >= \"a\")\n", "[line 1] operands must be numbers or strings, got int and string"},
+		{"print(true > false)\n", "[line 1] operands must be numbers or strings, got bool and bool"},
+		{"print(b\"a\" + \"b\")\n", "[line 1] operands must be numbers or strings or bytes, got bytes and string"},
+		{"let xs: int[] = [1]\nprint(xs + 1)\n", "[line 2] operands must be numbers or strings or bytes, got int[] and int"},
+	}
+	for _, tc := range cases {
+		_, _, err := New().Compile(parse(tc.source))
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("source %q: error=%v, want %q", tc.source, err, tc.want)
+		}
+	}
+}
+
+func TestArithmeticOperandsCompatibleStillCompile(t *testing.T) {
+	for _, source := range []string{
+		"print(1 + 2.5)\n",
+		"print(2.5 - 1)\n",
+		"print(\"a\" + \"b\")\n",
+		"print(b\"a\" + b\"b\")\n",
+		"print(\"a\" < \"b\")\n",
+		"print(1 < 2.5)\n",
+		"print(7 % 2)\n",
+		// Fronteira dinamica: any e tipo desconhecido ficam para o runtime.
+		"let v: any = 1\nprint(v + \"x\")\nprint(v < 2)\nprint(v % 2)\n",
+		"print(desconhecido + 1)\n",
+		// ref auto-deref: `ref int` + int e int + int.
+		"let n: int = 1\nlet r: ref int = ref n\nprint(r + 1)\nprint(1 < r)\n",
+		// Igualdade tem regra propria e nao entra aqui.
+		"print(1 == \"a\")\nprint(1 != \"a\")\n",
+	} {
+		if _, _, err := New().Compile(parse(source)); err != nil {
+			t.Errorf("source %q deveria compilar: %v", source, err)
+		}
+	}
+}
+
+// A checagem e uma funcao PURA sobre os tipos estaticos (nil = erro nenhum) e
+// roda antes de qualquer emissao: o bytecode de programa valido nao muda por
+// construcao (prova no corpus: diff de disassembly antes x depois, no PR).
+func TestCheckArithmeticOperandsIsPureOverStaticTypes(t *testing.T) {
+	intT, strT, anyT := builtinType("int"), builtinType("string"), builtinType("any")
+	if err := checkArithmeticOperands("+", intT, strT); err == nil {
+		t.Fatal("int + string deveria falhar")
+	}
+	for _, pair := range [][2]interface{}{{intT, intT}, {anyT, strT}, {nil, strT}, {strT, nil}} {
+		var l, r = toType(pair[0]), toType(pair[1])
+		if err := checkArithmeticOperands("+", l, r); err != nil {
+			t.Fatalf("%v + %v nao deveria falhar: %v", l, r, err)
+		}
+	}
+	// Operador fora do conjunto (igualdade, logico, bitwise) e no-op.
+	for _, op := range []string{"==", "!=", "&&", "||", "&", "<<"} {
+		if err := checkArithmeticOperands(op, intT, strT); err != nil {
+			t.Fatalf("%s nao e da alcada desta checagem: %v", op, err)
+		}
+	}
+}
+
+func toType(v interface{}) ast.NoxyType {
+	if v == nil {
+		return nil
+	}
+	return v.(ast.NoxyType)
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1332,6 +1332,11 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		if err := c.checkBitwiseOperands(n.Operator, leftType, rightType); err != nil {
 			return nil, nil, err
 		}
+		// Issue #75: int + string, bool * int, bytes < bytes... sao erro de
+		// compilacao com o texto do runtime (arith_operand_checks.go).
+		if err := checkArithmeticOperands(n.Operator, leftType, rightType); err != nil {
+			return nil, nil, fmt.Errorf("[line %d] %v", n.Token.Line, err)
+		}
 
 		switch n.Operator {
 		case "+":

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.17.0"
+const Version = "v0.17.1"


### PR DESCRIPTION
Fecha #75. Inclui o bump para **v0.17.1** (patch: sem sintaxe nem opcode novo; bytecode de programa válido idêntico a 0.17.0) — version.go, CHANGELOG (`[0.17.1] - 2026-08-23`), README, AGENTS, spec, site.

## Resumo

`int + string`, `bool * int`, `string - string`, `float % int`, `bytes < bytes`, `string < int`... passam a ser erro de **compilação**, com o texto do runtime mais os dois tipos — mesmo padrão do #56 para `!`, `~` e bitwise:

```
>>> let x = 10
>>> x + "ola"
Compiler error: [line 1] operands must be numbers or strings or bytes, got int and string
```

Antes o compilador emitia o opcode genérico e só a VM reclamava — valia para anotado (`let x: int`) e inferido (`let x = 10`, #41) igualmente.

- `checkArithmeticOperands` (`internal/compiler/arith_operand_checks.go`): função pura sobre os tipos estáticos, chamada no `InfixExpression` logo após `checkBitwiseOperands`, antes de qualquer emissão. Regras = as do runtime (`+`: números/string+string/bytes+bytes; `- * /`: números; `%`: int%int; `< > <= >=`: números ou string+string). `any`/tipo desconhecido passam (runtime); `ref T` já chega desembrulhado; `==`/`!=` fora; struct já era recusado antes. Dentro de genérico roda por instância (`em soma<bool> (instanciado na linha N): ...`).
- **Zero custo em runtime**: bytecode de programa válido idêntico — hash dos chunks (principal + funções aninhadas) de 354 arquivos do corpus (`noxy_examples`, `tests/test_features`, `noxy_libs`, `benchmarks`) antes × depois sem diferença. O único arquivo que muda é `noxy_examples/error_type.nx` (erro intencional `int - string`, já fora do runner), que passa de runtime error para compile error.
- `internal/chunk/chunk_test.go`: o programa de cobertura do disassembler usava `fa % fb` (float % float, que a VM rejeita) só para emitir `OP_MODULO`; agora usa um operando `any`.
- Spec §8: nova subseção *Static operand checks* (tabela operador/aceita/mensagem) e caveat em *Comparison*; CHANGELOG `[Unreleased]`.

## Verificação

- `go test ./...` limpo; `run_all_tests_concurrent.nx` 179/179; varredura de `tests/`, `noxy_libs/`, `benchmarks/`: nenhum programa dependia do buraco.
- Testes novos: mismatches (12 casos + `null` + cadeia genérica), compatíveis (misto int/float, string ordering incl. `<=`/`>=`, bytes `+`, `any`, desconhecido, `ref`, `==`/`!=`, genérico int/string/float), função pura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)