### PR TITLE
docs(ext): registrar invariantes revisados de extensibilidade e reposicionar o tier B (issue #110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,12 @@ interpretador). Os dois contratos são travados por
 **Extensões e plugins**: extensões WASM rodam no wazero sem WASI e com
 `capabilities = []` obrigatório (M1) — o loader rejeita manifesto com
 capability. Plugins (`sys.load_plugin`) são processos externos falando JSON;
-a VM não os isola.
+a VM não os isola. Desde a issue #110 (2026-08-29) a divisão é por perfil:
+wasm para computação pura; I/O, SO, drivers e SDKs vão para plugins por
+processo (tier B, spec na #80) — as capabilities do wasm (M2) estão suspensas
+e o invariante 5 do RFC #78 ("VM não desestabilizável") não é mais requisito.
+Invariantes revisados em
+`docs/superpowers/specs/2026-08-29-extensibility-invariants-revision.md`.
 
 ---
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -5,6 +5,12 @@ hashing, codecs, parsers — as a single platform-independent `.wasm` artifact,
 loaded by the VM's embedded WebAssembly runtime (wazero). Design:
 `docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md`.
 
+**Scope (issue #110).** WASM extensions are for pure computation over their
+arguments — buffer in, buffer out. I/O, OS access, network, drivers and SDK
+bindings are the job of process plugins (tier B, issue #80); the wasm
+capability plan (`capabilities`, M2) is suspended. Pick the backend by the
+API's profile. Invariants: `docs/superpowers/specs/2026-08-29-extensibility-invariants-revision.md`.
+
 ## Package layout
 
 ```
@@ -42,8 +48,9 @@ because a handle only means something to the instance that minted it.
 
 A non-empty `capabilities` list is rejected outright: the loader errors on
 `noxy_ext.toml` parsing rather than silently ignoring capabilities the host
-does not implement yet. M1 ships zero capabilities — every extension is a
-pure function of its declared arguments (see ABI v1 summary below).
+does not implement (the capability plan is suspended — issue #110; I/O
+belongs to process plugins). M1 ships zero capabilities — every extension is
+a pure function of its declared arguments (see ABI v1 summary below).
 
 Export names must match `^[a-z][a-z0-9_]*$` and start with `<name>_`. Before
 registering any export, the loader checks every declared export against the

--- a/docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md
+++ b/docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md
@@ -8,6 +8,16 @@ WASM cannot express; formalizing it is a separate spec. In-process dynamic
 libraries were rejected in the RFC for violating invariant 5 and are not
 revisited here.
 
+> **Amended 2026-08-29 (issue #110).** The RFC's five invariants were revised
+> by the author — see `2026-08-29-extensibility-invariants-revision.md`.
+> Invariant 5 ("the VM cannot be destabilized") is no longer a requirement;
+> "cross-compile, and the user never compiles" is the decisive filter.
+> Consequences for this document: tier B (process plugins) is the **primary**
+> path for I/O, OS access and drivers — not a second tier; the capability
+> plan of §9 and phase M2 of §14 are suspended; approach C stays out for the
+> cross-compilation cost it imposes on authors, not for invariant 5. The
+> original text is kept as written, with amendment notes where superseded.
+
 ## Goal and Scope
 
 **Goal:** a third party can publish a native-performance module — compression,
@@ -395,6 +405,14 @@ let it do. v1 policy:
 
 Tier B (process plugins) can make no such guarantee; its spec must say so.
 
+> **Amended 2026-08-29 (issue #110).** Invariant 5 was dropped, so tier B
+> no longer needs to make that guarantee — process isolation is a bonus, not
+> a requirement. The `random`/`clock`/`fs`/`net` capability namespaces above
+> are **suspended**: I/O is tier B's job (issue #80). A restricted WASI
+> preview1 grant (clock, random, stdout→`nx_log`; no filesystem mount, no
+> sockets) is the candidate answer to authoring friction, in its own issue
+> if pursued.
+
 ## 10. ABI evolution
 
 - `noxy:host/v1` is additive-only: new imports may be added (instantiation
@@ -439,9 +457,19 @@ Acceptance benchmark for the implementation (gates merge):
 - **Out-of-process plugins as the only mechanism** (RFC approach B): survives
   as tier 2. Rejected as primary for the per-call cost (~50–500 µs — three
   orders above the boundary here) and the N-artifacts-per-release packaging.
+  *Amended 2026-08-29 (issue #110): now the primary mechanism for I/O, OS
+  access and drivers; wasm stays primary for pure computation. The
+  N-artifacts cost is accepted — Go cross-compiles the whole matrix without
+  cgo — and the per-call cost is irrelevant for I/O-bound APIs.*
 - **In-process dynamic libraries via purego** (RFC approach C): best raw
   performance, violates invariant 5 by construction. Rejected; not even
   behind a flag until someone brings a use case tier B cannot serve.
+  *Amended 2026-08-29 (issue #110): invariant 5 is gone; the rejection now
+  rests on (a) Go `-buildmode=c-shared` requiring cgo and a C toolchain per
+  target, which forfeits the cross-compile advantage; (b) a permanently
+  stable C-API over `Value`; (c) the gain mattering only for hot per-element
+  calls, which wasm serves. Reopens on a concrete case needing the whole OS
+  and hot calls that cannot be batched.*
 - **Host-side handle table with accessor imports** (the "rich ABI"): rejected
   for v1, §3. Re-openable with evidence: a concrete extension whose profiled
   copy cost dominates and whose API cannot be made chunky.
@@ -490,6 +518,8 @@ Named in the RFC, owned here:
 - **M2 — capabilities.** `noxy:cap/random/v1` + `noxy:cap/clock/v1`, grant
   lines in `noxy.mod`, `--get` prompt. Reference extension exercising them
   (proposed: an argon2/password-hashing lib).
+  *Suspended 2026-08-29 (issue #110): I/O and OS access are tier B's job;
+  see `2026-08-29-extensibility-invariants-revision.md`.*
 - **M3 — core diet, decision only.** Measure binary share of
   `modernc.org/sqlite` (+`libc`) with `go tool nm` size accounting; if it is
   the expected majority share, spec sqlite-as-extension (needs
@@ -517,5 +547,8 @@ Named in the RFC, owned here:
 - **Tier B formalization** — versioned handshake for `sys_load_plugin`,
   msgpack framing, platform-artifact selection in the package manager; its
   own spec, sharing the manifest and `noxy.sum` machinery where possible.
+  *Now issue #80 (spec) with the deltas of issue #110: NXB framing (not
+  msgpack), binaries as release assets per platform, portable `noxy.sum`,
+  `noxy_terminal` and `noxy_dynamodb` as the reference extensions.*
 - **REPL story** — loading extensions from the REPL session works via the
   same module path; poisoning semantics in a long-lived REPL deserve a test.

--- a/docs/superpowers/specs/2026-08-29-extensibility-invariants-revision.md
+++ b/docs/superpowers/specs/2026-08-29-extensibility-invariants-revision.md
@@ -1,0 +1,184 @@
+# Extensibility Invariants — Revision (2026-08-29)
+
+Amends `2026-08-23-wasm-extension-mechanism-design.md`. Decision record:
+issue #110. Related: RFC #78 (closed), issue #80 (tier B spec), PR #79
+(wasm M1, v0.18.0).
+
+This document is the authoritative statement of the invariants that any
+extensibility mechanism for Noxy must satisfy. Where the 2026-08-23 spec
+cites "invariant N", read the revised table below; the spec keeps its
+original text with amendment notes at the points it supersedes.
+
+## Why a revision
+
+RFC #78 listed five "non-negotiable" invariants. Reviewing the record on
+2026-08-28 showed that they were written together with the answer, not
+before it: the RFC was opened on 2026-08-23 at 21:43Z, the spec that answers
+it was committed 47 minutes later (`5435900`), and PR #79 with the whole M1
+implementation was merged about five hours after the RFC. No commit before
+2026-08-23 mentions a single binary or cross-compilation; the first
+`GOOS=darwin` in the repository is the spec's own commit. The spec's claim
+that "CI enforces `CGO_ENABLED=0`" corresponds to an environment variable in
+one workflow (`network-deadlines.yml`, since 2026-08-14) and to the Lambda
+build scripts from January.
+
+Invariants 1 and 2 have real roots — a static Linux binary built from a
+Windows machine for the Lambda runtime since January 2026. Invariants 3, 4
+and 5 were declared on the spot, and invariant 5 is the one that did the
+decisive work against in-process dynamic libraries.
+
+The RFC's own problem statement has two halves — "performance **or talking
+to the operating system** … no path to bindings for … **database
+drivers**" — and the wasm mechanism serves only the first. The two native
+extensions that existed before the RFC, `estevaofon/noxy_dynamodb`
+(2026-01) and `estevaofon/noxy_terminal` (2026-08), are both I/O; neither is
+expressible as a wasm extension. The only wasm extension, `noxy_regex`, was
+created the day after the RFC to validate the mechanism.
+
+None of this invalidates the wasm design for what it does. It obliges the
+project to record the invariants the author actually holds and to
+re-evaluate the alternatives against them.
+
+## The invariants (authoritative)
+
+Stated by the author on 2026-08-28, in the author's words:
+
+> R1. Não precisa ser binário único, mas é preferível.
+> R2. Eu gostaria que seja cross compile e sem necessidade do usuário
+> compilar, assim como o Python.
+> R3. Concordo no sentido de ser cross-plataforma.
+> R4. Concordo, sem compilação pelo usuário.
+> R5. Não é necessário, muito restritivo.
+
+| # | RFC #78 (2026-08-23) | Revised (2026-08-28) |
+|---|---|---|
+| 1 | Distribution as a single binary | **Preferred, not required.** |
+| 2 | Cross-compilation without an external toolchain | **Kept**, and extended: whoever installs an extension never compiles — the Python model. |
+| 3 | Platform parity (Linux, macOS, Windows) | **Kept** (cross-platform). |
+| 4 | The end user does not compile | **Kept**, strongly. |
+| 5 | The VM cannot be destabilized | **Dropped.** Too restrictive. An extension may crash the VM, as a C extension may crash Python. |
+
+The decisive filter is 2 + 4: an author must be able to produce artifacts
+for every supported platform cheaply, and a user must never need a
+toolchain. Invariant 5 no longer constrains the choice of mechanism;
+isolation, where a mechanism provides it, is a bonus.
+
+## Decision
+
+### 1. Process plugins (tier B) are the primary path for I/O
+
+For I/O, OS access, drivers and SDK bindings — the second half of the RFC's
+problem — the out-of-process plugin is the primary mechanism, not a "second
+tier" and not a consciously accepted cost. It satisfies invariants 2, 3 and 4
+at the lowest cost to authors because of a structural advantage Python never
+had: Go cross-compiles to every target from any machine, without cgo.
+
+```sh
+for os in linux darwin windows; do for arch in amd64 arm64; do
+  GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o dist/noxy-plugin-pg-$os-$arch .
+done; done
+```
+
+Six binaries, one command, no C toolchain. The pure-Go driver ecosystem
+(`pgx`, `go-sql-driver/mysql`, `mongo-go`, `go-redis`, the AWS SDK,
+`modernc.org/sqlite`) becomes available with `go get`. This is exactly what
+`noxy_dynamodb` and `noxy_terminal` needed.
+
+### 2. wasm (tier A) stays, for pure computation
+
+The wasm mechanism is shipped, costs about 4 MiB and serves its niche:
+compression, regex, hashing, parsers — buffer in, buffer out. What changes:
+the bespoke capability plan (`noxy:cap/random`, `noxy:cap/clock`,
+`noxy:cap/net`, `noxy:cap/fs`; spec §9, phase M2 in §14) is **suspended**.
+I/O goes to tier B. A restricted WASI preview1 grant (clock, random,
+stdout→`nx_log`; no filesystem mount, no sockets) is the candidate answer
+to authoring friction — today standard Go cannot produce a production
+extension, because it only targets `wasip1` and the loader refuses WASI
+(`internal/ext/exttest/exttest.go`). That is its own issue if pursued.
+
+### 3. In-process dynamic libraries (approach C) stay deferred — for the right reasons
+
+Invariant 5 is gone, so the original rejection no longer applies. Approach C
+stays out for three other reasons:
+
+1. **It forfeits the advantage.** A Go plugin becomes a `.so`/`.dll` only
+   through `-buildmode=c-shared`, which requires cgo, which cross-compiled
+   requires a C toolchain per target (mingw for Windows, the Apple SDK for
+   macOS). The author is back to the expensive CI matrix that pure-Go tier B
+   avoids.
+2. **It demands a permanently stable C-API over `Value`.** The layout cannot
+   leak, so the surface would be a handle table with accessor functions,
+   frozen forever because every published `.so` depends on it. NXB is a wire
+   format; `Value` stays free to evolve.
+3. **Its gain only appears where wasm already is.** 50 ns versus ~20 µs
+   matters for hot per-element calls — and hot computation goes to wasm.
+   For I/O, 20 µs is noise.
+
+Reopen on a concrete library that needs the whole OS **and** hot calls that
+cannot be batched. Even then, the first answer may be pointwise (that library
+enters the core in Go) rather than a new mechanism.
+
+## Mechanisms against the revised invariants
+
+| | wasm (A) | process (B) | in-process dylib (C) |
+|---|---|---|---|
+| Cross-platform | one artifact serves all | one binary per OS/arch | one `.so/.dylib/.dll` per OS/arch |
+| Author cross-compiles painlessly | yes | **yes, in Go** (no cgo) | no: Go `c-shared` needs cgo + a C toolchain per target; Rust/C need the Apple SDK for macOS |
+| User never compiles | yes | yes (prebuilt assets) | yes, but costlier for the author to deliver |
+| OS / network / drivers | no (until capabilities) | **full** | full |
+| Per-call cost | ≈4 µs | ≈10–50 µs with NXB framing (50–500 µs with today's JSON) | ≈50 ns |
+| Extension crashes | trap; instance poisoned | process dies; VM survives | VM dies |
+| Coupling to `Value` | none (NXB) | none (NXB) | stable C-API of handles/accessors, forever |
+
+Choose by workload: pure computation → wasm; I/O, OS, drivers, SDKs →
+process plugin; whole OS plus a hot loop → no mechanism for now (core in Go,
+or approach C when the case appears).
+
+## "The user never compiles", end to end
+
+1. **Author**: `main.go` (uses the plugin SDK; imports anything pure-Go),
+   `noxy_ext.toml` with `kind = "process"` and typed `[[export]]` entries,
+   and the `.nx` wrapper. Runs the build matrix above; publishes a tag and a
+   release with the binaries and a `checksums.txt`.
+2. **User**: `noxy --get github.com/you/noxy_pg@v1.2.0`. The package manager
+   clones the repo (manifest + wrapper, as today), reads
+   `kind = "process"`, detects `GOOS/GOARCH`, downloads only the matching
+   asset (`noxy-plugin-<name>-<os>-<arch>[.exe]`) into
+   `noxy_libs/<domain>/<user>/<repo>/bin/`, and records the hashes of
+   **all** published assets in `noxy.sum`, so the committed lockfile is
+   valid for a teammate on macOS and for a Lambda on Linux. No build for the
+   platform is an error at `--get` time, never at runtime; there is no
+   compile-from-source fallback, by design (invariant 4).
+3. **Runtime**: on first call the VM verifies the hash against `noxy.sum`,
+   spawns the process, performs the versioned handshake, and exchanges NXB
+   frames over stdin/stdout.
+
+An author writing in Rust, C or anything else is allowed — the mechanism only
+requires an executable that speaks the protocol — but then the author carries
+the per-platform CI matrix, as in Python. The user still never compiles.
+
+## What this changes elsewhere
+
+- **Wasm spec (2026-08-23)**: amendment notes in §1 (approach C), §9
+  (capabilities suspended; tier B no longer bound to invariant 5), §12
+  (approaches B and C), §14 (M2 suspended), §15 (tier B follow-up now
+  #80 + #110).
+- **Issue #80 (tier B spec)** keeps its technical design — one boundary, two
+  transports; NXB over the pipe; `kind = "process"` in the manifest; a Go
+  SDK. Issue #110 lists the deltas: primary-for-I/O framing; invariant 5
+  as bonus; binaries as release assets, not committed; portable `noxy.sum`;
+  reference extensions are `noxy_terminal` and `noxy_dynamodb`; migration of
+  `sys_load_plugin` removes the compiler's `PluginNativeNames` special case;
+  errors surface as Noxy errors with a per-call timeout; the SDK is a
+  requirement of the first delivery.
+- **User docs** (`docs/EXTENSIONS.md`, `AGENTS.md`): scope note — wasm for
+  computation, process plugins for I/O.
+
+## Related, out of scope here
+
+- **TLS is absent from the core.** `http_client.nx` uses `"https"` only to
+  choose port 443; there is no `crypto/tls` anywhere. The wasm spec §14
+  itself says TLS belongs in the core. Its own issue, with priority above
+  any wasm M2 work.
+- Restricted WASI for wasm authoring; OS-level process sandboxing; a package
+  registry; any change to the wasm ABI v1.


### PR DESCRIPTION
## Summary
- Registra no repositório os invariantes de extensibilidade **revisados pelo autor em 2026-08-28** (issue #110): binário único passa a preferível; cross-compile + "usuário não compila, como no Python" vira o filtro decisivo; cross-plataforma mantido; **invariante 5 ("VM não desestabilizável") derrubado**.
- Documenta a linha do tempo que motivou a revisão (RFC #78 → spec → PR #79 em ~5 h no mesmo dia; invariantes sem rastro anterior; o desenho cobriu só a metade "performance" do problema do RFC — `noxy_dynamodb` e `noxy_terminal` são I/O e o tier A não serve nenhuma).
- Registra a decisão: **tier B (plugin por processo) é o caminho principal para I/O, SO, drivers e SDKs** (Go cross-compila a matriz sem cgo); wasm fica só para computação pura, com o plano de capabilities (M2, `noxy:cap/*`) **suspenso**; approach C (dylib via purego) segue adiada, agora pelo custo de cross-compile (`c-shared` exige cgo) e pela C-API estável sobre `Value`, não pelo invariante 5.
- Emenda a spec wasm de 2026-08-23 **sem reescrever o histórico**: notas `Amended 2026-08-29 (issue #110)` em §1, §9, §12 (abordagens B e C), §14 (M2 suspenso) e §15 (tier B → #80 + #110).
- Nota de escopo nos docs de usuário: wasm para computação, processo para I/O.

## Components
- `docs/superpowers/specs/2026-08-29-extensibility-invariants-revision.md` (novo, 184 linhas) — fonte autoritativa dos invariantes (com as palavras do autor), decisão, tabela mecanismos × invariantes, fluxo "usuário não compila" ponta a ponta, o que muda na spec wasm e na #80, relacionados (TLS ausente no core).
- `docs/superpowers/specs/2026-08-23-wasm-extension-mechanism-design.md` — 6 notas de emenda (+33 linhas, 0 removidas).
- `docs/EXTENSIONS.md` — parágrafo **Scope (issue #110)** após a introdução; texto das capabilities passa de "not implemented yet" para "suspended".
- `AGENTS.md` — parágrafo "Extensões e plugins" ganha a divisão por perfil e o ponteiro para o doc de invariantes.
- Sem mudança de código, sem CHANGELOG (convenção do repo para PRs só de docs, como o #109).

## Related Issues
- Issue #110 (decisão; este PR fecha o item "Spec wasm anotada" da lista "O que fazer").
- Issue #80 (spec do tier B) — os deltas listados na #110 ainda precisam ser incorporados lá.
- RFC #78, PR #79.

## Test Plan
- [x] Diff conferido com `git diff --numstat` (6/1, 9/2, 33/0, 184/0) e `file`: CRLF preservado nos arquivos editados
- [x] Novo doc sem `{{`/`{%` (GitHub Pages renderiza `docs/**/*.md` pelo Liquid)
- [x] 6 notas de emenda presentes na spec wasm (§1, §9, §12×2, §14, §15)
- [ ] Autor revisa a redação dos invariantes revisados (R1–R5) — é a palavra dele que fica registrada
- [ ] Após o merge: atualizar a #80 com os deltas da #110 e abrir a issue do TLS no core
