### PR TITLE
docs(dynamodb): corrigir o import do exemplo — use github_com.estevaofon.noxy_dynamodb.dynamodb (issue #80)

### DIFF
--- a/docs/DYNAMODB.md
+++ b/docs/DYNAMODB.md
@@ -6,7 +6,7 @@ To install follow the instructions presented in the noxy_dynamodb repository:
 ## Usage Example
 
 ```noxy
-use github_com.estevaofon.noxy_dynamodb as dynamodb
+use github_com.estevaofon.noxy_dynamodb.dynamodb as dynamodb
 
 func main() -> void
     // 1. Connect (Uses default AWS credentials)


### PR DESCRIPTION
## Summary
- `docs/DYNAMODB.md` repetia o exemplo do README do `noxy_dynamodb` com `use github_com.estevaofon.noxy_dynamodb as dynamodb`. Como o wrapper do pacote é `dynamodb.nx` dentro de `noxy_dynamodb/`, esse `use` resolve como módulo de diretório (`resolveModule`: sem `noxy_dynamodb.nx`/`main.nx` no diretório) e `dynamodb.connect(...)` falha em runtime. A forma correta hoje é `use github_com.estevaofon.noxy_dynamodb.dynamodb as dynamodb`.
- Docs-only; mesma correção aberta no repo do plugin (README). A migração do plugin para `kind = "process"` (checkbox 6 da #80) vai reescrever esta página inteira.

## Components
- `docs/DYNAMODB.md` — linha do `use`.

## Related Issues
- #80 (checkbox 6, migração do `noxy_dynamodb`)

## Test Plan
- [x] Verificado com `go run ./cmd/noxy` em `develop` (6fe1433) num pacote de teste com o mesmo layout: forma de diretório falha (`undefined property … in module/map`), forma `.dynamodb` funciona.
- [x] Sem `{{`/`{%` (Liquid do Pages); diff de 1 linha (`git diff --numstat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSYynGCX4YehTGrk286DV
