### PR TITLE
Fila de issues 2026-08-28 + bump v0.21.0: #87 corpus, #93a/#93b empréstimo, #96 campo por índice, #53 item 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,6 @@ contrato é travado por `internal/vm/inline_guard_test.go` — se você mexer em
 ---
 
 **Última Atualização**: 2026-08-22  
-**Versão**: 1.0 (Noxy VM 0.20.0)
+**Versão**: 1.0 (Noxy VM 0.21.0)
 
 *Este documento é vivo - atualize ao adicionar features significativas.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## [0.21.0] - 2026-08-28
 
 Campos de struct por **índice**, dos dois lados. A instância guarda os campos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,108 @@
 # Changelog
 
+
+## [0.21.0] - 2026-08-28
+
+Campos de struct por **índice**, dos dois lados. A instância guarda os campos
+em `Slots` na ordem da declaração (issue #86, PR #95) e o compilador resolve
+`p.x` para o índice do slot quando conhece o struct da base (issue #96); o
+empréstimo `ref p.x` resolve o índice uma vez, na criação, em vez de um hash
+por nível a cada acesso (issue #93 b). O teto de 256 níveis no caminho de um
+empréstimo, que matava uma BST por posse degenerada, sai (issue #93 a). Tudo
+com semântica, mensagens e contagem RC idênticas; `-race` no pacote `vm`
+inteiro no CI.
+
+### Changed (BREAKING) — só para quem embute a VM em Go (issue #86)
+
+| Antes (0.20) | Agora (0.21) |
+|---|---|
+| `ObjInstance.Fields map[string]Value` | `ObjInstance.Slots []Value`, na ordem de `ObjStruct.Fields`; `Get/Set/MustSet/Field/Range/Snapshot` por nome continuam, `FieldIndex(name)` em `ObjStruct` |
+| `NewInstanceWith(def, map)` | continua; novo `NewInstanceAdopting(def, slots)` (move: o chamador já reteve) |
+
+Nada muda na linguagem. O `fatal error: concurrent map read and map write` em
+`b.inner.value = …` concorrente some junto com o map por instância; a spec
+nunca prometeu atomicidade para escritas concorrentes no mesmo campo, e o
+teste (`!race`) fixa só que o runtime não cai.
+
+### Added
+
+- `OP_GET_FIELD` / `OP_SET_FIELD` / `OP_GET_FIELD_MUT` `[idx u8][nome u16]`
+  (issue #96), emitidos quando o tipo estático da base é um struct do programa
+  (inclusive instâncias genéricas e structs de escopo local). Base `any`,
+  módulos e `ref p.x` ficam nos opcodes por nome; bytecode com base `any`
+  inalterado. O nome viaja no operando porque **`json_loads` monta definições
+  de struct em ordem alfabética** e essas instâncias entram em contêineres
+  tipados — o caminho rápido confere `Fields[idx] == nome` e cai no funil por
+  nome quando não bate. `OP_SET_FIELD` é statement (sem `OP_POP`).
+- `ObjRef.Slot` (issue #93 b): `OP_REF_PROPERTY` resolve o índice do campo na
+  criação; `descend`/`referenceStorageMode`/setter usam o slot sob a mesma
+  guarda. Zero é seguro para `ObjRef` montado à mão.
+- Benchmarks: `bench_struct_records.nx` (5 campos, 60k construções — o bench
+  da #40 que nunca tinha chegado a `develop`), `bench_bst_owned.nx` /
+  `bench_bst_ref.nx` (as fixtures da #93, 20k chaves); `bench_borrow_path.nx`
+  ganha `CHECKSUM:` (o guard de equivalência o pulava).
+- Specs `2026-08-28-vm-perf-issue-96-struct-field-index-design.md` e
+  `2026-08-28-vm-perf-issue-93b-borrow-path-design.md` (a segunda registra por
+  que "fast path quando `Owners == 1`" é inseguro sem validar a cadeia, e o
+  desenho da cache por época que fica como follow-up).
+
+### Fixed
+
+- **#93 (a)** — `maxBorrowPathDepth = 256` limitava a cadeia de `Base` de um
+  empréstimo com a justificativa de que "um caminho real tem a profundidade do
+  lvalue escrito no fonte", falsa desde a 0.20: `insert(ref node.esquerda, v)`
+  recursivo e `r = ref r.prox` num laço encadeiam um nível por passo, e uma BST
+  por posse degenerada com ~256 nós morria com `reference path too deep`. O
+  teto sai (a cadeia não cicla por construção); `maxRefHopDepth` fica só em
+  `derefPlace`.
+- **#87** — `noxy_examples/KandR_in_noxy/`: sete arquivos não compilavam desde
+  a migração para `ref` explícito (`let i: int = pos`, `length(v)` com
+  `v: ref int[]`, `append(s.items, …)`); só `ch02_mismatch.nx` e
+  `ch02_redeclare.nx`, exemplos de erro intencionais, seguem não compilando.
+- **#53 item 4** — `test_crypto_debug.nx` imprimia `FAIL` em toda execução e
+  saía com 0: o `hex_to_bytes` do exemplo passava por `strings.from_char_code`,
+  que codifica valores ≥ 0x80 em dois bytes UTF-8. `to_bytes(int[])` fecha o
+  round-trip, e cada FAIL termina com `sys.exit(1)` para o runner enxergar.
+
+### Performance
+
+`develop` (0.20.0 + #95) × 0.21.0, intercalado, mediana de 9, mesma máquina:
+
+| bench | antes | depois | delta |
+|---|---|---|---|
+| `bench_path_update` (`cells[i].hits = …`) | 238,9 ms | 163,0 ms | **−31,8 %** |
+| `bench_bst_owned` (BST por posse, 20k) | 816,7 | 575,8 | **−29,5 %** |
+| `bench_borrow_path` (`ref root.b.c.xs[0]`) | 594,4 | 531,8 | **−10,5 %** |
+| `bench_bst_ref` | 227,0 | 212,0 | −6,6 % |
+| `bench_struct_records` | 134,7 | 126,5 | −6,1 % |
+| demais (bubblesort, conway, call_*, map_churn, spawn_sum, generic_vs_hand) | | | −1,7 … +1,5 % (ruído) |
+
+BST por posse com 50k chaves aleatórias: 2,35 s → 1,62 s. Perfis: em
+`bench_path_update` somem `FieldIndex`/`mapaccess2_faststr`/`aeshashbody`
+(15 %) e `Retain`/`Release` de `int` (10 %); na BST por posse o hashing por
+nível cai de 16 % para 1 % e o `reflect` de `validateReferencedValue` sai do
+caminho de todo acesso por ref. Corpus 180/180; diff de saída antes × depois
+0 divergentes. Detalhes em `benchmarks/RESULTS.md`.
+
+### Docs
+
+- Spec §2.2 regra 6 e §5 (issue #92): um campo `ref T` é uma **aresta
+  compartilhada** — a cópia de um struct é independente através dos campos de
+  valor e continua apontando para o mesmo referente através dos campos `ref`;
+  os dois idiomas (posse e `ref`) ficam documentados lado a lado; exemplo
+  novo `noxy_examples/bst_owned.nx` (BST por posse) ao lado de `bst.nx`.
+
+### Conhecido, não consertado
+
+- BST por posse **degenerada** continua O(profundidade²): 1000 chaves
+  ordenadas passam (antes morriam) mas levam ~12 s, contra ~0,4 s com
+  `ref TreeNode` nos filhos. O que resta é a caminhada do modelo de lugar
+  (0.20), agora sem hash; matar o quadrático exige a cache por época da spec do
+  #93 b (§6) — follow-up de arquitetura.
+- #100 — o cache do construtor de struct do PR #70 nunca chegou a `develop`:
+  `validateStructConstructorArguments` é 46 % de `bench_struct_records`.
+- #53 item 1(a) — `json_loads` em struct dentro de array compartilhado ainda
+  vaza.
 ## [0.20.0] - 2026-08-25
 
 Uma referência para dentro de um contêiner denota um **LUGAR**, não um objeto

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.20.0](https://img.shields.io/badge/noxy-0.20.0-blue)](CHANGELOG.md)
+[![noxy 0.21.0](https://img.shields.io/badge/noxy-0.21.0-blue)](CHANGELOG.md)
 
 # Noxy
 
@@ -205,7 +205,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.20.0
+Noxy REPL v0.21.0
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,57 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## feature/issue-queue-2026-08-28 (a52c7e1) × empréstimo aninhado com slot — issue #93 (b) (4026c43)
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · protocolo
+intercalado, mediana de 9; sessão mais carregada que a do #96 (só o delta
+intra-rodada é comparável). Dados brutos e perfis em
+[`results/2026-08-28-issue-93b-borrow-path-raw.md`](results/2026-08-28-issue-93b-borrow-path-raw.md).
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-93b-borrow-path-design.md`.
+
+O que mudou: `OP_REF_PROPERTY` resolve o índice do campo UMA vez, na criação do
+ref (`ObjRef.Slot`); `descend`, `referenceStorageMode` e o setter de
+propriedade usam `Slots[Slot]` quando a definição da instância no lugar tem
+esse nome nesse slot (`fieldSlotOf`, a mesma guarda do #96 — definições de
+`json_loads` vêm em ordem alfabética, ObjRef montado à mão deixa zero), senão
+`FieldIndex` por nome como antes. `validateReferencedValue` (o `defer` de todo
+acesso por ref) decide os payloads comuns por type switch antes do `reflect`.
+O modelo de lugar da #83 não muda: o custo continua O(profundidade) por acesso,
+com constante menor; "fast path quando `Owners == 1`" é inseguro sem validar a
+cadeia (contra-exemplo na spec §2) e a cache por época fica como follow-up (§6).
+
+**Verificação completa:** `go test ./...` verde; `go test -race ./internal/vm`
+verde; **corpus 180/180**; **diff de saída base × head: 149 iguais, 0 divergentes**.
+
+### Headline — base × head (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | base_ms | head_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_bst_owned (novo: BST por posse, 20k) | 780,9 | 565,8 | **−27,5 %** | ✅ o caso da issue |
+| bench_borrow_path (agora com `CHECKSUM:`) | 564,7 | 507,7 | **−10,1 %** | ✅ `ref root.b.c.xs[0]` |
+| bench_share_mutate | 115,4 | 107,4 | −6,9 % | ➖ ruído/`validateReferencedValue` |
+| bench_call_readonly | 572,5 | 546,5 | −4,5 % | ➖ ruído |
+| bench_map_churn | 212,3 | 207,0 | −2,5 % | ➖ ruído |
+| bench_call_ref | 1109,4 | 1091,6 | −1,6 % | ➖ ruído |
+| bench_spawn_sum | 400,7 | 394,4 | −1,6 % | ➖ ruído |
+| bench_struct_records | 127,4 | 126,0 | −1,1 % | ➖ ruído |
+| bench_generic_vs_hand | 431,6 | 432,9 | +0,3 % | ✅ sentinela de `run()` |
+| bench_bst_ref (novo: gêmeo com `ref TreeNode`) | 216,7 | 217,9 | +0,6 % | ➖ não passa pelo caminho |
+| bench_bubblesort | 740,0 | 744,5 | +0,6 % | ➖ ruído |
+| bench_path_update | 162,0 | 163,1 | +0,7 % | ➖ ruído |
+| bench_conway | 1264,3 | 1283,4 | +1,5 % | ✅ gate CoW (≤ +5 %) |
+| bench_call_light / typed_call_map / value_call_mutate | ~28–32 | ~27–29 | −4…−11 % | ➖ piso¹ |
+
+¹ ~30 ms com piso de processo ~10 ms: não decidem nada.
+
+### Perfil (`--cpuprofile`, BST por posse 50k, máquina livre)
+
+2,20 s → **1,60 s**. `FieldIndex`/`mapaccess2_faststr`/`aeshashbody` 16,4 % →
+~1 %; `validateReferencedValue` (reflect) → 0,5 %. Sobra a caminhada
+(`borrowContainer` + `descend` + `referenceStorageMode` ≈ 50 %), agora
+dominada pela estrutura do laço e pelo RC da unicização; `fieldSlotOf` 11 % (a
+comparação do nome é 4,6 %).
+
 ## develop (2a627bc) × campo de struct por índice — issue #96 (perf/issue-96-struct-field-index, 79af956)
 
 **Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · protocolo

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,59 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## develop (2a627bc) × campo de struct por índice — issue #96 (perf/issue-96-struct-field-index, 79af956)
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · protocolo
+intercalado, mediana de 9. Máquina sem `go test` nem build durante o A/B.
+Dados brutos e perfis em
+[`results/2026-08-28-issue-96-struct-field-index-raw.md`](results/2026-08-28-issue-96-struct-field-index-raw.md).
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`.
+
+O que mudou: quando o tipo estático da base é um struct do programa, o
+compilador resolve `p.x` para o índice de slot (posição na declaração — a
+ordem dos `Slots` desde o #95) e emite `OP_GET_FIELD` / `OP_SET_FIELD` /
+`OP_GET_FIELD_MUT` com operando `[idx u8][nome u16]`. O nome vai junto porque
+`json_loads` monta definições de struct em ordem alfabética e essas instâncias
+entram em contêineres tipados: o caminho rápido confere `Fields[idx] == nome`
+(comparação de string curta) e cai no funil por nome quando não bate. Base
+`any`, módulos e `ref p.x` inalterados; `OP_SET_FIELD` é statement e só chama
+`Retain`/`Release` quando um dos lados pode ter contador. Os `case` por nome
+passaram a chamar os mesmos métodos que os fallbacks (`field_ops.go`).
+
+**Verificação completa:** `go test ./...` verde; `go test -race ./internal/vm`
+verde; **corpus 180/180**; **diff de saída base × head: 149 iguais, 0
+divergentes**; sem a guarda, o teste da instância JSON reordenada falha.
+
+### Headline — base × head (`interleaved_compare.ps1 -Runs 9`)
+
+| bench | base_ms | head_ms | delta | veredito |
+|---|---|---|---|---|
+| bench_path_update | 238,8 | 160,7 | **−32,7 %** | ✅ `cells[i].hits = cells[i].hits + 1`: sem hash de campo, sem `Retain`/`Release` de `int` |
+| bench_struct_records | 145,9 | 136,1 | **−6,7 %** | ✅ só as leituras; 47 % do bench é a validação do construtor (cache do PR #70 nunca chegou a `develop` — follow-up) |
+| bench_share_mutate | 111,9 | 109,7 | −2,0 % | ✅ gate CoW |
+| bench_conway | 1212,1 | 1196,3 | −1,3 % | ✅ gate CoW (≤ +5 %) |
+| bench_map_churn | 210,2 | 208,7 | −0,7 % | ➖ ruído |
+| bench_bubblesort | 659,8 | 655,6 | −0,6 % | ➖ ruído |
+| bench_generic_vs_hand | 419,7 | 420,6 | +0,2 % | ✅ sentinela de `run()`: sem regressão de codegen |
+| bench_call_ref | 995,5 | 999,5 | +0,4 % | ➖ ruído |
+| bench_call_readonly | 448,3 | 450,9 | +0,6 % | ➖ ruído |
+| bench_spawn_sum | 411,6 | 414,7 | +0,8 % | ➖ ruído |
+| bench_typed_call_map | 27,6 | 28,4 | +2,9 % | ➖ piso¹ (gate CoW ok) |
+| bench_call_light | 27,0 | 27,0 | 0 % | ➖ piso¹ |
+| bench_value_call_mutate | 27,9 | 27,8 | −0,4 % | ➖ piso¹ |
+
+¹ ~27 ms com piso de processo ~10 ms: não decidem nada. `bench_borrow_path` e
+`bench_hash31_bytes` foram pulados pelo guard de `CHECKSUM:` (nenhum dos dois
+binários imprime a linha — pré-existente).
+
+### Perfil (`--cpuprofile`, carga ×10/×15)
+
+`bench_path_update`: `FieldIndex` 15,2 % cum (`mapaccess2_faststr` 14,2 %,
+`aeshashbody` 4,3 %) e `Retain`+`Release` 10 % na base → **ausentes** no head;
+sobra `IsShared` da cadeia `_MUT` (16 %) e `memeqbody` 2,8 % (a guarda).
+`bench_struct_records`: hashing de campo ausente no head; o topo continua
+`validateStructConstructorArguments` (46,9 % cum), fora do escopo.
+
 ## v0.15.1 (c1cc12a) × protocolo de chamada — v0.15.2 (perf/issue-66-call-protocol, 868d435)
 
 **Data:** 2026-08-22 · Windows 11 · Intel Core 7 150U (mesma máquina do item

--- a/benchmarks/bench_borrow_path.nx
+++ b/benchmarks/bench_borrow_path.nx
@@ -49,9 +49,7 @@ func main()
         k = k + 1
     end
 
-    print(arr[0])
-    print(root.b.c.xs[0])
-    print(root.b.c.xs[1])
+    print(f"CHECKSUM:{arr[0] + root.b.c.xs[0] * 3 + root.b.c.xs[1] * 7}")
 end
 
 main()

--- a/benchmarks/bench_bst_owned.nx
+++ b/benchmarks/bench_bst_owned.nx
@@ -1,0 +1,39 @@
+// BST por POSSE (campo composto nulavel + `ref` ao slot para mutar in-place):
+// `insert(ref node.esquerda, v)` recursivo encadeia Base um nivel por chamada,
+// e cada acesso no nivel k re-resolve k niveis (modelo de lugar da #83). E o
+// pior caso do emprestimo aninhado (issue #93b); o gemeo bench_bst_ref.nx usa
+// `ref TreeNode` nos filhos e nao passa por esse caminho.
+struct TreeNode
+    valor: int
+    esquerda: TreeNode
+    direita: TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+func count(node: ref TreeNode) -> int
+    if *node == null then
+        return 0
+    end
+    return 1 + count(ref node.esquerda) + count(ref node.direita)
+end
+func main() -> void
+    let raiz: TreeNode = null
+    let seed: int = 12345
+    let i: int = 0
+    while i < 20000 do
+        seed = (seed * 1103515245 + 12345) % 2147483648
+        insert(ref raiz, seed % 1000000)
+        i = i + 1
+    end
+    print(f"CHECKSUM:{count(ref raiz)}")
+end
+main()

--- a/benchmarks/bench_bst_ref.nx
+++ b/benchmarks/bench_bst_ref.nx
@@ -1,0 +1,42 @@
+// Gemeo de bench_bst_owned.nx com filhos `ref TreeNode`: cada no e uma celula
+// promovida a heap, e o acesso nao caminha o caminho do emprestimo (issue #93).
+struct TreeNode
+    valor: int
+    esquerda: ref TreeNode
+    direita: ref TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if v < node.valor then
+        if node.esquerda == null then
+            let novo: TreeNode = TreeNode(v, null, null)
+            node.esquerda = ref novo
+        else
+            insert(node.esquerda, v)
+        end
+    else
+        if node.direita == null then
+            let novo: TreeNode = TreeNode(v, null, null)
+            node.direita = ref novo
+        else
+            insert(node.direita, v)
+        end
+    end
+end
+func count(node: ref TreeNode) -> int
+    if node == null then
+        return 0
+    end
+    return 1 + count(node.esquerda) + count(node.direita)
+end
+func main() -> void
+    let raiz: TreeNode = TreeNode(500000, null, null)
+    let seed: int = 12345
+    let i: int = 0
+    while i < 20000 do
+        seed = (seed * 1103515245 + 12345) % 2147483648
+        insert(ref raiz, seed % 1000000)
+        i = i + 1
+    end
+    print(f"CHECKSUM:{count(ref raiz)}")
+end
+main()

--- a/benchmarks/bench_struct_records.nx
+++ b/benchmarks/bench_struct_records.nx
@@ -1,0 +1,36 @@
+// Registros: struct de 5 campos construida em laco (60.000 vezes) e passada
+// por valor a duas funcoes — uma le 3 campos, outra constroi outra struct a
+// partir dela. E o formato do perfil da issue #40 (validacao de construtor).
+struct Registro
+    id: int
+    nome: string
+    valor: int
+    ativo: bool
+    grupo: int
+end
+
+func pontuar(r: Registro) -> int
+    if r.ativo then
+        return r.valor + r.grupo
+    end
+    return r.valor
+end
+
+func promover(r: Registro) -> Registro
+    return Registro(r.id, r.nome, r.valor + 1, true, r.grupo)
+end
+
+func main()
+    let i: int = 0
+    let acc: int = 0
+    while i < 60000 do
+        let r: Registro = Registro(i, "reg", i % 100, i % 2 == 0, i % 7)
+        acc = acc + pontuar(r)
+        let p: Registro = promover(r)
+        acc = acc + p.valor
+        i = i + 1
+    end
+    print(f"CHECKSUM:{acc}")
+end
+
+main()

--- a/benchmarks/results/2026-08-28-issue-93b-borrow-path-raw.md
+++ b/benchmarks/results/2026-08-28-issue-93b-borrow-path-raw.md
@@ -1,0 +1,96 @@
+# Dados brutos — custo por nível do empréstimo aninhado (issue #93, parte b): base × head
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · laptop, na
+tomada. Sessão mais carregada que a do #96 (Creative Cloud/Dropbox em fundo;
+`bench_bubblesort` 660 → 740 ms entre as duas rodadas) — só o delta intra-rodada
+é comparável. Runner e `compare_examples.ps1` rodaram ANTES do A/B.
+
+**Binários** (scratchpad):
+
+| rótulo | commit | o que é |
+|---|---|---|
+| `base` | a52c7e1 | topo de `feature/issue-queue-2026-08-28` antes do #93b (= develop a855077 + #87 + #93a + #96 + #53-4) |
+| `head` | 4026c43 | + `ObjRef.Slot` resolvido em `OP_REF_PROPERTY`, `fieldSlotOf` em `descend`/`referenceStorageMode`/setter, `validateReferencedValue` sem `reflect` no caso comum, `derefPlace` só com `VAL_REF` |
+
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-93b-borrow-path-design.md`.
+
+**Protocolo:** `interleaved_compare.ps1 -Runs 9` (`pwsh -NoProfile -File`),
+mediana de 9. Benches novos neste commit: `bench_bst_owned.nx` /
+`bench_bst_ref.nx` (as fixtures da issue, 20k chaves, `CHECKSUM:`);
+`bench_borrow_path.nx` ganhou `CHECKSUM:` (era pulado pelo guard).
+
+## 1. Headline — base × head (mediana de 9)
+
+| bench | base_a52c7e1_ms | head_4026c43_ms | delta |
+|---|---|---|---|
+| bench_borrow_path.nx | 564.7 | 507.7 | **-10.1%** |
+| bench_bst_owned.nx | 780.9 | 565.8 | **-27.5%** |
+| bench_bst_ref.nx | 216.7 | 217.9 | 0.6% |
+| bench_bubblesort.nx | 740 | 744.5 | 0.6% |
+| bench_call_light.nx | 32.3 | 28.8 | -10.8% |
+| bench_call_readonly.nx | 572.5 | 546.5 | -4.5% |
+| bench_call_ref.nx | 1109.4 | 1091.6 | -1.6% |
+| bench_conway.nx | 1264.3 | 1283.4 | 1.5% |
+| bench_generic_vs_hand.nx | 431.6 | 432.9 | 0.3% |
+| bench_map_churn.nx | 212.3 | 207 | -2.5% |
+| bench_path_update.nx | 162 | 163.1 | 0.7% |
+| bench_share_mutate.nx | 115.4 | 107.4 | -6.9% |
+| bench_spawn_sum.nx | 400.7 | 394.4 | -1.6% |
+| bench_struct_records.nx | 127.4 | 126 | -1.1% |
+| bench_typed_call_map.nx | 28.2 | 27 | -4.3% |
+| bench_value_call_mutate.nx | 28.4 | 27 | -4.9% |
+
+Pulado: `bench_hash31_bytes.nx` (não imprime `CHECKSUM:`; pré-existente).
+
+## 2. Fixtures da issue (uma execução cada, máquina carregada — só a razão vale)
+
+| fixture | base | head |
+|---|---|---|
+| `p_owned` 50k aleatórias | 6,36 s | 3,60 s (×1,77) |
+| `p_owned_sorted` 1000 ordenadas | 21,2 s | 11,1 s (×1,9) |
+
+Com a máquina livre, `p_owned` 50k: 2,20 s (base, perfil do #96) → **1,60 s** (head).
+
+## 3. Perfil — `p_owned` 50k (`--cpuprofile`, uma execução)
+
+**Base** (binário do #96, mesmo caminho do empréstimo) — 2,20 s, 2,74 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `borrowContainer` | 10,2 % | 53,7 % |
+| `referenceStorageMode` | 3,3 % | 59,5 % |
+| `descend` | 12,4 % | 32,5 % |
+| `derefPlace` | 6,9 % | 6,9 % |
+| `(*ObjInstance).Get` → `FieldIndex` → `mapaccess2_faststr` + `aeshashbody` | — | **16,4 %** |
+| GC (`scanSpan`, `tryDeferToSpanScan`, `scanObjectsSmall`) | — | ~25 % |
+
+**Head 4026c43** — 1,60 s, 1,95 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `borrowContainer` | 12,8 % | 41,0 % |
+| `referenceStorageMode` | 6,2 % | 48,2 % |
+| `descend` | 5,1 % | 12,8 % |
+| `fieldSlotOf` (guarda `Fields[Slot] == Name`) | 6,2 % | 11,3 % |
+| ↳ `memeqbody` | 4,6 % | 4,6 % |
+| `sync/atomic.(*Int32).Add` (Retain/Release na caminhada de escrita) | 7,7 % | 7,7 % |
+| `FieldIndex` / `mapaccess2_faststr` / `validateReferencedValue` | 0,5 % cada | ~1 % |
+| GC | — | ~20 % |
+
+Leitura: o hashing por nível saiu (16 % → 1 %) e o `reflect` do `defer` também;
+o que sobra é a caminhada em si (O(profundidade) por acesso, modelo de lugar da
+#83) — `borrowContainer` + `descend` + `referenceStorageMode` ainda são ~50 %
+do tempo, agora dominados pela estrutura do laço e pelo RC da unicização, não
+por lookup. É o custo que só a cache por época (spec §6) remove.
+
+## 4. Verificação
+
+- `go test ./...` verde; `go test -race ./internal/vm -count=1` verde (24 s).
+- Corpus `run_all_tests_concurrent.nx` com o head: **180/180**.
+- `compare_examples.ps1` base × head: **149 iguais, 0 divergentes, 70 excluídos**.
+- Testes novos: `ObjRef` com `Slot` errado/fora da faixa resolve pelo nome e
+  erra igual em campo inexistente; `ref xs[0].valor` em instância JSON
+  reordenada escreve o campo certo; BST profunda com cópia CoW dá o mesmo
+  resultado. `TestMalformedReferenceRejectsTaskPayload` pegou a primeira versão
+  do fast path de `validateReferencedValue` (aceitava `VAL_TASK` com payload
+  string) — o switch ficou restrito a `VAL_OBJ`/`VAL_REF`.

--- a/benchmarks/results/2026-08-28-issue-96-struct-field-index-raw.md
+++ b/benchmarks/results/2026-08-28-issue-96-struct-field-index-raw.md
@@ -1,0 +1,127 @@
+# Dados brutos — campo de struct por índice em compilação (issue #96): base × head
+
+**Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · laptop, na
+tomada. Máquina sem `go test` nem build durante as medições (o runner do
+corpus e o `compare_examples.ps1` rodaram ANTES do A/B, nunca junto).
+
+**Binários** (em disco local, scratchpad da sessão):
+
+| rótulo | commit | o que é |
+|---|---|---|
+| `base` | 2a627bc | `develop` depois de #95 (slots), #97 (corpus) e #98 (#93a) |
+| `head` | 79af956 | + `OP_GET_FIELD` / `OP_SET_FIELD` / `OP_GET_FIELD_MUT` emitidos para base tipada; funis `getPropertyGeneric`/`setPropertyGeneric`/`getPropMutGeneric` |
+
+Spec: `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`.
+
+**Protocolo:** `benchmarks/interleaved_compare.ps1 -Runs 9` (`pwsh -NoProfile
+-File`), execuções intercaladas na mesma janela, guard de `CHECKSUM:` entre
+binários, mediana de 9. `bench_struct_records.nx` entrou na suíte neste PR
+(993b464, resgatado de 93625ac — o comentário de fechamento da #40 registra que
+o original nunca foi commitado).
+
+## 1. Headline — base × head (mediana de 9)
+
+| bench | base_2a627bc_ms | head_79af956_ms | delta |
+|---|---|---|---|
+| bench_bubblesort.nx | 659.8 | 655.6 | -0.6% |
+| bench_call_light.nx | 27 | 27 | 0% |
+| bench_call_readonly.nx | 448.3 | 450.9 | 0.6% |
+| bench_call_ref.nx | 995.5 | 999.5 | 0.4% |
+| bench_conway.nx | 1212.1 | 1196.3 | -1.3% |
+| bench_generic_vs_hand.nx | 419.7 | 420.6 | 0.2% |
+| bench_map_churn.nx | 210.2 | 208.7 | -0.7% |
+| bench_path_update.nx | 238.8 | 160.7 | **-32.7%** |
+| bench_share_mutate.nx | 111.9 | 109.7 | -2% |
+| bench_spawn_sum.nx | 411.6 | 414.7 | 0.8% |
+| bench_struct_records.nx | 145.9 | 136.1 | **-6.7%** |
+| bench_typed_call_map.nx | 27.6 | 28.4 | 2.9% |
+| bench_value_call_mutate.nx | 27.9 | 27.8 | -0.4% |
+
+Pulados pelo guard de equivalência — **nenhum dos dois binários** imprime
+`CHECKSUM:` neles (pré-existente, não é deste PR): `bench_borrow_path.nx`
+(imprime `200000` duas vezes) e `bench_hash31_bytes.nx` (imprime
+`bytes=… hash31=… ms=…`).
+
+## 2. Bytecode dos benches (`noxy -disassembly`)
+
+| bench | opcodes de campo no head |
+|---|---|
+| bench_path_update | 4× `OP_GET_FIELD`, 2× `OP_SET_FIELD`; nenhum `OP_GET_PROPERTY`/`OP_SET_PROPERTY` |
+| bench_struct_records | 9× `OP_GET_FIELD`; nenhum por nome |
+
+## 3. Perfis (`noxy --cpuprofile`, carga ampliada para juntar amostra, uma execução)
+
+`prof_path_update.nx` = `bench_path_update` com `round < 5000` (×10);
+`prof_struct_records.nx` = `bench_struct_records` com `i < 900000` (×15).
+`go tool pprof -top`.
+
+### 3.1 `bench_path_update` ×10
+
+**Base 2a627bc** — 2,18 s, 2,11 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 47,4 % | 100 % |
+| `push` + `pop` | 8,5 + 6,6 % | 15,2 % |
+| `value.Retain` + `value.Release` | 5,2 + 2,4 % | 6,6 + 3,3 % |
+| `value.IsShared` (+ `ownersOf`) | 4,7 % (+ 5,2 %) | 7,6 % |
+| **`(*ObjStruct).FieldIndex`** | 0,9 % | **15,2 %** |
+| ↳ `runtime.mapaccess2_faststr` | 2,8 % | 14,2 % |
+| ↳ `aeshashbody` | 4,3 % | 4,3 % |
+| ↳ `memequal` + `memeqbody` | 1,9 + 1,4 % | — |
+| `(*ObjInstance).Get` | 1,4 % | 11,4 % |
+
+**Head 79af956** — 1,44 s, 1,41 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 68,1 % | 99,3 % |
+| `value.IsShared` (+ `ownersOf`) | 9,9 % (+ 6,4 %) | 16,3 % |
+| `push` + `pop` | 5,0 + 1,4 % | 6,4 % |
+| `memeqbody` (a guarda `Fields[idx] == nome`) | 2,8 % | 2,8 % |
+| `unicizeOwnedSlot` | 2,8 % | 5,0 % |
+| `FieldIndex` / `mapaccess2_faststr` / `aeshashbody` / `Retain` / `Release` | — | **ausentes** |
+
+Leitura: o hashing de campo (15 %) e as chamadas `Retain`/`Release` (10 %, no-op
+para `int`) saíram do caminho; o que sobra é `IsShared` do `OP_GET_LOCAL_MUT`
++ `OP_GET_INDEX_MUT` da cadeia de mutação (`cells[i].hits = …`), fora do
+escopo desta issue.
+
+### 3.2 `bench_struct_records` ×15
+
+**Base 2a627bc** — 1,76 s, 2,09 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 10,5 % | 78,0 % |
+| **`validateStructConstructorArguments`** | 1,4 % | **45,9 %** |
+| ↳ `runtimeTypeComplete` | 2,4 % | 40,7 % |
+| ↳ `runtime.mapassign_fast64ptr` (o `make(map)` de memoização, por construção) | 1,9 % | 27,3 % |
+| `callPreparedValue` | 1,9 % | 7,2 % |
+| `FieldIndex` / `mapaccess2_faststr` | — | não aparecem no top-22 |
+
+**Head 79af956** — 1,56 s, 1,77 s de amostras:
+
+| símbolo | flat | cum |
+|---|---|---|
+| `(*VM).run` | 7,9 % | 80,8 % |
+| `validateStructConstructorArguments` | 1,7 % | 46,9 % |
+| ↳ `runtimeTypeComplete` | 1,7 % | 39,0 % |
+| `FieldIndex` / `mapaccess2_faststr` / `aeshashbody` / `(*ObjInstance).Get` | — | **ausentes** (grep em `-nodecount=200`) |
+
+Leitura: neste bench o índice de campo só acelera as leituras de `pontuar`/
+`promover` (−6,7 %); o custo dominante é a validação do construtor, que refaz
+`runtimeTypeComplete(schema, make(map…))` a cada `Registro(...)`. O cache do
+construtor do PR #70 (`ctorCache` em `ObjStruct`, commit 131c352) **não está em
+`develop`**: o #70 foi mergeado em `perf/issue-66-call-protocol` 23 s depois de
+o #69 entrar em `develop` (`git merge-base --is-ancestor 131c352 develop` →
+não). Follow-up próprio.
+
+## 4. Verificação
+
+- `go test ./...` verde; `go test -race ./internal/vm -count=1` verde (24 s).
+- Corpus `run_all_tests_concurrent.nx` com o head: **180/180** (3,1 s).
+- `compare_examples.ps1` base × head: **149 iguais, 0 divergentes, 70 excluídos**.
+- gofmt limpo nos arquivos tocados (checado em cópias sem CR).
+- Mutação: sem a guarda `Fields[idx] == nome`, `TestFieldIndexGuardsReorderedJSONInstance`
+  falha (`n.valor` lê o slot de `proximo`).

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,14 +1,20 @@
-| bench | v0151_ms | call_ms | delta |
+| bench | base_2a627bc_ms | head_79af956_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 776.9 | 694.1 | -10.7% |
-| bench_call_light.nx | 19.9 | 19.7 | -1% |
-| bench_call_readonly.nx | 531.3 | 537.4 | 1.1% |
-| bench_call_ref.nx | 1137.1 | 1149.9 | 1.1% |
-| bench_conway.nx | 1253.2 | 1275.3 | 1.8% |
-| bench_generic_vs_hand.nx | 456.6 | 448.7 | -1.7% |
-| bench_map_churn.nx | 194.3 | 200.1 | 3% |
-| bench_path_update.nx | 229.8 | 231.8 | 0.9% |
-| bench_share_mutate.nx | 100.6 | 103.3 | 2.7% |
-| bench_spawn_sum.nx | 398.8 | 369.8 | -7.3% |
-| bench_typed_call_map.nx | 22.3 | 22.5 | 0.9% |
-| bench_value_call_mutate.nx | 21.1 | 21.2 | 0.5% |
+| bench_bubblesort.nx | 659.8 | 655.6 | -0.6% |
+| bench_call_light.nx | 27 | 27 | 0% |
+| bench_call_readonly.nx | 448.3 | 450.9 | 0.6% |
+| bench_call_ref.nx | 995.5 | 999.5 | 0.4% |
+| bench_conway.nx | 1212.1 | 1196.3 | -1.3% |
+| bench_generic_vs_hand.nx | 419.7 | 420.6 | 0.2% |
+| bench_map_churn.nx | 210.2 | 208.7 | -0.7% |
+| bench_path_update.nx | 238.8 | 160.7 | -32.7% |
+| bench_share_mutate.nx | 111.9 | 109.7 | -2% |
+| bench_spawn_sum.nx | 411.6 | 414.7 | 0.8% |
+| bench_struct_records.nx | 145.9 | 136.1 | -6.7% |
+| bench_typed_call_map.nx | 27.6 | 28.4 | 2.9% |
+| bench_value_call_mutate.nx | 27.9 | 27.8 | -0.4% |
+
+Pulados (sem equivalencia entre os dois binarios):
+
+- bench_borrow_path.nx — sem CHECKSUM no base_2a627bc
+- bench_hash31_bytes.nx — sem CHECKSUM no base_2a627bc

--- a/benchmarks/results/interleaved.md
+++ b/benchmarks/results/interleaved.md
@@ -1,20 +1,22 @@
-| bench | base_2a627bc_ms | head_79af956_ms | delta |
+| bench | base_a52c7e1_ms | head_4026c43_ms | delta |
 |---|---|---|---|
-| bench_bubblesort.nx | 659.8 | 655.6 | -0.6% |
-| bench_call_light.nx | 27 | 27 | 0% |
-| bench_call_readonly.nx | 448.3 | 450.9 | 0.6% |
-| bench_call_ref.nx | 995.5 | 999.5 | 0.4% |
-| bench_conway.nx | 1212.1 | 1196.3 | -1.3% |
-| bench_generic_vs_hand.nx | 419.7 | 420.6 | 0.2% |
-| bench_map_churn.nx | 210.2 | 208.7 | -0.7% |
-| bench_path_update.nx | 238.8 | 160.7 | -32.7% |
-| bench_share_mutate.nx | 111.9 | 109.7 | -2% |
-| bench_spawn_sum.nx | 411.6 | 414.7 | 0.8% |
-| bench_struct_records.nx | 145.9 | 136.1 | -6.7% |
-| bench_typed_call_map.nx | 27.6 | 28.4 | 2.9% |
-| bench_value_call_mutate.nx | 27.9 | 27.8 | -0.4% |
+| bench_borrow_path.nx | 564.7 | 507.7 | -10.1% |
+| bench_bst_owned.nx | 780.9 | 565.8 | -27.5% |
+| bench_bst_ref.nx | 216.7 | 217.9 | 0.6% |
+| bench_bubblesort.nx | 740 | 744.5 | 0.6% |
+| bench_call_light.nx | 32.3 | 28.8 | -10.8% |
+| bench_call_readonly.nx | 572.5 | 546.5 | -4.5% |
+| bench_call_ref.nx | 1109.4 | 1091.6 | -1.6% |
+| bench_conway.nx | 1264.3 | 1283.4 | 1.5% |
+| bench_generic_vs_hand.nx | 431.6 | 432.9 | 0.3% |
+| bench_map_churn.nx | 212.3 | 207 | -2.5% |
+| bench_path_update.nx | 162 | 163.1 | 0.7% |
+| bench_share_mutate.nx | 115.4 | 107.4 | -6.9% |
+| bench_spawn_sum.nx | 400.7 | 394.4 | -1.6% |
+| bench_struct_records.nx | 127.4 | 126 | -1.1% |
+| bench_typed_call_map.nx | 28.2 | 27 | -4.3% |
+| bench_value_call_mutate.nx | 28.4 | 27 | -4.9% |
 
 Pulados (sem equivalencia entre os dois binarios):
 
-- bench_borrow_path.nx — sem CHECKSUM no base_2a627bc
-- bench_hash31_bytes.nx — sem CHECKSUM no base_2a627bc
+- bench_hash31_bytes.nx — sem CHECKSUM no base_a52c7e1

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2278,7 +2278,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.20.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.21.0`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.20.0</span>
+                    <span class="version-badge-tag">v0.21.0</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.20.0
+print(sys.version)           // v0.21.0
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/docs/superpowers/specs/2026-08-28-vm-perf-issue-93b-borrow-path-design.md
+++ b/docs/superpowers/specs/2026-08-28-vm-perf-issue-93b-borrow-path-design.md
@@ -1,0 +1,90 @@
+# VM Perf — Custo por nível do empréstimo aninhado (issue #93, parte b)
+
+**Data:** 2026-08-28 · **Issue:** [#93](https://github.com/estevaofon/noxy/issues/93) (b) · **Branch:** `perf/issue-93b-borrow-path` · **Base:** `develop` (b4eca8a, pós-#96/#98)
+
+## 1. Contexto (medido nesta sessão)
+
+BST por posse (`esquerda: TreeNode` + `insert(ref node.esquerda, v)`), 50k
+chaves aleatórias: **2,26 s** na base, contra 0,69 s da versão com `ref`. O
+#96 não mudou nada aqui (2,29 s): o caminho do empréstimo resolve o campo por
+NOME em cada nível. Perfil (head do #96):
+
+| símbolo | flat | cum |
+|---|---|---|
+| `borrowContainer` | 10,2 % | 53,7 % |
+| `descend` | 12,4 % | 32,5 % |
+| `referenceStorageMode` (+ `defer` com `validateReferencedValue` → `reflect`) | 3,3 % | 59,5 % |
+| `derefPlace` | 6,9 % | 6,9 % |
+| `(*ObjInstance).Get` → `FieldIndex` → `mapaccess2_faststr`/`aeshashbody` | — | **16,4 %** |
+| GC (`scanSpan`, `tryDeferToSpanScan`, `scanObjectsSmall`) | — | ~25 % |
+
+Por que O(profundidade²): `insert` no nível k cria `ref node.esquerda` com
+`Base` encadeado k vezes; cada acesso (`*node`, `node.valor`, criação do ref
+seguinte) re-resolve os k níveis. É o modelo de lugar da #83 (correto: o
+caminho é a identidade do empréstimo) e este PR **não** o muda.
+
+## 2. Por que "fast path quando `Owners == 1`" não serve como está
+
+A direção sugerida na issue ("contêiner único → não precisa unicizar nem
+regravar") é insegura sem validar a cadeia: com `r = ref a.inner`, depois
+`let b = a` e `a.inner = Inner(9)` (que clona `a` para `a'` na célula), o
+`Container` congelado de `r` — o `a` velho — fica com `Owners == 1` (só `b` o
+possui) e **fora do lugar** `a.inner`: escrever por `r` iria parar em `b`.
+Unicidade do objeto não prova que ele ainda está no lugar; só a caminhada
+prova. Uma versão segura ("cada nível da cadeia ainda aponta para o filho
+congelado, todos únicos") continua O(profundidade), só com constante menor.
+
+Matar o quadrático exige memoizar a resolução entre acessos, com um sinal de
+invalidação global (época que sobe a cada gravação de composto em qualquer
+lugar — SET_LOCAL/GLOBAL/upvalue/campo/elemento/map, natives que trocam
+elementos, gravação de volta do CoW). É uma mudança de arquitetura com cauda
+longa de sites (esquecer um = cache obsoleta = escrita no objeto errado).
+Fica documentada como follow-up (§6), não entra aqui.
+
+## 3. O que este PR faz (constante por nível)
+
+1. **Slot no `ObjRef`.** `OP_REF_PROPERTY` resolve `FieldIndex(nome)` UMA vez,
+   na criação (o contêiner já é resolvido ali para as checagens), e guarda em
+   `ObjRef.Slot`. `descend` e `referenceStorageMode` (caso `REF_PROPERTY`) usam
+   `Slots[Slot]` quando `Slot < len(Fields) && Fields[Slot] == Name` — a mesma
+   guarda do #96 (definições de JSON em ordem alfabética, ObjRef montado à mão
+   por natives/testes com `Slot` zero). Falhou → `Get(nome)` como hoje.
+   O `referenceSetter` de propriedade recebe o slot já validado e grava
+   `Slots[slot]` em vez de `MustSet(nome)`.
+2. **`validateReferencedValue` sem `reflect` no caso comum.** Type switch nos
+   payloads concretos (`*ObjInstance`, `*ObjArray`, `*ObjMap`, `string`,
+   `*ObjRef`…) antes de cair no `reflect.ValueOf` genérico — mesma semântica
+   (nil → "invalid referenced object").
+3. **`descend` sem chamada quando o contêiner não é ref**: o teste
+   `container.Type == VAL_REF` fica inline antes de `derefPlace`.
+
+Semântica, mensagens, linhas e contagem RC idênticas; os sete repros da #83
+(`borrow_place_test.go`) continuam o critério.
+
+## 4. Verificação
+
+- `go test ./internal/vm -run 'Borrow|Ref'` e `go test ./...` verdes; `-race` no
+  pacote `vm`.
+- Teste novo: `ObjRef{REF_PROPERTY, Slot: errado}` montado à mão resolve pelo
+  nome (a guarda); ref a campo de instância JSON reordenada lê e escreve o
+  campo certo.
+- Benches novos na suíte: `bench_bst_owned.nx` / `bench_bst_ref.nx` (as
+  fixtures da issue, com `CHECKSUM:`); `bench_borrow_path.nx` ganha `CHECKSUM:`
+  (imprimia três números soltos e o guard de equivalência o pulava).
+- A/B intercalado base × head, mediana de 9; corpus 180/180; `compare_examples`.
+
+## 5. Riscos
+
+| risco | mitigação |
+|---|---|
+| `Slot` errado (ObjRef de native/teste, JSON) | guarda `Fields[Slot] == Name`; zero value é seguro |
+| `validateReferencedValue` deixar passar payload nil | switch cobre os tipos que a VM guarda em `Obj`; o `default` continua no `reflect` |
+
+## 6. Follow-up (não incluído): cache por época
+
+`ObjRef` guardaria `(container resolvido, época, modo)`; `vm`/`value` uma
+época global atômica que sobe em toda gravação de composto em lugar e em toda
+gravação de volta do CoW; acesso com época igual reusa o contêiner (leitura) ou
+o caminho já unicizado (escrita). Transforma O(profundidade) por acesso em
+O(1) amortizado; exige inventário completo dos sites de gravação (VM, natives
+`append/pop/sort/remove`, `json_loads`, canais).

--- a/docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md
+++ b/docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md
@@ -1,0 +1,168 @@
+# VM Perf — Campo de struct por índice em compilação (issue #96)
+
+**Data:** 2026-08-28 · **Issue:** [#96](https://github.com/estevaofon/noxy/issues/96) · **Branch:** `perf/issue-96-struct-field-index` · **Base:** `develop` (2a627bc, pós-#95/#97/#98)
+
+## 1. Contexto (medido nesta sessão, binário de 2a627bc)
+
+Desde o #95 uma instância guarda os campos em `Slots []Value` na ordem da
+declaração e `ObjStruct` tem o índice nome→slot. O caminho quente de
+`OP_GET_PROPERTY`/`OP_SET_PROPERTY`/`OP_GET_PROP_MUT` continua fazendo **um
+lookup por string** por acesso (`Struct.FieldIndex(name)` = `mapaccess2_faststr`
++ `aeshashbody`).
+
+**`bench_path_update`** (`cells[i].hits = cells[i].hits + 1`, carga ×10 para
+amostra): `FieldIndex` **15,2 % cum**, `mapaccess2_faststr` 14,2 %, `aeshashbody`
+4,3 %, `memequal` 1,9 %; `Retain`+`Release` 10 % (no-op para `int`, mas chamadas
+reais); `push`/`pop` 15 %.
+
+**`bench_struct_records`** (5 campos, 60k construções, duas funções por valor —
+resgatado de 93625ac, nunca tinha chegado a `develop`): o topo **não é** o
+hashing de campo. `validateStructConstructorArguments` **45,9 % cum**, via
+`runtimeTypeComplete` 40,7 % e `mapassign_fast64ptr` 27,3 % — o `make(map...)`
+de memoização é refeito a cada construção porque o cache do construtor do PR #70
+(`ctorCache` em `ObjStruct`, commit 131c352) **nunca chegou a `develop`**: o #70
+foi mergeado em `perf/issue-66-call-protocol` 23 s depois de o #69 entrar em
+`develop`. Achado colateral; fica como follow-up próprio (§7.4). Neste bench o
+ganho do índice de campo é limitado às leituras `r.ativo`/`r.valor`/`r.grupo`.
+
+## 2. Objetivo e não-objetivos
+
+**Objetivo:** quando o tipo estático da base é um struct do programa, resolver
+`p.x` para o índice de slot em compilação e acessar `Slots[idx]` sem hashing.
+Semântica, saída, mensagens e linhas de erro, contagem RC e CoW **idênticas**;
+opcodes só por append; bytecode com base `any`/módulo **inalterado**.
+
+**Não-objetivos:** `ref p.x` (`OP_REF_PROPERTY` fica: o `ObjRef` é resolvido
+por NOME em `references.go` — `descend`, `referenceStorageMode`, `sameBorrowBase`;
+é a parte do #93b); formas fundidas com slot local (`OP_GET_LOCAL_FIELD`);
+fundir o `OP_DEREF` de base `ref`; structs de módulo (ficam por nome, como a
+issue pede); o cache do construtor (§7.4).
+
+## 3. Desenho
+
+### 3.1 A premissa da issue está errada: precisa de guarda
+
+A issue diz "struct de JSON dinâmico tem a própria definição, então a base
+tipada nunca aponta para ele". Falso: `buildTypedJSONValue`
+(`json_population.go:357-397`) cria uma `ObjStruct` NOVA com os campos em
+**ordem alfabética** (`sort.Strings`) para todo valor de struct que o
+`json_loads` **cria** (elemento novo de `Node[]`, campo que era `null`, valor
+novo de map). Essa instância entra num contêiner tipado: `let n: Node = xs[0]`
+tem tipo estático `Node` (slot 0 = `valor`) e instância com slot 0 = `proximo`.
+Um `OP_GET_FIELD 0` cego leria o campo errado.
+
+Por isso o operando carrega o índice **e** o nome, e o caminho rápido confere
+`idx < len(Slots) && Struct.Fields[idx] == name` — uma comparação de string
+curta (Go compara tamanho, depois ponteiro, depois bytes) no lugar do hash.
+Falhou a guarda → funil genérico por nome, o mesmo que o opcode antigo. A
+guarda também cobre definições montadas por natives/bytecode de teste sem
+índice. Corrigir o JSON para reutilizar a definição declarada não cabe aqui:
+`RuntimeTypeInfo.Fields` é map sem ordem, e a definição própria é onde o JSON
+guarda `JSONDynamicFields` por instância.
+
+### 3.2 Opcodes (append ao fim de `internal/chunk/chunk.go`, após `OP_GET_LOCAL_2`)
+
+| opcode | operando | pilha | espelha |
+|---|---|---|---|
+| `OP_GET_FIELD` | `[idx u8][nome u16]` | `[inst] → [val]` | `OP_GET_PROPERTY` |
+| `OP_SET_FIELD` | `[idx u8][nome u16]` | `[inst, val] → []` | `OP_SET_PROPERTY` + `OP_POP` |
+| `OP_GET_FIELD_MUT` | `[idx u8][nome u16]` | `[inst] → [val unicizado]` | `OP_GET_PROP_MUT` |
+
+`OP_SET_FIELD` é statement (não empilha; o compilador não emite `OP_POP`
+depois). Estruturas com mais de 255 campos ficam por nome.
+
+### 3.3 VM — caminho rápido e fallback exato
+
+Os corpos de `OP_GET_PROPERTY`, `OP_SET_PROPERTY` e `OP_GET_PROP_MUT` saem
+para métodos `getPropertyGeneric(c, ip, name)`, `setPropertyGeneric(c, ip, name)`
+e `getPropMutGeneric(c, ip, name)`; os `case` genéricos passam a chamá-los (uma
+chamada a mais por opcode genérico — `any`, módulos — o mesmo custo que a #66
+aceitou com `getIndexGeneric`/`setIndexGeneric`; sentinela `bench_generic_vs_hand`).
+
+- **`OP_GET_FIELD`**: topo é `*ObjInstance` (assertion), guarda §3.1 →
+  `stack[top-1] = Slots[idx]` no lugar. Senão `getPropertyGeneric` (base ainda
+  na pilha): ref auto-deref, `ObjMap`, `null`, mensagens e linha idênticas —
+  `Lines[ip-1]` é o último byte de operando, gravado com a linha do opcode.
+- **`OP_SET_FIELD`**: `[inst, val]`; instância + guarda; campo `ref T`
+  (`RefFields != nil && RefFields[name]` — nil quando o struct não tem campo ref,
+  então sem custo no caso comum) → genérico, que aplica `refSlotWriteError`;
+  senão `old := Slots[idx]`; se `NeverTracked(val) && NeverTracked(old)` grava
+  sem `Retain`/`Release` (são no-op nesses valores — não é uma variante NORC,
+  é a mesma semântica sem a chamada); senão `Retain(val); Slots[idx] = val;
+  Release(old)`. Limpa os dois slots da pilha. Fallback: `setPropertyGeneric` +
+  `vm.LastPopped = vm.pop()` (o `OP_POP` da sequência genérica). O caminho
+  rápido não grava `LastPopped`, como as escritas fundidas da #66.
+- **`OP_GET_FIELD_MUT`**: instância + guarda; `fieldVal := Slots[idx]`; se
+  `IsShared(fieldVal)` clona e grava de volta com retain-antes-de-release (o
+  corpo do genérico); resultado no lugar. Senão `getPropMutGeneric`.
+
+Base `ref` (`r.x` com `r: ref Ponto`): o compilador já emite `OP_DEREF`
+(leitura) / `OP_DEREF_MUT` (lvalue) antes, então o opcode novo vê a instância;
+não muda.
+
+### 3.4 Compilador
+
+`fieldSlot(owner, member) (idx int, ok bool)` em `member_types.go`, irmã de
+`memberType`: `unwrapRefType(owner)` é `*PrimitiveType`, `structDeclaration`
+existe, `structOrigin(decl) == ""` (struct do programa — inclui instâncias
+genéricas monomorfizadas `main::Stack<int>` e structs de escopo local, cuja
+`FieldsList` é a mesma que vira `ObjStruct.Fields`), campo achado em
+`FieldsList` na posição `idx ≤ 255`. Tudo o mais → `ok=false` → opcode por nome.
+
+Sites: leitura (`compiler.go` `case *ast.MemberAccessExpression`) → `OP_GET_FIELD`;
+atribuição (`compiler.go` alvo `MemberAccessExpression`) → `OP_SET_FIELD` sem
+`OP_POP`; base de lvalue aninhado (`cow_lowering.go` `compileLValueBase`) →
+`OP_GET_FIELD_MUT`. `use m select` e `ref p.x` inalterados. Checagens de tipo,
+mensagens e ordem inalteradas (o índice é decidido depois delas).
+
+## 4. Invariantes e guards executáveis
+
+- `chunk_test.go`: sentinela de `TestEveryOpcodeHasASymbolicNameWithoutGaps` →
+  `OP_GET_FIELD_MUT`; disassembler ganha `fieldInstruction` (3 bytes) e
+  `disassemblyProgram` já tem `p.x = soma(p.x, 10)` com base tipada.
+- `cow_lowering_test.go`: walker `collectOpcodes` ganha o caso de 3 bytes;
+  allowlist do lowering ganha `OP_GET_FIELD_MUT`/`OP_SET_FIELD`.
+- Bytecode (pacote `compiler`, via disassembler): local tipado → `OP_GET_FIELD`
+  com o índice certo; `any` → `OP_GET_PROPERTY`; namespace `mod.f` → por nome;
+  `ref Ponto` → `OP_DEREF` + `OP_GET_FIELD`; `p.x = v` → `OP_SET_FIELD` sem
+  `OP_POP`; `p.a.b = v` → `OP_GET_FIELD_MUT` + `OP_SET_FIELD`; instância
+  genérica → por índice; struct de módulo via `select` → por nome.
+- Comportamento (pacote `vm`): **instância JSON com ordem invertida lida e
+  escrita por base tipada** (a guarda); tabela de erros idênticos base tipada ×
+  `any` (null, ref nula, campo inexistente via `any`); RC (`OwnersCount` após
+  `box.value = y` com composto — `TestSetPropertyReleasesOldRetainsNew` passa a
+  exercitar o opcode novo); CoW (`p.inner.x = 1` com `inner` compartilhado
+  clona uma vez, cópia intacta); campo `ref T` escrito por base tipada com ref e
+  com null; `-race` no pacote `vm` inteiro.
+- `go test ./...`, corpus `run_all_tests_concurrent.nx` 180/180,
+  `compare_examples.ps1` 0 divergentes.
+
+## 5. Medição
+
+Binários no scratchpad: `noxy_base.exe` (2a627bc) × head.
+`interleaved_compare.ps1 -Runs 9`; perfil de `bench_path_update` e
+`bench_struct_records` (carga ×10/×15) sem `mapaccess2_faststr`/`aeshashbody`
+vindos de `FieldIndex`; gates CoW ≤ +5 % (`bench_typed_call_map`,
+`bench_share_mutate`, `bench_call_light`, `bench_conway`);
+`bench_generic_vs_hand` como sentinela do despacho. Seção nova no topo de
+`RESULTS.md` + `results/2026-08-28-issue-96-struct-field-index-raw.md`.
+
+## 6. Riscos
+
+| risco | mitigação |
+|---|---|
+| definição com outra ordem (JSON, natives) | guarda `Fields[idx] == name` em runtime + teste com instância JSON invertida |
+| campo `ref T` escrito sem a checagem do slot | fast path recusa quando `RefFields[name]`; genérico decide |
+| pular RC de um composto | `NeverTracked(val) && NeverTracked(old)`; oráculo `OwnersCount` |
+| fallback divergir do genérico | funil único: os `case` genéricos chamam os mesmos métodos |
+| mexer em `run()` regredir o despacho | `bench_generic_vs_hand` |
+
+## 7. Decisões tomadas sem consulta (para a review)
+
+1. Guarda por nome no operando em vez de identidade da definição (§3.1): não
+   exige que o compilador tenha o `*ObjStruct` no site de acesso e cobre
+   qualquer definição.
+2. Sem variante NORC: `OP_SET_FIELD` decide o RC em runtime por `NeverTracked`.
+3. `OP_REF_PROPERTY` fora do escopo (o custo do empréstimo é o #93b).
+4. Cache do construtor (PR #70) ausente em `develop` — não resgatado aqui; é
+   45 % de `bench_struct_records` e merece PR próprio (issue a abrir).

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -161,6 +161,13 @@ const (
 	// GET_LOCAL(+CONSTANT+ADD_INT) fundidos; semantica identica.
 	OP_GET_LOCAL_ADD_IMM_INT // [slot u8][imm i8]; push local(int)+imm (wrappa como OP_ADD_INT)
 	OP_GET_LOCAL_2           // [a u8][b u8]; push local a, push local b
+	// perf issue #96: campo de struct por INDICE de slot quando o compilador
+	// conhece o struct da base. Operando [idx u8][nome u16]: o nome e a guarda
+	// de runtime (uma definicao com outra ordem — json_loads monta a sua em
+	// ordem alfabetica — cai no caminho por nome) e o texto das mensagens.
+	OP_GET_FIELD     // [idx u8][name u16]; pops instance, pushes field
+	OP_SET_FIELD     // [idx u8][name u16]; pops val, instance; statement (nao empilha)
+	OP_GET_FIELD_MUT // [idx u8][name u16]; pops instance, pushes field unicizado (OP_GET_PROP_MUT)
 )
 
 func (op OpCode) String() string {
@@ -275,6 +282,12 @@ func (op OpCode) String() string {
 		return "OP_GET_LOCAL_ADD_IMM_INT"
 	case OP_GET_LOCAL_2:
 		return "OP_GET_LOCAL_2"
+	case OP_GET_FIELD:
+		return "OP_GET_FIELD"
+	case OP_SET_FIELD:
+		return "OP_SET_FIELD"
+	case OP_GET_FIELD_MUT:
+		return "OP_GET_FIELD_MUT"
 	case OP_ADD:
 		return "OP_ADD"
 	case OP_SUBTRACT:
@@ -612,6 +625,12 @@ func (c *Chunk) disassembleInstruction(offset int) int {
 		return c.slotDeltaInstruction("OP_GET_LOCAL_ADD_IMM_INT", offset)
 	case OP_GET_LOCAL_2:
 		return c.twoSlotInstruction("OP_GET_LOCAL_2", offset)
+	case OP_GET_FIELD:
+		return c.fieldInstruction("OP_GET_FIELD", offset)
+	case OP_SET_FIELD:
+		return c.fieldInstruction("OP_SET_FIELD", offset)
+	case OP_GET_FIELD_MUT:
+		return c.fieldInstruction("OP_GET_FIELD_MUT", offset)
 	case OP_DEFER:
 		return c.byteInstruction("OP_DEFER", offset)
 	case OP_RETURN:
@@ -774,4 +793,19 @@ func (c *Chunk) closureInstruction(name string, offset int) int {
 		}
 	}
 	return offset
+}
+
+// fieldInstruction: [idx u8][name u16] — imprime o indice de slot e o nome
+// (constante) do campo, como em `OP_GET_FIELD    1 'y'`.
+func (c *Chunk) fieldInstruction(name string, offset int) int {
+	idx := c.Code[offset+1]
+	constant := uint16(c.Code[offset+2])<<8 | uint16(c.Code[offset+3])
+	fmt.Printf("%-16s %4d '", name, idx)
+	if int(constant) < len(c.Constants) {
+		fmt.Print(c.Constants[constant])
+	} else {
+		fmt.Print("?")
+	}
+	fmt.Printf("'\n")
+	return offset + 4
 }

--- a/internal/chunk/chunk_test.go
+++ b/internal/chunk/chunk_test.go
@@ -45,7 +45,7 @@ func TestEveryOpcodeHasASymbolicNameWithoutGaps(t *testing.T) {
 	}
 	// Sentinela: o último opcode declarado em chunk.go precisa estar nomeado.
 	// Se você acrescentou um opcode depois dele, atualize aqui também.
-	if last := int(chunk.OP_SET_REF_LOCAL_INDEX_ARRAY_NORC); firstUnnamed >= 0 && firstUnnamed <= last {
+	if last := int(chunk.OP_GET_FIELD_MUT); firstUnnamed >= 0 && firstUnnamed <= last {
 		t.Fatalf("opcode %d está abaixo do último declarado (%d) e não tem nome em String()", firstUnnamed, last)
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -882,9 +882,13 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			}
 
 			// Field Name
-			nameConst := c.makeConstant(value.NewString(memberExp.Member))
-			c.emitOpWithConstantIndex(chunk.OP_SET_PROPERTY, nameConst)
-			c.emitByte(byte(chunk.OP_POP))
+			if idx, ok := c.fieldSlot(leftType, memberExp.Member); ok {
+				c.emitFieldOp(chunk.OP_SET_FIELD, idx, memberExp.Member)
+			} else {
+				nameConst := c.makeConstant(value.NewString(memberExp.Member))
+				c.emitOpWithConstantIndex(chunk.OP_SET_PROPERTY, nameConst)
+				c.emitByte(byte(chunk.OP_POP))
+			}
 
 		} else {
 			return nil, nil, fmt.Errorf("[line %d] assignment target not supported yet", c.currentLine)
@@ -988,8 +992,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			leftType = ref.ElementType
 		}
 
-		nameConst := c.makeConstant(value.NewString(n.Member))
-		c.emitOpWithConstantIndex(chunk.OP_GET_PROPERTY, nameConst)
+		if idx, ok := c.fieldSlot(leftType, n.Member); ok {
+			c.emitFieldOp(chunk.OP_GET_FIELD, idx, n.Member)
+		} else {
+			nameConst := c.makeConstant(value.NewString(n.Member))
+			c.emitOpWithConstantIndex(chunk.OP_GET_PROPERTY, nameConst)
+		}
 
 		// RESOLVE FIELD TYPE: memberType resolve o dono pela declaracao que
 		// designa (`File` e `io.File` igual) e devolve o tipo do campo ja na

--- a/internal/compiler/cow_lowering.go
+++ b/internal/compiler/cow_lowering.go
@@ -70,8 +70,12 @@ func (c *Compiler) compileLValueBase(expr ast.Expression) (ast.NoxyType, bool, e
 		if err != nil {
 			return nil, false, err
 		}
-		nameConst := c.makeConstant(value.NewString(n.Member))
-		c.emitOpWithConstantIndex(chunk.OP_GET_PROP_MUT, nameConst)
+		if idx, ok := c.fieldSlot(leftType, n.Member); ok {
+			c.emitFieldOp(chunk.OP_GET_FIELD_MUT, idx, n.Member)
+		} else {
+			nameConst := c.makeConstant(value.NewString(n.Member))
+			c.emitOpWithConstantIndex(chunk.OP_GET_PROP_MUT, nameConst)
+		}
 		// memberType: dono resolvido pela declaracao (`File` ≡ `io.File`) e
 		// tipo do campo ja na visao do programa (issue #58 item 1).
 		t, wasRef := c.derefMutIfRef(c.memberType(leftType, n.Member))

--- a/internal/compiler/cow_lowering_test.go
+++ b/internal/compiler/cow_lowering_test.go
@@ -61,6 +61,9 @@ func collectOpcodes(t *testing.T, code *chunk.Chunk) map[chunk.OpCode]int {
 				chunk.OP_MARK_REF_TARGET_TYPE, chunk.OP_MARK_RUNTIME_VALUE_TYPE,
 				chunk.OP_SET_GLOBAL_BORROW:
 				offset += 2
+			case chunk.OP_GET_FIELD, chunk.OP_SET_FIELD, chunk.OP_GET_FIELD_MUT:
+				// perf issue #96: [idx u8][nome u16]
+				offset += 3
 			case chunk.OP_CLOSURE:
 				// [const_index] [upvalue_count] ([is_local, index])*
 				if offset+1 < len(c.Code) {

--- a/internal/compiler/field_index.go
+++ b/internal/compiler/field_index.go
@@ -1,0 +1,59 @@
+package compiler
+
+import (
+	"noxy-vm/internal/ast"
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Campo de struct por indice em compilacao (issue #96).
+//
+// Desde o #95 uma instancia guarda os campos em Slots na ordem da declaracao
+// (ObjStruct.Fields vem de StructStatement.FieldsList, compiler.go). Quando o
+// tipo estatico da base e um struct do PROGRAMA, a posicao do campo em
+// FieldsList E o indice do slot em runtime, e o acesso sai em OP_GET_FIELD /
+// OP_SET_FIELD / OP_GET_FIELD_MUT com [idx][nome] — sem hashing no caminho
+// quente. O nome vai junto porque a VM confere `Fields[idx] == nome` antes de
+// usar o indice: json_loads monta definicoes proprias em ordem alfabetica
+// (spec 2026-08-28 §3.1), e essas instancias entram em conteineres tipados.
+
+// maxFieldSlot: o indice viaja em 1 byte; struct maior fica por nome.
+const maxFieldSlot = 255
+
+// fieldSlot devolve o indice de slot de `member` no struct estatico `owner`
+// (desembrulhando `ref`), ou ok=false quando o acesso tem de ficar por nome:
+// base `any`/desconhecida, campo inexistente (o erro e do memberType/runtime),
+// struct de MODULO (a issue #96 os deixa por nome; a definicao de runtime e
+// emitida pelo compilador do modulo) ou indice acima de 255.
+func (c *Compiler) fieldSlot(owner ast.NoxyType, member string) (int, bool) {
+	primitive, ok := unwrapRefType(owner).(*ast.PrimitiveType)
+	if !ok {
+		return 0, false
+	}
+	definition := c.structDeclaration(primitive.Name)
+	if definition == nil || c.structOrigin(definition) != "" {
+		return 0, false
+	}
+	for i, field := range definition.FieldsList {
+		if field.Name == member {
+			if i > maxFieldSlot {
+				return 0, false
+			}
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// emitFieldOp emite op [idx u8][nome u16] (o nome como constante, o mesmo
+// operando que a familia por nome usa).
+func (c *Compiler) emitFieldOp(op chunk.OpCode, idx int, member string) {
+	nameConst := c.makeConstant(value.NewString(member))
+	if nameConst > 65535 {
+		panic("constant pool overflow: too many constants in chunk")
+	}
+	c.emitByte(byte(op))
+	c.emitByte(byte(idx))
+	c.emitByte(byte((nameConst >> 8) & 0xff))
+	c.emitByte(byte(nameConst & 0xff))
+}

--- a/internal/compiler/struct_field_index_compile_test.go
+++ b/internal/compiler/struct_field_index_compile_test.go
@@ -1,0 +1,224 @@
+package compiler
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/chunk"
+)
+
+// Campo de struct por índice em compilação (issue #96). Quando o tipo
+// estático da base é um struct do PROGRAMA, `p.x` resolve para o índice de
+// slot na declaração e o compilador emite OP_GET_FIELD / OP_SET_FIELD /
+// OP_GET_FIELD_MUT com `[idx][nome]`; base `any` e struct de módulo ficam nos
+// opcodes por nome. Cada regra tem caso positivo e negativo, lidos da saída
+// do disassembler (que conhece a largura de cada operando).
+
+const fieldIndexPrelude = `
+struct Ponto
+    x: int
+    y: int
+end
+struct Caixa
+    tag: string
+    p: Ponto
+end
+`
+
+// disassemblyText devolve o texto do disassembler de um chunk, para afirmar
+// o OPERANDO (índice e nome) e não só o nome do opcode.
+func disassemblyText(t *testing.T, code *chunk.Chunk) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan string)
+	go func() {
+		out, _ := io.ReadAll(reader)
+		done <- string(out)
+	}()
+	previous := os.Stdout
+	os.Stdout = writer
+	code.Disassemble("t")
+	_ = writer.Close()
+	os.Stdout = previous
+	return <-done
+}
+
+func compiledFunctionChunk(t *testing.T, source, name string) *chunk.Chunk {
+	t.Helper()
+	code, _, err := New().Compile(parse(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fnChunk := findFunctionChunk(code, name)
+	if fnChunk == nil {
+		t.Fatalf("function %q not found", name)
+	}
+	return fnChunk
+}
+
+func assertFieldOperand(t *testing.T, text, op string, idx int, name string) {
+	t.Helper()
+	pattern := regexp.MustCompile(op + `\s+` + strconv.Itoa(idx) + ` '` + regexp.QuoteMeta(name) + `'`)
+	if !pattern.MatchString(text) {
+		t.Fatalf("esperava %s %d '%s' no disassembly:\n%s", op, idx, name, text)
+	}
+}
+
+func TestTypedStructFieldReadUsesSlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    return p.y
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_GET_FIELD", 1, "y")
+}
+
+func TestAnyBaseFieldReadStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> any
+    return a.y
+end
+`, "g")
+	assertHas(t, ops, "OP_GET_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD")
+}
+
+func TestRefStructBaseDerefsThenReadsBySlotIndex(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func f(r: ref Ponto) -> int
+    return r.x
+end
+`, "f")
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	for k, name := range ops {
+		if name == "OP_GET_FIELD" {
+			if k == 0 || ops[k-1] != "OP_DEREF" {
+				t.Fatalf("OP_GET_FIELD sobre base ref precisa vir depois de OP_DEREF: %s", strings.Join(ops, " "))
+			}
+		}
+	}
+}
+
+func TestTypedStructFieldWriteIsStatementBySlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    p.y = 5
+    return p.y
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+	assertNotFollowedByPop(t, ops, "OP_SET_FIELD")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_SET_FIELD", 1, "y")
+}
+
+func TestAnyBaseFieldWriteStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> void
+    a.y = 5
+end
+`, "g")
+	assertHas(t, ops, "OP_SET_PROPERTY")
+	assertLacks(t, ops, "OP_SET_FIELD")
+}
+
+func TestNestedFieldWriteUsesMutBySlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, fieldIndexPrelude+`
+func f(c: Caixa) -> int
+    c.p.x = 9
+    return c.p.x
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD_MUT")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROP_MUT")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+	text := disassemblyText(t, fn)
+	assertFieldOperand(t, text, "OP_GET_FIELD_MUT", 1, "p")
+	assertFieldOperand(t, text, "OP_SET_FIELD", 0, "x")
+}
+
+func TestAnyBaseNestedFieldWriteStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func g(a: any) -> void
+    a.p.x = 9
+end
+`, "g")
+	assertHas(t, ops, "OP_GET_PROP_MUT")
+	assertHas(t, ops, "OP_SET_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD_MUT")
+	assertLacks(t, ops, "OP_SET_FIELD")
+}
+
+func TestGlobalAndArrayElementStructBasesUseSlotIndex(t *testing.T) {
+	ops := topLevelOpcodes(t, fieldIndexPrelude+`
+let p: Ponto = Ponto(1, 2)
+let xs: Ponto[] = [p]
+let i: int = 0
+xs[i].y = p.x + xs[i].y
+`)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+}
+
+func TestGenericStructInstanceUsesSlotIndex(t *testing.T) {
+	fn := compiledFunctionChunk(t, `
+struct Pilha<T>
+    nome: string
+    itens: T[]
+end
+func f(s: Pilha<int>) -> int
+    return length(s.itens)
+end
+`, "f")
+	ops := opcodeNames(t, fn)
+	assertHas(t, ops, "OP_GET_FIELD")
+	assertLacks(t, ops, "OP_GET_PROPERTY")
+	assertFieldOperand(t, disassemblyText(t, fn), "OP_GET_FIELD", 1, "itens")
+}
+
+// Campo declarado `ref T`: a escrita por base tipada continua por índice — a
+// checagem do slot ref é do runtime (o fast path recusa e o genérico decide).
+func TestRefTypedFieldWriteUsesSlotIndex(t *testing.T) {
+	ops := functionOpcodes(t, `
+struct Node
+    v: int
+    next: ref Node
+end
+func f(a: Node, b: Node) -> void
+    a.next = ref b
+    a.next = null
+end
+`, "f")
+	assertHas(t, ops, "OP_SET_FIELD")
+	assertLacks(t, ops, "OP_SET_PROPERTY")
+}
+
+// `ref p.x` fica em OP_REF_PROPERTY: o ObjRef resolve por nome (issue #93b).
+func TestBorrowOfFieldStaysByName(t *testing.T) {
+	ops := functionOpcodes(t, fieldIndexPrelude+`
+func bump(r: ref int) -> void
+    *r = *r + 1
+end
+func f(p: Ponto) -> void
+    bump(ref p.y)
+end
+`, "f")
+	assertHas(t, ops, "OP_REF_PROPERTY")
+	assertLacks(t, ops, "OP_GET_FIELD")
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -687,6 +687,11 @@ type ObjRef struct {
 	Upvalue     *ObjUpvalue // For Local (safe, captured)
 	Container   Value       // For Property/Index (Object, Array, Map)
 	Index       Value       // For Index
+	// Slot: indice do campo (REF_PROPERTY) resolvido na criacao (issue #93b).
+	// E uma DICA: quem usa confere `Struct.Fields[Slot] == Name` antes, porque
+	// a instancia no lugar pode ter outra definicao (json_loads monta a sua em
+	// ordem alfabetica) e um ObjRef montado a mao deixa zero aqui.
+	Slot int
 	// Base e o LUGAR do contêiner, quando ele é conhecido (issue #83). Um
 	// empréstimo — `ref a[i]`, `ref p.x` — não denota um objeto, denota um
 	// LUGAR dentro de um composto que o copy-on-write pode bifurcar. Congelar

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.20.0"
+const Version = "v0.21.0"

--- a/internal/vm/borrow_place_test.go
+++ b/internal/vm/borrow_place_test.go
@@ -562,3 +562,67 @@ f(ref m["k"].x)`)
 		t.Fatalf("err=%v, want 'reference target no longer exists'", err)
 	}
 }
+
+// A profundidade do caminho de um empréstimo é dos DADOS (issue #93a). Uma
+// estrutura recursiva por posse — campo composto nulável, `ref` ao slot para
+// mutar in-place — encadeia Base um nível por chamada recursiva ou por
+// rebinding num laço. O teto de 256 que borrowContainer tinha matava uma BST
+// degenerada ou uma lista com ~256 nós com "reference path too deep"; a
+// caminhada não tem teto porque a cadeia não pode ciclar (ver maxRefHopDepth).
+func TestBorrowPlacePathDepthIsData(t *testing.T) {
+	t.Run("BST por posse com 300 chaves ordenadas (> 256): um nível de Base por chamada", func(t *testing.T) {
+		got := captureVMSource(t, `struct TreeNode
+    valor: int
+    esquerda: TreeNode
+    direita: TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+func count(node: ref TreeNode) -> int
+    if *node == null then
+        return 0
+    end
+    return 1 + count(ref node.esquerda) + count(ref node.direita)
+end
+let raiz: TreeNode = null
+let i: int = 0
+while i < 300 do
+    insert(ref raiz, i)
+    i = i + 1
+end
+test_report(count(ref raiz))`)
+		assertReportedInt(t, got, 300)
+	})
+
+	t.Run("lista por posse com 1000 nós: um nível de Base por rebinding, sem recursão", func(t *testing.T) {
+		got := captureVMSource(t, `struct Node
+    valor: int
+    prox: Node
+end
+let head: Node = null
+let r: ref Node = ref head
+let i: int = 0
+while i < 1000 do
+    *r = Node(i, null)
+    r = ref r.prox
+    i = i + 1
+end
+let n: int = 0
+let c: ref Node = ref head
+while *c != null do
+    n = n + c.valor
+    c = ref c.prox
+end
+test_report(n)`)
+		assertReportedInt(t, got, 499500)
+	})
+}

--- a/internal/vm/borrow_slot_test.go
+++ b/internal/vm/borrow_slot_test.go
@@ -1,0 +1,116 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Slot no ObjRef (issue #93b): OP_REF_PROPERTY resolve o indice do campo uma
+// vez, na criacao; descend/referenceStorageMode usam Slots[Slot] quando a
+// definicao da instancia tem esse nome nesse slot. O Slot e uma DICA: um
+// ObjRef montado a mao (natives, testes) deixa zero, e a instancia no lugar
+// pode ter outra definicao (json_loads monta a sua em ordem alfabetica) —
+// nos dois casos a guarda cai no FieldIndex por nome, como antes.
+
+func TestRefPropertyWrongSlotHintFallsBackToName(t *testing.T) {
+	def := value.NewStruct("P", []string{"a", "b"}).Obj.(*value.ObjStruct)
+	inst := value.NewInstance(def)
+	instObj := inst.Obj.(*value.ObjInstance)
+	instObj.Slots[0] = value.NewInt(10)
+	instObj.Slots[1] = value.NewInt(20)
+
+	// Slot 1 aponta para "b", mas o ref e de "a": a guarda tem de ignorar a dica.
+	ref := &value.ObjRef{RefType: value.REF_PROPERTY, Container: inst, Name: "a", Slot: 1}
+	machine := New()
+	got, err := machine.lookupReferenceValue(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Int() != 10 {
+		t.Fatalf("leitura por ref com Slot errado leu %s, esperava 10 (campo a)", got.String())
+	}
+	if err := machine.storeReferenceValue(value.Value{Type: value.VAL_REF, Obj: ref}, value.NewInt(99)); err != nil {
+		t.Fatal(err)
+	}
+	if instObj.Slots[0].Int() != 99 || instObj.Slots[1].Int() != 20 {
+		t.Fatalf("escrita por ref com Slot errado: slots=%s/%s, esperava 99/20", instObj.Slots[0].String(), instObj.Slots[1].String())
+	}
+
+	// Slot fora da faixa tambem e so uma dica invalida.
+	ref.Slot = 7
+	if got, err := machine.lookupReferenceValue(ref); err != nil || got.Int() != 99 {
+		t.Fatalf("Slot fora da faixa: got %v, %v", got, err)
+	}
+	// Campo inexistente continua sendo erro, com a mesma mensagem.
+	ref.Name = "zzz"
+	if _, err := machine.lookupReferenceValue(ref); err == nil || err.Error() != "undefined property 'zzz'" {
+		t.Fatalf("esperava undefined property 'zzz', obtido %v", err)
+	}
+}
+
+// A instancia que o json_loads cria tem os campos em ordem alfabetica
+// ([proximo, valor], nao [valor, proximo]). O `ref xs[0].valor` resolve o
+// Slot na propria instancia (1), e a escrita atraves dele chega no campo
+// certo; a copia por valor `n` continua independente.
+func TestBorrowOfReorderedJSONInstanceFieldWritesTheRightSlot(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+func bump(r: ref int) -> void
+    *r = *r + 100
+end
+let xs: Node[] = []
+let ok: bool = json_loads("[{\"valor\": 7, \"proximo\": null}]", ref xs)
+let n: Node = xs[0]
+bump(ref xs[0].valor)
+let r: ref int = ref xs[0].valor
+*r = *r + 1
+test_report([to_str(ok), to_str(xs[0].valor), to_str(n.valor), to_str(xs[0].proximo == null)])
+`)
+	reportedStrings(t, got, []string{"true", "108", "7", "true"})
+}
+
+// BST por posse com chaves ordenadas: o caminho do emprestimo com Slot da o
+// mesmo resultado que antes (os sete repros da #83 sao o criterio de
+// semantica; este e o de resultado no caso profundo).
+func TestBorrowSlotDeepOwnedTreeMatches(t *testing.T) {
+	got := captureVMSource(t, `
+struct TreeNode
+    valor: int
+    esquerda: TreeNode
+    direita: TreeNode
+end
+func insert(node: ref TreeNode, v: int) -> void
+    if *node == null then
+        *node = TreeNode(v, null, null)
+        return
+    end
+    if v < node.valor then
+        insert(ref node.esquerda, v)
+    else
+        insert(ref node.direita, v)
+    end
+end
+func soma(node: ref TreeNode) -> int
+    if *node == null then
+        return 0
+    end
+    return node.valor + soma(ref node.esquerda) + soma(ref node.direita)
+end
+let raiz: TreeNode = null
+let seed: int = 12345
+let i: int = 0
+while i < 500 do
+    seed = (seed * 1103515245 + 12345) % 2147483648
+    insert(ref raiz, seed % 1000)
+    i = i + 1
+end
+let copia: TreeNode = raiz
+insert(ref raiz, 5000)
+test_report([to_str(soma(ref raiz) - soma(ref copia))])
+`)
+	reportedStrings(t, got, []string{"5000"})
+}

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -1441,105 +1441,92 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				return err
 			}
 
+		// perf issue #96: campo por INDICE quando o compilador conhece o
+		// struct da base. Guarda: a definicao da instancia tem esse nome nesse
+		// slot (json_loads monta definicoes em ordem alfabetica; natives e
+		// bytecode de teste podem montar qualquer coisa). Falhou → o funil por
+		// nome (field_ops.go), com as mesmas mensagens e a mesma linha.
+		case chunk.OP_GET_FIELD:
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-1].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name {
+				vm.stack[top-1] = inst.Slots[idx]
+				continue
+			}
+			if err := vm.getPropertyGeneric(c, ip, name); err != nil {
+				return err
+			}
+
+		case chunk.OP_SET_FIELD:
+			// [inst, val] -> []. Statement: nao empilha. Campo `ref T` fica com
+			// o generico (guarda do slot ref). Retain/Release sao no-op em
+			// valores NeverTracked — pular a chamada nao muda a contagem.
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-2].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name && (inst.Struct.RefFields == nil || !inst.Struct.RefFields[name]) {
+				val := vm.stack[top-1]
+				old := inst.Slots[idx]
+				if value.NeverTracked(val) && value.NeverTracked(old) {
+					inst.Slots[idx] = val
+				} else {
+					value.Retain(val)
+					inst.Slots[idx] = val
+					value.Release(old)
+				}
+				vm.stack[top-1] = value.Value{}
+				vm.stack[top-2] = value.Value{}
+				vm.stackTop = top - 2
+				continue
+			}
+			if err := vm.setPropertyGeneric(c, ip, name); err != nil {
+				return err
+			}
+			vm.LastPopped = vm.pop()
+
+		case chunk.OP_GET_FIELD_MUT:
+			idx := int(c.Code[ip])
+			nameIdx := int(c.Code[ip+1])<<8 | int(c.Code[ip+2])
+			ip += 3
+			name := c.Constants[nameIdx].Obj.(string)
+			top := vm.stackTop
+			if inst, ok := vm.stack[top-1].Obj.(*value.ObjInstance); ok && inst != nil && inst.Struct != nil && idx < len(inst.Slots) && idx < len(inst.Struct.Fields) && inst.Struct.Fields[idx] == name {
+				fieldVal := inst.Slots[idx]
+				if value.IsShared(fieldVal) {
+					old := fieldVal
+					fieldVal = vm.copyValue(fieldVal)
+					// RC: retain-antes-de-release em torno da troca
+					value.Retain(fieldVal)
+					inst.Slots[idx] = fieldVal
+					value.Release(old)
+				}
+				vm.stack[top-1] = fieldVal
+				continue
+			}
+			if err := vm.getPropMutGeneric(c, ip, name); err != nil {
+				return err
+			}
+
 		case chunk.OP_GET_PROPERTY:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
-			nameVal := c.Constants[index]
-			name := nameVal.Obj.(string)
-
-			instanceVal := vm.pop()
-
-			// Auto-dereference if instance is a ref
-			if instanceVal.Type == value.VAL_REF {
-				resolved, err := vm.resolveReferenceValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = resolved
-			}
-
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances/maps have properties")
-			}
-
-			if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
-				val, ok := instance.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s'", name)
-				}
-				vm.push(val)
-			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
-				// Allow accessing map keys as properties (for modules)
-				val, ok := mapObj.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
-				}
-				vm.push(val)
-			} else {
-				return vm.runtimeError(c, ip, "only instances and maps have properties")
+			name := c.Constants[index].Obj.(string)
+			if err := vm.getPropertyGeneric(c, ip, name); err != nil {
+				return err
 			}
 
 		case chunk.OP_SET_PROPERTY:
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
-			nameVal := c.Constants[index]
-			name := nameVal.Obj.(string)
-
-			val := vm.pop()
-			instanceVal := vm.pop()
-
-			// Auto-dereference if instance is a ref.
-			//
-			// issue #83: aqui a referência é ALVO DE ESCRITA, então a
-			// resolução tem de ser em modo de escrita — unicizar o caminho e
-			// gravar os clones de volta. Com `resolveReferenceValue` (modo de
-			// leitura) a mutação ia direto no objeto compartilhado e vazava
-			// numa cópia posterior, que é o bug do #83 chegando por um site de
-			// escrita tipado `any`: `func setx(p: any) -> void  p.x = 99 end`
-			// chamada com `setx(ref arr[0])`. É o caminho dinâmico; via base
-			// tipada o compilador emite a família *_MUT, que já unicizava.
-			if instanceVal.Type == value.VAL_REF {
-				resolved, err := vm.unicizeThroughRefValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = resolved
+			name := c.Constants[index].Obj.(string)
+			if err := vm.setPropertyGeneric(c, ip, name); err != nil {
+				return err
 			}
-
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances have properties")
-			}
-			instance, ok := instanceVal.Obj.(*value.ObjInstance)
-			if !ok {
-				return vm.runtimeError(c, ip, "only instances have properties")
-			}
-
-			// Struct e nominal, de campos fixos (spec §5): escrever num nome
-			// fora da declaracao e o mesmo "undefined property" da leitura
-			// (issue #61 item 2 — antes a escrita criava o campo em silencio).
-			// Via base tipada o compilador ja rejeitou (`unknown field`); aqui
-			// so dispara em fronteira dinamica (`any`). O caminho quente e um
-			// lookup no indice SO-LEITURA da declaracao (issue #86: o map por
-			// instancia, que duas routines escreviam, nao existe mais).
-			slot, declared := instance.Struct.FieldIndex(name)
-			if !declared {
-				return vm.runtimeError(c, ip, "undefined property '%s'", name)
-			}
-			old := instance.Slots[slot]
-
-			// Guard do slot ref (spec 2026-08-20-ref-slot-invariant §6.3):
-			// via base tipada o compilador ja rejeitou; aqui so dispara em
-			// fronteira dinamica (`any`). Lookup em mapa nil e gratuito.
-			if instance.Struct.FieldIsRef(name) && val.Type != value.VAL_REF && val.Type != value.VAL_NULL {
-				return vm.runtimeError(c, ip, "%s", refSlotWriteError(structRefFieldTypeName(instance.Struct, name), val))
-			}
-
-			// RC: retain-antes-de-release (campo e dono duravel); Release
-			// em slot null e no-op (nao e VAL_OBJ)
-			value.Retain(val)
-			instance.Slots[slot] = val
-			value.Release(old)
-			vm.push(val)
 
 		case chunk.OP_SET_PROPERTY_DEREF:
 			index := c.Code[ip]
@@ -1705,48 +1692,8 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			index := int(c.Code[ip])<<8 | int(c.Code[ip+1])
 			ip += 2
 			name := c.Constants[index].Obj.(string)
-			instanceVal := vm.pop()
-			if instanceVal.Type == value.VAL_REF {
-				uniq, err := vm.unicizeThroughRefValue(instanceVal)
-				if err != nil {
-					return vm.runtimeError(c, ip, "%s", err)
-				}
-				instanceVal = uniq
-			}
-			if instanceVal.Type != value.VAL_OBJ {
-				return vm.runtimeError(c, ip, "only instances/maps have properties")
-			}
-			if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
-				slot, ok := instance.Struct.FieldIndex(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s'", name)
-				}
-				fieldVal := instance.Slots[slot]
-				if value.IsShared(fieldVal) {
-					old := fieldVal
-					fieldVal = vm.copyValue(fieldVal)
-					// RC: retain-antes-de-release em torno da troca
-					value.Retain(fieldVal)
-					instance.Slots[slot] = fieldVal
-					value.Release(old)
-				}
-				vm.push(fieldVal)
-			} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
-				// Membros de módulo (e maps acessados como propriedade)
-				stored, ok := mapObj.Get(name)
-				if !ok {
-					return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
-				}
-				v, changed := vm.unicize(stored)
-				if changed {
-					// RC: retain-antes-de-release em torno da troca
-					value.Retain(v)
-					mapObj.Set(name, v)
-					value.Release(stored)
-				}
-				vm.push(v)
-			} else {
-				return vm.runtimeError(c, ip, "only instances and maps have properties")
+			if err := vm.getPropMutGeneric(c, ip, name); err != nil {
+				return err
 			}
 
 		case chunk.OP_DEREF_MUT:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -451,6 +451,14 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 			// Push a reference wrapping the container and property name,
 			// so a later dereference or assignment can resolve this field.
 
+			// issue #93b: o indice do campo e resolvido UMA vez, aqui; descend e
+			// referenceStorageMode conferem `Fields[Slot] == Name` antes de usar.
+			slot := 0
+			if instance, ok := container.Obj.(*value.ObjInstance); ok && instance != nil {
+				if i, ok := instance.Struct.FieldIndex(name); ok {
+					slot = i
+				}
+			}
 			vm.push(value.Value{
 				Type: value.VAL_REF,
 				Obj: &value.ObjRef{
@@ -458,6 +466,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 					Container: container,
 					Base:      base,
 					Name:      name,
+					Slot:      slot,
 				},
 			})
 

--- a/internal/vm/field_ops.go
+++ b/internal/vm/field_ops.go
@@ -1,0 +1,147 @@
+package vm
+
+import (
+	"noxy-vm/internal/chunk"
+	"noxy-vm/internal/value"
+)
+
+// Campo de struct por indice (issue #96): OP_GET_FIELD / OP_SET_FIELD /
+// OP_GET_FIELD_MUT levam [idx][nome]. O caminho rapido (em run()) usa o indice
+// quando `Fields[idx] == nome` na definicao da instancia; qualquer outra coisa
+// — base ref, null, any que virou map, definicao com outra ordem (json_loads
+// monta a sua em ordem alfabetica), campo `ref T` na escrita — cai nos funis
+// abaixo, que sao os corpos dos opcodes por nome extraidos em metodo. Os
+// `case` genericos chamam os mesmos metodos: uma fonte para mensagens, linha
+// (`Lines[ip-1]`, o ultimo byte de operando) e semantica CoW/RC.
+
+// getPropertyGeneric: OP_GET_PROPERTY. [base] -> [val].
+func (vm *VM) getPropertyGeneric(c *chunk.Chunk, ip int, name string) error {
+	instanceVal := vm.pop()
+
+	// Auto-dereference if instance is a ref
+	if instanceVal.Type == value.VAL_REF {
+		resolved, err := vm.resolveReferenceValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = resolved
+	}
+
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances/maps have properties")
+	}
+
+	if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
+		val, ok := instance.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s'", name)
+		}
+		vm.push(val)
+	} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
+		// Allow accessing map keys as properties (for modules)
+		val, ok := mapObj.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
+		}
+		vm.push(val)
+	} else {
+		return vm.runtimeError(c, ip, "only instances and maps have properties")
+	}
+	return nil
+}
+
+// setPropertyGeneric: OP_SET_PROPERTY. [base, val] -> [val] (o compilador
+// emite OP_POP depois do opcode por nome; a forma por indice consome o push).
+func (vm *VM) setPropertyGeneric(c *chunk.Chunk, ip int, name string) error {
+	val := vm.pop()
+	instanceVal := vm.pop()
+
+	// issue #83: aqui a referência é ALVO DE ESCRITA, então a resolução tem de
+	// ser em modo de escrita — unicizar o caminho e gravar os clones de volta.
+	if instanceVal.Type == value.VAL_REF {
+		resolved, err := vm.unicizeThroughRefValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = resolved
+	}
+
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances have properties")
+	}
+	instance, ok := instanceVal.Obj.(*value.ObjInstance)
+	if !ok {
+		return vm.runtimeError(c, ip, "only instances have properties")
+	}
+
+	// Struct e nominal, de campos fixos (spec §5): escrever num nome fora da
+	// declaracao e o mesmo "undefined property" da leitura (issue #61 item 2).
+	slot, declared := instance.Struct.FieldIndex(name)
+	if !declared {
+		return vm.runtimeError(c, ip, "undefined property '%s'", name)
+	}
+	old := instance.Slots[slot]
+
+	// Guard do slot ref (spec 2026-08-20-ref-slot-invariant §6.3):
+	// via base tipada o compilador ja rejeitou; aqui so dispara em
+	// fronteira dinamica (`any`) e no fallback do OP_SET_FIELD, que recusa
+	// campo `ref T` no caminho rapido. Lookup em mapa nil e gratuito.
+	if instance.Struct.FieldIsRef(name) && val.Type != value.VAL_REF && val.Type != value.VAL_NULL {
+		return vm.runtimeError(c, ip, "%s", refSlotWriteError(structRefFieldTypeName(instance.Struct, name), val))
+	}
+
+	// RC: retain-antes-de-release (campo e dono duravel); Release
+	// em slot null e no-op (nao e VAL_OBJ)
+	value.Retain(val)
+	instance.Slots[slot] = val
+	value.Release(old)
+	vm.push(val)
+	return nil
+}
+
+// getPropMutGeneric: OP_GET_PROP_MUT. [base] -> [campo unicizado].
+func (vm *VM) getPropMutGeneric(c *chunk.Chunk, ip int, name string) error {
+	instanceVal := vm.pop()
+	if instanceVal.Type == value.VAL_REF {
+		uniq, err := vm.unicizeThroughRefValue(instanceVal)
+		if err != nil {
+			return vm.runtimeError(c, ip, "%s", err)
+		}
+		instanceVal = uniq
+	}
+	if instanceVal.Type != value.VAL_OBJ {
+		return vm.runtimeError(c, ip, "only instances/maps have properties")
+	}
+	if instance, ok := instanceVal.Obj.(*value.ObjInstance); ok {
+		slot, ok := instance.Struct.FieldIndex(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s'", name)
+		}
+		fieldVal := instance.Slots[slot]
+		if value.IsShared(fieldVal) {
+			old := fieldVal
+			fieldVal = vm.copyValue(fieldVal)
+			// RC: retain-antes-de-release em torno da troca
+			value.Retain(fieldVal)
+			instance.Slots[slot] = fieldVal
+			value.Release(old)
+		}
+		vm.push(fieldVal)
+	} else if mapObj, ok := instanceVal.Obj.(*value.ObjMap); ok {
+		// Membros de módulo (e maps acessados como propriedade)
+		stored, ok := mapObj.Get(name)
+		if !ok {
+			return vm.runtimeError(c, ip, "undefined property '%s' in module/map", name)
+		}
+		v, changed := vm.unicize(stored)
+		if changed {
+			value.Retain(v)
+			mapObj.Set(name, v)
+			value.Release(stored)
+		}
+		vm.push(v)
+	} else {
+		return vm.runtimeError(c, ip, "only instances and maps have properties")
+	}
+	return nil
+}

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -69,7 +69,7 @@ func (s referenceSetter) set(updated value.Value) {
 	case setterPtr:
 		*s.ptr = updated
 	case setterProperty:
-		s.instance.MustSet(s.name, updated)
+		s.instance.Slots[s.index] = updated // indice validado por fieldSlotOf em referenceStorageMode
 	case setterArray:
 		s.array.Elements[s.index] = updated
 	case setterMap:
@@ -87,6 +87,32 @@ func validateReferencedValue(stored value.Value) error {
 	}
 	if stored.Obj == nil {
 		return fmt.Errorf("invalid referenced object")
+	}
+	// Caminho comum sem reflect (issue #93b): os payloads que a VM guarda em
+	// Obj no caminho quente. Ponteiro tipado nil cai no reflect abaixo, que e
+	// quem o reporta.
+	switch stored.Type {
+	case value.VAL_OBJ:
+		switch o := stored.Obj.(type) {
+		case *value.ObjInstance:
+			if o != nil {
+				return nil
+			}
+		case *value.ObjArray:
+			if o != nil {
+				return nil
+			}
+		case *value.ObjMap:
+			if o != nil {
+				return nil
+			}
+		case string:
+			return nil
+		}
+	case value.VAL_REF:
+		if o, ok := stored.Obj.(*value.ObjRef); ok && o != nil {
+			return nil
+		}
 	}
 	object := reflect.ValueOf(stored.Obj)
 	switch object.Kind() {
@@ -229,9 +255,11 @@ func (vm *VM) derefPlace(container value.Value, forWrite bool) (value.Value, err
 // `step` é o ObjRef daquele nível; só RefType+Name/Index são lidos, nunca a
 // base dele — quem sequencia os níveis é borrowContainer.
 func (vm *VM) descend(container value.Value, step *value.ObjRef, forWrite bool) (value.Value, error) {
-	container, err := vm.derefPlace(container, forWrite)
-	if err != nil {
-		return value.Value{}, err
+	if container.Type == value.VAL_REF {
+		var err error
+		if container, err = vm.derefPlace(container, forWrite); err != nil {
+			return value.Value{}, err
+		}
 	}
 	if container.Type != value.VAL_OBJ {
 		return value.Value{}, fmt.Errorf("Target is not indexable")
@@ -241,16 +269,17 @@ func (vm *VM) descend(container value.Value, step *value.ObjRef, forWrite bool) 
 		if !ok || instance == nil {
 			return value.Value{}, fmt.Errorf("Target is not an instance")
 		}
-		child, ok := instance.Get(step.Name)
-		if !ok {
+		slot := fieldSlotOf(instance, step)
+		if slot < 0 {
 			return value.Value{}, fmt.Errorf("undefined property '%s'", step.Name)
 		}
+		child := instance.Slots[slot]
 		if !forWrite {
 			return child, nil
 		}
 		if unique, changed := vm.unicize(child); changed {
 			value.Retain(unique)
-			instance.MustSet(step.Name, unique)
+			instance.Slots[slot] = unique
 			value.Release(child)
 			return unique, nil
 		}
@@ -345,11 +374,11 @@ func (vm *VM) referenceStorageMode(ref *value.ObjRef, forWrite bool) (stored val
 		if container.Type != value.VAL_OBJ || !ok || instance == nil {
 			return value.Value{}, false, referenceSetter{}, fmt.Errorf("Target is not an instance")
 		}
-		stored, ok := instance.Get(ref.Name)
-		if !ok {
+		slot := fieldSlotOf(instance, ref)
+		if slot < 0 {
 			return value.Value{}, false, referenceSetter{}, fmt.Errorf("undefined property '%s'", ref.Name)
 		}
-		return stored, true, referenceSetter{kind: setterProperty, instance: instance, name: ref.Name}, nil
+		return instance.Slots[slot], true, referenceSetter{kind: setterProperty, instance: instance, name: ref.Name, index: slot}, nil
 	case value.REF_INDEX:
 		container, err := vm.borrowContainer(ref, forWrite)
 		if err != nil {
@@ -566,4 +595,20 @@ func borrowBaseAddr(ref *value.ObjRef) string {
 		return fmt.Sprintf("<index %s of %s>", base.Index.String(), borrowBaseAddr(base))
 	}
 	return "<invalid base>"
+}
+
+// fieldSlotOf devolve o indice do campo de um REF_PROPERTY na instancia que
+// esta no lugar AGORA, ou -1 se ela nao tem o campo. ref.Slot e a dica
+// resolvida na criacao (OP_REF_PROPERTY, issue #93b): vale quando a definicao
+// da instancia tem esse nome nesse slot — nao vale para definicoes montadas
+// pelo json_loads (ordem alfabetica) nem para ObjRef montado a mao (Slot
+// zero), que caem no FieldIndex por nome, como antes.
+func fieldSlotOf(instance *value.ObjInstance, ref *value.ObjRef) int {
+	if s := ref.Slot; s >= 0 && s < len(instance.Slots) && s < len(instance.Struct.Fields) && instance.Struct.Fields[s] == ref.Name {
+		return s
+	}
+	if s, ok := instance.Struct.FieldIndex(ref.Name); ok && s < len(instance.Slots) {
+		return s
+	}
+	return -1
 }

--- a/internal/vm/references.go
+++ b/internal/vm/references.go
@@ -115,10 +115,21 @@ func extractReferenceValue(input value.Value) (*value.ObjRef, error) {
 	return ref, nil
 }
 
-// maxBorrowPathDepth limita a caminhada de um empréstimo até a raiz. Um
-// caminho real tem a profundidade do lvalue escrito no fonte; o teto só existe
-// para que bytecode malformado (um ref que se aponta) erre em vez de girar.
-const maxBorrowPathDepth = 256
+// maxRefHopDepth limita derefPlace: quantos refs em sequência um LUGAR pode
+// guardar antes de chegar ao contêiner de verdade. Um lugar declarado `ref T`
+// guarda um ref cujo referente é um valor, então o laço dá uma volta só; o
+// teto é o backstop para um lugar `any` cujo ref aponte para outro lugar `any`
+// — um ciclo assim erra em vez de girar.
+//
+// A cadeia de Base (borrowContainer) NÃO tem teto (issue #93a). A profundidade
+// dela é dos DADOS, não do bytecode: `insert(ref node.esquerda, v)` recursivo
+// ou `r = ref r.prox` num laço encadeiam um nível por passo, e uma lista por
+// posse tem quantos nós o programa quiser — o teto de 256 que havia aqui
+// (justificado por "um caminho real tem a profundidade do lvalue escrito no
+// fonte", verdade até a #83) matava uma BST degenerada com ~256 nós. E a
+// cadeia não pode ciclar: Base é preenchido uma vez, na criação, com um ref
+// que já existia, e nunca reatribuído — cada nó é mais novo que o seu Base.
+const maxRefHopDepth = 256
 
 // borrowContainer devolve o contêiner ATUAL de um empréstimo (issue #83).
 //
@@ -157,9 +168,6 @@ func (vm *VM) borrowContainer(ref *value.ObjRef, forWrite bool) (value.Value, er
 		if !ok || parent == nil {
 			return value.Value{}, fmt.Errorf("invalid reference value")
 		}
-		if len(chain) > maxBorrowPathDepth {
-			return value.Value{}, fmt.Errorf("reference path too deep")
-		}
 		chain = append(chain, parent)
 		cursor = parent
 	}
@@ -194,7 +202,7 @@ func (vm *VM) borrowContainer(ref *value.ObjRef, forWrite bool) (value.Value, er
 // que OP_REF_PROPERTY/OP_REF_INDEX já faziam na criação.
 func (vm *VM) derefPlace(container value.Value, forWrite bool) (value.Value, error) {
 	for depth := 0; container.Type == value.VAL_REF; depth++ {
-		if depth > maxBorrowPathDepth {
+		if depth > maxRefHopDepth {
 			return value.Value{}, fmt.Errorf("reference path too deep")
 		}
 		var err error

--- a/internal/vm/struct_field_index_e2e_test.go
+++ b/internal/vm/struct_field_index_e2e_test.go
@@ -1,0 +1,178 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Ponta a ponta (fonte -> compilador -> VM) do campo de struct por índice
+// (issue #96): mesmo resultado, mesma semântica CoW/RC e mesmas mensagens de
+// erro do caminho por nome. Cada caso "tipado" tem o gêmeo `any`, que continua
+// no genérico: os dois têm de concordar.
+
+const fieldIndexPrelude = `
+struct Ponto
+    x: int
+    y: int
+end
+struct Caixa
+    tag: string
+    p: Ponto
+end
+`
+
+func reportedStrings(t *testing.T, got value.Value, want []string) {
+	t.Helper()
+	cells := semArray(t, got)
+	if len(cells) != len(want) {
+		t.Fatalf("células=%d, want %d: %s", len(cells), len(want), got.String())
+	}
+	for i, cell := range cells {
+		if s, ok := cell.Obj.(string); !ok || s != want[i] {
+			t.Fatalf("célula %d: got %s, want %q", i, cell.String(), want[i])
+		}
+	}
+}
+
+func TestFieldIndexReadWriteMatchesByName(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+func f(p: Ponto) -> int
+    p.y = p.x * 10
+    return p.y + p.x
+end
+let g: Ponto = Ponto(3, 4)
+let a: any = Ponto(3, 4)
+g.y = g.x * 10
+a.y = a.x * 10
+test_report([to_str(f(Ponto(2, 0))), to_str(g.y + g.x), to_str(a.y + a.x)])
+`)
+	reportedStrings(t, got, []string{"22", "33", "33"})
+}
+
+// A GUARDA (spec §3.1): json_loads cria a própria definição de struct com os
+// campos em ORDEM ALFABÉTICA para todo valor de struct que ele constrói. A
+// instância entra num contêiner tipado, então a base tipada aponta para um
+// layout diferente da declaração (slot 0 = `proximo`, não `valor`). Ler e
+// escrever por índice nela tem de conferir o nome e cair no caminho por nome.
+func TestFieldIndexGuardsReorderedJSONInstance(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    valor: int
+    proximo: ref Node
+end
+let xs: Node[] = []
+let ok: bool = json_loads("[{\"valor\": 7, \"proximo\": null}]", ref xs)
+let n: Node = xs[0]
+n.valor = n.valor + 1
+xs[0].valor = xs[0].valor * 10
+let dyn: any = xs[0]
+test_report([to_str(ok), to_str(n.valor), to_str(xs[0].valor), to_str(dyn.valor), to_str(n.proximo == null)])
+`)
+	reportedStrings(t, got, []string{"true", "8", "70", "70", "true"})
+}
+
+func TestFieldIndexNestedWriteClonesSharedChildOnce(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+let a: Caixa = Caixa("a", Ponto(1, 2))
+let b: Caixa = a
+a.p.x = 5
+a.tag = "z"
+test_report([to_str(b.p.x), to_str(a.p.x), b.tag, a.tag])
+`)
+	reportedStrings(t, got, []string{"1", "5", "a", "z"})
+}
+
+func TestFieldIndexWriteRetainsNewReleasesOld(t *testing.T) {
+	got := captureVMSource(t, fieldIndexPrelude+`
+struct Holder
+    inner: int[]
+end
+let y1: int[] = [1]
+let y2: int[] = [2]
+let h: Holder = Holder([])
+h.inner = y1
+h.inner = y2
+test_report([y1, y2, h.inner])
+`)
+	cells := semArray(t, got)
+	y1 := cells[0].Obj.(*value.ObjArray)
+	y2 := cells[1].Obj.(*value.ObjArray)
+	// y1: a variável global (1) — o campo soltou; y2: global + campo + a
+	// célula do array reportado (o test_report retém ao construir o literal).
+	if y1.Owners.Load() >= y2.Owners.Load() {
+		t.Fatalf("esperava y1 com menos donos que y2 depois de h.inner = y2: y1=%d y2=%d", y1.Owners.Load(), y2.Owners.Load())
+	}
+}
+
+func TestFieldIndexRefTypedFieldWriteAndReadThrough(t *testing.T) {
+	got := captureVMSource(t, `
+struct Node
+    v: int
+    next: ref Node
+end
+func main() -> void
+    let a: Node = Node(1, null)
+    let b: Node = Node(2, null)
+    a.next = ref b
+    b.v = 3
+    let seen: int = a.next.v
+    a.next = null
+    test_report([to_str(seen), to_str(a.next == null), to_str(b.v)])
+end
+main()
+`)
+	reportedStrings(t, got, []string{"3", "true", "3"})
+}
+
+// Tabela de erros idênticos: a base tipada erra com a MESMA mensagem que a
+// base `any` para o mesmo estado de runtime.
+func TestFieldIndexErrorsMatchByName(t *testing.T) {
+	cases := []struct{ name, typed, dynamic, want string }{
+		{"read through null base",
+			"let p: Ponto = null\nlet v: int = p.x\n",
+			"let p: any = null\nlet v: any = p.x\n",
+			"only instances/maps have properties"},
+		{"write through null base",
+			"let p: Ponto = null\np.x = 1\n",
+			"let p: any = null\np.x = 1\n",
+			"only instances have properties"},
+		{"nested write through null base",
+			"let c: Caixa = null\nc.p.x = 1\n",
+			"let c: any = null\nc.p.x = 1\n",
+			"only instances/maps have properties"},
+		{"read through null ref",
+			"let r: ref Ponto = null\nlet v: int = r.x\n",
+			"", // sem gêmeo any: o OP_DEREF é da base ref tipada
+			"cannot dereference null reference"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typedErr := interpretVMSource(t, New(), fieldIndexPrelude+tc.typed)
+			if typedErr == nil || !strings.Contains(typedErr.Error(), tc.want) {
+				t.Fatalf("tipado: esperava %q, obtido %v", tc.want, typedErr)
+			}
+			if tc.dynamic == "" {
+				return
+			}
+			dynErr := interpretVMSource(t, New(), fieldIndexPrelude+tc.dynamic)
+			if dynErr == nil || !strings.Contains(dynErr.Error(), tc.want) {
+				t.Fatalf("any: esperava %q, obtido %v", tc.want, dynErr)
+			}
+		})
+	}
+}
+
+// Linha do erro: o operando novo tem 3 bytes; a linha reportada continua a
+// da statement.
+func TestFieldIndexErrorLineIsTheStatement(t *testing.T) {
+	err := interpretVMSource(t, New(), fieldIndexPrelude+`
+let p: Ponto = null
+let a: int = 1
+let v: int = p.x
+`)
+	if err == nil || !strings.Contains(err.Error(), "line 13]") {
+		t.Fatalf("esperava erro na linha 13, obtido %v", err)
+	}
+}

--- a/noxy_examples/KandR_in_noxy/ch03_shellsort.nx
+++ b/noxy_examples/KandR_in_noxy/ch03_shellsort.nx
@@ -1,6 +1,6 @@
 // shellsort: ordena v em ordem crescente
 func shellsort(v: ref int[])
-    let n: int = length(v)
+    let n: int = length(*v)
     let gap: int = n / 2
     while gap > 0 do
         let i: int = gap

--- a/noxy_examples/KandR_in_noxy/ch06_generic_stack.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_generic_stack.nx
@@ -4,11 +4,11 @@ struct Stack<T>
 end
 
 func push<T>(s: ref Stack<T>, item: T)
-    append(s.items, item)
+    append(ref s.items, item)
 end
 
 func take<T>(s: ref Stack<T>) -> T
-    return pop(s.items)
+    return pop(ref s.items)
 end
 
 let ints: Stack<int> = Stack([])        // T = int, pela anotação

--- a/noxy_examples/KandR_in_noxy/ch06_keycount.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_keycount.nx
@@ -21,7 +21,7 @@ let NKEYS: int = length(keytab)
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) && text[i] != "_" do
         i = i + 1                   // pula o que não é letra
     end

--- a/noxy_examples/KandR_in_noxy/ch06_keycount_ref.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_keycount_ref.nx
@@ -19,7 +19,7 @@ let keytab: Key[] = [
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) && text[i] != "_" do
         i = i + 1
     end

--- a/noxy_examples/KandR_in_noxy/ch06_struct_ref.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_struct_ref.nx
@@ -9,7 +9,7 @@ print(pp.x, pp.y)                   // o acesso a campos dispensa o -> de C
 pp.x = 7                            // escreve no original através da referência
 print(origin.x)
 
-let copy: Point = pp                // let lê através da ref: copia o struct
+let copy: Point = *pp               // let lê através da ref: copia o struct
 copy.y = 99
 print(origin.y, copy.y)
 

--- a/noxy_examples/KandR_in_noxy/ch06_tree.nx
+++ b/noxy_examples/KandR_in_noxy/ch06_tree.nx
@@ -37,7 +37,7 @@ end
 // getword: extrai a próxima palavra de text a partir de *pos; "" no fim
 func getword(text: string, pos: ref int) -> string
     let n: int = length(text)
-    let i: int = pos
+    let i: int = *pos
     while i < n && !is_alpha(text[i]) do
         i = i + 1
     end

--- a/noxy_examples/KandR_in_noxy/ch08_pool.nx
+++ b/noxy_examples/KandR_in_noxy/ch08_pool.nx
@@ -17,8 +17,8 @@ func pool_alloc<T>(p: ref Pool<T>, v: T) -> int
         p.next[i] = -1
         return i
     end
-    append(p.items, v)                  // sem slots livres: cresce
-    append(p.next, -1)
+    append(ref p.items, v)                  // sem slots livres: cresce
+    append(ref p.next, -1)
     return length(p.items) - 1
 end
 

--- a/noxy_examples/test_crypto_debug.nx
+++ b/noxy_examples/test_crypto_debug.nx
@@ -1,5 +1,5 @@
 use crypto
-use strings
+use sys
 
 // Teste isolado de encrypt/decrypt
 
@@ -22,7 +22,7 @@ print(f"Encrypted length: {length(encrypted)}")
 
 if encrypted == null then
     print("ERRO: encrypted é null!")
-    return
+    sys.exit(1)
 end
 
 let decrypted: bytes = crypto.aes256_gcm_decrypt(chave, encrypted)
@@ -32,6 +32,7 @@ if to_str(decrypted) == texto then
     print("PASS: Ciclo direto funciona!")
 else
     print("FAIL: Ciclo direto falhou")
+    sys.exit(1)
 end
 
 print("")
@@ -76,14 +77,9 @@ func hex_to_bytes(hex_str: string) -> bytes
         i = i + 2
     end
     
-    // Converter int[] para bytes
-    let byte_str: string = ""
-    let j: int = 0
-    while j < length(result) do
-        byte_str = byte_str + strings.from_char_code(result[j])
-        j = j + 1
-    end
-    return to_bytes(byte_str)
+    // int[] -> bytes direto: passar por string (from_char_code) codificava
+    // cada valor >= 0x80 como um rune UTF-8 de 2 bytes e o tamanho nao fechava
+    return to_bytes(result)
 end
 
 let hex_enc: string = bytes_to_hex(encrypted)
@@ -98,16 +94,19 @@ if length(back_to_bytes) == length(encrypted) then
     print("PASS: Tamanhos iguais")
 else
     print(f"FAIL: Tamanhos diferentes! {length(back_to_bytes)} vs {length(encrypted)}")
+    sys.exit(1)
 end
 
 let decrypted2: bytes = crypto.aes256_gcm_decrypt(chave, back_to_bytes)
 if decrypted2 == null then
     print("FAIL: Descriptografia após hex falhou")
+    sys.exit(1)
 else
     print(f"Decrypted2: {to_str(decrypted2)}")
     if to_str(decrypted2) == texto then
         print("PASS: Ciclo com hex funciona!")
     else
         print("FAIL: Texto diferente após hex")
+        sys.exit(1)
     end
 end


### PR DESCRIPTION
## O que é

Uma branch só com os itens da fila, para revisão e merge **pelo dono**. Os PRs #97, #98, #99 e #101 foram mergeados em `develop` por engano pela sessão; `develop` voltou para `a855077` e o mesmo conteúdo está aqui, em 7 commits lineares. O #93b (custo por nível do empréstimo aninhado) vai continuar **nesta mesma branch** — o PR cresce.

## Commits

1. **8be2fa9 — #87 corpus.** `KandR_in_noxy/`: além do `ch06_keycount_ref.nx` da issue, mais 6 arquivos tinham resíduo da migração do #82 (`*pos`, `*pp`, `length(*v)`, `append(ref s.items, …)`, `pop(ref …)`). Só `ch02_mismatch.nx`/`ch02_redeclare.nx` (erros intencionais) seguem não compilando.
2. **f3bfcac — #93 (a).** O teto `maxBorrowPathDepth = 256` sai da cadeia de `Base` (ela não cicla por construção; a profundidade é dos dados — `r = ref r.prox` em laço também encadeia sem gastar frame, então "ordem de `FramesMax`" seria igualmente arbitrário). Fica `maxRefHopDepth` só em `derefPlace`. Fixture de 1000 chaves ordenadas passa (n = 1000, em 24,9 s — o custo é a parte b). Testes: BST com 300 chaves (> 256) e lista com 1000 nós por rebinding.
3. **c74fbc6 / 789285e / 10202a2 / a5bb306 — #96.** `OP_GET_FIELD`/`OP_SET_FIELD`/`OP_GET_FIELD_MUT` com operando `[idx u8][nome u16]` quando a base é struct do programa; `any`/módulo/`ref p.x` por nome. **Guarda de runtime** `Fields[idx] == nome` porque `json_loads` monta definições em ordem alfabética e elas entram em contêineres tipados (a premissa da issue era falsa; teste falha sem a guarda). Corpos de `OP_GET_PROPERTY`/`OP_SET_PROPERTY`/`OP_GET_PROP_MUT` viraram funis (`field_ops.go`) chamados pelos `case` genéricos e pelos fallbacks. Spec em `docs/superpowers/specs/2026-08-28-vm-perf-issue-96-struct-field-index-design.md`; resultados no topo de `benchmarks/RESULTS.md` + raw. **A/B intercalado (mediana de 9): `bench_path_update` −32,7 %, `bench_struct_records` −6,7 %** (bench resgatado de 93625ac), `bench_conway` −1,3 %, `bench_generic_vs_hand` +0,2 %. Achado colateral: cache do construtor do PR #70 nunca chegou a `develop` (46 % de `bench_struct_records`) → #100.
4. **a52c7e1 — #53 item 4.** `test_crypto_debug.nx`: o bug era do exemplo (`from_char_code` codifica ≥ 0x80 em 2 bytes; agora `to_bytes(int[])`) e cada FAIL sai com `sys.exit(1)`.

## Verificação (no conteúdo equivalente, antes do reset)

`go test ./...` verde; `go test -race ./internal/vm` verde; corpus `run_all_tests_concurrent.nx` **180/180**; `compare_examples.ps1` base × head **149 iguais, 0 divergentes**; CI verde em todos os 4 PRs originais.

Refs #87, #93, #96, #53. Não fecha nada automaticamente — fechar issues fica com o dono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
