### PR TITLE
perf(vm): campo de struct por índice em compilação — OP_GET_FIELD/OP_SET_FIELD/OP_GET_FIELD_MUT (issue #96)

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,59 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## develop (2a627bc) × campo de struct por índice — issue #96 (perf/issue-96-struct-field-index, 79af956)
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · protocolo
+intercalado, mediana de 9. Máquina sem `go test` nem build durante o A/B.
+Dados brutos e perfis em
+[`results/2026-08-28-issue-96-struct-field-index-raw.md`](results/2026-08-28-issue-96-struct-field-index-raw.md).
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`.
+
+O que mudou: quando o tipo estático da base é um struct do programa, o
+compilador resolve `p.x` para o índice de slot (posição na declaração — a
+ordem dos `Slots` desde o #95) e emite `OP_GET_FIELD` / `OP_SET_FIELD` /
+`OP_GET_FIELD_MUT` com operando `[idx u8][nome u16]`. O nome vai junto porque
+`json_loads` monta definições de struct em ordem alfabética e essas instâncias
+entram em contêineres tipados: o caminho rápido confere `Fields[idx] == nome`
+(comparação de string curta) e cai no funil por nome quando não bate. Base
+`any`, módulos e `ref p.x` inalterados; `OP_SET_FIELD` é statement e só chama
+`Retain`/`Release` quando um dos lados pode ter contador. Os `case` por nome
+passaram a chamar os mesmos métodos que os fallbacks (`field_ops.go`).
+
+**Verificação completa:** `go test ./...` verde; `go test -race ./internal/vm`
+verde; **corpus 180/180**; **diff de saída base × head: 149 iguais, 0
+divergentes**; sem a guarda, o teste da instância JSON reordenada falha.
+
+### Headline — base × head (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | base_ms | head_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_path_update | 238,8 | 160,7 | **−32,7 %** | ✅ `cells[i].hits = cells[i].hits + 1`: sem hash de campo, sem `Retain`/`Release` de `int` |
+| bench_struct_records | 145,9 | 136,1 | **−6,7 %** | ✅ só as leituras; 47 % do bench é a validação do construtor (cache do PR #70 nunca chegou a `develop` — follow-up) |
+| bench_share_mutate | 111,9 | 109,7 | −2,0 % | ✅ gate CoW |
+| bench_conway | 1212,1 | 1196,3 | −1,3 % | ✅ gate CoW (≤ +5 %) |
+| bench_map_churn | 210,2 | 208,7 | −0,7 % | ➖ ruído |
+| bench_bubblesort | 659,8 | 655,6 | −0,6 % | ➖ ruído |
+| bench_generic_vs_hand | 419,7 | 420,6 | +0,2 % | ✅ sentinela de `run()`: sem regressão de codegen |
+| bench_call_ref | 995,5 | 999,5 | +0,4 % | ➖ ruído |
+| bench_call_readonly | 448,3 | 450,9 | +0,6 % | ➖ ruído |
+| bench_spawn_sum | 411,6 | 414,7 | +0,8 % | ➖ ruído |
+| bench_typed_call_map | 27,6 | 28,4 | +2,9 % | ➖ piso¹ (gate CoW ok) |
+| bench_call_light | 27,0 | 27,0 | 0 % | ➖ piso¹ |
+| bench_value_call_mutate | 27,9 | 27,8 | −0,4 % | ➖ piso¹ |
+
+¹ ~27 ms com piso de processo ~10 ms: não decidem nada. `bench_borrow_path` e
+`bench_hash31_bytes` foram pulados pelo guard de `CHECKSUM:` (nenhum dos dois
+binários imprime a linha — pré-existente).
+
+### Perfil (`--cpuprofile`, carga ×10/×15)
+
+`bench_path_update`: `FieldIndex` 15,2 % cum (`mapaccess2_faststr` 14,2 %,
+`aeshashbody` 4,3 %) e `Retain`+`Release` 10 % na base → **ausentes** no head;
+sobra `IsShared` da cadeia `_MUT` (16 %) e `memeqbody` 2,8 % (a guarda).
+`bench_struct_records`: hashing de campo ausente no head; o topo continua
+`validateStructConstructorArguments` (46,9 % cum), fora do escopo.
+
 ## v0.15.1 (c1cc12a) × protocolo de chamada — v0.15.2 (perf/issue-66-call-protocol, 868d435)
 
 **Data:** 2026-08-22 · Windows 11 · Intel Core 7 150U (mesma máquina do item

--- a/benchmarks/bench_struct_records.nx
+++ b/benchmarks/bench_struct_records.nx
@@ -1,0 +1,36 @@
+// Registros: struct de 5 campos construida em laco (60.000 vezes) e passada
+// por valor a duas funcoes — uma le 3 campos, outra constroi outra struct a
+// partir dela. E o formato do perfil da issue #40 (validacao de construtor).
+struct Registro
+    id: int
+    nome: string
+    valor: int
+    ativo: bool
+    grupo: int
+end
+
+func pontuar(r: Registro) -> int
+    if r.ativo then
+        return r.valor + r.grupo
+    end
+    return r.valor
+end
+
+func promover(r: Registro) -> Registro
+    return Registro(r.id, r.nome, r.valor + 1, true, r.grupo)
+end
+
+func main()
+    let i: int = 0
+    let acc: int = 0
+    while i < 60000 do
+        let r: Registro = Registro(i, "reg", i % 100, i % 2 == 0, i % 7)
+        acc = acc + pontuar(r)
+        let p: Registro = promover(r)
+        acc = acc + p.valor
+        i = i + 1
+    end
+    print(f"CHECKSUM:{acc}")
+end
+
+main()

--- a/benchmarks/results/2026-08-28-issue-96-struct-field-index-raw.md
+++ b/benchmarks/results/2026-08-28-issue-96-struct-field-index-raw.md
@@ -1,0 +1,127 @@
+# Dados brutos — campo de struct por índice em compilação (issue #96): base × head
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · laptop, na
+tomada. Máquina sem `go test` nem build durante as medições (o runner do
+corpus e o `compare_examples.ps1` rodaram ANTES do A/B, nunca junto).
+
+**Binários** (em disco local, scratchpad da sessão):
+
+| rótulo | commit | o que é |
+|---|---|---|
+| `base` | 2a627bc | `develop` depois de #95 (slots), #97 (corpus) e #98 (#93a) |
+| `head` | 79af956 | + `OP_GET_FIELD` / `OP_SET_FIELD` / `OP_GET_FIELD_MUT` emitidos para base tipada; funis `getPropertyGeneric`/`setPropertyGeneric`/`getPropMutGeneric` |
+
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`.
+
+**Protocolo:** `benchmarks/interleaved_compare.ps1 -Runs 9` (`pwsh -NoProfile
+-File`), execuções intercaladas na mesma janela, guard de `CHECKSUM:` entre
+binários, mediana de 9. `bench_struct_records.nx` entrou na suíte neste PR
+(993b464, resgatado de 93625ac — o comentário de fechamento da #40 registra que
+o original nunca foi commitado).
+
+## 1. Headline — base × head (mediana de 9)
+
+| bench | base_2a627bc_ms | head_79af956_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 659.8 | 655.6 | -0.6% |
+| bench_call_light.nx | 27 | 27 | 0% |
+| bench_call_readonly.nx | 448.3 | 450.9 | 0.6% |
+| bench_call_ref.nx | 995.5 | 999.5 | 0.4% |
+| bench_conway.nx | 1212.1 | 1196.3 | -1.3% |
+| bench_generic_vs_hand.nx | 419.7 | 420.6 | 0.2% |
+| bench_map_churn.nx | 210.2 | 208.7 | -0.7% |
+| bench_path_update.nx | 238.8 | 160.7 | **-32.7%** |
+| bench_share_mutate.nx | 111.9 | 109.7 | -2% |
+| bench_spawn_sum.nx | 411.6 | 414.7 | 0.8% |
+| bench_struct_records.nx | 145.9 | 136.1 | **-6.7%** |
+| bench_typed_call_map.nx | 27.6 | 28.4 | 2.9% |
+| bench_value_call_mutate.nx | 27.9 | 27.8 | -0.4% |
+
+Pulados pelo guard de equivalência — **nenhum dos dois binários** imprime
+`CHECKSUM:` neles (pré-existente, não é deste PR): `bench_borrow_path.nx`
+(imprime `200000` duas vezes) e `bench_hash31_bytes.nx` (imprime
+`bytes=… hash31=… ms=…`).
+
+## 2. Bytecode dos benches (`noxy -disassembly`)
+
+| bench | opcodes de campo no head |
+|---|---|
+| bench_path_update | 4× `OP_GET_FIELD`, 2× `OP_SET_FIELD`; nenhum `OP_GET_PROPERTY`/`OP_SET_PROPERTY` |
+| bench_struct_records | 9× `OP_GET_FIELD`; nenhum por nome |
+
+## 3. Perfis (`noxy --cpuprofile`, carga ampliada para juntar amostra, uma execução)
+
+`prof_path_update.nx` = `bench_path_update` com `round < 5000` (×10);
+`prof_struct_records.nx` = `bench_struct_records` com `i < 900000` (×15).
+`go tool pprof -top`.
+
+### 3.1 `bench_path_update` ×10
+
+**Base 2a627bc** — 2,18 s, 2,11 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 47,4 % | 100 % |
+| `push` + `pop` | 8,5 + 6,6 % | 15,2 % |
+| `value.Retain` + `value.Release` | 5,2 + 2,4 % | 6,6 + 3,3 % |
+| `value.IsShared` (+ `ownersOf`) | 4,7 % (+ 5,2 %) | 7,6 % |
+| **`(*ObjStruct).FieldIndex`** | 0,9 % | **15,2 %** |
+| ↳ `runtime.mapaccess2_faststr` | 2,8 % | 14,2 % |
+| ↳ `aeshashbody` | 4,3 % | 4,3 % |
+| ↳ `memequal` + `memeqbody` | 1,9 + 1,4 % | — |
+| `(*ObjInstance).Get` | 1,4 % | 11,4 % |
+
+**Head 79af956** — 1,44 s, 1,41 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 68,1 % | 99,3 % |
+| `value.IsShared` (+ `ownersOf`) | 9,9 % (+ 6,4 %) | 16,3 % |
+| `push` + `pop` | 5,0 + 1,4 % | 6,4 % |
+| `memeqbody` (a guarda `Fields[idx] == nome`) | 2,8 % | 2,8 % |
+| `unicizeOwnedSlot` | 2,8 % | 5,0 % |
+| `FieldIndex` / `mapaccess2_faststr` / `aeshashbody` / `Retain` / `Release` | — | **ausentes** |
+
+Leitura: o hashing de campo (15 %) e as chamadas `Retain`/`Release` (10 %, no-op
+para `int`) saíram do caminho; o que sobra é `IsShared` do `OP_GET_LOCAL_MUT`
++ `OP_GET_INDEX_MUT` da cadeia de mutação (`cells[i].hits = …`), fora do
+escopo desta issue.
+
+### 3.2 `bench_struct_records` ×15
+
+**Base 2a627bc** — 1,76 s, 2,09 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 10,5 % | 78,0 % |
+| **`validateStructConstructorArguments`** | 1,4 % | **45,9 %** |
+| ↳ `runtimeTypeComplete` | 2,4 % | 40,7 % |
+| ↳ `runtime.mapassign_fast64ptr` (o `make(map)` de memoização, por construção) | 1,9 % | 27,3 % |
+| `callPreparedValue` | 1,9 % | 7,2 % |
+| `FieldIndex` / `mapaccess2_faststr` | — | não aparecem no top-22 |
+
+**Head 79af956** — 1,56 s, 1,77 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 7,9 % | 80,8 % |
+| `validateStructConstructorArguments` | 1,7 % | 46,9 % |
+| ↳ `runtimeTypeComplete` | 1,7 % | 39,0 % |
+| `FieldIndex` / `mapaccess2_faststr` / `aeshashbody` / `(*ObjInstance).Get` | — | **ausentes** (grep em `-nodecount=200`) |
+
+Leitura: neste bench o índice de campo só acelera as leituras de `pontuar`/
+`promover` (−6,7 %); o custo dominante é a validação do construtor, que refaz
+`runtimeTypeComplete(schema, make(map…))` a cada `Registro(...)`. O cache do
+construtor do PR #70 (`ctorCache` em `ObjStruct`, commit 131c352) **não está em
+`develop`**: o #70 foi mergeado em `perf/issue-66-call-protocol` 23 s depois de
+o #69 entrar em `develop` (`git merge-base --is-ancestor 131c352 develop` →
+não). Follow-up próprio.
+
+## 4. Verificação
+
+- `go test ./...` verde; `go test -race ./internal/vm -count=1` verde (24 s).
+- Corpus `run_all_tests_concurrent.nx` com o head: **180/180** (3,1 s).
+- `compare_examples.ps1` base × head: **149 iguais, 0 divergentes, 70 excluídos**.
+- gofmt limpo nos arquivos tocados (checado em cópias sem CR).
+- Mutação: sem a guarda `Fields[idx] == nome`, `TestFieldIndexGuardsReorderedJSONInstance`
+  falha (`n.valor` lê o slot de `proximo`).

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,14 +1,20 @@
-| bench | v0151_ms | call_ms | delta |
+| bench | base_2a627bc_ms | head_79af956_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 776.9 | 694.1 | -10.7% |
-| bench_call_light.nx | 19.9 | 19.7 | -1% |
-| bench_call_readonly.nx | 531.3 | 537.4 | 1.1% |
-| bench_call_ref.nx | 1137.1 | 1149.9 | 1.1% |
-| bench_conway.nx | 1253.2 | 1275.3 | 1.8% |
-| bench_generic_vs_hand.nx | 456.6 | 448.7 | -1.7% |
-| bench_map_churn.nx | 194.3 | 200.1 | 3% |
-| bench_path_update.nx | 229.8 | 231.8 | 0.9% |
-| bench_share_mutate.nx | 100.6 | 103.3 | 2.7% |
-| bench_spawn_sum.nx | 398.8 | 369.8 | -7.3% |
-| bench_typed_call_map.nx | 22.3 | 22.5 | 0.9% |
-| bench_value_call_mutate.nx | 21.1 | 21.2 | 0.5% |
+| bench_bubblesort.nx | 659.8 | 655.6 | -0.6% |
+| bench_call_light.nx | 27 | 27 | 0% |
+| bench_call_readonly.nx | 448.3 | 450.9 | 0.6% |
+| bench_call_ref.nx | 995.5 | 999.5 | 0.4% |
+| bench_conway.nx | 1212.1 | 1196.3 | -1.3% |
+| bench_generic_vs_hand.nx | 419.7 | 420.6 | 0.2% |
+| bench_map_churn.nx | 210.2 | 208.7 | -0.7% |
+| bench_path_update.nx | 238.8 | 160.7 | -32.7% |
+| bench_share_mutate.nx | 111.9 | 109.7 | -2% |
+| bench_spawn_sum.nx | 411.6 | 414.7 | 0.8% |
+| bench_struct_records.nx | 145.9 | 136.1 | -6.7% |
+| bench_typed_call_map.nx | 27.6 | 28.4 | 2.9% |
+| bench_value_call_mutate.nx | 27.9 | 27.8 | -0.4% |
+
+Pulados (sem equivalencia entre os dois binarios):
+
+- bench_borrow_path.nx — sem CHECKSUM no base_2a627bc
+- bench_hash31_bytes.nx — sem CHECKSUM no base_2a627bc

