### PR TITLE
docs(spec): campo `ref` é aresta compartilhada; cópia independente através dos campos de valor (issue #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ someone actually writes to it.
 ## Three rules
 
 **1. Variables are values.** Assigning, passing, or returning a struct, array
-or map gives you an independent value — at any depth. `ref` is the single,
-visible mechanism for sharing, and it is part of the type. It is written at
-the call site too — `push(ref xs)` — so a call that can mutate your value
-looks different from one that cannot.
+or map gives you an independent value — at any depth, through every field
+that is not `ref`. `ref` is the single, visible mechanism for sharing, and it
+is part of the type: written at the call site — `push(ref xs)` — so a call
+that can mutate your value looks different from one that cannot; or written
+in a struct declaration — `next: ref Node` — so a value that shares says so
+in its type.
 
 ```noxy
 func push(xs: int[])       // cannot touch the caller's array

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -153,7 +153,9 @@ followed by (an optional sign and) a digit is not part of the literal.
 #### Value Semantics (Copy-on-Write)
 
 Arrays, maps, and structs are composite **values**. Every binding without
-`ref` behaves as an independent deep copy, at any depth:
+`ref` behaves as an independent deep copy, at any depth through every *value*
+field — a field, element or map value declared `ref T` is the one edge a copy
+shares (rule 6):
 
 1. **Assignment copies**: `let b = a` and `x = y` produce independent values.
 2. **Calls copy**: arguments to non-`ref` parameters are independent values —
@@ -170,6 +172,17 @@ Arrays, maps, and structs are composite **values**. Every binding without
    variables by name and globals are shared by name — those are the only
    other places where two names can see one slot, and the only ones that
    need coordination under concurrency (see §2.3 R9).
+   A `ref` **field** (or a `(ref T)[]` element, or a `map[K, ref T]` value)
+   is such a slot edge *inside* a value: copying the container copies the
+   edge, not its target, so the original and every copy reach the same
+   target. A type is **ref-carrying** when any field, element or map value
+   is `ref T` or is itself ref-carrying. Rules 1–5 hold for a ref-carrying
+   value exactly as for any other — the copy is independent through every
+   value field — but the sharing is declared in the *type*, at the struct
+   declaration, and does not appear at the assignment, call site, container
+   read or channel that copies it. To own a nested composite instead of
+   sharing it, declare the field without `ref` (`next: Node`, nullable) —
+   see §5 *Self-Reference* for both idioms.
 7. **`==`/`!=` on composites is structural** (recursive by content). `ref`
    values compare by slot identity and are not dereferenced — both as fields
    nested inside a composite and as the two operands of a direct comparison.
@@ -184,15 +197,9 @@ at the binding site — composites are marked as shared and cloned lazily, one
 level at a time, at the first mutation. Read-only sharing therefore costs
 O(1); programs never observe the difference, only the performance.
 
-One documented edge: a `ref` taken *into* a container (`ref arr[0]`, a `ref`
-field) pins that container's identity at creation time. If the container is
-copied *afterwards*, writes through the pre-existing `ref` are visible to
-copies that have not yet materialized. Take refs after, not before, sharing.
-Tracked as issue #83.
-
 #### Concurrency and composite values
 
-Shared routines use synchronized global bindings, module state, maps, and runtime handle registries. An individual binding lookup/update or map operation is safe from the Go runtime's concurrent-map crash, but synchronization is not recursive and does not make a read-modify-write sequence atomic. Normal calls, `spawn`, and `spawn_task` all follow the value-semantics parameter rules above — the legacy `spawn` identity exception was removed in 0.4.0 — so data handed to another routine by argument or channel is race-free by construction. Concurrent mutation of intentionally shared state (globals, `ref`) still requires coordination through channels or another explicit single-owner protocol.
+Shared routines use synchronized global bindings, module state, maps, and runtime handle registries. An individual binding lookup/update or map operation is safe from the Go runtime's concurrent-map crash, but synchronization is not recursive and does not make a read-modify-write sequence atomic. Normal calls, `spawn`, and `spawn_task` all follow the value-semantics parameter rules above — the legacy `spawn` identity exception was removed in 0.4.0 — so data handed to another routine by argument or channel is race-free by construction — unless its type is ref-carrying (rule 6): a `ref` field travels as a shared edge and needs the same coordination as a `ref` argument. Concurrent mutation of intentionally shared state (globals, `ref` — as argument or as field) still requires coordination through channels or another explicit single-owner protocol.
 
 #### Arrays (Dynamic and Fixed)
 
@@ -213,7 +220,7 @@ let zeroed: int[100] = zeros(100)
 ```
 
 **Pass-by-Value Behavior**:
-Arrays are passed by **VALUE**: the callee's array is independent at any depth (copy-on-write). Use `ref` when the function must modify the caller's array.
+Arrays are passed by **VALUE**: the callee's array is independent at any depth through value elements (copy-on-write; a `(ref T)[]` element is a shared edge — §2.2 rule 6). Use `ref` when the function must modify the caller's array.
 
 #### Maps (Hashmaps)
 
@@ -224,7 +231,7 @@ scores["Bob"] = 50
 ```
 
 **Pass-by-Value Behavior**:
-Maps are passed by **VALUE**: the callee's map is independent at any depth (copy-on-write). Use `ref` when the function must modify the caller's map.
+Maps are passed by **VALUE**: the callee's map is independent at any depth through value entries (copy-on-write; a `map[K, ref T]` value is a shared edge — §2.2 rule 6). Use `ref` when the function must modify the caller's map.
 
 **Iteration order is undefined**: a map is backed by a Go map, so `for k in m`,
 `keys(m)` and printing a map may produce a different order on each run and
@@ -241,7 +248,7 @@ end
 ```
 
 **Pass-by-Value Behavior**:
-Structs are passed by **VALUE**: the callee's instance is independent at any depth (copy-on-write), including nested composite fields. Use `ref` when the function must modify the caller's original instance.
+Structs are passed by **VALUE**: the callee's instance is independent at any depth through value fields (copy-on-write), including nested composite fields declared without `ref`. A field declared `ref T` is a shared edge: the callee's copy reaches the caller's target (§2.2 rule 6). Use `ref` when the function must modify the caller's original instance.
 
 ---
 ### 2.3 References (`ref`)
@@ -741,11 +748,11 @@ Exact function types may also appear in parameters, returns, struct fields, map 
 
 ### 4.3 Parameter Passing Semantics (CRITICAL)
 
-Noxy uses **Pass-by-Value** by default. Primitive values are copied directly. Composite values (arrays, maps, and structs) behave as independent deep copies at any depth, implemented with copy-on-write (see §2.2).
+Noxy uses **Pass-by-Value** by default. Primitive values are copied directly. Composite values (arrays, maps, and structs) behave as independent deep copies at any depth through value fields, implemented with copy-on-write (see §2.2); a field declared `ref T` is the one edge a copy shares (§2.2 rule 6).
 
 #### Pass-by-Value (Default)
 
-When a composite value is passed to a parameter without `ref`, the function's view is fully independent of the caller's — mutating it at any depth never affects the caller:
+When a composite value is passed to a parameter without `ref`, the function's view is independent of the caller's through every value field — mutating it at any depth never affects the caller:
 
 ```noxy
 func modify(arr: int[]) -> void
@@ -774,6 +781,32 @@ let box: Box = Box(values)
 mutate_nested(box)
 // box.values is still [1, 2]
 // values is still [1, 2]
+```
+
+The boundary of that independence is a field declared `ref`. The sharing is
+written in the struct declaration, not in the signature or at the call site:
+
+```noxy
+struct Node
+    value: int
+    next: ref Node
+end
+
+struct Holder
+    inner: ref Node      // Holder is ref-carrying (§2.2 rule 6)
+end
+
+func touch(h: Holder) -> void
+    h.inner.value = 777  // writes through the shared edge
+end
+
+let target: Node = Node(1, null)
+let holder: Holder = Holder(ref target)
+
+touch(holder)
+// target.value is now 777: the callee's copy of `holder` holds the same
+// `ref` — `Holder` declared that. With `inner: Node` instead, target.value
+// would still be 1.
 ```
 
 #### Pass-by-Reference (`ref`)
@@ -815,7 +848,50 @@ typed base (`unknown field`), and at runtime through a dynamic one
 `d.zzz = 1`). No path adds a field to an instance.
 
 ### Self-Reference
