### PR TITLE
docs(dynamodb): extensão por processo — --get, API v0.2.0 e Lambda sem PATH (issue #80)

### DIFF
--- a/docs/AWS_LAMBDA_LAYER.md
+++ b/docs/AWS_LAMBDA_LAYER.md
@@ -4,7 +4,7 @@ This walkthrough explains how to deploy Noxy as an AWS Lambda Layer and deploy y
 
 ## 1. Build the Layer
 
-Run the layer build script to create `noxy_layer.zip`. This archive contains the Noxy runtime, the `bootstrap` executable, and shared libraries (like DynamoDB).
+Run the layer build script to create `noxy_layer.zip`. This archive contains the Noxy runtime (built for Linux, `GOOS=linux GOARCH=amd64` — or `arm64` for Graviton) and the `bootstrap` executable.
 
 ```bash
 ./build_layer.sh
@@ -22,7 +22,7 @@ Run the layer build script to create `noxy_layer.zip`. This archive contains the
 
 ## 2. Build the Function
 
-Run the function build script to create `function.zip`. This archive contains ONLY your function code (`function.nx`).
+Run the function build script to create `function.zip`. This archive contains your function code (`function.nx`) and, when the function uses packages, its `noxy_libs/` and `noxy.sum` (see [Packages and extensions](#packages-and-extensions-dynamodb) below).
 
 ```bash
 ./build_function.sh
@@ -45,10 +45,40 @@ Run the function build script to create `function.zip`. This archive contains ON
 ## How it Works
 
 -   **Layer (`/opt`)**:
-    -   `/opt/bin`: Noxy interpreter (`noxy`) and Plugins (`noxy-plugin-dynamodb`).
+    -   `/opt/bin`: the Noxy interpreter (`noxy`).
     -   `/opt/bootstrap`: The entry point script.
     -   `/opt/runtime`: The Noxy runtime loop scripts (`exec_runtime.nx`, `runtime.nx`).
 -   **Function (`/var/task`)**:
-    -   Contains only your `function.nx`.
+    -   Your `function.nx`, plus `noxy_libs/` and `noxy.sum` when it uses packages.
 
-The `bootstrap` script ensures `/opt/bin` is in the `PATH`, allowing Noxy to find plugins automatically. It also sets `NOXY_PATH` so the runtime module can be found.
+The `bootstrap` script sets `NOXY_PATH` so the runtime module can be found. Nothing else goes on `PATH`: extensions are not looked up there (see below).
+
+## Packages and extensions (DynamoDB)
+
+Since v0.23.0, [`noxy_dynamodb`](DYNAMODB.md) is a process extension: a package directory holding the manifest, the wrapper and a per-platform binary under `bin/`, which the VM starts itself on the first call — it does **not** search `PATH` for plugins. The package is found by the module resolver like any other package, and its binary is verified against `noxy.sum` when the package lives under the VM root's `noxy_libs/`. The VM root is the directory of the script `noxy` was started with (`/var/task` when `bootstrap` runs the function script directly; `/opt/runtime` when it runs the runtime loop script, which then imports the function).
+
+Two layouts work:
+
+1. **Verified — under the root's `noxy_libs/`.** Ship the package as `noxy --get` installs it, next to the root's `noxy.sum`:
+
+   ```
+   <root>/noxy.sum
+   <root>/noxy_libs/github_com/estevaofon/noxy_dynamodb/
+   ├── noxy_ext.toml
+   ├── noxy_dynamodb.nx
+   └── bin/noxy-plugin-dynamodb-linux-amd64        # executable; -linux-arm64 on Graviton
+   ```
+
+   `noxy --get github.com/estevaofon/noxy_dynamodb@v0.2.0` on any workstation records the hashes of **all** published binaries in `noxy.sum`, so a `noxy.sum` generated on Windows or macOS verifies the Linux binary the Lambda runs. `--get` only downloads the workstation's own binary, though: fetch the Lambda's from the release page into `bin/` before zipping:
+
+   ```bash
+   curl -L -o noxy_libs/github_com/estevaofon/noxy_dynamodb/bin/noxy-plugin-dynamodb-linux-amd64 \
+     https://github.com/estevaofon/noxy_dynamodb/releases/download/v0.2.0/noxy-plugin-dynamodb-linux-amd64
+   chmod +x noxy_libs/github_com/estevaofon/noxy_dynamodb/bin/noxy-plugin-dynamodb-linux-amd64
+   ```
+
+   The execute bit must survive the zip (build the archive on Linux, or in a Linux step of your pipeline), and the binary's architecture must match the function's (`x86_64` → `linux-amd64`, `arm64` → `linux-arm64`).
+
+2. **Unverified — in a `NOXY_PATH` root.** Put the same package directory under a root listed in `NOXY_PATH` (for example `/opt/noxy_libs/github_com/estevaofon/noxy_dynamodb/` in the layer, with `NOXY_PATH=/opt/noxy_libs:/opt/runtime` in `bootstrap`). The resolver finds it, but `noxy.sum` is not consulted outside the root's `noxy_libs/` — a development layout, convenient for a shared layer, without the integrity check.
+
+Credentials come from the function's execution role through the default AWS chain; `capabilities = ["net", "env"]` in the manifest is exactly that. Give the role `dynamodb:*` permissions on the tables the function touches.

--- a/docs/AWS_LAMBDA_LAYER.md
+++ b/docs/AWS_LAMBDA_LAYER.md
@@ -69,11 +69,11 @@ Two layouts work:
    └── bin/noxy-plugin-dynamodb-linux-amd64        # executable; -linux-arm64 on Graviton
    ```
 
-   `noxy --get github.com/estevaofon/noxy_dynamodb@v0.2.0` on any workstation records the hashes of **all** published binaries in `noxy.sum`, so a `noxy.sum` generated on Windows or macOS verifies the Linux binary the Lambda runs. `--get` only downloads the workstation's own binary, though: fetch the Lambda's from the release page into `bin/` before zipping:
+   `noxy --get github.com/estevaofon/noxy_dynamodb@v0.3.0` on any workstation records the hashes of **all** published binaries in `noxy.sum`, so a `noxy.sum` generated on Windows or macOS verifies the Linux binary the Lambda runs. `--get` only downloads the workstation's own binary, though: fetch the Lambda's from the release page into `bin/` before zipping:
 
    ```bash
    curl -L -o noxy_libs/github_com/estevaofon/noxy_dynamodb/bin/noxy-plugin-dynamodb-linux-amd64 \
-     https://github.com/estevaofon/noxy_dynamodb/releases/download/v0.2.0/noxy-plugin-dynamodb-linux-amd64
+     https://github.com/estevaofon/noxy_dynamodb/releases/download/v0.3.0/noxy-plugin-dynamodb-linux-amd64
    chmod +x noxy_libs/github_com/estevaofon/noxy_dynamodb/bin/noxy-plugin-dynamodb-linux-amd64
    ```
 

--- a/docs/DYNAMODB.md
+++ b/docs/DYNAMODB.md
@@ -9,7 +9,7 @@ No Go toolchain, no build step. Requires Noxy **0.23.0** or newer.
 ## Installation
 
 ```bash
-noxy --get github.com/estevaofon/noxy_dynamodb@v0.2.0
+noxy --get github.com/estevaofon/noxy_dynamodb@v0.3.0
 ```
 
 Without `@version`, `--get` resolves the newest release tag. The package
@@ -52,8 +52,8 @@ func main() -> void
         print(f"Found user: {found['name']}")
     end
 
-    // 4. Scan and query return every matching item, all pages
-    let users: map[string, any][] = dynamodb.scan(client, "Users")
+    // 4. Scan and query take a limit; page through big tables with scan_page
+    let users: map[string, any][] = dynamodb.scan(client, "Users", 100)
     print(f"{length(users)} user(s)")
 
     dynamodb.close(client)
@@ -72,8 +72,16 @@ main()
 | `get_item(client, table, key)` | `map[string, any]?` (`null` when missing) | raises |
 | `update_item(client, table, key, update_expression, expression_values)` | `bool` | `false` |
 | `delete_item(client, table, key)` | `bool` | `false` |
-| `scan(client, table)` | `map[string, any][]` | raises |
-| `query(client, table, key_condition, expression_values)` | `map[string, any][]` | raises |
+| `scan(client, table, limit)` | `map[string, any][]` — up to `limit` items | raises |
+| `scan_page(client, table, limit, start_key)` | `Page{items, last_key: map[string, any]?}` — one request | raises |
+| `query(client, table, key_condition, expression_values, limit)` | `map[string, any][]` — up to `limit` items | raises |
+| `query_page(client, table, key_condition, expression_values, limit, start_key)` | `Page` — one request | raises |
+
+`scan` and `query` follow pagination only as far as `limit` requires and ask
+DynamoDB for no more than the remainder per request; `limit = 0` means every
+item (opt-in — on a large table that runs until the 60 s call deadline). To
+walk a big table in pieces, loop on `scan_page` / `query_page`, passing
+`page.last_key` back as `start_key` until it is `null`.
 
 Failures are the extension's runtime errors — `extension 'dynamodb' failed:
 <message from AWS>` — capturable with `call_result` (`use errors select *`).

--- a/docs/DYNAMODB.md
+++ b/docs/DYNAMODB.md
@@ -1,36 +1,93 @@
-# DynamoDB Plugin for Noxy
+# DynamoDB for Noxy
 
-To install follow the instructions presented in the noxy_dynamodb repository:
-[https://github.com/estevaofon/noxy_dynamodb](https://github.com/estevaofon/noxy_dynamodb)
+[`noxy_dynamodb`](https://github.com/estevaofon/noxy_dynamodb) is a DynamoDB
+client packaged as a **process extension** (`kind = "process"`, see
+[docs/EXTENSIONS.md](EXTENSIONS.md)): `noxy --get` downloads a prebuilt
+binary for your platform, verifies it, and records its hash in `noxy.sum`.
+No Go toolchain, no build step. Requires Noxy **0.23.0** or newer.
 
-## Usage Example
+## Installation
+
+```bash
+noxy --get github.com/estevaofon/noxy_dynamodb@v0.2.0
+```
+
+Without `@version`, `--get` resolves the newest release tag. The package
+lands in `noxy_libs/github_com/estevaofon/noxy_dynamodb/`:
+
+```
+noxy_libs/github_com/estevaofon/noxy_dynamodb/
+├── noxy_ext.toml                                  # kind = "process"
+├── noxy_dynamodb.nx                               # typed wrapper
+└── bin/noxy-plugin-dynamodb-windows-amd64.exe     # this platform's binary
+```
+
+`noxy.sum` gets one line for the manifest plus one per published binary
+(linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64,
+windows/arm64) — commit it: the same lockfile verifies a teammate's macOS
+download and a Lambda's Linux binary.
+
+## Usage example
 
 ```noxy
-use github_com.estevaofon.noxy_dynamodb.dynamodb as dynamodb
+use github_com.estevaofon.noxy_dynamodb as dynamodb
 
 func main() -> void
-    // 1. Connect (Uses default AWS credentials)
+    // 1. Connect — credentials and region come from the environment
     let client: dynamodb.Client = dynamodb.connect({"region": "us-east-1"})
 
-    // 2. Put Item
+    // 2. Put item
     let item: map[string, any] = {
         "id": "user_123",
         "name": "Estevao",
         "email": "estevao@example.com"
     }
-    
     if dynamodb.put_item(client, "Users", item) then
         print("Item saved successfully!")
     end
 
-    // 3. Get Item
-    let key: map[string, any] = {"id": "user_123"}
-    let result: map[string, any] = dynamodb.get_item(client, "Users", key)
-    
-    if result != null then
-        print(f"Found user: {result['name']}")
+    // 3. Get item — null when the key does not exist
+    let found: map[string, any]? = dynamodb.get_item(client, "Users", {"id": "user_123"})
+    if found != null then
+        print(f"Found user: {found['name']}")
     end
+
+    // 4. Scan and query return every matching item, all pages
+    let users: map[string, any][] = dynamodb.scan(client, "Users")
+    print(f"{length(users)} user(s)")
+
+    dynamodb.close(client)
 end
 
 main()
 ```
+
+## API
+
+| Function | Returns | On failure |
+|---|---|---|
+| `connect(options: map[string, any])` | `Client` | raises |
+| `close(client: Client)` | `void` | raises |
+| `put_item(client, table, item)` | `bool` | `false` |
+| `get_item(client, table, key)` | `map[string, any]?` (`null` when missing) | raises |
+| `update_item(client, table, key, update_expression, expression_values)` | `bool` | `false` |
+| `delete_item(client, table, key)` | `bool` | `false` |
+| `scan(client, table)` | `map[string, any][]` | raises |
+| `query(client, table, key_condition, expression_values)` | `map[string, any][]` | raises |
+
+Failures are the extension's runtime errors — `extension 'dynamodb' failed:
+<message from AWS>` — capturable with `call_result` (`use errors select *`).
+A dead plugin process surfaces as `extension 'dynamodb' trapped: ...` and
+poisons the extension for the rest of the program. Each call has a 60 s
+deadline. Numbers come back as `float`; structs go in as maps of their
+fields. Connect options: `"region"` (else `AWS_REGION` / shared config, else
+`us-east-1`), `"endpoint"` (DynamoDB Local) and `"profile"`. Full reference,
+type mapping and the migration notes from v0.1.x: the
+[repository README](https://github.com/estevaofon/noxy_dynamodb#readme).
+
+## AWS Lambda
+
+Deploy the installed package directory — with the Linux binary in `bin/`
+and the execute bit — next to your `noxy.mod` and `noxy.sum`. The VM
+verifies the binary against `noxy.sum` before starting it; nothing goes on
+`PATH`. See [docs/AWS_LAMBDA_LAYER.md](AWS_LAMBDA_LAYER.md).


### PR DESCRIPTION
## Summary
- `docs/DYNAMODB.md` reescrito para a `noxy_dynamodb` v0.3.0 como extensão por processo: instalação com `noxy --get github.com/estevaofon/noxy_dynamodb@v0.3.0` (sem Go), layout do pacote (`bin/` + `noxy.sum` com os hashes dos 6 binários), exemplo com `use github_com.estevaofon.noxy_dynamodb as dynamodb` (wrapper renomeado para `noxy_dynamodb.nx`), tabela da API (`Client{handle: int}`, `connect` levanta erro, `get_item -> map[string, any]?`, `scan`/`query -> map[string, any][]` com `limit` (0 = tudo), `scan_page`/`query_page -> Page{items, last_key}` para tabelas grandes, `close`), erros `failed`/`trapped` e opções de `connect` (`region`, `endpoint`, `profile`).
- `docs/AWS_LAMBDA_LAYER.md`: nenhum plugin no `PATH` — o pacote vai em `noxy_libs/github_com/estevaofon/noxy_dynamodb/` com `bin/noxy-plugin-dynamodb-linux-{amd64,arm64}` executável e `noxy.sum` (verificado, raiz da VM = diretório do script inicial), ou num root do `NOXY_PATH` (sem verificação); download do asset Linux a partir da release; bit de execução e arquitetura (Graviton → `linux-arm64`).
- Checkbox 6 da #80 marcado: `noxy_dynamodb` migrada e validada em Windows e Linux.
- Docs-only, sem entrada no CHANGELOG (como a #115).

## Components
- `docs/DYNAMODB.md`
- `docs/AWS_LAMBDA_LAYER.md`
- Externo (já publicado): https://github.com/estevaofon/noxy_dynamodb tags `v0.2.0` e `v0.3.0` (limit + páginas) — releases com os 6 binários + `checksums.txt` gerados pelo workflow do template do SDK; depende de `sdk/noxyplugin/v0.1.0` e da release `v0.23.0` do noxy (ambas em `6fe1433`).

## Related Issues
- Issue #80 (checkbox 6)

## Test Plan
- [x] `noxy --get github.com/estevaofon/noxy_dynamodb@v0.3.0` em projeto limpo no Windows: `bin/noxy-plugin-dynamodb-windows-amd64.exe` com sha256 igual ao `checksums.txt` + `noxy.sum` com 7 linhas
- [x] `noxy --get github.com/estevaofon/noxy_dynamodb` (sem versão) no Linux (WSL, noxy v0.23.0): resolve a tag mais nova, `bin/noxy-plugin-dynamodb-linux-amd64` 0755 + `noxy.sum` com 7 linhas, `dynamodb declares: net, env`
- [x] Fumaça contra tabela real nas duas plataformas (put/get/update/delete/scan/query, `null` em `get_item`, tipos int/float/bool/array/map/null, `connect({})` pela cadeia padrão, dois handles), sem aviso TOFU
- [x] Tabela inexistente → `extension 'dynamodb' failed: … ResourceNotFoundException`; handle fechado → `failed`; opção desconhecida → `failed`; processo morto → `poisoned by an earlier trap`
- [ ] Deploy real no Lambda com o layout documentado (não exercitado nesta PR)

- [x] v0.3.0: `scan(limit)` para ao juntar `limit` itens (Limit por requisição = restante), `limit = 0` = tudo, negativo → `failed`; laço `scan_page` (5 itens em 3 páginas de 2, `last_key == null` no fim), `query_page`; validado no Windows e no Linux