--- a/docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md
+++ b/docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md
@@ -1,0 +1,168 @@
+# VM Perf — Campo de struct por índice em compilação (issue #96)
+
+**Data:** 2026-08-28 · **Issue:** [#96](https://github.com/estevaofon/noxy/issues/96) · **Branch:** `perf/issue-96-struct-field-index` · **Base:** `develop` (2a627bc, pós-#95/#97/#98)
+
+## 1. Contexto (medido nesta sessão, binário de 2a627bc)
+
+Desde o #95 uma instância guarda os campos em `Slots []Value` na ordem da
+declaração e `ObjStruct` tem o índice nome→slot. O caminho quente de
+`OP_GET_PROPERTY`/`OP_SET_PROPERTY`/`OP_GET_PROP_MUT` continua fazendo **um
+lookup por string** por acesso (`Struct.FieldIndex(name)` = `mapaccess2_faststr`
++ `aeshashbody`).
+
+**`bench_path_update`** (`cells[i].hits = cells[i].hits + 1`, carga ×10 para
+amostra): `FieldIndex` **15,2 % cum**, `mapaccess2_faststr` 14,2 %, `aeshashbody`
+4,3 %, `memequal` 1,9 %; `Retain`+`Release` 10 % (no-op para `int`, mas chamadas
+reais); `push`/`pop` 15 %.
+
+**`bench_struct_records`** (5 campos, 60k construções, duas funções por valor —
+resgatado de 93625ac, nunca tinha chegado a `develop`): o topo **não é** o
+hashing de campo. `validateStructConstructorArguments` **45,9 % cum**, via
+`runtimeTypeComplete` 40,7 % e `mapassign_fast64ptr` 27,3 % — o `make(map...)`
+de memoização é refeito a cada construção porque o cache do construtor do PR #70
+(`ctorCache` em `ObjStruct`, commit 131c352) **nunca chegou a `develop`**: o #70
+foi mergeado em `perf/issue-66-call-protocol` 23 s depois de o #69 entrar em
+`develop`. Achado colateral; fica como follow-up próprio (§7.4). Neste bench o
+ganho do índice de campo é limitado às leituras `r.ativo`/`r.valor`/`r.grupo`.
+
+## 2. Objetivo e não-objetivos
+
+**Objetivo:** quando o tipo estático da base é um struct do programa, resolver
+`p.x` para o índice de slot em compilação e acessar `Slots[idx]` sem hashing.
+Semântica, saída, mensagens e linhas de erro, contagem RC e CoW **idênticas**;
+opcodes só por append; bytecode com base `any`/módulo **inalterado**.
+
+**Não-objetivos:** `ref p.x` (`OP_REF_PROPERTY` fica: o `ObjRef` é resolvido
+por NOME em `references.go` — `descend`, `referenceStorageMode`, `sameBorrowBase`;
+é a parte do #93b); formas fundidas com slot local (`OP_GET_LOCAL_FIELD`);
+fundir o `OP_DEREF` de base `ref`; structs de módulo (ficam por nome, como a
+issue pede); o cache do construtor (§7.4).
+
+## 3. Desenho
+
+### 3.1 A premissa da issue está errada: precisa de guarda
+
+A issue diz "struct de JSON dinâmico tem a própria definição, então a base
+tipada nunca aponta para ele". Falso: `buildTypedJSONValue`
+(`json_population.go:357-397`) cria uma `ObjStruct` NOVA com os campos em
+**ordem alfabética** (`sort.Strings`) para todo valor de struct que o
+`json_loads` **cria** (elemento novo de `Node[]`, campo que era `null`, valor
+novo de map). Essa instância entra num contêiner tipado: `let n: Node = xs[0]`
+tem tipo estático `Node` (slot 0 = `valor`) e instância com slot 0 = `proximo`.
+Um `OP_GET_FIELD 0` cego leria o campo errado.
+
+Por isso o operando carrega o índice **e** o nome, e o caminho rápido confere
+`idx < len(Slots) && Struct.Fields[idx] == name` — uma comparação de string
+curta (Go compara tamanho, depois ponteiro, depois bytes) no lugar do hash.
+Falhou a guarda → funil genérico por nome, o mesmo que o opcode antigo. A
+guarda também cobre definições montadas por natives/bytecode de teste sem
+índice. Corrigir o JSON para reutilizar a definição declarada não cabe aqui:
+`RuntimeTypeInfo.Fields` é map sem ordem, e a definição própria é onde o JSON
+guarda `JSONDynamicFields` por instância.
+
+### 3.2 Opcodes (append ao fim de `internal/chunk/chunk.go`, após `OP_GET_LOCAL_2`)
+
+| opcode | operando | pilha | espelha |
+|---|---|---|---|
+| `OP_GET_FIELD` | `[idx u8][nome u16]` | `[inst] → [val]` | `OP_GET_PROPERTY` |
+| `OP_SET_FIELD` | `[idx u8][nome u16]` | `[inst, val] → []` | `OP_SET_PROPERTY` + `OP_POP` |
+| `OP_GET_FIELD_MUT` | `[idx u8][nome u16]` | `[inst] → [val unicizado]` | `OP_GET_PROP_MUT` |
+
+`OP_SET_FIELD` é statement (não empilha; o compilador não emite `OP_POP`
+depois). Estruturas com mais de 255 campos ficam por nome.
+
+### 3.3 VM — caminho rápido e fallback exato
+
+Os corpos de `OP_GET_PROPERTY`, `OP_SET_PROPERTY` e `OP_GET_PROP_MUT` saem
+para métodos `getPropertyGeneric(c, ip, name)`, `setPropertyGeneric(c, ip, name)`
+e `getPropMutGeneric(c, ip, name)`; os `case` genéricos passam a chamá-los (uma
+chamada a mais por opcode genérico — `any`, módulos — o mesmo custo que a #66
+aceitou com `getIndexGeneric`/`setIndexGeneric`; sentinela `bench_generic_vs_hand`).
+
+- **`OP_GET_FIELD`**: topo é `*ObjInstance` (assertion), guarda §3.1 →
+  `stack[top-1] = Slots[idx]` no lugar. Senão `getPropertyGeneric` (base ainda
+  na pilha): ref auto-deref, `ObjMap`, `null`, mensagens e linha idênticas —
+  `Lines[ip-1]` é o último byte de operando, gravado com a linha do opcode.
+- **`OP_SET_FIELD`**: `[inst, val]`; instância + guarda; campo `ref T`
+  (`RefFields != nil && RefFields[name]` — nil quando o struct não tem campo ref,
+  então sem custo no caso comum) → genérico, que aplica `refSlotWriteError`;
+  senão `old := Slots[idx]`; se `NeverTracked(val) && NeverTracked(old)` grava
+  sem `Retain`/`Release` (são no-op nesses valores — não é uma variante NORC,
+  é a mesma semântica sem a chamada); senão `Retain(val); Slots[idx] = val;
+  Release(old)`. Limpa os dois slots da pilha. Fallback: `setPropertyGeneric` +
+  `vm.LastPopped = vm.pop()` (o `OP_POP` da sequência genérica). O caminho
+  rápido não grava `LastPopped`, como as escritas fundidas da #66.
+- **`OP_GET_FIELD_MUT`**: instância + guarda; `fieldVal := Slots[idx]`; se
+  `IsShared(fieldVal)` clona e grava de volta com retain-antes-de-release (o
+  corpo do genérico); resultado no lugar. Senão `getPropMutGeneric`.
+
+Base `ref` (`r.x` com `r: ref Ponto`): o compilador já emite `OP_DEREF`
+(leitura) / `OP_DEREF_MUT` (lvalue) antes, então o opcode novo vê a instância;
+não muda.
+
+### 3.4 Compilador
+
+`fieldSlot(owner, member) (idx int, ok bool)` em `member_types.go`, irmã de
+`memberType`: `unwrapRefType(owner)` é `*PrimitiveType`, `structDeclaration`
+existe, `structOrigin(decl) == ""` (struct do programa — inclui instâncias
+genéricas monomorfizadas `main::Stack<int>` e structs de escopo local, cuja
+`FieldsList` é a mesma que vira `ObjStruct.Fields`), campo achado em
+`FieldsList` na posição `idx ≤ 255`. Tudo o mais → `ok=false` → opcode por nome.
+
+Sites: leitura (`compiler.go` `case *ast.MemberAccessExpression`) → `OP_GET_FIELD`;
+atribuição (`compiler.go` alvo `MemberAccessExpression`) → `OP_SET_FIELD` sem
+`OP_POP`; base de lvalue aninhado (`cow_lowering.go` `compileLValueBase`) →
+`OP_GET_FIELD_MUT`. `use m select` e `ref p.x` inalterados. Checagens de tipo,
+mensagens e ordem inalteradas (o índice é decidido depois delas).
+
+## 4. Invariantes e guards executáveis
+
+- `chunk_test.go`: sentinela de `TestEveryOpcodeHasASymbolicNameWithoutGaps` →
+  `OP_GET_FIELD_MUT`; disassembler ganha `fieldInstruction` (3 bytes) e
+  `disassemblyProgram` já tem `p.x = soma(p.x, 10)` com base tipada.
+- `cow_lowering_test.go`: walker `collectOpcodes` ganha o caso de 3 bytes;
+  allowlist do lowering ganha `OP_GET_FIELD_MUT`/`OP_SET_FIELD`.
+- Bytecode (pacote `compiler`, via disassembler): local tipado → `OP_GET_FIELD`
+  com o índice certo; `any` → `OP_GET_PROPERTY`; namespace `mod.f` → por nome;
+  `ref Ponto` → `OP_DEREF` + `OP_GET_FIELD`; `p.x = v` → `OP_SET_FIELD` sem
+  `OP_POP`; `p.a.b = v` → `OP_GET_FIELD_MUT` + `OP_SET_FIELD`; instância
+  genérica → por índice; struct de módulo via `select` → por nome.
+- Comportamento (pacote `vm`): **instância JSON com ordem invertida lida e
+  escrita por base tipada** (a guarda); tabela de erros idênticos base tipada ×
+  `any` (null, ref nula, campo inexistente via `any`); RC (`OwnersCount` após
+  `box.value = y` com composto — `TestSetPropertyReleasesOldRetainsNew` passa a
+  exercitar o opcode novo); CoW (`p.inner.x = 1` com `inner` compartilhado
+  clona uma vez, cópia intacta); campo `ref T` escrito por base tipada com ref e
+  com null; `-race` no pacote `vm` inteiro.
+- `go test ./...`, corpus `run_all_tests_concurrent.nx` 180/180,
+  `compare_examples.ps1` 0 divergentes.
+
+## 5. Medição
+
+Binários no scratchpad: `noxy_base.exe` (2a627bc) × head.
+`interleaved_compare.ps1 -Runs 9`; perfil de `bench_path_update` e
+`bench_struct_records` (carga ×10/×15) sem `mapaccess2_faststr`/`aeshashbody`
+vindos de `FieldIndex`; gates CoW ≤ +5 % (`bench_typed_call_map`,
+`bench_share_mutate`, `bench_call_light`, `bench_conway`);
+`bench_generic_vs_hand` como sentinela do despacho. Seção nova no topo de
+`RESULTS.md` + `results/2026-08-28-issue-96-struct-field-index-raw.md`.
+
+## 6. Riscos
+
+| risco | mitigação |
+|---|---|
+| definição com outra ordem (JSON, natives) | guarda `Fields[idx] == name` em runtime + teste com instância JSON invertida |
+| campo `ref T` escrito sem a checagem do slot | fast path recusa quando `RefFields[name]`; genérico decide |
+| pular RC de um composto | `NeverTracked(val) && NeverTracked(old)`; oráculo `OwnersCount` |
+| fallback divergir do genérico | funil único: os `case` genéricos chamam os mesmos métodos |
+| mexer em `run()` regredir o despacho | `bench_generic_vs_hand` |
+
+## 7. Decisões tomadas sem consulta (para a review)
+
+1. Guarda por nome no operando em vez de identidade da definição (§3.1): não
+   exige que o compilador tenha o `*ObjStruct` no site de acesso e cobre
+   qualquer definição.
+2. Sem variante NORC: `OP_SET_FIELD` decide o RC em runtime por `NeverTracked`.
+3. `OP_REF_PROPERTY` fora do escopo (o custo do empréstimo é o #93b).
+4. Cache do construtor (PR #70) ausente em `develop` — não resgatado aqui; é
+   45 % de `bench_struct_records` e merece PR próprio (issue a abrir).

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -161,6 +161,13 @@ const (
 	// GET_LOCAL(+CONSTANT+ADD_INT) fundidos; semantica identica.
 	OP_GET_LOCAL_ADD_IMM_INT // [slot u8][imm i8]; push local(int)+imm (wrappa como OP_ADD_INT)
 	OP_GET_LOCAL_2           // [a u8][b u8]; push local a, push local b
+	// perf issue #96: campo de struct por INDICE de slot quando o compilador
+	// conhece o struct da base. Operando [idx u8][nome u16]: o nome e a guarda
+	// de runtime (uma definicao com outra ordem — json_loads monta a sua em
+	// ordem alfabetica — cai no caminho por nome) e o texto das mensagens.
+	OP_GET_FIELD     // [idx u8][name u16]; pops instance, pushes field
+	OP_SET_FIELD     // [idx u8][name u16]; pops val, instance; statement (nao empilha)
+	OP_GET_FIELD_MUT // [idx u8][name u16]; pops instance, pushes field unicizado (OP_GET_PROP_MUT)
 )
 
 func (op OpCode) String() string {
@@ -275,6 +282,12 @@ func (op OpCode) String() string {
 		return "OP_GET_LOCAL_ADD_IMM_INT"
 	case OP_GET_LOCAL_2:
 		return "OP_GET_LOCAL_2"
+	case OP_GET_FIELD:
+		return "OP_GET_FIELD"
+	case OP_SET_FIELD:
+		return "OP_SET_FIELD"
+	case OP_GET_FIELD_MUT:
+		return "OP_GET_FIELD_MUT"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -612,6 +625,12 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.slotDeltaInstruction("OP_GET_LOCAL_ADD_IMM_INT", offset)
 	case OP_GET_LOCAL_2:
 		return c.twoSlotInstruction("OP_GET_LOCAL_2", offset)
+	case OP_GET_FIELD:
+		return c.fieldInstruction("OP_GET_FIELD", offset)
+	case OP_SET_FIELD:
+		return c.fieldInstruction("OP_SET_FIELD", offset)
+	case OP_GET_FIELD_MUT:
+		return c.fieldInstruction("OP_GET_FIELD_MUT", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:
@@ -774,4 +793,19 @@ func (c *Chunk) closureInstruction(name string, offset int) int {
 		}
 	}
 	return offset
+}
+
+// fieldInstruction: [idx u8][name u16] — imprime o indice de slot e o nome
+// (constante) do campo, como em `OP_GET_FIELD    1 'y'`.
+func (c *Chunk) fieldInstruction(name string, offset int) int {
+	idx := c.Code[offset+1]
+	constant := uint16(c.Code[offset+2])<<8 | uint16(c.Code[offset+3])
+	fmt.Printf("%-16s %4d '", name, idx)
+	if int(constant) < len(c.Constants) {
+		fmt.Print(c.Constants[constant])
+	} else {
+		fmt.Print("?")
+	}
+	fmt.Printf("'\n")
+	return offset + 4
 }

--- a/internal/chunk/chunk_test.go
+++ b/internal/chunk/chunk_test.go
@@ -45,7 +45,7 @@ func TestEveryOpcodeHasASymbolicNameWithoutGaps(t *testing.T) {
 	}
 	// Sentinela: o último opcode declarado em chunk.go precisa estar nomeado.
 	// Se você acrescentou um opcode depois dele, atualize aqui também.
-	if last := int(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC); firstUnnamed >= 0 && firstUnnamed <= last {
+	if last := int(chunk.OP_GET_FIELD_MUT); firstUnnamed >= 0 && firstUnnamed <= last {
 		t.Fatalf("opcode %d está abaixo do último declarado (%d) e não tem nome em String()", firstUnnamed, last)
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -882,9 +882,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 
 			// Field Name
-			nameConst := c.makeConstant(value.NewString(memberExp.Member))
-			c.emitOpWithConstantIndex(chunk.OP_SET_PROPERTY, nameConst)
-			c.emitByte(byte(chunk.OP_POP))
+			if idx, ok := c.fieldSlot(leftType, memberExp.Member); ok {
+				c.emitFieldOp(chunk.OP_SET_FIELD, idx, memberExp.Member)
+			} else {
+				nameConst := c.makeConstant(value.NewString(memberExp.Member))
+				c.emitOpWithConstantIndex(chunk.OP_SET_PROPERTY, nameConst)
+				c.emitByte(byte(chunk.OP_POP))
+			}
 
 		} else {
 			return nil, nil, fmt.Errorf("[line %d] assignment target not supported yet", c.currentLine)
@@ -988,8 +992,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			leftType = ref.ElementType
 		}
 
-		nameConst := c.makeConstant(value.NewString(n.Member))
-		c.emitOpWithConstantIndex(chunk.OP_GET_PROPERTY, nameConst)
+		if idx, ok := c.fieldSlot(leftType, n.Member); ok {
+			c.emitFieldOp(chunk.OP_GET_FIELD, idx, n.Member)
+		} else {
+			nameConst := c.makeConstant(value.NewString(n.Member))
+			c.emitOpWithConstantIndex(chunk.OP_GET_PROPERTY, nameConst)
+		}
 
 		// RESOLVE FIELD TYPE: memberType resolve o dono pela declaracao que
 		// designa (`File` e `io.File` igual) e devolve o tipo do campo ja na

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -70,8 +70,12 @@ func (c *Compiler) compileLValueBase(expr ast.Expression) (ast.NoxyType, bool, e
 		if err != nil {
 			return nil, false, err
 		}
-		nameConst := c.makeConstant(value.NewString(n.Member))
-		c.emitOpWithConstantIndex(chunk.OP_GET_PROP_MUT, nameConst)
+		if idx, ok := c.fieldSlot(leftType, n.Member); ok {
+			c.emitFieldOp(chunk.OP_GET_FIELD_MUT, idx, n.Member)
+		} else {
+			nameConst := c.makeConstant(value.NewString(n.Member))
+			c.emitOpWithConstantIndex(chunk.OP_GET_PROP_MUT, nameConst)
+		}
 		// memberType: dono resolvido pela declaracao (`File` ≡ `io.File`) e
 		// tipo do campo ja na visao do programa (issue #58 item 1).
 		t, wasRef := c.derefMutIfRef(c.memberType(leftType, n.Member))

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -61,6 +61,9 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				chunk.OP_MARK_REF_TARGET_TYPE, chunk.OP_MARK_RUNTIME_VALUE_TYPE,
 				chunk.OP_SET_GLOBAL_BORROW:
 				offset += 2
+			case chunk.OP_GET_FIELD, chunk.OP_SET_FIELD, chunk.OP_GET_FIELD_MUT:
+				// perf issue #96: [idx u8][nome u16]
+				offset += 3
 			case chunk.OP_CLOSURE:
 				// [const_index] [upvalue_count] ([is_local, index])*
 				if offset+1 < len(c.Code) {

--- a/internal/compiler/field_index.go
+++ b/internal/compiler/field_index.go
@@ -1,0 +1,59 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Campo de struct por indice em compilacao (issue #96).
+//
+// Desde o #95 uma instancia guarda os campos em Slots na ordem da declaracao
+// (ObjStruct.Fields vem de StructStatement.FieldsList, compiler.go). Quando o
+// tipo estatico da base e um struct do PROGRAMA, a posicao do campo em
+// FieldsList E o indice do slot em runtime, e o acesso sai em OP_GET_FIELD /
+// OP_SET_FIELD / OP_GET_FIELD_MUT com [idx][nome] — sem hashing no caminho
+// quente. O nome vai junto porque a VM confere `Fields[idx] == nome` antes de
+// usar o indice: json_loads monta definicoes proprias em ordem alfabetica
+// (spec 2026-08-28 §3.1), e essas instancias entram em conteineres tipados.
+
+// maxFieldSlot: o indice viaja em 1 byte; struct maior fica por nome.
+const maxFieldSlot = 255
+
+// fieldSlot devolve o indice de slot de `member` no struct estatico `owner`
+// (desembrulhando `ref`), ou ok=false quando o acesso tem de ficar por nome:
+// base `any`/desconhecida, campo inexistente (o erro e do memberType/runtime),
+// struct de MODULO (a issue #96 os deixa por nome; a definicao de runtime e
+// emitida pelo compilador do modulo) ou indice acima de 255.
+func (c *Compiler) fieldSlot(owner ast.NoxyType, member string) (int, bool) {
+	primitive, ok := unwrapRefType(owner).(*ast.PrimitiveType)
+	if !ok {
+		return 0, false
+	}
+	definition := c.structDeclaration(primitive.Name)
+	if definition == nil || c.structOrigin(definition) != "" {
+		return 0, false
+	}
+	for i, field := range definition.FieldsList {
+		if field.Name == member {
+			if i > maxFieldSlot {
+				return 0, false
+			}
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// emitFieldOp emite op [idx u8][nome u16] (o nome como constante, o mesmo
+// operando que a familia por nome usa).
+func (c *Compiler) emitFieldOp(op chunk.OpCode, idx int, member string) {
+	nameConst := c.makeConstant(value.NewString(member))
+	if nameConst > 65535 {
+		panic("constant pool overflow: too many constants in chunk")
+	}
+	c.emitByte(byte(op))
+	c.emitByte(byte(idx))
+	c.emitByte(byte((nameConst >> 8) & 0xff))
+	c.emitByte(byte(nameConst & 0xff))
+}

--- a/internal/compiler/struct_field_index_compile_test.go
+++ b/internal/compiler/struct_field_index_compile_test.go
@@ -1,0 +1,224 @@
+package compiler
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+// Campo de struct por índice em compilação (issue #96). Quando o tipo
+// estático da base é um struct do PROGRAMA, `p.x` resolve para o índice de
+// slot na declaração e o compilador emite OP_GET_FIELD / OP_SET_FIELD /
+// OP_GET_FIELD_MUT com `[idx][nome]`; base `any` e struct de módulo ficam nos
+// opcodes por nome. Cada regra tem caso positivo e negativo, lidos da saída
+// do disassembler (que conhece a largura de cada operando).
+
+const fieldIndexPrelude = `
+struct Ponto
+    x: int
+    y: int
+end
+struct Caixa
+    tag: string
+    p: Ponto
+end
+`
+
+// disassemblyText devolve o texto do disassembler de um chunk, para afirmar
+// o OPERANDO (índice e nome) e não só o nome do opcode.
+func disassemblyText(t *testing.T, code *chunk.Chunk) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan string)
+	go func() {
+		out, _ := io.ReadAll(reader)
+		done <- string(out)
+	}()
+	previous := os.Stdout
+	os.Stdout = writer
+	code.Disassemble("t")
+	_ = writer.Close()
+	os.Stdout = previous
+	return <-done
+}
+
+func compiledFunctionChunk(t *testing.T, source, name string) *chunk.Chunk {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fnChunk := findFunctionChunk(code, name)
+	if fnChunk == nil {
+		t.Fatalf("function %q not found", name)
+	}
+	return fnChunk
+}
+
+func assertFieldOperand(t *testing.T, text, op string, idx int, name string) {
+	t.Helper()
+	pattern := regexp.MustCompile(op + `\s+` + strconv.Itoa(idx) + ` '` + regexp.QuoteMeta(name) + `'`)
+	if !pattern.MatchString(text) {
+		t.Fatalf("esperava %s %d '%s' no disassembly:\n%s", op, idx, name, text)
+	}
+}
+
+func TestTypedStructFieldReadUsesSlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    return p.y
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_GET_FIELD", 1, "y")
+}
+
+func TestAnyBaseFieldReadStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> any
+    return a.y
+end
+`, "g")
+	assertHas(t, ops, "OP_GET_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD")
+}
+
+func TestRefStructBaseDerefsThenReadsBySlotIndex(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func f(r: ref Ponto) -> int
+    return r.x
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	for k, name := range ops {
+		if name == "OP_GET_FIELD" {
+			if k == 0 || ops[k-1] != "OP_DEREF" {
+				t.Fatalf("OP_GET_FIELD sobre base ref precisa vir depois de OP_DEREF: %s", strings.Join(ops, " "))
+			}
+		}
+	}
+}
+
+func TestTypedStructFieldWriteIsStatementBySlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    p.y = 5
+    return p.y
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+	assertNotFollowedByPop(t, ops, "OP_SET_FIELD")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_SET_FIELD", 1, "y")
+}
+
+func TestAnyBaseFieldWriteStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> void
+    a.y = 5
+end
+`, "g")
+	assertHas(t, ops, "OP_SET_PROPERTY")
+	assertLacks(t, ops, "OP_SET_FIELD")
+}
+
+func TestNestedFieldWriteUsesMutBySlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(c: Caixa) -> int
+    c.p.x = 9
+    return c.p.x
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD_MUT")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROP_MUT")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+	text := disassemblyText(t, fn)
+	assertFieldOperand(t, text, "OP_GET_FIELD_MUT", 1, "p")
+	assertFieldOperand(t, text, "OP_SET_FIELD", 0, "x")
+}
+
+func TestAnyBaseNestedFieldWriteStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> void
+    a.p.x = 9
+end
+`, "g")
+	assertHas(t, ops, "OP_GET_PROP_MUT")
+	assertHas(t, ops, "OP_SET_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD_MUT")
+	assertLacks(t, ops, "OP_SET_FIELD")
+}
+
+func TestGlobalAndArrayElementStructBasesUseSlotIndex(t *testing.T) {
+	ops := topLevelOpcodes(t, fieldIndexPrelude+`
+let p: Ponto = Ponto(1, 2)
+let xs: Ponto[] = [p]
+let i: int = 0
+xs[i].y = p.x + xs[i].y
+`)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+}
+
+func TestGenericStructInstanceUsesSlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, `
+struct Pilha<T>
+    nome: string
+    itens: T[]
+end
+func f(s: Pilha<int>) -> int
+    return length(s.itens)
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_GET_FIELD", 1, "itens")
+}
+
+// Campo declarado `ref T`: a escrita por base tipada continua por índice — a
+// checagem do slot ref é do runtime (o fast path recusa e o genérico decide).
+func TestRefTypedFieldWriteUsesSlotIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct Node
+    v: int
+    next: ref Node
+end
+func f(a: Node, b: Node) -> void
+    a.next = ref b
+    a.next = null
+end
+`, "f")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+}
+
+// `ref p.x` fica em OP_REF_PROPERTY: o ObjRef resolve por nome (issue #93b).
+func TestBorrowOfFieldStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func bump(r: ref int) -> void
+    *r = *r + 1
+end
+func f(p: Ponto) -> void
+    bump(ref p.y)
+end
+`, "f")
+	assertHas(t, ops, "OP_REF_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD")
+}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1441,105 +1441,92 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return err
 			}
 
+		// perf issue #96: campo por INDICE quando o compilador conhece o
+		// struct da base. Guarda: a definicao da instancia tem esse nome nesse
+		// slot (json_loads monta definicoes em ordem alfabetica; natives e
+		// bytecode de teste podem montar qualquer coisa). Falhou → o funil por
+		// nome (field_ops.go), com as mesmas mensagens e a mesma linha.
+		case chunk.OP_GET_FIELD:
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-1].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name {
+				vm.stack[top-1] = inst.Slots[idx]
+				continue
+			}
+			if err := vm.getPropertyGeneric(c, ip, name); err != nil {
+				return err
+			}
+
+		case chunk.OP_SET_FIELD:
+			// [inst, val] -> []. Statement: nao empilha. Campo `ref T` fica com
+			// o generico (guarda do slot ref). Retain/Release sao no-op em
+			// valores NeverTracked — pular a chamada nao muda a contagem.
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-2].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name && (inst.Struct.RefFields == nil || !inst.Struct.RefFields[name]) {
+				val := vm.stack[top-1]
+				old := inst.Slots[idx]
+				if value.NeverTracked(val) && value.NeverTracked(old) {
+					inst.Slots[idx] = val
+				} else {
+					value.Retain(val)
+					inst.Slots[idx] = val
+					value.Release(old)
+				}
+				vm.stack[top-1] = value.Value{}
+				vm.stack[top-2] = value.Value{}
+				vm.stackTop = top - 2
+				continue
+			}
+			if err := vm.setPropertyGeneric(c, ip, name); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_GET_FIELD_MUT:
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-1].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name {
+				fieldVal := inst.Slots[idx]
+				if value.IsShared(fieldVal) {
+					old := fieldVal
+					fieldVal = vm.copyValue(fieldVal)
+					// RC: retain-antes-de-release em torno da troca
+					value.Retain(fieldVal)
+					inst.Slots[idx] = fieldVal
+					value.Release(old)
+				}
+				vm.stack[top-1] = fieldVal
+				continue
+			}
+			if err := vm.getPropMutGeneric(c, ip, name); err != nil {
+				return err
+			}
+
 		case chunk.OP_GET_PROPERTY:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
