### PR TITLE
fix(corpus): KandR_in_noxy — resíduos da migração para ref explícito (issue #87)

### DIFF
--- a/noxy_examples/KandR_in_noxy/ch03_shellsort.nx
+++ b/noxy_examples/KandR_in_noxy/ch03_shellsort.nx
@@ -1,6 +1,6 @@
 // shellsort: ordena v em ordem crescente
 func shellsort(v: ref int[])
-    let n: int = length(v)
+    let n: int = length(*v)
     let gap: int = n / 2
     while gap > 0 do
         let i: int = gap

--- a/noxy_examples/KandR_in_noxy/ch06_generic_stack.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_generic_stack.nx
@@ -4,11 +4,11 @@ struct Stack<T>
 end
 
 func push<T>(s: ref Stack<T>, item: T)
-    append(s.items, item)
+    append(ref s.items, item)
 end
 
 func take<T>(s: ref Stack<T>) -> T
-    return pop(s.items)
+    return pop(ref s.items)
 end
 
 let ints: Stack<int> = Stack([])        // T = int, pela anotação

--- a/noxy_examples/KandR_in_noxy/ch06_keycount.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_keycount.nx
@@ -21,7 +21,7 @@ let NKEYS: int = length(keytab)
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) && text[i] != "_" do
         i = i + 1                   // pula o que não é letra
     end

--- a/noxy_examples/KandR_in_noxy/ch06_keycount_ref.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_keycount_ref.nx
@@ -19,7 +19,7 @@ let keytab: Key[] = [
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) && text[i] != "_" do
         i = i + 1
     end

--- a/noxy_examples/KandR_in_noxy/ch06_struct_ref.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_struct_ref.nx
@@ -9,7 +9,7 @@ print(pp.x, pp.y)                   // o acesso a campos dispensa o -> de C
 pp.x = 7                            // escreve no original através da referência
 print(origin.x)
 
-let copy: Point = pp                // let lê através da ref: copia o struct
+let copy: Point = *pp               // let lê através da ref: copia o struct
 copy.y = 99
 print(origin.y, copy.y)
 

--- a/noxy_examples/KandR_in_noxy/ch06_tree.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_tree.nx
@@ -37,7 +37,7 @@ end
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) do
         i = i + 1
     end

--- a/noxy_examples/KandR_in_noxy/ch08_pool.nx
+++ b/noxy_examples/KandR_in_noxy/ch08_pool.nx
@@ -17,8 +17,8 @@ func pool_alloc<T>(p: ref Pool<T>, v: T) -> int
         p.next[i] = -1
         return i
     end
-    append(p.items, v)                  // sem slots livres: cresce
-    append(p.next, -1)
+    append(ref p.items, v)                  // sem slots livres: cresce
+    append(ref p.next, -1)
     return length(p.items) - 1
 end
 


### PR DESCRIPTION
## Summary

`ch06_keycount_ref.nx` (o arquivo da #87) parava na linha 22 em `let i: int = pos` — resíduo da migração do #82 (R2: uma ref nunca é lida sem `*`). Como a issue previa ("pode haver outros sites da mesma migração escondidos"), varri o diretório inteiro — o runner `run_all_tests_concurrent.nx` só cobre a raiz de `noxy_examples/` — e achei o mesmo resíduo em mais seis arquivos. Todas as correções são exatamente as que o hint do compilador sugere:

| arquivo | site | correção |
|---|---|---|
| `ch06_keycount_ref.nx` | l.22 | `let i: int = *pos` |
| `ch06_keycount.nx` | l.24 | `let i: int = *pos` |
| `ch06_tree.nx` | l.40 | `let i: int = *pos` |
| `ch06_struct_ref.nx` | l.12 | `let copy: Point = *pp` |
| `ch03_shellsort.nx` | l.3 | `length(*v)` com `v: ref int[]` |
| `ch06_generic_stack.nx` | l.7, l.11 | `append(ref s.items, item)`, `pop(ref s.items)` |
| `ch08_pool.nx` | l.20, l.21 | `append(ref p.items, v)`, `append(ref p.next, -1)` |

## Verificação

- Varredura de `noxy_examples/KandR_in_noxy/*.nx` com o binário desta branch: os únicos que não compilam são `ch02_mismatch.nx` e `ch02_redeclare.nx`, exemplos de erro intencionais (comentário `// ERRO:` no fonte).
- Os sete corrigidos executam e produzem a saída esperada; os que exigem `argv` (`ch06_keycount*.nx`, `ch06_tree.nx`) rodados com `ch01_sample.txt` / o próprio fonte. O `return ref keytab[mid]` (l.46) que a #83 não viu agora é exercitado.
- Nenhum teste Go ou script referencia o diretório; sem mudança em código.

## Fora do escopo

A #87 sugere um gate de CI que só compile todo o corpus (`noxy_examples/`, `internal/stdlib/`, `tests/`). Não há flag de só-compilar no binário hoje; fica como follow-up se o dono quiser — abro issue separada se pedirem.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
