### PR TITLE
docs: int_to_result_noxy_v2 e try_config com Result<T> + try; spec e site sem o envelope-map do call_result (issue #105 follow-up)

### DIFF
--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -2174,10 +2174,11 @@ The core builtins have static return types where the result never varies —
 `keys(map[K, V]) -> K[]`, `slice` (same type as its first argument) — so a
 value of theirs is checked like any other expression (`let s: string =
 length(xs)` is a compile error) and can initialize an inferred `let` (§3).
-The others (`json_parse`, `task_await`, `call_result`, `make_chan`, ...) are
-dynamic-boundary builtins: their result is `any` or untyped and needs an
-annotation. A function the program declares with a builtin's name shadows the
-builtin, static type included.
+`call_result` is typed by its callee (`errors.Result<R>`, §7). The others
+(`json_parse`, `task_await`, `make_chan`, ...) are dynamic-boundary builtins:
+their result is `any` or untyped and needs an annotation. A function the
+program declares with a builtin's name shadows the builtin, static type
+included.
 
 ### Collections
 - `length(arr_or_map) -> int`
@@ -2229,8 +2230,8 @@ let back: bytes = hex_decode(hex)   // b"Hello"
 ### Type inspection
 
 `type(v: any) -> string` returns the runtime type name of a value. Its main
-use is inspecting `any` values at dynamic boundaries (`call_result` and
-`task_await` envelopes, JSON, channel payloads). The names:
+use is inspecting `any` values at dynamic boundaries (`task_await`
+envelopes, JSON, channel payloads). The names:
 
 | Value | `type(v)` |
 |-------|-----------|
@@ -2256,8 +2257,9 @@ print(type(null))       // null
 ```
 
 `type` reports the runtime representation, not the static annotation: a
-`call_result` envelope reports `"map"` (its physical shape at the dynamic
-boundary), and any value bound to `any` reports what it actually is. The
+`call_result` envelope reports `"Result<int>"` (it is a genuine
+`errors.Result<int>` instance — the struct-instance row above — never
+`"map"`), and any value bound to `any` reports what it actually is. The
 `%T` verb of `fmt` uses the same table.
 
 ### Concurrency and Supervised Tasks

--- a/docs/index.html
+++ b/docs/index.html
@@ -428,7 +428,7 @@ func parse(text: string) -> int
 end
 
 // call_result turns a runtime failure into data
-let r: CallResult = call_result(parse, "abc")
+let r = call_result(parse, "abc")   // r: Result&lt;int&gt;
 if r.ok then
     print(r.value)
 else
@@ -686,34 +686,36 @@ print(get("missing"))   // (empty)</code></pre>
                 </div>
                 <div class="example-tab" id="safe-division">
                     <h3>Safe Division</h3>
-                    <p>Result pattern for operations whose failure is an expected outcome: the result struct
-                        carries an <code>ok</code> flag the caller must branch on.</p>
-                    <pre><code class="language-go">struct Result
-    is_ok: bool
-    value: int
-    error: string
-end
+                    <p>Result pattern for operations whose failure is an expected outcome: the stdlib
+                        <code>Result&lt;T&gt;</code> carries an <code>ok</code> flag the caller must branch on
+                        (the branch narrows <code>value</code> to <code>T</code>), and <code>try</code>
+                        propagates a failure to the caller.</p>
+                    <pre><code class="language-go">use errors select *
 
-func Ok(value: int) -> Result
-    return Result(true, value, "")
-end
-
-func Err(error_name: string) -> Result
-    return Result(false, 0, error_name)
-end
-
-func safe_divide(a: int, b: int) -> Result
+func safe_divide(a: int, b: int) -> Result&lt;int&gt;
     if b == 0 then
         return Err("DIVISION_BY_ZERO")
     end
     return Ok(a / b)
 end
 
-let result: Result = safe_divide(10, 0)
-if result.is_ok then
-    print(f"Result: {result.value}")
+// try: if a step fails, average returns that same Failure
+func average(a: int, b: int, divisor: int) -> Result&lt;int&gt;
+    let x: int = try safe_divide(a, divisor)
+    let y: int = try safe_divide(b, divisor)
+    return Ok((x + y) / 2)
+end
+
+let result = safe_divide(10, 0)        // Result&lt;int&gt;
+if result.ok then
+    print(f"Result: {result.value}")   // value narrowed to int here
 else
-    print(f"Error: {result.error}")
+    print(f"Error: {result.failure.message}")
+end
+
+let avg = average(10, 20, 0)
+if !avg.ok then
+    print(f"Error: {avg.failure.message}")   // the Failure from safe_divide
 end</code></pre>
                 </div>
                 <div class="example-tab" id="closures">

--- a/docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md
+++ b/docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md
@@ -206,7 +206,10 @@ rationale is recorded:
   validation) reject them. The wrapper `.nx` idiom already in use — have the
   native fill a wrapper-constructed instance, or annotate the map
   structurally — carries over. This is a known, already-documented seam, not
-  a new one.
+  a new one. *(Later note, 0.22.0 — issue #105: the `call_result` envelope is
+  now a genuine `errors.Result<T>` instance, not a struct-shaped map; the seam
+  described here remains for maps returned by natives — spec §7,
+  "Representation".)*
 
 **Extension-held state** stays inside the guest instance, behind an integer
 id the guest mints, wrapped in a struct by the `.nx` wrapper:

--- a/noxy_examples/int_to_result_noxy_v2.nx
+++ b/noxy_examples/int_to_result_noxy_v2.nx
@@ -1,0 +1,213 @@
+// int_to_result_noxy_v2.nx — to_int_result reimplementado em noxy PURO, agora
+// sobre o Result<T> da stdlib (spec §7, issue #105).
+//
+// A primeira versao (int_to_result_noxy.nx) precisou declarar o proprio
+// `struct Resultado<T>` e so conseguia comparar `ok` e `value` com o builtin.
+// Desde 0.22.0 existe UM `Result<T>` em `errors`, e a reimplementacao usa
+// exatamente o envelope da stdlib:
+//
+//   - `Ok(v)` / `Err(msg)` constroem o Result<int>; nenhum struct ad hoc;
+//   - dispatch de tipo sobre `any` com o builtin type(v);
+//   - parse manual de string base 10 com deteccao de overflow de int64
+//     (to_int nao serve no caminho de falha: ele LEVANTA);
+//   - as mensagens de falha seguem o formato do builtin, entao o oraculo
+//     compara o envelope inteiro: ok, value e failure.message;
+//   - `try` propaga a falha em `soma`, que encadeia dois parses.
+//
+// Saida esperada (26 casos):
+//   MATCH  (int)    42                            Ok(42)
+//   MATCH  (float)  3.990000                      Ok(3)
+//   MATCH  (string) "abc"                         Err(cannot convert string "abc" to int)
+//   MATCH  (string) "9223372036854775808"         Err(cannot convert string "9223372036854775808" to int: out of range)
+//   MATCH  (float)  NaN                           Err(cannot convert float NaN to int)
+//   MATCH  (bytes)  "12"                          Err(cannot convert bytes "12" to int)
+//   ...
+//   soma("40", 2.9)        = Ok(42)
+//   soma("40", "quarenta") = Err(cannot convert string "quarenta" to int)
+//
+//   TODOS OS CASOS BATEM COM O BUILTIN
+
+use strings select char_at, substring, index_of
+use convert select *
+use errors select *
+
+// ---- implementacao ----
+
+// Como o builtin escreve um valor na mensagem: texto entre aspas, o resto via to_str.
+// (Nao replica o escape %q de Go nem o corte em 64 caracteres: nenhum caso abaixo os toca.)
+func render(v: any) -> string
+    let kind: string = type(v)
+    if kind == "string" || kind == "bytes" then
+        return "\"" + to_str(v) + "\""
+    end
+    return to_str(v)
+end
+
+// "<tipo> <valor>", como o builtin descreve a entrada rejeitada.
+func describe(v: any) -> string
+    return type(v) + " " + render(v)
+end
+
+let DIGITS: string = "0123456789"
+let MIN_INT: int = -9223372036854775807 - 1
+let MIN_DIV10: int = -922337203685477580  // MIN_INT / 10, truncado
+
+// Parse manual de inteiro decimal, mesmo contrato do strconv.ParseInt(s, 10, 64):
+// sinal opcional, so digitos, sem espacos. Acumula NEGATIVO para conseguir
+// representar exatamente MIN_INT (-2^63), que nao tem simetrico positivo.
+// to_int nao serve no caminho de falha: ele LEVANTA (spec §7, "raise for bugs").
+func parse_int_text(text: string) -> Result<int>
+    let invalid: string = "cannot convert " + describe(text) + " to int"
+    let s: string = text
+    let negative: bool = false
+    if length(s) > 0 then
+        let first: string = char_at(s, 0)
+        if first == "-" || first == "+" then
+            negative = first == "-"
+            s = substring(s, 1, length(s))
+        end
+    end
+    if length(s) == 0 then
+        return Err(invalid)
+    end
+    let acc: int = 0
+    for ch in s do
+        let d: int = index_of(DIGITS, ch)
+        if d < 0 then
+            return Err(invalid)
+        end
+        // proximo passo seria acc*10 - d; estoura int64?
+        if acc < MIN_DIV10 || (acc == MIN_DIV10 && d > 8) then
+            return Err(invalid + ": out of range")
+        end
+        acc = acc * 10 - d
+    end
+    if !negative then
+        if acc == MIN_INT then
+            return Err(invalid + ": out of range")
+        end
+        acc = -acc
+    end
+    return Ok(acc)
+end
+
+// Dispatch sobre `any` com o builtin type(v); cada ramo devolve Ok(...) ou Err(...).
+func int_to_result_noxy(v: any) -> Result<int>
+    let kind: string = type(v)
+    if kind == "int" then
+        return Ok(to_int(v))
+    end
+    if kind == "float" then
+        let f: float = to_float(v)
+        // NaN e ±Inf antes da faixa, como o builtin (mensagem sem "out of range"):
+        // NaN e o unico float != dele mesmo; Inf - Inf da NaN.
+        if f != f || f - f != 0.0 then
+            return Err("cannot convert " + describe(v) + " to int")
+        end
+        if f < -9223372036854775808.0 || f >= 9223372036854775808.0 then
+            return Err("cannot convert " + describe(v) + " to int: out of range")
+        end
+        // faixa validada: aqui to_int nunca levanta, so trunca em direcao a zero
+        return Ok(to_int(f))
+    end
+    if kind == "string" then
+        return parse_int_text(to_str(v))
+    end
+    return Err("cannot convert " + describe(v) + " to int")
+end
+
+// ---- propagacao com try ----
+
+// Dois parses encadeados: em sucesso `try` vale o int; na primeira falha a
+// funcao devolve a MESMA Failure ao chamador, sem `if !r.ok then return … end`.
+func soma(a: any, b: any) -> Result<int>
+    let x: int = try int_to_result_noxy(a)
+    let y: int = try int_to_result_noxy(b)
+    return Ok(x + y)
+end
+
+// ---- teste: compara com o builtin to_int_result em cada entrada ----
+
+// `if r.ok then` estreita r.value de int? para int: to_str recebe um int.
+func show(r: Result<int>) -> string
+    if r.ok then
+        return "Ok(" + to_str(r.value) + ")"
+    end
+    return "Err(" + r.failure.message + ")"
+end
+
+// O envelope inteiro tem que bater: ok, value em sucesso, failure.message em falha.
+func same_outcome(mine: Result<int>, builtin: Result<int>) -> bool
+    if mine.ok != builtin.ok then
+        return false
+    end
+    if mine.ok then
+        return mine.value == builtin.value
+    end
+    return mine.failure.message == builtin.failure.message
+end
+
+func check(input: any) -> bool
+    let mine: Result<int> = int_to_result_noxy(input)
+    let builtin: Result<int> = to_int_result(input)
+    let same: bool = same_outcome(mine, builtin)
+    let verdict: string = "MATCH"
+    if !same then
+        verdict = "DIFF!"
+    end
+    let line: string = fmt("%-6s %-8s %-29s %s", verdict, "(" + type(input) + ")", render(input), show(mine))
+    if !same then
+        line = line + "   builtin=" + show(builtin)
+    end
+    print(line)
+    return same
+end
+
+let INF: float = 1.0e308 * 10.0   // estoura para +Inf
+let NAN: float = INF - INF
+
+let tests: any[] = [
+    42,
+    -7,
+    3.99,
+    -3.99,
+    "123",
+    "-123",
+    "+99",
+    "0",
+    "00123",
+    "",
+    "-",
+    "abc",
+    "12.5",
+    " 42",
+    "9223372036854775807",
+    "-9223372036854775808",
+    "9223372036854775808",
+    "-9223372036854775809",
+    9223372036854775808.0,
+    -9223372036854775808.0,
+    INF,
+    -INF,
+    NAN,
+    true,
+    null,
+    b"12"
+]
+
+let all_ok: bool = true
+for t in tests do
+    if !check(t) then
+        all_ok = false
+    end
+end
+
+print("")
+print("soma(\"40\", 2.9)        = " + show(soma("40", 2.9)))
+print("soma(\"40\", \"quarenta\") = " + show(soma("40", "quarenta")))
+print("")
+if all_ok then
+    print("TODOS OS CASOS BATEM COM O BUILTIN")
+else
+    print("HOUVE DIVERGENCIA — ver linhas DIFF! acima")
+end

--- a/noxy_examples/try_config.nx
+++ b/noxy_examples/try_config.nx
@@ -2,17 +2,27 @@
 //
 // Cada nivel que antes repetia `if r.ok == false then return … end` a mao
 // escreve `try`: em sucesso vale o valor; em falha a funcao corrente
-// devolve a MESMA Failure ao chamador. Saida esperada:
+// devolve a MESMA Failure ao chamador. O payload aqui e uma struct de tres
+// campos: dentro de `if r.ok then`, `r.value` e um Config e os campos saem
+// direto (`r.value.host`); `let c: Config = r.value` copia a struct inteira;
+// e num `try` o Config sai como valor comum, sem `.value`. Saida esperada:
 //
-//   porta = 8080
+//   host = localhost, porta = 8080, timeout = 30
+//   url = http://localhost:8080
 //   falhou: cannot convert string "oitenta" to int
+//   falhou: esperava host:porta:timeout, veio "localhost:8080"
 //   falhou: config vazia
+//   url("localhost:8080:30") = http://localhost:8080
+//   url("localhost:8080:x") falhou: cannot convert string "x" to int
 
 use errors select *
 use convert select *
+use strings select split, SplitResult
 
 struct Config
+    host: string
     porta: int
+    timeout: int
 end
 
 // Uma "leitura" que pode falhar como dado: texto vazio nao e config.
@@ -23,20 +33,53 @@ func le_texto(texto: string) -> Result<string>
     return Ok(texto)
 end
 
+// "host:porta:timeout" em tres partes — o T do Result tambem pode ser array.
+func separa(texto: string) -> Result<string[]>
+    let sp = split(texto, ":")
+    if sp.count != 3 then
+        return Err("esperava host:porta:timeout, veio \"" + texto + "\"")
+    end
+    return Ok(sp.parts)
+end
+
 func le_config(texto: string) -> Result<Config>
-    let bruto: string = try le_texto(texto)     // Result<string> -> string, ou retorna a falha
-    let porta: int = try to_int_result(bruto)   // Result<int> -> int, ou retorna a falha
-    return Ok(Config(porta))
+    let bruto: string = try le_texto(texto)         // Result<string> -> string, ou retorna a falha
+    let partes: string[] = try separa(bruto)        // Result<string[]> -> string[]
+    let porta: int = try to_int_result(partes[1])   // Result<int> -> int
+    let timeout: int = try to_int_result(partes[2])
+    return Ok(Config(partes[0], porta, timeout))
+end
+
+// O Config sai do try como valor comum: nenhum `.value`, nenhum teste de null.
+func url(texto: string) -> Result<string>
+    let c: Config = try le_config(texto)
+    return Ok("http://" + c.host + ":" + to_str(c.porta))
 end
 
 func mostra(r: Result<Config>) -> void
     if r.ok then
-        print("porta = " + to_str(r.value.porta))
+        // r.value estreitado de Config? para Config: campos direto...
+        print("host = " + r.value.host + ", porta = " + to_str(r.value.porta) + ", timeout = " + to_str(r.value.timeout))
+        // ...ou a struct inteira de uma vez
+        let c: Config = r.value
+        print("url = http://" + c.host + ":" + to_str(c.porta))
     else
         print("falhou: " + r.failure.message)
     end
 end
 
-mostra(le_config("8080"))
-mostra(le_config("oitenta"))
+func mostra_url(texto: string) -> void
+    let r = url(texto)
+    if r.ok then
+        print("url(\"" + texto + "\") = " + r.value)
+    else
+        print("url(\"" + texto + "\") falhou: " + r.failure.message)
+    end
+end
+
+mostra(le_config("localhost:8080:30"))
+mostra(le_config("localhost:oitenta:30"))
+mostra(le_config("localhost:8080"))
 mostra(le_config(""))
+mostra_url("localhost:8080:30")
+mostra_url("localhost:8080:x")


### PR DESCRIPTION
Follow-up da #105 / PRs #106 e #107: mais dois exemplos com `Result<T>` + `try`, e a documentação viva deixa de descrever o envelope do `call_result` como map.

## Summary
- `noxy_examples/int_to_result_noxy_v2.nx` (novo, Task 15 da #105): `to_int_result` reimplementado em noxy puro sobre o `Result<T>` de `errors` — `Ok`/`Err` no lugar do `struct Resultado<T>` próprio da v1, dispatch por `type(v)`, parse decimal manual com detecção de overflow de int64 (acumula negativo para representar `MIN_INT`), mensagens no formato do builtin. O oráculo compara o envelope inteiro (`ok`, `value` e `failure.message`) em 26 casos, com `+Inf`/`-Inf`/`NaN` novos; `soma()` demonstra `try` encadeando dois parses. A v1 (`int_to_result_noxy.nx`) fica como registro da era do struct próprio.
- `noxy_examples/try_config.nx`: `Config` passa a ter três campos (`host:porta:timeout`) para mostrar o payload struct multi-campo — dentro de `if r.ok then` os campos saem de `r.value.host` direto ou pela cópia `let c: Config = r.value`; em `url()` o `Config` sai do `try` como valor comum, sem `.value` nem teste de null. `separa()` devolve `Result<string[]>` (o `T` também pode ser array). Dois casos de falha novos (formato errado, `timeout` inválido).
- **Spec §10** ainda dizia que `call_result` é builtin de fronteira dinâmica (resultado `any`, precisa de anotação) e que `type()` do envelope reporta `"map"`. Desde 0.22.0 o envelope é instância real de `errors.Result<R>`, tipada pelo callee: `type(r)` e `fmt("%T", r)` dão `Result<int>` (conferido no binário). Três parágrafos corrigidos; a seção "Representation" de §7 já estava certa.
- **Site** (`docs/index.html`): o tab "Errors & defer" ainda anotava `let r: CallResult = call_result(...)` — tipo que não existe mais (erro de compilação). Agora `let r = call_result(parse, "abc")   // r: Result<int>`. O tab "Safe Division" declarava o próprio `struct Result {is_ok, value, error}` com `Ok`/`Err` à mão (o mesmo padrão morto que o #107 tirou de `safe_division.nx`); reescrito com `errors.Result<int>`, narrowing em `if result.ok then` e `try` em `average()`. Os dois trechos foram rodados como estão no site.
- Nota posterior no design doc do mecanismo wasm (`docs/superpowers/specs/2026-08-23-…`), que usava o envelope do `call_result` como exemplo de "struct-shaped map".

## Components
- `noxy_examples/int_to_result_noxy_v2.nx` — novo (213 linhas); entra automaticamente no corpus de `run_all_tests_concurrent.nx`.
- `noxy_examples/try_config.nx` — reescrito (+59/−8); saída esperada atualizada no cabeçalho.
- `docs/NOXY_LANGUAGE_SPEC.md` §10 (Built-in Functions / Type inspection) — 3 parágrafos.
- `docs/index.html` — tabs "Errors & defer" e "Safe Division".
- `docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md` — nota posterior, sem mudar o desenho.
- Sem mudança em runtime, stdlib ou CHANGELOG (docs/exemplos, como no #107).

## Related Issues
- Issue #105 (follow-up; não fecha)

## Test Plan
- [x] `noxy noxy_examples/try_config.nx` — 7 linhas de saída iguais ao cabeçalho, exit 0
- [x] `noxy noxy_examples/int_to_result_noxy_v2.nx` — `TODOS OS CASOS BATEM COM O BUILTIN`, exit 0
- [x] Suíte concorrente 182/182 em cada commit de exemplo
- [x] `type(call_result(parse, "abc"))` / `fmt("%T", …)` = `Result<int>`, `type(r.failure)` = `Failure` — probe rodado no binário antes de reescrever a spec
- [x] Os dois trechos novos do site compilam e imprimem o esperado (`Error: DIVISION_BY_ZERO` ×2; `invalid: …` / `working` / `cleanup runs last`)
- [ ] Review do texto dos comentários nos dois exemplos
- [ ] Conferir o render do tab "Safe Division" no site publicado (`&lt;`/`&gt;` nos genéricos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTWMbXUcEJGWiayWs3X7uZ