-			nameVal := c.Constants[index]
-			name := nameVal.Obj.(string)
-
-			instanceVal := vm.pop()
-
-			// Auto-dereference if instance is a ref
-			if instanceVal.Type == value.VAL_REF {
-				resolved, err := vm.resolveReferenceValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = resolved
-			}
-
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances/maps have properties")
-			}
-
-			if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
-				val, ok := instance.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s'", name)
-				}
-				vm.push(val)
-			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
-				// Allow accessing map keys as properties (for modules)
-				val, ok := mapObj.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
-				}
-				vm.push(val)
-			} else {
-				return vm.runtimeError(c, ip, "only instances and maps have properties")
+			name := c.Constants[index].Obj.(string)
+			if err := vm.getPropertyGeneric(c, ip, name); err != nil {
+				return err
 			}
 
 		case chunk.OP_SET_PROPERTY:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
-			nameVal := c.Constants[index]
-			name := nameVal.Obj.(string)
-
-			val := vm.pop()
-			instanceVal := vm.pop()
-
-			// Auto-dereference if instance is a ref.
-			//
-			// issue #83: aqui a referência é ALVO DE ESCRITA, então a
-			// resolução tem de ser em modo de escrita — unicizar o caminho e
-			// gravar os clones de volta. Com `resolveReferenceValue` (modo de
-			// leitura) a mutação ia direto no objeto compartilhado e vazava
-			// numa cópia posterior, que é o bug do #83 chegando por um site de
-			// escrita tipado `any`: `func setx(p: any) -> void  p.x = 99 end`
-			// chamada com `setx(ref arr[0])`. É o caminho dinâmico; via base
-			// tipada o compilador emite a família *_MUT, que já unicizava.
-			if instanceVal.Type == value.VAL_REF {
-				resolved, err := vm.unicizeThroughRefValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = resolved
+			name := c.Constants[index].Obj.(string)
+			if err := vm.setPropertyGeneric(c, ip, name); err != nil {
+				return err
 			}
-
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances have properties")
-			}
-			instance, ok := instanceVal.Obj.(*value.ObjInstance)
-			if !ok {
-				return vm.runtimeError(c, ip, "only instances have properties")
-			}
-
-			// Struct e nominal, de campos fixos (spec §5): escrever num nome
-			// fora da declaracao e o mesmo "undefined property" da leitura
-			// (issue #61 item 2 — antes a escrita criava o campo em silencio).
-			// Via base tipada o compilador ja rejeitou (`unknown field`); aqui
-			// so dispara em fronteira dinamica (`any`). O caminho quente e um
-			// lookup no indice SO-LEITURA da declaracao (issue #86: o map por
-			// instancia, que duas routines escreviam, nao existe mais).
-			slot, declared := instance.Struct.FieldIndex(name)
-			if !declared {
-				return vm.runtimeError(c, ip, "undefined property '%s'", name)
-			}
-			old := instance.Slots[slot]
-
-			// Guard do slot ref (spec 2026-08-20-ref-slot-invariant §6.3):
-			// via base tipada o compilador ja rejeitou; aqui so dispara em
-			// fronteira dinamica (`any`). Lookup em mapa nil e gratuito.
-			if instance.Struct.FieldIsRef(name) && val.Type != value.VAL_REF && val.Type != value.VAL_NULL {
-				return vm.runtimeError(c, ip, "%s", refSlotWriteError(structRefFieldTypeName(instance.Struct, name), val))
-			}
-
-			// RC: retain-antes-de-release (campo e dono duravel); Release
-			// em slot null e no-op (nao e VAL_OBJ)
-			value.Retain(val)
-			instance.Slots[slot] = val
-			value.Release(old)
-			vm.push(val)
 
 		case chunk.OP_SET_PROPERTY_DEREF:
 			index := c.Code[ip]
@@ -1705,48 +1692,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			name := c.Constants[index].Obj.(string)
-			instanceVal := vm.pop()
-			if instanceVal.Type == value.VAL_REF {
-				uniq, err := vm.unicizeThroughRefValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = uniq
-			}
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances/maps have properties")
-			}
-			if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
-				slot, ok := instance.Struct.FieldIndex(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s'", name)
-				}
-				fieldVal := instance.Slots[slot]
-				if value.IsShared(fieldVal) {
-					old := fieldVal
-					fieldVal = vm.copyValue(fieldVal)
-					// RC: retain-antes-de-release em torno da troca
-					value.Retain(fieldVal)
-					instance.Slots[slot] = fieldVal
-					value.Release(old)
-				}
-				vm.push(fieldVal)
-			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
-				// Membros de módulo (e maps acessados como propriedade)
-				stored, ok := mapObj.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
-				}
-				v, changed := vm.unicize(stored)
-				if changed {
-					// RC: retain-antes-de-release em torno da troca
-					value.Retain(v)
-					mapObj.Set(name, v)
-					value.Release(stored)
-				}
-				vm.push(v)
-			} else {
-				return vm.runtimeError(c, ip, "only instances and maps have properties")
+			if err := vm.getPropMutGeneric(c, ip, name); err != nil {
+				return err
 			}
 
 		case chunk.OP_DEREF_MUT:

--- a/internal/vm/field_ops.go
+++ b/internal/vm/field_ops.go
@@ -1,0 +1,147 @@
+package vm
+
+import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Campo de struct por indice (issue #96): OP_GET_FIELD / OP_SET_FIELD /
+// OP_GET_FIELD_MUT levam [idx][nome]. O caminho rapido (em run()) usa o indice
+// quando `Fields[idx] == nome` na definicao da instancia; qualquer outra coisa
+// — base ref, null, any que virou map, definicao com outra ordem (json_loads
+// monta a sua em ordem alfabetica), campo `ref T` na escrita — cai nos funis
+// abaixo, que sao os corpos dos opcodes por nome extraidos em metodo. Os
+// `case` genericos chamam os mesmos metodos: uma fonte para mensagens, linha
+// (`Lines[ip-1]`, o ultimo byte de operando) e semantica CoW/RC.
+
+// getPropertyGeneric: OP_GET_PROPERTY. [base] -> [val].
+func (vm *VM) getPropertyGeneric(c *chunk.Chunk, ip int, name string) error {
+	instanceVal := vm.pop()
+
+	// Auto-dereference if instance is a ref
+	if instanceVal.Type == value.VAL_REF {
+		resolved, err := vm.resolveReferenceValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = resolved
+	}
+
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances/maps have properties")
+	}
+
+	if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
+		val, ok := instance.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s'", name)
+		}
+		vm.push(val)
+	} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
+		// Allow accessing map keys as properties (for modules)
+		val, ok := mapObj.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
+		}
+		vm.push(val)
+	} else {
+		return vm.runtimeError(c, ip, "only instances and maps have properties")
+	}
+	return nil
+}
+
+// setPropertyGeneric: OP_SET_PROPERTY. [base, val] -> [val] (o compilador
+// emite OP_POP depois do opcode por nome; a forma por indice consome o push).
+func (vm *VM) setPropertyGeneric(c *chunk.Chunk, ip int, name string) error {
+	val := vm.pop()
+	instanceVal := vm.pop()
+
+	// issue #83: aqui a referência é ALVO DE ESCRITA, então a resolução tem de
+	// ser em modo de escrita — unicizar o caminho e gravar os clones de volta.
+	if instanceVal.Type == value.VAL_REF {
+		resolved, err := vm.unicizeThroughRefValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = resolved
+	}
+
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances have properties")
+	}
+	instance, ok := instanceVal.Obj.(*value.ObjInstance)
+	if !ok {
+		return vm.runtimeError(c, ip, "only instances have properties")
+	}
+
+	// Struct e nominal, de campos fixos (spec §5): escrever num nome fora da
+	// declaracao e o mesmo "undefined property" da leitura (issue #61 item 2).
+	slot, declared := instance.Struct.FieldIndex(name)
+	if !declared {
+		return vm.runtimeError(c, ip, "undefined property '%s'", name)
+	}
+	old := instance.Slots[slot]
+
+	// Guard do slot ref (spec 2026-08-20-ref-slot-invariant §6.3):
+	// via base tipada o compilador ja rejeitou; aqui so dispara em
+	// fronteira dinamica (`any`) e no fallback do OP_SET_FIELD, que recusa
+	// campo `ref T` no caminho rapido. Lookup em mapa nil e gratuito.
+	if instance.Struct.FieldIsRef(name) && val.Type != value.VAL_REF && val.Type != value.VAL_NULL {
+		return vm.runtimeError(c, ip, "%s", refSlotWriteError(structRefFieldTypeName(instance.Struct, name), val))
+	}
+
+	// RC: retain-antes-de-release (campo e dono duravel); Release
+	// em slot null e no-op (nao e VAL_OBJ)
+	value.Retain(val)
+	instance.Slots[slot] = val
+	value.Release(old)
+	vm.push(val)
+	return nil
+}
+
+// getPropMutGeneric: OP_GET_PROP_MUT. [base] -> [campo unicizado].
+func (vm *VM) getPropMutGeneric(c *chunk.Chunk, ip int, name string) error {
+	instanceVal := vm.pop()
+	if instanceVal.Type == value.VAL_REF {
+		uniq, err := vm.unicizeThroughRefValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = uniq
+	}
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances/maps have properties")
+	}
+	if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
+		slot, ok := instance.Struct.FieldIndex(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s'", name)
+		}
+		fieldVal := instance.Slots[slot]
+		if value.IsShared(fieldVal) {
+			old := fieldVal
+			fieldVal = vm.copyValue(fieldVal)
+			// RC: retain-antes-de-release em torno da troca
+			value.Retain(fieldVal)
+			instance.Slots[slot] = fieldVal
+			value.Release(old)
+		}
+		vm.push(fieldVal)
+	} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
+		// Membros de módulo (e maps acessados como propriedade)
+		stored, ok := mapObj.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
+		}
+		v, changed := vm.unicize(stored)
+		if changed {
+			value.Retain(v)
+			mapObj.Set(name, v)
+			value.Release(stored)
+		}
+		vm.push(v)
+	} else {
+		return vm.runtimeError(c, ip, "only instances and maps have properties")
+	}
+	return nil
+}

