### PR TITLE
fix(vm): cadeia de Base de um empréstimo sem teto — profundidade é dos dados (issue #93a)

### DIFF
--- a/internal/vm/borrow_place_test.go
+++ b/internal/vm/borrow_place_test.go
@@ -562,3 +562,67 @@ f(ref m["k"].x)`)
 		t.Fatalf("err=%v, want 'reference target no longer exists'", err)
 	}
 }
+
+// A profundidade do caminho de um empréstimo é dos DADOS (issue #93a). Uma
+// estrutura recursiva por posse — campo composto nulável, `ref` ao slot para
+// mutar in-place — encadeia Base um nível por chamada recursiva ou por
+// rebinding num laço. O teto de 256 que borrowContainer tinha matava uma BST
+// degenerada ou uma lista com ~256 nós com "reference path too deep"; a
+// caminhada não tem teto porque a cadeia não pode ciclar (ver maxRefHopDepth).
+func TestBorrowPlacePathDepthIsData(t *testing.T) {
+	t.Run("BST por posse com 300 chaves ordenadas (> 256): um nível de Base por chamada", func(t *testing.T) {
+		got := captureVMSource(t, `struct TreeNode
+    valor: int
+    esquerda: TreeNode
+    direita: TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+func count(node: ref TreeNode) -> int
+    if *node == null then
+        return 0
+    end
+    return 1 + count(ref node.esquerda) + count(ref node.direita)
+end
+let raiz: TreeNode = null
+let i: int = 0
+while i < 300 do
+    insert(ref raiz, i)
+    i = i + 1
+end
+test_report(count(ref raiz))`)
+		assertReportedInt(t, got, 300)
+	})
+
+	t.Run("lista por posse com 1000 nós: um nível de Base por rebinding, sem recursão", func(t *testing.T) {
+		got := captureVMSource(t, `struct Node
+    valor: int
+    prox: Node
+end
+let head: Node = null
+let r: ref Node = ref head
+let i: int = 0
+while i < 1000 do
+    *r = Node(i, null)
+    r = ref r.prox
+    i = i + 1
+end
+let n: int = 0
+let c: ref Node = ref head
+while *c != null do
+    n = n + c.valor
+    c = ref c.prox
+end
+test_report(n)`)
+		assertReportedInt(t, got, 499500)
+	})
+}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -115,10 +115,21 @@ func extractReferenceValue(input value.Value) (*value.ObjRef, error) {
 	return ref, nil
 }
 
-// maxBorrowPathDepth limita a caminhada de um empréstimo até a raiz. Um
-// caminho real tem a profundidade do lvalue escrito no fonte; o teto só existe
-// para que bytecode malformado (um ref que se aponta) erre em vez de girar.
-const maxBorrowPathDepth = 256
+// maxRefHopDepth limita derefPlace: quantos refs em sequência um LUGAR pode
+// guardar antes de chegar ao contêiner de verdade. Um lugar declarado `ref T`
+// guarda um ref cujo referente é um valor, então o laço dá uma volta só; o
+// teto é o backstop para um lugar `any` cujo ref aponte para outro lugar `any`
+// — um ciclo assim erra em vez de girar.
+//
+// A cadeia de Base (borrowContainer) NÃO tem teto (issue #93a). A profundidade
+// dela é dos DADOS, não do bytecode: `insert(ref node.esquerda, v)` recursivo
+// ou `r = ref r.prox` num laço encadeiam um nível por passo, e uma lista por
+// posse tem quantos nós o programa quiser — o teto de 256 que havia aqui
+// (justificado por "um caminho real tem a profundidade do lvalue escrito no
+// fonte", verdade até a #83) matava uma BST degenerada com ~256 nós. E a
+// cadeia não pode ciclar: Base é preenchido uma vez, na criação, com um ref
+// que já existia, e nunca reatribuído — cada nó é mais novo que o seu Base.
+const maxRefHopDepth = 256
 
 // borrowContainer devolve o contêiner ATUAL de um empréstimo (issue #83).
 //
@@ -157,9 +168,6 @@ func (vm *VM) borrowContainer(ref *value.ObjRef, forWrite bool) (value.Value, er
 		if !ok || parent == nil {
 			return value.Value{}, fmt.Errorf("invalid reference value")
 		}
-		if len(chain) > maxBorrowPathDepth {
-			return value.Value{}, fmt.Errorf("reference path too deep")
-		}
 		chain = append(chain, parent)
 		cursor = parent
 	}
@@ -194,7 +202,7 @@ func (vm *VM) borrowContainer(ref *value.ObjRef, forWrite bool) (value.Value, er
 // que OP_REF_PROPERTY/OP_REF_INDEX já faziam na criação.
 func (vm *VM) derefPlace(container value.Value, forWrite bool) (value.Value, error) {
 	for depth := 0; container.Type == value.VAL_REF; depth++ {
-		if depth > maxBorrowPathDepth {
+		if depth > maxRefHopDepth {
 			return value.Value{}, fmt.Errorf("reference path too deep")
 		}
 		var err error


### PR DESCRIPTION
## Summary

Parte (a) da #93. `maxBorrowPathDepth = 256` limitava a caminhada raiz→contêiner em `borrowContainer` (`internal/vm/references.go`) com a justificativa de que "um caminho real tem a profundidade do lvalue escrito no fonte". Isso é falso desde a #83: `insert(ref node.esquerda, v)` recursivo encadeia `ObjRef.Base` um nível por chamada, e — achado ao investigar — `r = ref r.prox` num laço encadeia um nível por iteração **sem gastar frame**. A profundidade é dos dados; uma BST degenerada ou lista por posse com ~256 nós morria com `reference path too deep`.

Por isso não subi o teto para a ordem de `FramesMax` (seria igualmente arbitrário para o caso do laço): **o teto sai da cadeia de Base**. Ela não pode ciclar por construção — `Base` é preenchido uma vez, na criação (`OP_REF_PROPERTY`/`OP_REF_INDEX`, `executor.go`), com um ref que já existia, e nunca reatribuído; cada nó é mais novo que o seu `Base`, então a caminhada termina.

O que fica é `maxRefHopDepth` (mesmo valor, 256), usado só em `derefPlace`: quantos refs em sequência um *lugar* pode guardar até o contêiner de verdade — um lugar `ref T` dá uma volta; o teto é backstop para lugares `any`. O comentário agora descreve o que a constante limita e por que a cadeia de Base não precisa de teto.

## Verificação

- `go test ./internal/vm -run BorrowPlace` verde — os sete repros da #83 continuam sendo o critério; `go test ./...` verde.
- Teste novo `TestBorrowPlacePathDepthIsData`: BST por posse com 300 chaves ordenadas (> 256, via recursão) e lista por posse com 1000 nós (via rebinding em laço). 0,7 s.
- Fixture da issue (`p_owned_sorted`, 1000 ordenadas) com o binário desta branch: `owned: n = 1000`, exit 0 — em **24,9 s**. Esse tempo é o custo O(profundidade²) por inserção, parte (b) da #93, **de propósito fora deste PR** (o handoff pediu para não mexer no custo aqui; ele vem depois do #96). É também por isso que o teste Go usa 300 e não 1000.
- Sondei se um ciclo por `any` chega a `derefPlace` (`a.v = ref b.v; b.v = ref a.v; ref a.v.v`): falha antes, na criação do ref (`Property reference base must be an object`). O comentário fala em backstop, não afirma que o ciclo é construível.

Refs #93 (parte a). Parte (b) fica aberta na mesma issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
