### PR TITLE
fix(vm): json_loads respeita CoW nos níveis aninhados + itens 2 e 3 — fecha a issue #53

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,6 +3,31 @@
 Registro corrido das comparações de performance, mais recente primeiro. Cada
 seção compara dois binários pelo protocolo intercalado (ver Reprodução no fim).
 
+## Guards de slot `ref` no caminho `any` — issue #53 item 2 (medido em 2026-08-28, v0.21.0 + #104)
+
+A #50 pôs um guard em toda escrita genérica: `arrayElementIsRefSlot` (um
+`Load()` atômico da tag) em `OP_SET_INDEX` e `FieldIsRef` (lookup em map nil
+para struct sem campo `ref`) em `OP_SET_PROPERTY`. Estava estimado em ~1 ns e
+nunca tinha sido medido. Desde a #66 (`*_NORC`) e a #96 (`OP_SET_FIELD`) o
+caminho **tipado** não passa por esses opcodes — é exatamente a alternativa da
+spec §6.3 ("guard só quando o compilador não conhece a base") — então o custo
+restante é só das escritas por `any`.
+
+Micro `benchmarks/bench_dyn_write.nx` (novo na suíte; 1,2 M escritas por base
+`any`: `xs[k] = …` e `c.hits = …`), binário com guard × binário com o guard
+desligado nos dois funis, intercalado, mediana de 9, duas rodadas:
+
+| rodada | guard | sem guard | delta |
+|---|---|---|---|
+| 1 | 105,2 ms | 99,9 ms | +5,3 % |
+| 2 | 96,7 ms | 94,6 ms | +2,1 % |
+
+≈ 2–4 ns por escrita dinâmica. `bench_path_update` (caminho tipado) nas mesmas
+condições: 165,1 × 165,0 ms — **0 %**. Trocar `FieldIsRef` por teste de nil
+antes do lookup não moveu o ponteiro (+2,3 % na rodada 2) e foi descartado.
+Conclusão: o guard custa o que a fronteira dinâmica custa e só onde ela é
+necessária; nada a fazer no compilador.
+
 ## feature/issue-queue-2026-08-28 (a52c7e1) × empréstimo aninhado com slot — issue #93 (b) (4026c43)
 
 **Data:** 2026-08-28 · Windows 11 · Intel Core 7 150U · pwsh 7.6.5 · protocolo

--- a/benchmarks/bench_dyn_write.nx
+++ b/benchmarks/bench_dyn_write.nx
@@ -1,0 +1,31 @@
+// Escrita por base DINAMICA (`any`): OP_SET_INDEX e OP_SET_PROPERTY genericos,
+// os unicos que ainda pagam o guard de slot `ref` da #50 em toda escrita
+// (`arrayElementIsRefSlot` = um Load atomico da tag; `FieldIsRef` = lookup num
+// map nil quando o struct nao tem campo ref). O caminho tipado saiu daqui na
+// #66 (NORC) e na #96 (OP_SET_FIELD). Issue #53 item 2: sentinela do custo.
+struct Cell
+    hits: int
+    score: int
+end
+
+func main()
+    let xs: any = [0, 0, 0, 0, 0, 0, 0, 0]
+    let c: any = Cell(0, 0)
+    let i: int = 0
+    while i < 400000 do
+        let k: int = i % 8
+        xs[k] = xs[k] + 1
+        c.hits = c.hits + 1
+        c.score = c.score + k
+        i = i + 1
+    end
+    let s: int = 0
+    i = 0
+    while i < 8 do
+        s = s + xs[i]
+        i = i + 1
+    end
+    print(f"CHECKSUM:{s + c.hits + c.score}")
+end
+
+main()

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2294,7 +2294,11 @@ the UTF-8 error in `error`, even when the process exited with code 0.
 `json_dumps`, `json_parse` and `json_loads` are documented in
 [`JSON_SUPPORT.md`](JSON_SUPPORT.md). `json_loads(text, ref target)` populates an
 existing typed target in place and returns `false` (with no partial writes)