--- a/internal/vm/struct_field_index_e2e_test.go
+++ b/internal/vm/struct_field_index_e2e_test.go
@@ -1,0 +1,178 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Ponta a ponta (fonte -> compilador -> VM) do campo de struct por índice
+// (issue #96): mesmo resultado, mesma semântica CoW/RC e mesmas mensagens de
+// erro do caminho por nome. Cada caso "tipado" tem o gêmeo `any`, que continua
+// no genérico: os dois têm de concordar.
+
+const fieldIndexPrelude = `
+struct Ponto
+    x: int
+    y: int
+end
+struct Caixa
+    tag: string
+    p: Ponto
+end
+`
+
+func reportedStrings(t *testing.T, got value.Value, want []string) {
+	t.Helper()
+	cells := semArray(t, got)
+	if len(cells) != len(want) {
+		t.Fatalf("células=%d, want %d: %s", len(cells), len(want), got.String())
+	}
+	for i, cell := range cells {
+		if s, ok := cell.Obj.(string); !ok || s != want[i] {
+			t.Fatalf("célula %d: got %s, want %q", i, cell.String(), want[i])
+		}
+	}
+}
+
+func TestFieldIndexReadWriteMatchesByName(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    p.y = p.x * 10
+    return p.y + p.x
+end
+let g: Ponto = Ponto(3, 4)
+let a: any = Ponto(3, 4)
+g.y = g.x * 10
+a.y = a.x * 10
+test_report([to_str(f(Ponto(2, 0))), to_str(g.y + g.x), to_str(a.y + a.x)])
+`)
+	reportedStrings(t, got, []string{"22", "33", "33"})
+}
+
+// A GUARDA (spec §3.1): json_loads cria a própria definição de struct com os
+// campos em ORDEM ALFABÉTICA para todo valor de struct que ele constrói. A
+// instância entra num contêiner tipado, então a base tipada aponta para um
+// layout diferente da declaração (slot 0 = `proximo`, não `valor`). Ler e
+// escrever por índice nela tem de conferir o nome e cair no caminho por nome.
+func TestFieldIndexGuardsReorderedJSONInstance(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+let xs: Node[] = []
+let ok: bool = json_loads("[{\"valor\": 7, \"proximo\": null}]", ref xs)
+let n: Node = xs[0]
+n.valor = n.valor + 1
+xs[0].valor = xs[0].valor * 10
+let dyn: any = xs[0]
+test_report([to_str(ok), to_str(n.valor), to_str(xs[0].valor), to_str(dyn.valor), to_str(n.proximo == null)])
+`)
+	reportedStrings(t, got, []string{"true", "8", "70", "70", "true"})
+}
+
+func TestFieldIndexNestedWriteClonesSharedChildOnce(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+let a: Caixa = Caixa("a", Ponto(1, 2))
+let b: Caixa = a
+a.p.x = 5
+a.tag = "z"
+test_report([to_str(b.p.x), to_str(a.p.x), b.tag, a.tag])
+`)
+	reportedStrings(t, got, []string{"1", "5", "a", "z"})
+}
+
+func TestFieldIndexWriteRetainsNewReleasesOld(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+struct Holder
+    inner: int[]
+end
+let y1: int[] = [1]
+let y2: int[] = [2]
+let h: Holder = Holder([])
+h.inner = y1
+h.inner = y2
+test_report([y1, y2, h.inner])
+`)
+	cells := semArray(t, got)
+	y1 := cells[0].Obj.(*value.ObjArray)
+	y2 := cells[1].Obj.(*value.ObjArray)
+	// y1: a variável global (1) — o campo soltou; y2: global + campo + a
+	// célula do array reportado (o test_report retém ao construir o literal).
+	if y1.Owners.Load() >= y2.Owners.Load() {
+		t.Fatalf("esperava y1 com menos donos que y2 depois de h.inner = y2: y1=%d y2=%d", y1.Owners.Load(), y2.Owners.Load())
+	}
+}
+
+func TestFieldIndexRefTypedFieldWriteAndReadThrough(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    v: int
+    next: ref Node
+end
+func main() -> void
+    let a: Node = Node(1, null)
+    let b: Node = Node(2, null)
+    a.next = ref b
+    b.v = 3
+    let seen: int = a.next.v
+    a.next = null
+    test_report([to_str(seen), to_str(a.next == null), to_str(b.v)])
+end
+main()
+`)
+	reportedStrings(t, got, []string{"3", "true", "3"})
+}
+
+// Tabela de erros idênticos: a base tipada erra com a MESMA mensagem que a
+// base `any` para o mesmo estado de runtime.
+func TestFieldIndexErrorsMatchByName(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"read through null base",
+			"let p: Ponto = null\nlet v: int = p.x\n",
+			"let p: any = null\nlet v: any = p.x\n",
+			"only instances/maps have properties"},
+		{"write through null base",
+			"let p: Ponto = null\np.x = 1\n",
+			"let p: any = null\np.x = 1\n",
+			"only instances have properties"},
+		{"nested write through null base",
+			"let c: Caixa = null\nc.p.x = 1\n",
+			"let c: any = null\nc.p.x = 1\n",
+			"only instances/maps have properties"},
+		{"read through null ref",
+			"let r: ref Ponto = null\nlet v: int = r.x\n",
+			"", // sem gêmeo any: o OP_DEREF é da base ref tipada
+			"cannot dereference null reference"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), fieldIndexPrelude+tc.typed)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if tc.dynamic == "" {
+				return
+			}
+			dynErr := interpretVMSource(t, New(), fieldIndexPrelude+tc.dynamic)
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("any: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}
+
+// Linha do erro: o operando novo tem 3 bytes; a linha reportada continua a
+// da statement.
+func TestFieldIndexErrorLineIsTheStatement(t *testing.T) {
+	err := interpretVMSource(t, New(), fieldIndexPrelude+`
+let p: Ponto = null
+let a: int = 1
+let v: int = p.x
+`)
+	if err == nil || !strings.Contains(err.Error(), "line 13]") {
+		t.Fatalf("esperava erro na linha 13, obtido %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Quando o tipo estático da base é um struct do programa (inclui instâncias genéricas monomorfizadas e structs de escopo local), o compilador resolve `p.x` para a posição na declaração — que é o índice do slot desde o #95 — e emite `OP_GET_FIELD` / `OP_SET_FIELD` / `OP_GET_FIELD_MUT` com operando `[idx u8][nome u16]`. Base `any`, namespace/módulo e `ref p.x` (`OP_REF_PROPERTY`: o `ObjRef` resolve por nome, território do #93b) ficam como estavam; **bytecode com base `any` inalterado**.

Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`. Resultados: seção nova no topo de `benchmarks/RESULTS.md` + `results/2026-08-28-issue-96-struct-field-index-raw.md`.

### A premissa da issue está errada — por isso há uma guarda

A issue diz "struct de JSON dinâmico tem a própria definição, então a base tipada nunca aponta para ele". `buildTypedJSONValue` (`json_population.go`) monta uma `ObjStruct` **nova com os campos em ordem alfabética** para todo valor de struct que `json_loads` cria, e essa instância entra em contêineres tipados (`let n: Node = xs[0]` com `xs: Node[]` populado por JSON tem slot 0 = `proximo`, não `valor`). Um `OP_GET_FIELD 0` cego leria o campo errado. O caminho rápido confere `idx < len(Slots) && Struct.Fields[idx] == nome` — comparação de string curta no lugar do hash (2,8 % do perfil) — e cai no funil por nome quando não bate. `TestFieldIndexGuardsReorderedJSONInstance` cobre o caso e **falha sem a guarda** (verificado por mutação).

### VM

Os corpos de `OP_GET_PROPERTY`/`OP_SET_PROPERTY`/`OP_GET_PROP_MUT` saíram para `getPropertyGeneric`/`setPropertyGeneric`/`getPropMutGeneric` (`field_ops.go`); os `case` genéricos e os fallbacks chamam os mesmos métodos — uma fonte para mensagens, linha (`Lines[ip-1]`) e semântica CoW/RC, o mesmo funil que a #66 fez com `getIndexGeneric`/`setIndexGeneric` (custo: uma chamada a mais por opcode por nome; `bench_generic_vs_hand` +0,2 %). `OP_SET_FIELD` é statement (sem `OP_POP`), recusa campo `ref T` no caminho rápido (o genérico aplica a guarda do slot ref) e pula `Retain`/`Release` só quando valor novo e velho são `NeverTracked` (as chamadas seriam no-op). `OP_GET_FIELD_MUT` uniciza o filho compartilhado e grava de volta como `OP_GET_PROP_MUT`.

## Resultados (A/B intercalado, mediana de 9)

| bench | base 2a627bc | head | delta |
|---|---|---|---|
| bench_path_update | 238,8 ms | 160,7 ms | **−32,7 %** |
| bench_struct_records (novo na suíte, resgatado de 93625ac) | 145,9 | 136,1 | **−6,7 %** |
| bench_conway (gate CoW) | 1212,1 | 1196,3 | −1,3 % |
| bench_share_mutate (gate CoW) | 111,9 | 109,7 | −2,0 % |
| bench_generic_vs_hand (sentinela de `run()`) | 419,7 | 420,6 | +0,2 % |
| demais | | | −0,7 … +0,8 % (ruído); benches de ~27 ms ±3 % (piso) |

Perfil de `bench_path_update` (carga ×10): `FieldIndex` 15,2 % cum (`mapaccess2_faststr`/`aeshashbody`) e `Retain`+`Release` 10 % na base → **ausentes** no head. `bench_struct_records`: hashing de campo ausente; o topo continua `validateStructConstructorArguments` (46,9 %) — ver follow-up.

## Verificação

- `go test ./...` verde; `go test -race ./internal/vm -count=1` verde.
- Corpus `run_all_tests_concurrent.nx`: **180/180**. `compare_examples.ps1` base × head: **149 iguais, 0 divergentes**.
- Testes novos: bytecode via disassembler (tipado → índice com o slot certo; `any`/namespace/`ref p.x` por nome; escrita sem `OP_POP`; aninhado → `_MUT`; genérico → índice), ponta a ponta (JSON reordenado, CoW de filho compartilhado, RC, campo `ref` escrito e lido através, tabela de erros idênticos tipado × `any`, linha do erro). Sentinela do `chunk_test` e walker do `cow_lowering_test` atualizados.

## Achado colateral (follow-up, não incluído)

O cache do construtor do PR #70 (`ctorCache` em `ObjStruct`, commit 131c352) **nunca chegou a `develop`**: o #70 foi mergeado em `perf/issue-66-call-protocol` 23 s depois de o #69 entrar em `develop`. `validateStructConstructorArguments` refaz `runtimeTypeComplete(schema, make(map…))` a cada construção — 46 % de `bench_struct_records`. Issue separada.

## Decisões sem consulta (spec §7)

1. Guarda por nome no operando, não por identidade da definição.
2. Sem variante NORC: `OP_SET_FIELD` decide o RC em runtime por `NeverTracked`.
3. `OP_REF_PROPERTY` fora do escopo (#93b).
4. Structs de módulo ficam por nome, como a issue pede (a definição de runtime vem do compilador do módulo com a mesma ordem; dá para estender depois).

Refs #96. Fecha o que sobrou de #40 e #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
