### PR TITLE
docs(examples): safe_division com Result<T> + try; exemplos fora do corpus migrados (issue #105 follow-up)

### DIFF
--- a/noxy_examples/KandR_in_noxy/ch07_parse.nx
+++ b/noxy_examples/KandR_in_noxy/ch07_parse.nx
@@ -5,20 +5,20 @@ use convert select *
 let lines: string[] = ["1.5", "2.25", "abc", "  -0.75 "]
 let sum: float = 0.0
 for line in lines do
-    let r: FloatResult = to_float_result(trim(line))
+    let r = to_float_result(trim(line))   // Result<float>
     if r.ok then
         sum = sum + r.value
     else
-        print("ignorando [" + line + "]: " + r.error)
+        print("ignorando [" + line + "]: " + r.failure.message)
     end
 end
 print(fmt("%.2f", sum))
 
 // scanf("%d %s %d", &day, monthname, &year) para "25 Dec 1988"
 let parts: SplitResult = split("25 Dec 1988", " ")
-let day: IntResult = to_int_result(parts.parts[0])
+let day = to_int_result(parts.parts[0])
 let month: string = parts.parts[1]
-let year: IntResult = to_int_result(parts.parts[2])
+let year = to_int_result(parts.parts[2])
 if day.ok && year.ok then
     print(day.value, month, year.value)
 end

--- a/noxy_examples/form_app.nx
+++ b/noxy_examples/form_app.nx
@@ -119,7 +119,7 @@ let host: string = "0.0.0.0"
 
 let port_env: EnvResult = getenv("PORT")
 if port_env.ok then
-    let parsed_port: IntResult = to_int_result(port_env.value)
+    let parsed_port = to_int_result(port_env.value)   // Result<int>
     if parsed_port.ok && parsed_port.value > 0 then
         port = parsed_port.value
     else
@@ -130,17 +130,12 @@ end
 print("Binding to " + host + ":" + to_str(port))
 let server: HttpServer = new_server(host, port)
 
-if start(server) then
+// API atual de http_server: bind_server + serve com o handler (o laco de
+// poll/send antigo — start/server_poll/server_send — nao existe mais; o
+// check de global inexistente da 0.22.0 e que acusou a chamada morta).
+if bind_server(ref server) then
     print("Server running. Open http://localhost:8080")
-    
-    while true do
-        let event: RequestEvent = server_poll(server)
-        
-        if event.type == "REQUEST" then
-            let resp: HttpResponse = handle_request(event.request)
-            server_send(server, event.client_index, resp)
-        end
-    end
+    serve(ref server, handle_request)
 else
     print("Failed to start server")
 end

--- a/noxy_examples/password_manager/server.nx
+++ b/noxy_examples/password_manager/server.nx
@@ -201,7 +201,7 @@ func handle_list_passwords() -> http_parser.HttpResponse
 end
 
 func handle_delete_password(id_str: string) -> http_parser.HttpResponse
-    let parsed_id: IntResult = to_int_result(id_str)
+    let parsed_id = to_int_result(id_str)   // Result<int>: `!ok ||` estreita value no operando direito e depois do return
     if !parsed_id.ok || parsed_id.value <= 0 then
         return http_server.response_error(400, "Invalid ID")
     end

--- a/noxy_examples/safe_division.nx
+++ b/noxy_examples/safe_division.nx
@@ -1,39 +1,57 @@
-struct Result
-    is_ok: bool      // true = Ok, false = Err
-    value: int       // valor quando sucesso
-    error: string     // nome do erro quando falha
-end
+// safe_division.nx — divisão segura com o Result<T> da stdlib (spec §7).
+//
+// Antes (ate 0.21) este exemplo declarava o proprio `struct Result` com
+// `is_ok`/`value`/`error` e as funcoes `Ok`/`Err` por conta propria. Desde
+// 0.22.0 (issue #105) existe UM `Result<T>` em `errors`, generico:
+//
+//   - `Ok(v)` / `Err(msg)` constroem; `if r.ok then` estreita `r.value` de
+//     `int?` para `int` — nenhum teste extra no caminho feliz;
+//   - `try expr` propaga a falha: numa funcao que devolve Result<V>, um
+//     Result<U> com ok=false vira `return` imediato da mesma Failure;
+//   - a falha continua sendo um VALOR: nada e lancado, nada desenrola pilha.
+//
+// Saida esperada:
+//   10 / 0 = Erro: DIVISION_BY_ZERO
+//   10 / 2 = 5
+//   media(10, 20, 5) = 3
+//   media(10, 20, 0) = Erro: DIVISION_BY_ZERO
 
-func Ok(value: int) -> Result
-    return Result(true, value, "")
-end
+use errors select *
 
-func Err(error_name: string) -> Result
-    return Result(false, 0, error_name)
-end
-
-// Divisão Segura:
-
-func safe_divide(a: int, b: int) -> Result
+func safe_divide(a: int, b: int) -> Result<int>
     if b == 0 then
         return Err("DIVISION_BY_ZERO")
     end
     return Ok(a / b)
 end
 
-func is_ok(result: Result) -> bool
-    return result.is_ok
+// Dois `try`: se qualquer divisao falhar, `media` devolve essa falha ao
+// chamador sem escrever `if !r.ok then return Fail(r.failure) end` duas vezes.
+func media(a: int, b: int, divisor: int) -> Result<int>
+    let x: int = try safe_divide(a, divisor)
+    let y: int = try safe_divide(b, divisor)
+    return Ok((x + y) / 2)
 end
 
-func test_division(a: int, b: int)
-    let result: Result = safe_divide(a, b)
-    if is_ok(result) then
-        print(f"{a} / {b}" + " = " + to_str(result.value))
+func test_division(a: int, b: int) -> void
+    let result = safe_divide(a, b)          // Result<int>
+    if result.ok then
+        print(f"{a} / {b} = " + to_str(result.value))     // result.value: int aqui
     else
-        print(f"{a} / {b}" + " = Erro: " + result.error)
+        print(f"{a} / {b} = Erro: " + result.failure.message)
     end
 end
 
-// Testes
-test_division(10, 0)  // Divisão por zero
-test_division(10, 2)  // Divisão válida
+func test_media(a: int, b: int, divisor: int) -> void
+    let m = media(a, b, divisor)
+    if m.ok then
+        print(f"media({a}, {b}, {divisor}) = " + to_str(m.value))
+    else
+        print(f"media({a}, {b}, {divisor}) = Erro: " + m.failure.message)
+    end
+end
+
+test_division(10, 0)   // divisao por zero
+test_division(10, 2)   // divisao valida
+test_media(10, 20, 5)  // as duas divisoes dao certo
+test_media(10, 20, 0)  // a primeira falha: `try` devolve a Failure de safe_divide

--- a/noxy_examples/to_int_conversion_demo.nx
+++ b/noxy_examples/to_int_conversion_demo.nx
@@ -2,11 +2,19 @@
 //
 // Mostra a diferença entre as duas formas de conversão numérica em Noxy:
 //   to_int(v)          - estrita: levanta erro de runtime se não conseguir converter
-//   to_int_result(v)   - recuperável: nunca levanta, devolve um IntResult{ok, value, error}
+//   to_int_result(v)   - recuperável: nunca levanta, devolve errors.Result<int>
 //
-// Regra de uso: to_int é para valores que JÁ deveriam ser numéricos (um bug se não forem).
-// to_int_result é para entrada não confiável (arquivo, variável de ambiente, rede, usuário).
+// Regra de uso (spec §7): to_int é para valores que JÁ deveriam ser numéricos
+// (um bug se não forem). to_int_result é para entrada não confiável (arquivo,
+// variável de ambiente, rede, usuário). Desde 0.22.0 (issue #105):
+//   - `if r.ok then` estreita r.value de int? para int;
+//   - `try` propaga a falha numa função que também devolve Result<T>;
+//   - a falha é um valor (r.failure.message), nunca uma exceção.
+//
+// Este arquivo derruba o script DE PROPÓSITO no final (seção 4), por isso
+// fica fora do corpus (run_all_tests_concurrent.nx).
 
+use errors select *
 use convert select *
 
 print("=== 1. to_int: conversões bem-sucedidas ===")
@@ -18,20 +26,22 @@ print("to_int(5.9)    = " + to_str(to_int(5.9)) + "   // trunca em direção a z
 print("to_int(-5.9)   = " + to_str(to_int(-5.9)) + "  // trunca em direção a zero")
 
 print("")
-print("=== 2. to_int_result: nunca levanta, sempre devolve um struct ===")
+print("=== 2. to_int_result: nunca levanta, sempre devolve um Result<int> ===")
 print("")
 
-let ok_case: IntResult = to_int_result("8080")
-print("to_int_result(\"8080\")")
-print("  ok=" + to_str(ok_case.ok) + " value=" + to_str(ok_case.value) + " error=[" + ok_case.error + "]")
+func mostra(entrada: string) -> void
+    let r = to_int_result(entrada)              // Result<int>
+    print("to_int_result(\"" + entrada + "\")")
+    if r.ok then
+        print("  ok=true  value=" + to_str(r.value))          // r.value: int aqui
+    else
+        print("  ok=false value=null failure=[" + r.failure.message + "]")
+    end
+end
 
-let bad_case: IntResult = to_int_result("notaport")
-print("to_int_result(\"notaport\")")
-print("  ok=" + to_str(bad_case.ok) + " value=" + to_str(bad_case.value) + " error=[" + bad_case.error + "]")
-
-let overflow_case: IntResult = to_int_result("99999999999999999999")
-print("to_int_result(\"99999999999999999999\")   // estoura int64")
-print("  ok=" + to_str(overflow_case.ok) + " value=" + to_str(overflow_case.value) + " error=[" + overflow_case.error + "]")
+mostra("8080")
+mostra("notaport")
+mostra("99999999999999999999")   // estoura int64
 
 print("")
 print("=== 3. Padrão real: ler uma porta de configuração não confiável ===")
@@ -40,18 +50,24 @@ print("")
 // Simula valores que poderiam vir de getenv("PORT").value — string, pode ou não ser numérica.
 let candidatos: string[] = ["3000", "abc", "-1", "65535"]
 
+// Validação como dado: a conversão E a faixa devolvem Result<int>. `try`
+// faz a falha da conversão sair daqui com a mesma mensagem, sem if manual.
+func porta_valida(raw: string) -> Result<int>
+    let porta: int = try to_int_result(raw)
+    if porta <= 0 || porta > 65535 then
+        return Err("fora do intervalo de portas")
+    end
+    return Ok(porta)
+end
+
 func resolve_port(raw: string, default_port: int) -> int
-    let parsed: IntResult = to_int_result(raw)
-    if !parsed.ok then
-        print("  \"" + raw + "\" -> inválido (" + parsed.error + "), usando padrão " + to_str(default_port))
-        return default_port
+    let r = porta_valida(raw)
+    if r.ok then
+        print("  \"" + raw + "\" -> porta " + to_str(r.value))
+        return r.value
     end
-    if parsed.value <= 0 || parsed.value > 65535 then
-        print("  \"" + raw + "\" -> fora do intervalo de portas, usando padrão " + to_str(default_port))
-        return default_port
-    end
-    print("  \"" + raw + "\" -> porta " + to_str(parsed.value))
-    return parsed.value
+    print("  \"" + raw + "\" -> inválido (" + r.failure.message + "), usando padrão " + to_str(default_port))
+    return default_port
 end
 
 let i: int = 0

--- a/noxy_examples/todo_app.nx
+++ b/noxy_examples/todo_app.nx
@@ -194,7 +194,7 @@ init_db()
 let port_str: string = getenv("PORT").value
 let port: int = 8080
 if !is_empty(port_str) then
-    let parsed_port: IntResult = to_int_result(port_str)
+    let parsed_port = to_int_result(port_str)   // Result<int>
     if parsed_port.ok && parsed_port.value > 0 then
         port = parsed_port.value
     else

--- a/noxy_examples/web_app.nx
+++ b/noxy_examples/web_app.nx
@@ -146,7 +146,7 @@ func handle_request(raw_json: string) -> Response
                 let m: map = body_map // Cast
                 if has_key(m, "name") then req.name = m["name"] end
                 if has_key(m, "age") then
-                    let parsed_age: IntResult = to_int_result(m["age"])
+                    let parsed_age = to_int_result(m["age"])   // Result<int>
                     if parsed_age.ok then
                         req.age = parsed_age.value
                     end


### PR DESCRIPTION
Follow-up da #105 / PR #106 nos exemplos.

## `safe_division.nx` reescrito com a sintaxe nova

Antes declarava o proprio `struct Result {is_ok, value, error}` e `Ok`/`Err` a mao. Agora usa `errors.Result<int>`, `Ok`/`Err` da stdlib, narrowing por `if r.ok then` e `try` para propagar (`media` faz duas divisoes e devolve a primeira falha sem `if` manual). Saida anotada no cabecalho; roda no corpus.

## Referencias mortas em exemplos fora do corpus

Seis arquivos ficaram fora da migracao do PR #106 por nao rodarem no `run_all_tests_concurrent.nx` (servidores/apps, ou crash intencional) e ainda citavam `IntResult`/`FloatResult`:

- `to_int_conversion_demo.nx` — reescrito por inteiro com `Result<int>`, narrowing e `try` (`porta_valida` propaga a falha da conversao); continua derrubando o script de proposito na secao 4.
- `form_app.nx`, `todo_app.nx`, `web_app.nx`, `password_manager/server.nx`, `KandR_in_noxy/ch07_parse.nx` — `let r: IntResult = …` → `let r = …` (`Result<int>`), `r.error` → `r.failure.message`. Os `if r.ok && r.value > 0` / `if !r.ok || r.value <= 0 then return` ja estreitam sozinhos.

## Bug latente pego pelo check de global inexistente

`form_app.nx` chamava `start(server)` + `server_poll`/`server_send` — API que nao existe mais em `http_server`. Trocado por `bind_server(ref server)` + `serve(ref server, handle_request)`, como `todo_app.nx`.

## Verificacao

Cada arquivo compila (`noxy <arquivo>`; os servidores sobem ate o `timeout`); corpus 181/181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