-when the payload does not fit. For a slot declared `ref T` **inside** the
+when the payload does not fit. "In place" keeps value semantics at every level:
+a composite that is shared somewhere inside the target (`let copia = t[0]`
+before the call) is cloned and the clone is written back to its parent —
+exactly what `t[0].a = v` does — while a uniquely owned container mutates
+without cloning. For a slot declared `ref T` **inside** the
 target (array element, struct field, map value): a slot that already holds a
 reference is written **through** it; a JSON `null` stores `null`; a non-null
 payload for a slot that is `null` (or for a new element/field) builds the `T`

--- a/internal/vm/index_ops.go
+++ b/internal/vm/index_ops.go
@@ -32,8 +32,10 @@ func (vm *VM) setIndexGeneric(c *chunk.Chunk, ip int) error {
 			// RuntimeType) so aceita ref/null; via base tipada o
 			// compilador ja rejeitou. O teste de val.Type vem antes
 			// para o Load() atomico so rodar em escritas nao-ref.
-			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL && arrayElementIsRefSlot(arr) {
-				return vm.runtimeError(c, ip, "%s", refSlotWriteError(arr.RuntimeType.Load().Element.String(), val))
+			if val.Type != value.VAL_REF && val.Type != value.VAL_NULL {
+				if tag := arr.RuntimeType.Load(); arrayTagIsRefSlot(tag) {
+					return vm.runtimeError(c, ip, "%s", refSlotWriteError(tag.Element.String(), val))
+				}
 			}
 			// RC: retain-antes-de-release (elemento e dono duravel)
 			old := arr.Elements[idx]

--- a/internal/vm/json_loads_cow_test.go
+++ b/internal/vm/json_loads_cow_test.go
@@ -1,0 +1,112 @@
+package vm
+
+import (
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// json_loads respeita a semântica de valor nos níveis ANINHADOS (issue #53
+// item 1). O alvo top-level já era unicizado em populateRef (#83); um filho
+// composto COMPARTILHADO — `let copia = t[0]` antes do json_loads — era
+// mutado no lugar por prepareJSON{Struct,Array,Map}Mutation, e a cópia via a
+// escrita. Cada caso afirma as duas metades: a cópia fica intacta E o alvo
+// recebe o payload.
+
+const jsonCowPrelude = `
+struct Pair
+    a: int
+    b: int
+end
+struct Box
+    p: Pair
+    tags: string[]
+end
+`
+
+func TestJSONLoadsClonesSharedNestedStructInArray(t *testing.T) {
+	got := captureVMSource(t, jsonCowPrelude+`
+let t: Pair[] = [Pair(0, 0)]
+let copia: Pair = t[0]
+let ok: bool = json_loads("[{\"a\":5,\"b\":6}]", ref t)
+test_report([to_str(ok), to_str(copia.a), to_str(copia.b), to_str(t[0].a), to_str(t[0].b)])
+`)
+	reportedStrings(t, got, []string{"true", "0", "0", "5", "6"})
+}
+
+func TestJSONLoadsClonesSharedNestedArrayAndMap(t *testing.T) {
+	got := captureVMSource(t, jsonCowPrelude+`
+let grid: int[][] = [[1, 2]]
+let linha: int[] = grid[0]
+let ok1: bool = json_loads("[[9, 9, 9]]", ref grid)
+let ms: map[string, int][] = [{"k": 1}]
+let m2: map[string, int] = ms[0]
+let ok2: bool = json_loads("[{\"k\": 7}]", ref ms)
+test_report([to_str(ok1), to_str(linha), to_str(grid[0]), to_str(ok2), to_str(m2["k"]), to_str(ms[0]["k"])])
+`)
+	reportedStrings(t, got, []string{"true", "[1, 2]", "[9, 9, 9]", "true", "1", "7"})
+}
+
+// Dois níveis: o elemento (Box) é compartilhado com c2; o Pair dentro dele
+// só tem um dono (o Box). Clonar o Box retém o Pair, que passa a ter dois
+// donos e clona por sua vez — a cópia c2 não vê nada, nem no campo aninhado
+// nem no array de strings.
+func TestJSONLoadsClonesCascadeThroughNestedLevels(t *testing.T) {
+	got := captureVMSource(t, jsonCowPrelude+`
+let boxes: Box[] = [Box(Pair(0, 0), ["x"])]
+let c2: Box = boxes[0]
+let ok: bool = json_loads("[{\"p\":{\"a\":8,\"b\":9},\"tags\":[\"y\",\"z\"]}]", ref boxes)
+test_report([to_str(ok), to_str(c2.p.a), to_str(c2.tags), to_str(boxes[0].p.a), to_str(boxes[0].p.b), to_str(boxes[0].tags)])
+`)
+	reportedStrings(t, got, []string{"true", "0", "[x]", "8", "9", "[y, z]"})
+}
+
+// Os casos (b), (c), (d) da issue já fechavam pelo top-level (#83); ficam
+// como regressão, junto com o controle por bytecode (e).
+func TestJSONLoadsTopLevelSharingStaysIsolated(t *testing.T) {
+	got := captureVMSource(t, jsonCowPrelude+`
+let xs: int[] = [1, 2]
+let ys: int[] = xs
+let ok2: bool = json_loads("[9, 9]", ref xs)
+let m: map[string, int] = {"k": 1}
+let m2: map[string, int] = m
+let ok3: bool = json_loads("{\"k\": 7}", ref m)
+let p: Pair = Pair(0, 0)
+let q: Pair = p
+let ok4: bool = json_loads("{\"a\":3,\"b\":4}", ref p)
+let r: Pair = Pair(0, 0)
+let s: Pair = r
+r.a = 3
+test_report([to_str(ys), to_str(xs), to_str(m2["k"]), to_str(m["k"]), to_str(q.a), to_str(p.a), to_str(s.a), to_str(r.a)])
+`)
+	reportedStrings(t, got, []string{"[1, 2]", "[9, 9]", "1", "7", "0", "3", "0", "3"})
+}
+
+// Dono único NÃO clona: o alvo e os filhos com um dono só mutam no lugar
+// (CloneCountValue não cresce). Com um alias ao elemento, exatamente um clone.
+func TestJSONLoadsDoesNotCloneUniqueOwners(t *testing.T) {
+	machine := vmWithCloneReset()
+	machine.DefineNative("clones_now", func(args []value.Value) value.Value {
+		return value.NewInt(CloneCountValue())
+	})
+	var reported value.Value
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			reported = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSource(t, machine, jsonCowPrelude+`
+let t: Pair[] = [Pair(0, 0), Pair(1, 1)]
+let antes: int = clones_now()
+let ok1: bool = json_loads("[{\"a\":5,\"b\":6},{\"a\":7,\"b\":8}]", ref t)
+let unico: int = clones_now() - antes
+let alias: Pair = t[1]
+let ok2: bool = json_loads("[{\"a\":1,\"b\":1},{\"a\":2,\"b\":2}]", ref t)
+let compartilhado: int = clones_now() - antes - unico
+test_report([to_str(ok1), to_str(unico), to_str(t[0].a), to_str(ok2), to_str(compartilhado), to_str(alias.a), to_str(t[1].a)])
+`); err != nil {
+		t.Fatal(err)
+	}
+	reportedStrings(t, reported, []string{"true", "0", "1", "true", "1", "7", "2"})
+}

--- a/internal/vm/json_population.go
+++ b/internal/vm/json_population.go
@@ -78,19 +78,19 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 			if current.Type != value.VAL_OBJ || !ok {
 				return nil, false
 			}
-			return prepareJSONArrayMutation(vm, array, schema.Element, data)
+			return prepareJSONArrayMutation(vm, current, array, schema.Element, data, set)
 		case value.TYPE_MAP:
 			mapping, ok := current.Obj.(*value.ObjMap)
 			if current.Type != value.VAL_OBJ || !ok || !jsonMapKeyCompatible(schema.Key) {
 				return nil, false
 			}
-			return prepareJSONMapMutation(vm, mapping, schema.Value, data)
+			return prepareJSONMapMutation(vm, current, mapping, schema.Value, data, set)
 		case value.TYPE_STRUCT:
 			instance, ok := current.Obj.(*value.ObjInstance)
 			if current.Type != value.VAL_OBJ || !ok || instance.Struct == nil || instance.Struct.Name != schema.Name {
 				return nil, false
 			}
-			return prepareJSONStructMutation(vm, instance, schema, data)
+			return prepareJSONStructMutation(vm, current, instance, schema, data, set)
 		default:
 			if set == nil {
 				return nil, false
@@ -106,11 +106,11 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 	if current.Type == value.VAL_OBJ {
 		switch object := current.Obj.(type) {
 		case *value.ObjArray:
-			return prepareJSONArrayMutation(vm, object, nil, data)
+			return prepareJSONArrayMutation(vm, current, object, nil, data, set)
 		case *value.ObjMap:
-			return prepareJSONMapMutation(vm, object, nil, data)
+			return prepareJSONMapMutation(vm, current, object, nil, data, set)
 		case *value.ObjInstance:
-			return prepareJSONStructMutation(vm, object, nil, data)
+			return prepareJSONStructMutation(vm, current, object, nil, data, set)
 		}
 	}
 	if set == nil {
@@ -126,7 +126,7 @@ func prepareJSONMutation(vm *VM, current value.Value, schema *value.RuntimeTypeI
 	return func() { set(replacement) }, true
 }
 
-func prepareJSONArrayMutation(vm *VM, array *value.ObjArray, elementSchema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+func prepareJSONArrayMutation(vm *VM, current value.Value, array *value.ObjArray, elementSchema *value.RuntimeTypeInfo, data interface{}, set jsonSetter) (jsonCommit, bool) {
 	dataArray, ok := data.([]interface{})
 	if !ok {
 		return nil, false
@@ -167,6 +167,7 @@ func prepareJSONArrayMutation(vm *VM, array *value.ObjArray, elementSchema *valu
 		added = append(added, created)
 	}
 	return func() {
+		target, writeBack := jsonCommitTarget(vm, current, set)
 		for _, commit := range commits {
 			commit()
 		}
@@ -178,11 +179,12 @@ func prepareJSONArrayMutation(vm *VM, array *value.ObjArray, elementSchema *valu
 		for j := len(dataArray); j < len(oldElements); j++ {
 			value.Release(oldElements[j])
 		}
-		array.Elements = newElements
+		target.Obj.(*value.ObjArray).Elements = newElements
+		writeBack()
 	}, true
 }
 
-func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+func prepareJSONMapMutation(vm *VM, current value.Value, mapping *value.ObjMap, valueSchema *value.RuntimeTypeInfo, data interface{}, set jsonSetter) (jsonCommit, bool) {
 	dataMap, ok := data.(map[string]interface{})
 	if !ok {
 		return nil, false
@@ -219,17 +221,19 @@ func prepareJSONMapMutation(vm *VM, mapping *value.ObjMap, valueSchema *value.Ru
 		added = append(added, created)
 	}
 	return func() {
+		target, writeBack := jsonCommitTarget(vm, current, set)
 		for _, commit := range commits {
 			commit()
 		}
 		for _, created := range added {
 			value.Retain(created) // RC: chave nova — o map vira dono
 		}
-		mapping.Replace(newData)
+		target.Obj.(*value.ObjMap).Replace(newData)
+		writeBack()
 	}, true
 }
 
-func prepareJSONStructMutation(vm *VM, instance *value.ObjInstance, schema *value.RuntimeTypeInfo, data interface{}) (jsonCommit, bool) {
+func prepareJSONStructMutation(vm *VM, current value.Value, instance *value.ObjInstance, schema *value.RuntimeTypeInfo, data interface{}, set jsonSetter) (jsonCommit, bool) {
 	dataMap, ok := data.(map[string]interface{})
 	if !ok || instance.Struct == nil {
 		return nil, false
@@ -267,10 +271,12 @@ func prepareJSONStructMutation(vm *VM, instance *value.ObjInstance, schema *valu
 		commits = append(commits, commit)
 	}
 	return func() {
+		target, writeBack := jsonCommitTarget(vm, current, set)
 		for _, commit := range commits {
 			commit()
 		}
-		instance.Slots = newSlots
+		target.Obj.(*value.ObjInstance).Slots = newSlots
+		writeBack()
 	}, true
 }
 
@@ -529,4 +535,23 @@ func jsonReferenceStorage(vm *VM, ref *value.ObjRef) (value.Value, jsonSetter, b
 		return value.Value{}, nil, false
 	}
 	return stored, jsonStoreThrough(vm, target), true
+}
+
+// jsonCommitTarget e a semantica de valor nos niveis ANINHADOS do json_loads
+// (issue #53 item 1). Roda no INICIO do commit de um conteiner — depois de
+// todos os prepares terem passado, entao nunca fica clone pendurado numa
+// falha. Se o conteiner esta compartilhado (`let copia = t[0]` antes do
+// json_loads) e ha como gravar de volta, clona (copyValue: raso, retem os
+// filhos — que passam a ver-se compartilhados e clonam por sua vez nos
+// PROPRIOS commits, que rodam depois deste passo) e devolve o clone como alvo
+// da atribuicao final mais um finalizador que o grava no pai pelo setter
+// (retain-novo/release-velho e do setter). Dono unico → muta no lugar, sem
+// clone. set == nil (populateObj: alvo passado por valor, sem lugar) → no
+// lugar, como antes. E a mesma disciplina da familia *_MUT do bytecode.
+func jsonCommitTarget(vm *VM, current value.Value, set jsonSetter) (value.Value, func()) {
+	if set == nil || !value.IsShared(current) {
+		return current, func() {}
+	}
+	clone := vm.copyValue(current)
+	return clone, func() { set(clone) }
 }

--- a/internal/vm/rc_uniqueness_test.go
+++ b/internal/vm/rc_uniqueness_test.go
@@ -1548,17 +1548,17 @@ func TestBorrowedUpvalueBoxDoesNotRetainOnClose(t *testing.T) {
 // compilador). O round 2 a inferia em runtime varrendo frame.Owned
 // (ownsSlotIndex), e essa resposta erra nas DUAS direcoes:
 //
-//   (a) under-count: um slot POSSUIDO (`let x: Node = null`) cujo ocupante era
-//       null/escalar na hora da captura nunca entrou em frame.Owned (Retain
-//       falha em nao-composto) — a caixa do upvalue era marcada emprestada por
-//       engano e o retain que ela devia ao fechar/gravar era PULADO. O no ficava
-//       com um dono a menos, parecia unico, e `picked.valor = 99` mutava no
-//       lugar: a escrita vazava para head.proximo, quebrando a independencia do
-//       vinculo por valor.
-//   (b) dec a menos: indices de slot sao REUSADOS entre blocos irmaos e
-//       frame.Owned nao e podado no fim do escopo — a entrada morta de um irmao
-//       fazia um slot realmente emprestado parecer possuido, e o guard do
-//       OP_GET_LOCAL_MUT era derrotado (release indevido, o bug original).
+//	(a) under-count: um slot POSSUIDO (`let x: Node = null`) cujo ocupante era
+//	    null/escalar na hora da captura nunca entrou em frame.Owned (Retain
+//	    falha em nao-composto) — a caixa do upvalue era marcada emprestada por
+//	    engano e o retain que ela devia ao fechar/gravar era PULADO. O no ficava
+//	    com um dono a menos, parecia unico, e `picked.valor = 99` mutava no
+//	    lugar: a escrita vazava para head.proximo, quebrando a independencia do
+//	    vinculo por valor.
+//	(b) dec a menos: indices de slot sao REUSADOS entre blocos irmaos e
+//	    frame.Owned nao e podado no fim do escopo — a entrada morta de um irmao
+//	    fazia um slot realmente emprestado parecer possuido, e o guard do
+//	    OP_GET_LOCAL_MUT era derrotado (release indevido, o bug original).
 //
 // Agora quem decide e o compilador: OP_GET_LOCAL_MUT_BORROW para local `ref` e
 // OP_MARK_UPVALUE_BORROW (emitido apos o OP_CLOSURE) para upvalue `ref`.
@@ -1692,12 +1692,12 @@ main()`
 //
 // Este teste ancora o RASTRO DE CONTAGEM, que e a invariante defensavel:
 //
-//   p1 = 1  o campo `proximo` do no anterior e o unico dono
-//   p2 = 2  `*n = v` grava o no no slot por valor `x` — dois donos reais
-//   p3 = 1  `x.valor = 99` clona por independencia (CoW): `x` passa a apontar o
-//           clone e o no volta a ter um dono
-//   p4 = 1  `u.valor = 77` atravessa um emprestimo e muta no lugar; nenhum dono
-//           entra ou sai
+//	p1 = 1  o campo `proximo` do no anterior e o unico dono
+//	p2 = 2  `*n = v` grava o no no slot por valor `x` — dois donos reais
+//	p3 = 1  `x.valor = 99` clona por independencia (CoW): `x` passa a apontar o
+//	        clone e o no volta a ter um dono
+//	p4 = 1  `u.valor = 77` atravessa um emprestimo e muta no lugar; nenhum dono
+//	        entra ou sai
 //
 // NOTA DE DIVERGENCIA CONSCIENTE: o binario pre-chave responde 50 aqui (soma
 // 0+20+30), porque o `*n = v` ligava o bit sticky do no PARA SEMPRE e a


### PR DESCRIPTION
## Summary

Fecha a #53 inteira (os itens 1b/1c/1d já tinham saído na #55 e o item 4 no #102). Quatro commits, um por item:

### 116af39 — item 1 (a): `json_loads` respeita CoW nos níveis aninhados

`let copia: Pair = t[0]` antes de `json_loads(s, ref t)` e a cópia via o payload. Os `prepare*` só constroem `newSlots`/`newElements`/`newData` e closures; o objeto só é tocado na atribuição final do commit. Então o clone acontece no início do commit do contêiner (`jsonCommitTarget`): depois de todos os prepares terem passado (sem escrita parcial, sem clone pendurado em falha), `copyValue` clona raso e retém os filhos — que se veem compartilhados e clonam por sua vez nos próprios commits — e um finalizador grava o clone no pai pelo setter. Dono único muta no lugar; `set == nil` (`populateObj`, alvo por valor) continua no lugar.

Testes (`json_loads_cow_test.go`): (a) struct em array; array/map aninhados; cascata de dois níveis; (b)/(c)/(d)+(e) como regressão; dono único não clona (`CloneCountValue`: 0 sem alias, 1 com alias). Spec §12 anotada.

### 001c910 — item 2: custo dos guards de slot `ref`, medido

`bench_dyn_write.nx` (novo; 1,2 M escritas por base `any`), guard × guard desligado, intercalado, mediana de 9, duas rodadas: **+5,3 % / +2,1 %** (≈ 2–4 ns por escrita dinâmica); `bench_path_update` (tipado) **0 %** — o caminho tipado já não passa pelos opcodes com guard desde #66/#96, que é a alternativa da spec §6.3. Nil-check antes do `FieldIsRef` não moveu o ponteiro e foi descartado. Registrado no `RESULTS.md`. Conclusão: nada a fazer no compilador.

### d8d5158 — item 3: `Load()` duplicado em `setIndexGeneric`

A tag do array é carregada uma vez e alimenta o guard e a mensagem. Sem mudança de comportamento.

### 40f4027 — item 3: `rc_uniqueness_test.go` no formato do `gofmt`

Commit isolado só de formatação, como a issue pede (arquivo era CRLF na árvore; o autocrlf normaliza e o diff é só a indentação dos dois blocos de comentário).

## Verificação

`go test ./...` verde; `go test -race ./internal/vm` verde; corpus `run_all_tests_concurrent.nx` **180/180**. CHANGELOG (0.21.1, `### Fixed`) fica para o próximo bump.

Closes #53 (efetivo ao chegar em `main`; fechar à mão após o merge em `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