-Structs can reference themselves using `ref`.
+
+A struct may contain its own type in two ways, and they mean different things.
+
+**Ownership — a field without `ref`.** A struct-typed field accepts `null`
+(§3), so a recursive structure with a single owner per node — a list, a tree —
+needs no `ref` in its declaration. The children are values: copying a node
+copies the whole subtree (copy-on-write, so the copy is lazy), and a callee
+that receives a node by value cannot reach the caller's tree. In-place
+mutation goes through a `ref` to the *slot* (§2.3 R1, R10):
+
+```noxy
+struct TreeNode
+    valor: int
+    esquerda: TreeNode      // owned, nullable
+    direita: TreeNode
+end
+
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+
+let raiz: TreeNode = null
+insert(ref raiz, 50)
+insert(ref raiz, 30)
+let copia: TreeNode = raiz
+copia.esquerda.valor = 999    // raiz.esquerda.valor is still 30
+```
+
+`noxy_examples/bst_owned.nx` is the reference program for this idiom. Its
+cost today is the nested borrow (`ref node.esquerda` inside a recursion) —
+tracked as issue #93; prefer it whenever the structure has one owner per node.
+
+**Sharing — a field declared `ref`.** When a node must be reachable from more
+than one place — a node with two parents, a doubly linked list (`prev`), a
+parent pointer, a graph with shared edges — the field is declared `ref` and
+the struct becomes *ref-carrying* (§2.2 rule 6):
 
 ```noxy
 struct Node
@@ -826,7 +902,12 @@ end
 
 A `ref` field is filled by rebinding it to a variable (`let novo: Node = ...;
 node.next = ref novo`) or cleared with `null`; assigning a raw `Node` to it is
-a compile error whether `node` is a `Node` or a `ref Node` (§2.3, §4.2).
+a compile error whether `node` is a `Node` or a `ref Node` (§2.3, §4.2). The
+sharing is the point of such a field, and it travels with every copy of the
+container: `let b = a`, `f(a)` with `f(x: Node)`, `arr[i]`, `chan_send` all
+hand out a value whose `next` reaches the *same* node — the copy is
+independent through its value fields and shares through its `ref` fields.
+That is declared once, in the struct, and not repeated at the call site.
 
 A struct may also reference itself through an **array field without `ref`**:
 value semantics without `ref` cannot form a cycle, so no `ref` is needed to
@@ -1967,7 +2048,7 @@ Task completion is published exactly once and can be awaited consistently by mul
 
 Timeout is local and non-terminal: it does not cancel the worker, consume the result, or mutate the task. Completion is preferred whenever it is observably available at the deadline. A wait that returns `"timeout"` may therefore be followed by a later wait that returns `"ok"` or `"error"`.
 
-Supervised tasks share globals, module state, runtime resources, closure environments, and the VM configuration. Ordinary composite arguments follow value semantics (independent at any depth, copy-on-write) and `ref` arguments retain reference identity. Intentionally shared state — globals, `ref`, closure upvalues — still requires explicit concurrency coordination.
+Supervised tasks share globals, module state, runtime resources, closure environments, and the VM configuration. Ordinary composite arguments follow value semantics (independent through value fields, copy-on-write; a ref-carrying argument shares its `ref` targets — §2.2 rule 6) and `ref` arguments retain reference identity. Intentionally shared state — globals, `ref` (as argument or as field), closure upvalues — still requires explicit concurrency coordination.
 
 ---
 
@@ -2477,8 +2558,8 @@ register, roll back, poison, or close the resource again.
 - **Heap-Backed Composite Types**: Objects (`struct`, `array`, `map`) are allocated on the heap.
     - **Variables**: Store a pointer to the heap object; sharing is managed by the copy-on-write runtime.
     - **Assignment**: Assigning a composite behaves as an independent deep copy (cloned lazily on first mutation).
-    - **Function Calls**: A parameter without `ref` receives an independent value at any depth (copy-on-write).
-    - **Reference Parameters**: A parameter declared with `ref` shares the caller's slot — the only sharing mechanism.
+    - **Function Calls**: A parameter without `ref` receives an independent value at any depth through value fields (copy-on-write); a `ref` field inside it is a shared edge (§2.2 rule 6).
+    - **Reference Parameters**: A parameter declared with `ref` shares the caller's slot — `ref`, as parameter or as field, is the only sharing mechanism.
 
 ### Call and operand stacks
 

--- a/docs/REF_SEMANTICS.md
+++ b/docs/REF_SEMANTICS.md
@@ -96,5 +96,15 @@ compartilha a célula entre routines — coordene, como com globais
 ## Parâmetros comuns e semântica de valor
 
 Sem `ref`, arrays, maps e structs são passados por **valor** — independentes
-em qualquer profundidade (copy-on-write). A assinatura sem `ref` garante que
-o chamador não é tocado; o call site sem `ref` garante o mesmo.
+em qualquer profundidade através dos campos de *valor* (copy-on-write). A
+assinatura sem `ref` garante que o chamador não é tocado através desses
+campos; o call site sem `ref` garante o mesmo.
+
+A fronteira é um campo declarado `ref`: ele é uma aresta compartilhada, e a
+cópia carrega a mesma aresta — `f(caixa)` com `caixa.inner: ref Node` deixa o
+callee escrever em `*caixa.inner`. Isso está escrito no **tipo** (`struct`),
+não na chamada (spec §2.2 regra 6). Para estrutura de dono único (lista,
+árvore), declare o campo sem `ref` — `next: Node` aceita `null` — e mute pelo
+slot: `insert(ref node.next, v)` (spec §5 *Self-Reference*,
+`noxy_examples/bst_owned.nx`). Reserve campo `ref` para compartilhamento de
+verdade: nó com dois pais, `prev`, ponteiro de pai, grafo.

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -16,7 +16,7 @@ Individual global-binding and map operations are synchronized and do not crash t
 
 These guarantees do not make a sequence of operations atomic. For example, `counter = counter + 1` is still a separate read and write. Likewise, arrays, structs, and composite values nested inside a map or global binding are not recursively synchronized. Coordinate compound operations and mutation of nested composite values with channels (or another explicit single-owner protocol).
 
-Normal function calls, `spawn`, and `spawn_task` all follow Noxy's value semantics (0.4.0+): an ordinary composite parameter is an independent value at any depth, implemented with copy-on-write — the legacy `spawn` identity exception was removed. Data handed to another routine by argument or channel is therefore race-free by construction. Intentionally shared state (globals, `ref`) still requires explicit coordination; the synchronized runtime foundation does not make compound mutations atomic.
+Normal function calls, `spawn`, and `spawn_task` all follow Noxy's value semantics (0.4.0+): an ordinary composite parameter is an independent value at any depth, implemented with copy-on-write — the legacy `spawn` identity exception was removed. Data handed to another routine by argument or channel is therefore race-free by construction — unless its type is *ref-carrying* (a field, element or map value declared `ref T`; spec §2.2 rule 6): a `ref` field travels with the copy as a shared edge, exactly like a `ref` argument, and the sharing is declared in the struct, not at the `spawn`. Intentionally shared state (globals, `ref` — as argument or as field) still requires explicit coordination; the synchronized runtime foundation does not make compound mutations atomic.
 
 A closure that captures a `ref` to a local shares that local's cell with
 every routine that runs the closure — it is a local only in name:
@@ -96,7 +96,7 @@ An error map contains `kind`, `message`, and `stack`. `kind` is `"runtime"` for 
 
 A timeout is non-terminal: it never cancels the worker, consumes its outcome, or changes the task. If completion is observable at the deadline, completion wins over timeout. A later or repeated wait therefore observes the same terminal outcome. Envelopes and error maps are fresh on every wait so their mutation cannot alter the private outcome, while a successful composite `value` preserves its original identity rather than being deep-copied.
 
-Supervised tasks share global/module runtime state and use the normal parameter rules: ordinary composite parameters are independent values at any depth (copy-on-write), while `ref` parameters and closure upvalues preserve shared identity. Coordinate concurrent access to intentionally shared state (globals, refs, upvalues) with channels or another explicit ownership protocol.
+Supervised tasks share global/module runtime state and use the normal parameter rules: ordinary composite parameters are independent values through every value field (copy-on-write), while `ref` parameters, `ref` fields and closure upvalues preserve shared identity. Coordinate concurrent access to intentionally shared state (globals, refs, upvalues) with channels or another explicit ownership protocol.
 
 The original `spawn` API remains detached for compatibility. Choose `spawn_task` only when the caller needs structured completion, replayable results, or failures it can inspect.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,7 +139,7 @@ print(f"Product: {product.name}")</code></pre>
                     </div>
                     <h3>Value Semantics</h3>
                     <p>Arrays, maps and structs are independent values at any depth: assignment, calls, container
-                        reads and channels never alias. Copy-on-write makes the copy free until the first write,
+                        reads and channels never alias — the only shared edge is a field you declared <code>ref</code>. Copy-on-write makes the copy free until the first write,
                         and <code>==</code> compares composites by content.</p>
                 </div>
                 <div class="feature-card">
@@ -486,9 +486,9 @@ print(fmt("Price: %.2f", product.price))</code></pre>
                 </div>
                 <div class="example-tab" id="value-semantics">
                     <h3>Value Semantics</h3>
-                    <p>Arrays, maps and structs are independent values at any depth. <code>ref</code> is the only
-                        way to share storage, and copy-on-write means the copy costs nothing until someone
-                        writes.</p>
+                    <p>Arrays, maps and structs are independent values at any depth. <code>ref</code> — as a parameter
+                        or as a struct field — is the only way to share storage, and copy-on-write means the copy
+                        costs nothing until someone writes.</p>
                     <pre><code class="language-go">struct Counter
     hits: int[]
 end

--- a/internal/vm/ref_field_copy_test.go
+++ b/internal/vm/ref_field_copy_test.go
@@ -1,0 +1,134 @@
+package vm
+
+import (
+	"testing"
+
+	"fmt"
+
+	"noxy-vm/internal/value"
+)
+
+// Contrato da spec §2.2 regra 6 / §4.3 / §5 Self-Reference (issue #92): uma
+// copia e independente atraves de todo campo de VALOR, em qualquer
+// profundidade; um campo declarado `ref T` e uma aresta compartilhada — a copia
+// carrega a mesma aresta, e a escrita atraves dela chega no alvo do original.
+// A diferenca esta so na DECLARACAO do struct: a atribuicao e a chamada sao
+// identicas nos dois programas.
+//
+// copyValue (calls.go) clona um nivel e retem os filhos; um VAL_REF cai no
+// `default: return v` — e isso, nao um bug, e o que este teste fixa.
+
+func reportedInts(t *testing.T, got value.Value, want int) []int64 {
+	t.Helper()
+	arr, ok := got.Obj.(*value.ObjArray)
+	if !ok || len(arr.Elements) != want {
+		t.Fatalf("test_report deveria receber um array de %d ints, veio %s", want, got.String())
+	}
+	out := make([]int64, want)
+	for i, el := range arr.Elements {
+		if el.Type != value.VAL_INT {
+			t.Fatalf("elemento %d nao e int: %s", i, el.String())
+		}
+		out[i] = el.Int()
+	}
+	return out
+}
+
+func TestRefFieldIsASharedEdgeAcrossCopies(t *testing.T) {
+	const program = `struct Node
+    value: int
+    next: ref Node
+end
+struct Holder
+    tag: string
+    inner: %s
+end
+func touch(h: Holder) -> void
+    h.inner.value = 777
+end
+let target: Node = Node(1, null)
+let holder: Holder = Holder("a", %s)
+let copia: Holder = holder
+copia.inner.value = 99
+let after_copy: int = target.value
+touch(holder)
+let after_call: int = target.value
+test_report([after_copy, after_call, holder.inner.value, copia.inner.value])`
+
+	t.Run("campo ref: original e copia alcancam o mesmo alvo", func(t *testing.T) {
+		src := fmt.Sprintf(program, "ref Node", "ref target")
+		got := reportedInts(t, captureVMSource(t, src), 4)
+		// A copia e a chamada por valor escrevem no alvo — o Holder e ref-carrying.
+		if got[0] != 99 || got[1] != 777 || got[2] != 777 || got[3] != 777 {
+			t.Fatalf("esperado [99 777 777 777] (aresta compartilhada), veio %v", got)
+		}
+	})
+
+	t.Run("campo por posse: original e copia sao independentes", func(t *testing.T) {
+		src := fmt.Sprintf(program, "Node", "target")
+		got := reportedInts(t, captureVMSource(t, src), 4)
+		// Mesmo programa, so a declaracao do campo muda: nada vaza.
+		if got[0] != 1 || got[1] != 1 || got[2] != 1 || got[3] != 99 {
+			t.Fatalf("esperado [1 1 1 99] (posse), veio %v", got)
+		}
+	})
+}
+
+// Idioma por posse da §5: filhos nulaveis sem `ref`, mutacao pelo ref ao SLOT.
+// A copia de uma arvore e independente em profundidade e o callee por valor
+// nao alcanca a arvore do chamador — e o mesmo vale para o struct generic.
+func TestOwnedRecursiveFieldsKeepValueSemantics(t *testing.T) {
+	got := reportedInts(t, captureVMSource(t, `struct TreeNode
+    valor: int
+    esquerda: TreeNode
+    direita: TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+func bump(node: TreeNode) -> int
+    if node == null then
+        return 0
+    end
+    node.valor = node.valor + 1000
+    return node.valor + bump(node.esquerda) + bump(node.direita)
+end
+struct GNode<T>
+    value: T,
+    next: GNode<T>
+end
+func push_back<T>(node: ref GNode<T>, v: T) -> void
+    if *node == null then
+        *node = GNode(v, null)
+        return
+    end
+    push_back(ref node.next, v)
+end
+let raiz: TreeNode = null
+insert(ref raiz, 50)
+insert(ref raiz, 30)
+insert(ref raiz, 70)
+let copia: TreeNode = raiz
+copia.esquerda.valor = 999
+let bumped: int = bump(raiz)
+let head: GNode<int> = null
+push_back(ref head, 1)
+push_back(ref head, 2)
+let lcopia: GNode<int> = head
+lcopia.next.value = 99
+test_report([raiz.esquerda.valor, copia.esquerda.valor, bumped, raiz.valor, head.next.value, lcopia.next.value])`), 6)
+	want := []int64{30, 999, 3150, 50, 2, 99}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("esperado %v, veio %v", want, got)
+		}
+	}
+}

--- a/noxy_examples/bst.nx
+++ b/noxy_examples/bst.nx
@@ -1,5 +1,9 @@
 // Binary Search Tree (BST) - Árvore Binária de Busca
 // Algoritmo clássico que testa structs com múltiplas referências
+//
+// Campos `ref` são arestas COMPARTILHADAS: toda cópia de um TreeNode alcança os
+// mesmos filhos (spec §2.2 regra 6). Para uma árvore de dono único com
+// semântica de valor completa, veja bst_owned.nx (campos sem `ref`).
 
 struct TreeNode
     valor: int

--- a/noxy_examples/bst_owned.nx
+++ b/noxy_examples/bst_owned.nx
@@ -1,0 +1,213 @@
+// Estruturas recursivas por POSSE — sem nenhum campo `ref` (spec §5 Self-Reference).
+//
+// Um campo de struct aceita `null`, então lista e árvore de dono único não
+// precisam de `ref` na declaração: os filhos são valores. A cópia é
+// independente em qualquer profundidade e um callee que recebe o nó por valor
+// não alcança a árvore do chamador. A mutação in-place vai pelo `ref` ao SLOT
+// (`insert(ref node.esquerda, v)`), não por um campo `ref`.
+//
+// Contraste com bst.nx / linked_list.nx, onde `esquerda: ref TreeNode` é uma
+// aresta compartilhada e toda cópia alcança os mesmos filhos (spec §2.2 regra 6).
+// Motivação: issue #92. Custo do empréstimo aninhado: issue #93.
+
+let total: int = 0
+let failures: int = 0
+
+func check(condicao: bool, nome: string)
+    total = total + 1
+    if condicao then
+        return
+    end
+    failures = failures + 1
+    print("  FALHOU: " + nome)
+end
+
+func check_int(obtido: int, esperado: int, nome: string)
+    check(obtido == esperado, nome + " (esperado " + to_str(esperado) + ", obtido " + to_str(obtido) + ")")
+end
+
+// ------------------------------------------------------------
+// Árvore binária de busca com filhos por posse
+// ------------------------------------------------------------
+
+struct TreeNode
+    valor: int
+    esquerda: TreeNode      // posse, nulável — sem ref
+    direita: TreeNode
+end
+
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+
+func height(node: ref TreeNode) -> int
+    if *node == null then
+        return 0
+    end
+    let l: int = height(ref node.esquerda)
+    let r: int = height(ref node.direita)
+    if l > r then
+        return l + 1
+    end
+    return r + 1
+end
+
+func count(node: TreeNode) -> int         // POR VALOR
+    if node == null then
+        return 0
+    end
+    return 1 + count(node.esquerda) + count(node.direita)
+end
+
+// Callee por valor que muta o que recebeu: não pode vazar para o chamador.
+func soma_mutando(node: TreeNode) -> int
+    if node == null then
+        return 0
+    end
+    node.valor = node.valor + 1000
+    return node.valor + soma_mutando(node.esquerda) + soma_mutando(node.direita)
+end
+
+// ------------------------------------------------------------
+// Lista encadeada generic por posse
+// ------------------------------------------------------------
+
+struct GNode<T>
+    value: T,
+    next: GNode<T>
+end
+
+func push_back<T>(node: ref GNode<T>, v: T) -> void
+    if *node == null then
+        *node = GNode(v, null)
+        return
+    end
+    push_back(ref node.next, v)
+end
+
+func remove_first<T>(node: ref GNode<T>, v: T) -> bool
+    if *node == null then
+        return false
+    end
+    if node.value == v then
+        *node = node.next          // o nó seguinte toma o lugar
+        return true
+    end
+    return remove_first(ref node.next, v)
+end
+
+func list_sum(node: GNode<int>) -> int
+    if node == null then
+        return 0
+    end
+    return node.value + list_sum(node.next)
+end
+
+// ------------------------------------------------------------
+// Fronteira de routine: Box por posse não compartilha nada com o worker
+// ------------------------------------------------------------
+
+struct Cell
+    value: int
+    next: Cell
+end
+
+struct Box
+    tag: string
+    inner: Cell         // posse — com `inner: ref Cell` o worker escreveria no chamador
+end
+
+func worker(b: Box) -> int
+    let i: int = 0
+    while i < 2000 do
+        b.inner.value = b.inner.value + 1
+        i = i + 1
+    end
+    return b.inner.value
+end
+
+func main() -> void
+    print("=== bst_owned: estruturas recursivas por posse ===")
+
+    // --- BST ---
+    let raiz: TreeNode = null
+    insert(ref raiz, 50)
+    insert(ref raiz, 30)
+    insert(ref raiz, 70)
+    insert(ref raiz, 20)
+    insert(ref raiz, 40)
+    check_int(height(ref raiz), 3, "altura")
+    check_int(count(raiz), 5, "contagem por valor")
+
+    let copia: TreeNode = raiz
+    copia.esquerda.valor = 999
+    check_int(raiz.esquerda.valor, 30, "copia independente em profundidade")
+    check_int(copia.esquerda.valor, 999, "copia recebeu a escrita")
+
+    let s: int = soma_mutando(raiz)
+    check_int(s, 5210, "callee por valor mutou a propria copia")
+    check_int(raiz.valor, 50, "callee por valor nao vazou (raiz)")
+    check_int(raiz.esquerda.valor, 30, "callee por valor nao vazou (filho)")
+
+    // subárvore lida por valor e mutada: não afeta a árvore
+    let sub: TreeNode = raiz.esquerda
+    sub.valor = -1
+    insert(ref sub, 35)
+    check_int(raiz.esquerda.valor, 30, "subarvore por valor e independente")
+    check_int(count(raiz), 5, "insercao na subarvore copiada nao entra na arvore")
+
+    // dois refs ao mesmo slot escrevem no mesmo lugar
+    let r1: ref TreeNode = ref raiz.direita
+    let r2: ref TreeNode = ref raiz.direita
+    r1.valor = 71
+    check_int(r2.valor, 71, "dois refs ao mesmo slot")
+    check_int(raiz.direita.valor, 71, "escrita pelo ref chega na arvore")
+
+    // --- lista generic ---
+    let head: GNode<int> = null
+    push_back(ref head, 1)
+    push_back(ref head, 2)
+    push_back(ref head, 3)
+    push_back(ref head, 4)
+    check_int(list_sum(head), 10, "lista generic por posse")
+
+    let snapshot: GNode<int> = head
+    check(remove_first(ref head, 2), "remocao no meio")
+    check(remove_first(ref head, 1), "remocao na cabeca")
+    check(remove_first(ref head, 4), "remocao no fim")
+    check(!remove_first(ref head, 99), "remocao de ausente")
+    check_int(list_sum(head), 3, "lista apos remocoes")
+    check_int(list_sum(snapshot), 10, "snapshot tomado antes das remocoes e independente")
+
+    // --- spawn_task com Box por posse ---
+    let alvo: Cell = Cell(1, null)
+    let caixa: Box = Box("a", alvo)
+    let t1: any = spawn_task(worker, caixa)
+    let t2: any = spawn_task(worker, caixa)
+    let e1: any = task_await(t1)
+    let e2: any = task_await(t2)
+    check(e1["status"] == "ok" && e2["status"] == "ok", "workers terminaram")
+    check_int(e1["value"], 2001, "worker 1 viu so a propria copia")
+    check_int(e2["value"], 2001, "worker 2 viu so a propria copia")
+    check_int(alvo.value, 1, "alvo intocado pelos workers")
+    check_int(caixa.inner.value, 1, "caixa intocada pelos workers")
+
+    print("Asercoes: " + to_str(total))
+    print("Passaram: " + to_str(total - failures))
+    print("Falharam: " + to_str(failures))
+    if failures > 0 then
+        print("=== FALHOU ===")
+        exit(1)
+    end
+    print("=== OK ===")
+end
+
+main()


### PR DESCRIPTION
Closes #92.

## O que muda

A spec afirmava "independent at any depth" sem ressalva em 12 lugares. Um campo declarado `ref T` viaja com a cópia como **aresta compartilhada** — `copyValue` (`internal/vm/calls.go:164`) clona um nível e um `VAL_REF` é o mesmo ponteiro — então `f(b: Box)` sem `ref` escreve no alvo de `b.inner`. Isso é coerente para uma referência; o que estava errado era o contrato escrito. **Nenhuma mudança de semântica.**

- **§2.2 regra 6** define tipo *ref-carrying* (campo/elemento/valor de map `ref T`, transitivo) e o limite: as regras 1–5 valem através de todo campo de **valor**; o compartilhamento está declarado no struct, não na atribuição/chamada/canal. Remove a nota "documented edge" da #83 (fechada em 0.20.0, R10).
- **§4.3** ganha o exemplo `Holder`/`Node` (a chamada sem `ref` que escreve no chamador, e por quê). §2.2 arrays/maps/structs, §7 supervised tasks e o modelo de memória citam a regra 6.
- **§5 Self-Reference** apresenta os **dois idiomas** e o limite de cada um:
  - *posse*: campo nulável sem `ref` + `ref` ao **slot** para mutar (`insert(ref node.esquerda, v)`) — lista/árvore de dono único, semântica de valor completa;
  - *compartilhamento*: campo `ref` — nó com dois pais, `prev`, ponteiro de pai, grafo.
  
  A sugestão 3 da issue ("separar os dois papéis") já existe na linguagem; faltava dizer. O custo do empréstimo aninhado que hoje limita o idioma por posse é a #93.
- README regra 1, `REF_SEMANTICS.md`, `concurrency.md` ("race-free by construction — unless ref-carrying") e `docs/index.html` ganham a ressalva.

## Testes

- `noxy_examples/bst_owned.nx` — fixture do idioma por posse: BST (cópia em profundidade, callee por valor, subárvore por valor, dois refs ao mesmo slot), lista generic `GNode<T>` com remoção meio/cabeça/fim e snapshot, `spawn_task` ×2 com `Box` por posse (sem crash, sem vazamento). 23 asserções; entra no `run_all_tests_concurrent.nx`.
- `internal/vm/ref_field_copy_test.go` — o **mesmo programa** com `inner: ref Node` e com `inner: Node` fixa os dois lados do contrato; mais o idioma por posse (árvore + generic).
- Os dois exemplos novos da spec foram extraídos e executados: imprimem o que o texto afirma (`777` / `30`).
- `go test ./internal/...` verde; `run_all_tests_concurrent.nx` 180/180.

## Fora deste PR

- #93 — teto `maxBorrowPathDepth = 256` e custo O(profundidade) do empréstimo aninhado.
- #86 — o crash é alcançável sem `ref` visível (comentado lá); `Fields` map→slice.
- Bump de versão (patch) em PR separado, como de costume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
