### PR TITLE
fix(ext): exttest.repoRoot acha a raiz pelo cwd — imune a GOFLAGS=-trimpath (issue #80)

### DIFF
--- a/internal/ext/exttest/exttest.go
+++ b/internal/ext/exttest/exttest.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -37,13 +36,30 @@ func isUnsupportedToolchainOutput(output string) bool {
 	return false
 }
 
+// repoRoot sobe a partir do diretorio do pacote em teste (o cwd de todo
+// "go test") ate o go.mod deste modulo. Nao usa runtime.Caller: com
+// GOFLAGS=-trimpath (configuracao de maquina) o caminho gravado no binario
+// e relativo ao modulo ("noxy-vm/...") e o chdir do go build dos guests
+// falhava.
 func repoRoot(tb testing.TB) string {
-	_, self, _, ok := runtime.Caller(0)
-	if !ok {
-		tb.Fatal("exttest: cannot locate caller")
+	tb.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		tb.Fatalf("exttest: getwd: %v", err)
 	}
-	// internal/ext/exttest/exttest.go -> raiz do repo
-	return filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(self))))
+	for {
+		if data, err := os.ReadFile(filepath.Join(dir, "go.mod")); err == nil {
+			first := strings.TrimSpace(strings.SplitN(string(data), "\n", 2)[0])
+			if first == "module noxy-vm" {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			tb.Fatal("exttest: go.mod of module noxy-vm not found above the test directory")
+		}
+		dir = parent
+	}
 }
 
 // BuildGuest compila testdata/guest com os ldflags dados e devolve os bytes

--- a/internal/ext/exttest/exttest_test.go
+++ b/internal/ext/exttest/exttest_test.go
@@ -1,6 +1,30 @@
 package exttest
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot tem de ser absoluto e apontar para o go.mod deste modulo mesmo
+// com GOFLAGS=-trimpath (configuracao de maquina): com runtime.Caller o
+// caminho gravado no binario e relativo ao modulo ("noxy-vm/...") e o chdir
+// do go build dos guests falhava.
+func TestRepoRootFindsModuleRoot(t *testing.T) {
+	root := repoRoot(t)
+	if !filepath.IsAbs(root) {
+		t.Fatalf("repoRoot must be absolute, got %q", root)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		t.Fatalf("go.mod at repoRoot %q: %v", root, err)
+	}
+	first := strings.TrimSpace(strings.SplitN(string(data), "\n", 2)[0])
+	if first != "module noxy-vm" {
+		t.Fatalf("repoRoot %q is not the noxy-vm module (first line %q)", root, first)
+	}
+}
 
 func TestBuildGuestProducesWasm(t *testing.T) {
 	data := BuildGuest(t, "")


### PR DESCRIPTION
## Summary
- `exttest.repoRoot` deixa de usar `runtime.Caller(0)` e passa a subir a partir do cwd do teste (o diretório do pacote, em todo `go test`) até o `go.mod` cujo primeiro linha é `module noxy-vm`. Com `GOFLAGS=-trimpath` (configuração de máquina em `%APPDATA%\go\env`, ausente no CI) o caminho gravado pelo `runtime.Caller` é relativo ao módulo (`noxy-vm/internal/ext/exttest/exttest.go`), `repoRoot` devolvia `noxy-vm` e o `go build` dos guests falhava com `chdir noxy-vm: The system cannot find the file specified` — em `internal/ext` (wasm desde o M1, e agora os testes de processo), `internal/ext/exttest`, `internal/vm` (`TestExtension*`, `TestProcessExtension*`, `TestCloseExtensions*`) e `cmd/noxy` (`TestSysExitClosesProcessExtensions`).
- Mesmo padrão já usado em `cmd/noxy/process_exit_test.go` (`repoRootForTest`) e `internal/vm/architecture_test.go` (walk a partir do cwd). Import `runtime` removido.
- Teste novo `TestRepoRootFindsModuleRoot` (absoluto + `go.mod` de `noxy-vm`): RED com o `-trimpath` da máquina (`repoRoot must be absolute, got "noxy-vm"`), GREEN após a mudança.
- Sem CHANGELOG: helper de teste, sem efeito para o usuário.

## Components
- `internal/ext/exttest/exttest.go` — `repoRoot` (+22/−6)
- `internal/ext/exttest/exttest_test.go` — `TestRepoRootFindsModuleRoot` (+25/−1)

## Related Issues
- #80 (testes de extensão por processo herdaram o helper)

## Test Plan
- [x] RED: `go test ./internal/ext/exttest -run TestRepoRootFindsModuleRoot` falha com o `-trimpath` da máquina pelo motivo esperado
- [x] GREEN com o `-trimpath` da máquina (antes falhavam): `go test ./internal/ext/exttest` (12.9s), `go test ./internal/ext` (14.8s), `go test ./internal/vm -run 'Extension|CloseExtensions'`, `go test ./cmd/noxy -run SysExitClosesProcessExtensions`
- [x] Sanidade sem o flag: `GOFLAGS=-trimpath=false go test ./internal/ext/exttest`
- [x] `go vet ./internal/ext/exttest`
- [x] CI (ubuntu + windows, sem `-trimpath`) verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSYynGCX4YehTGrk286DV
