### PR TITLE
fix(compiler): any aceito em return/argumento com guarda de runtime; builtins puros não encerram narrowing; diagnóstico do fato perdido (issue #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — Guia para agentes de IA no Noxy VM
 
 Máquina virtual de bytecode para a linguagem Noxy, em Go (módulo `noxy-vm`,
-Go 1.25). Versão corrente: `v0.23.0` (`internal/version/version.go`).
+Go 1.25). Versão corrente: `v0.23.1` (`internal/version/version.go`).
 
 **Fonte da verdade da linguagem: `docs/NOXY_LANGUAGE_SPEC.md`.** Regra de
 linguagem vem da spec ou de teste no binário — nunca de um exemplo. Este
@@ -176,4 +176,4 @@ hashes de todos em `noxy.sum`. Ver `docs/EXTENSIONS.md` e
 
 ---
 
-**Versão**: 1.2 (Noxy VM 0.23.0) — atualizado em 2026-08-29
+**Versão**: 1.2 (Noxy VM 0.23.1) — atualizado em 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ um global).
   `let x: int = nativo()` com `nativo() -> any` devolvendo `"texto"` rodava
   e deixava uma string em `x`; agora é erro de runtime `expected int, got
   string`. Compostos (array/map/chan) já eram checados. Código tipado não
-  paga nada: a guarda só é emitida onde o tipo estático é `any` ou
-  desconhecido.
+  paga nada: a guarda só é emitida onde o tipo estático é `any`. Tipo
+  estático **desconhecido** (nativo sem assinatura, membro de namespace)
+  segue sem guarda, como antes — ver follow-ups.
 - **Builtins centrais não encerram narrowing.** `print`, `to_str`, `length`,
   `fmt`, `keys`, `slice`, `range` e os demais da spec §10, quando não
   sombreados, são nativos puros que nunca rodam código Noxy — o fato
@@ -36,7 +37,8 @@ um global).
   between the test and this use` + `hint: test it again after the call, bind
   it first ('let v = m' before the 'if') and use 'v', or move the code into a
   function` (raiz `ref`, capturada, upvalue ou endereçada tem a frase
-  própria).
+  própria; fato derrubado na entrada de um laço diz `the loop body calls a
+  function that can run before this use`).
 - A marcação de runtime que falha (`OP_MARK_RUNTIME_VALUE_TYPE`) nomeia os
   dois tipos — `expected chan int, got chan string`, `expected int[4], got
   int[]`, `expected Envelope, got map` — no lugar de `runtime value metadata
@@ -49,7 +51,12 @@ um global).
 
 Follow-ups: atribuição (`x = v`, `s.f = v`, `xs[i] = v`) ainda não emite a
 guarda para primitivos vindos de `any` — três sub-caminhos com regras de
-`ref` próprias; simplificar o wrapper `noxy_dynamodb.nx` (outro repo).
+`ref` próprias. Tipo estático desconhecido ficou fora da guarda de
+propósito: a revisão achou wrappers da stdlib que devolvem `null` num
+`-> T` (`time.parse`, `time.parse_date`, `time.from_timestamp`,
+`sqlite.prepare`, …) — estender a guarda a nativos sem assinatura exige
+antes corrigir esses contratos (`T?` + migração). Simplificar o wrapper
+`noxy_dynamodb.nx` (outro repo).
 
 ## [0.23.0] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,27 @@ um global).
   compilava e falhava em runtime — `toca()` roda depois do teste e pode zerar
   `m`. O fato de raiz compartilhada não sai mais para o ramo (`if`, `while`,
   `else` de `||`); diagnóstico `a call in the condition ran after the test` +
-  hint `put the call before the test ('toca() && m != null')`. Dentro da
+  hint `put the call before the test ('toca(...) && m != null')`. Dentro da
   expressão nada muda (`dropAfterCall` já derrubava); local de valor e builtin
   puro seguem mantendo o fato.
+- **Revisão do PR #119** (achados confirmados por execução):
+  - `any` atravessa a fronteira só no **topo** do tipo: `ref any` não é
+    `ref int` (`bump(ref a)` com `a: any` volta a ser `expected ref int, got
+    ref any`), `any[]` não é `int[]`, `map[string, any]` não é
+    `map[string, int]` — elementos e alvo de `ref` são invariantes, como em
+    develop.
+  - A guarda tem um único ponto de emissão (`emitSlotGuards`), que cobre os
+    três sites que ficaram de fora: `*r = v`, `xs[i] = v` no caminho fundido
+    de local, e o valor de `append(ref xs, v)` (também a chave de `delete` e o
+    texto de `json_loads`).
+  - Narrowing: classificar a raiz não captura mais nada (`resolveUpvalue`
+    mutava — uma chave morta `p` capturava o `p` do pai); fato de local morre
+    com o escopo; `let print = …` dentro do laço torna a chamada homônima
+    impura já na entrada do laço; construtor de struct é puro; `eprint`,
+    `iprint`, `eiprint`, `append`, `pop`, `delete` entram no conjunto puro
+    (`json_loads` não: escreve através do `ref` e pode pôr `null` na raiz);
+    o registro do fato perdido na condição fica nos ramos do `if` (e depois
+    dele), não vaza para fora.
 - **Builtins centrais não encerram narrowing.** `print`, `to_str`, `length`,
   `fmt`, `keys`, `slice`, `range` e os demais da spec §10, quando não
   sombreados, são nativos puros que nunca rodam código Noxy — o fato

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [0.23.1] - 2026-08-29
+
+Issue #118 — dois atritos do wrapper de extensão (`noxy_dynamodb`): uma
+escolha de design da 0.7.0 que ficou obsoleta (`any` só entrava por `let`
+anotado) e uma lacuna de implementação (a f-string encerrava o narrowing de
+um global).
+
+### Changed
+- **`any` entra num slot tipado em qualquer posição** — `let` anotado,
+  argumento de assinatura exata e `return` — e o runtime confere o valor ali:
+  `expected int, got string`, `expected map[string, any][], got int[]`. Antes
+  só o `let` aceitava (`return nativo()` e `f(nativo())` eram `expected T,
+  got any`) e o wrapper precisava de um `let` temporário por função; agora
+  `func scan(...) -> map[string, any][]` pode `return dynamodb_scan(...)`
+  direto. A exceção continua o callable exato: `any` nunca vira
+  `func(int) -> int` (nem tipo que o contenha).
+- **A guarda do `let` anotado passou a valer para primitivos e structs.**
+  `let x: int = nativo()` com `nativo() -> any` devolvendo `"texto"` rodava
+  e deixava uma string em `x`; agora é erro de runtime `expected int, got
+  string`. Compostos (array/map/chan) já eram checados. Código tipado não
+  paga nada: a guarda só é emitida onde o tipo estático é `any` ou
+  desconhecido.
+- **Builtins centrais não encerram narrowing.** `print`, `to_str`, `length`,
+  `fmt`, `keys`, `slice`, `range` e os demais da spec §10, quando não
+  sombreados, são nativos puros que nunca rodam código Noxy — o fato
+  `m != null` de um global sobrevive a eles, inclusive na entrada de laço.
+  Em particular `f"{m['a']} {m['b']}"` (duas chamadas a `to_str` geradas
+  pelo parser) e `print(m["a"])` seguido de `print(m["b"])` compilam com `m`
+  global. Chamada a função do programa, `call_result`, `spawn_task`,
+  `task_await` e `func` bare continuam encerrando.
+- **Diagnóstico do fato perdido.** Ler um `T?` cujo fato foi derrubado por
+  uma chamada diz o porquê, em vez de sugerir o `if` que já está ali:
+  `'m' may be null: it was tested, but 'm' is a global and a call came
+  between the test and this use` + `hint: test it again after the call, bind
+  it first ('let v = m' before the 'if') and use 'v', or move the code into a
+  function` (raiz `ref`, capturada, upvalue ou endereçada tem a frase
+  própria).
+- A marcação de runtime que falha (`OP_MARK_RUNTIME_VALUE_TYPE`) nomeia os
+  dois tipos — `expected chan int, got chan string`, `expected int[4], got
+  int[]`, `expected Envelope, got map` — no lugar de `runtime value metadata
+  conflicts with static context`.
+
+### Docs
+- Spec §2.4 (builtins puros, diagnóstico, código em nível de arquivo), §4.2
+  (fronteira `any` checada em toda posição, wrapper sem `let` temporário),
+  §9 (f-string é `to_str`), §10.
+
+Follow-ups: atribuição (`x = v`, `s.f = v`, `xs[i] = v`) ainda não emite a
+guarda para primitivos vindos de `any` — três sub-caminhos com regras de
+`ref` próprias; simplificar o wrapper `noxy_dynamodb.nx` (outro repo).
+
 ## [0.23.0] - 2026-08-29
 
 Extensões por processo (tier B) como meio principal de I/O — issue #80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,16 @@ um global).
   `let x: int = nativo()` com `nativo() -> any` devolvendo `"texto"` rodava
   e deixava uma string em `x`; agora é erro de runtime `expected int, got
   string`. Compostos (array/map/chan) já eram checados. Código tipado não
-  paga nada: a guarda só é emitida onde o tipo estático é `any` ou
-  desconhecido.
+  paga nada: a guarda só é emitida onde o tipo estático é `any`. Tipo
+  estático **desconhecido** (nativo sem assinatura, membro de namespace
+  `m.f()`, plugin) segue sem guarda, como antes: ligar a guarda ali custava
+  +35–55 % por chamada de wrapper da stdlib e expunha nulls de crypto/net
+  que ninguém auditou — ver follow-ups.
 - **Atribuição também tem a guarda** (#120 item 2): `x = v`, `s.f = v`,
-  `xs[i] = v`, `m[k] = v`, upvalue e global com `v` de tipo `any` ou
-  desconhecido → `expected int, got string` em runtime. Um `int[]` escrito
-  via `any` num elemento `int` é recusado antes da escrita (antes caía no
-  caminho genérico do NORC).
-- **Tipo estático desconhecido entra na guarda** (nativo sem assinatura,
-  membro de namespace `m.f()`, plugin): a spec §4.2 sempre prometeu a
-  checagem. `let stmt: sqlite.Statement = sqlite.prepare(db, sql)` com SQL
-  inválido para em `expected Statement, got null` + hint na fronteira, em vez
-  de falhar depois.
+  `xs[i] = v`, `m[k] = v`, upvalue e global com `v` de tipo `any` →
+  `expected int, got string` em runtime. Um `int[]` escrito via `any` num
+  elemento `int` é recusado antes da escrita (antes caía no caminho genérico
+  do NORC).
 - **Contratos da stdlib (BREAKING, #120 item 1)**: `time.parse` e
   `time.parse_date` → `DateTime?`; `sqlite.prepare` → `Statement?`. Auditoria
   cruzando todos os wrappers `-> T` com os `return null` dos nativos: eram os
@@ -39,9 +37,10 @@ um global).
   de argumento, inalcançável pelo wrapper tipado). Migração: com `use m
   select …`, `let dt: DateTime = parse(s)` vira `expected DateTime, got
   DateTime?` — escreva `let dt = parse(s)` e teste `if dt != null then`;
-  pela forma `m.f()` nada muda na compilação, mas null num slot `T` é erro de
-  runtime na fronteira (item acima). `time_demo.nx` e `sqlite_showcase.nx`
-  migrados.
+  pela forma `m.f()` (membro de namespace, sem tipo estático) nada muda:
+  compila e o null segue chegando ao slot como antes — o contrato de retorno
+  dos natives é follow-up. `time_demo.nx`, `sqlite_showcase.nx` e
+  `defer_lifo.nx` migrados.
 - **`&&`/`||` com chamada no operando direito** (#120 item 3, pré-existente
   desde 0.22.0): `if m != null && toca() then m["k"] end` com `m` global
   compilava e falhava em runtime — `toca()` roda depois do teste e pode zerar
@@ -55,7 +54,14 @@ um global).
     `ref int` (`bump(ref a)` com `a: any` volta a ser `expected ref int, got
     ref any`), `any[]` não é `int[]`, `map[string, any]` não é
     `map[string, int]` — elementos e alvo de `ref` são invariantes, como em
-    develop.
+    develop. E um `any` que carrega referência (R2) continua entrando em
+    `ref T` (R5: fronteira dinâmica, modo validado em runtime), mas agora o
+    **alvo** é conferido também: `inc(a)` com `a` guardando `ref string` →
+    `function 'inc' argument 1: expected ref int, got ref string`
+    (`validateRefTargets`, só no caminho `OP_CALL` de modo não provado —
+    código tipado não paga); `let r: ref int = a` / `return a` →
+    `expected ref int, got ref string` pela guarda do slot. Em 0.23.0 os três
+    liam a string como int em silêncio. Alvo `null` segue encaminhado.
   - A guarda tem um único ponto de emissão (`emitSlotGuards`), que cobre os
     três sites que ficaram de fora: `*r = v`, `xs[i] = v` no caminho fundido
     de local, e o valor de `append(ref xs, v)` (também a chave de `delete` e o
@@ -94,7 +100,10 @@ um global).
   (fronteira `any` checada em toda posição, wrapper sem `let` temporário),
   §9 (f-string é `to_str`), §10.
 
-Follow-up: simplificar o wrapper `noxy_dynamodb.nx` (outro repo) removendo
+Follow-ups: #121 (natives que devolvem `null` como dado sob wrapper `-> T` —
+crypto/net — `T?` ou erro tipado); #122 (contrato de retorno dos natives +
+fast path no `OP_MARK`, para religar a guarda em tipo desconhecido sem custo
+por chamada); simplificar o wrapper `noxy_dynamodb.nx` (outro repo) removendo
 os `let` temporários.
 
 ## [0.23.0] - 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,36 @@ um global).
   `let x: int = nativo()` com `nativo() -> any` devolvendo `"texto"` rodava
   e deixava uma string em `x`; agora é erro de runtime `expected int, got
   string`. Compostos (array/map/chan) já eram checados. Código tipado não
-  paga nada: a guarda só é emitida onde o tipo estático é `any`. Tipo
-  estático **desconhecido** (nativo sem assinatura, membro de namespace)
-  segue sem guarda, como antes — ver follow-ups.
+  paga nada: a guarda só é emitida onde o tipo estático é `any` ou
+  desconhecido.
+- **Atribuição também tem a guarda** (#120 item 2): `x = v`, `s.f = v`,
+  `xs[i] = v`, `m[k] = v`, upvalue e global com `v` de tipo `any` ou
+  desconhecido → `expected int, got string` em runtime. Um `int[]` escrito
+  via `any` num elemento `int` é recusado antes da escrita (antes caía no
+  caminho genérico do NORC).
+- **Tipo estático desconhecido entra na guarda** (nativo sem assinatura,
+  membro de namespace `m.f()`, plugin): a spec §4.2 sempre prometeu a
+  checagem. `let stmt: sqlite.Statement = sqlite.prepare(db, sql)` com SQL
+  inválido para em `expected Statement, got null` + hint na fronteira, em vez
+  de falhar depois.
+- **Contratos da stdlib (BREAKING, #120 item 1)**: `time.parse` e
+  `time.parse_date` → `DateTime?`; `sqlite.prepare` → `Statement?`. Auditoria
+  cruzando todos os wrappers `-> T` com os `return null` dos nativos: eram os
+  únicos três com null como resultado de dado (os demais nulls são validação
+  de argumento, inalcançável pelo wrapper tipado). Migração: com `use m
+  select …`, `let dt: DateTime = parse(s)` vira `expected DateTime, got
+  DateTime?` — escreva `let dt = parse(s)` e teste `if dt != null then`;
+  pela forma `m.f()` nada muda na compilação, mas null num slot `T` é erro de
+  runtime na fronteira (item acima). `time_demo.nx` e `sqlite_showcase.nx`
+  migrados.
+- **`&&`/`||` com chamada no operando direito** (#120 item 3, pré-existente
+  desde 0.22.0): `if m != null && toca() then m["k"] end` com `m` global
+  compilava e falhava em runtime — `toca()` roda depois do teste e pode zerar
+  `m`. O fato de raiz compartilhada não sai mais para o ramo (`if`, `while`,
+  `else` de `||`); diagnóstico `a call in the condition ran after the test` +
+  hint `put the call before the test ('toca() && m != null')`. Dentro da
+  expressão nada muda (`dropAfterCall` já derrubava); local de valor e builtin
+  puro seguem mantendo o fato.
 - **Builtins centrais não encerram narrowing.** `print`, `to_str`, `length`,
   `fmt`, `keys`, `slice`, `range` e os demais da spec §10, quando não
   sombreados, são nativos puros que nunca rodam código Noxy — o fato
@@ -49,14 +76,8 @@ um global).
   (fronteira `any` checada em toda posição, wrapper sem `let` temporário),
   §9 (f-string é `to_str`), §10.
 
-Follow-ups: atribuição (`x = v`, `s.f = v`, `xs[i] = v`) ainda não emite a
-guarda para primitivos vindos de `any` — três sub-caminhos com regras de
-`ref` próprias. Tipo estático desconhecido ficou fora da guarda de
-propósito: a revisão achou wrappers da stdlib que devolvem `null` num
-`-> T` (`time.parse`, `time.parse_date`, `time.from_timestamp`,
-`sqlite.prepare`, …) — estender a guarda a nativos sem assinatura exige
-antes corrigir esses contratos (`T?` + migração). Simplificar o wrapper
-`noxy_dynamodb.nx` (outro repo).
+Follow-up: simplificar o wrapper `noxy_dynamodb.nx` (outro repo) removendo
+os `let` temporários.
 
 ## [0.23.0] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.23.0](https://img.shields.io/badge/noxy-0.23.0-blue)](CHANGELOG.md)
+[![noxy 0.23.1](https://img.shields.io/badge/noxy-0.23.1-blue)](CHANGELOG.md)
 
 # Noxy
 
@@ -222,7 +222,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.23.0
+Noxy REPL v0.23.1
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -621,16 +621,33 @@ on an `errors.Result<T>` (which narrows `r.value`, §7). A `ref x` taken on a
 narrowed `x: T?` is a `ref T`.
 
 **What ends a narrowing.** An assignment to the expression or to a prefix of
-its path (`p = q`, `no = …` for `no.prox`); any call, for a path whose root
+its path (`p = q`, `no = …` for `no.prox`); a call, for a path whose root
 is a `ref`-typed variable, a global, an upvalue, a captured local or a local
 whose address was taken with `ref` — someone else may reach it during the
 call; a write through a reference (`*r = v`, `r.f = v`), which drops every
 member-path fact; and entering a loop whose body assigns the root. A path
 rooted at a plain value local survives calls: value semantics (§2.2)
-guarantee nobody outside the frame can reach it. When a fact is lost, test
-again or bind first (`let n = no.prox` then `if n != null then … end`).
-Facts never survive into a different function: a closure body starts with
-none.
+guarantee nobody outside the frame can reach it.
+
+A call to a core builtin (§10: `print`, `to_str`, `length`, `fmt`, `keys`,
+`slice`, `range`, …) that the program has not shadowed ends **no**
+narrowing: those natives never run Noxy code, so nothing can reach the root
+during the call. That is why `f"{m['a']} {m['b']}"` (two `to_str` calls,
+§9) and `print(m["a"])` followed by `print(m["b"])` keep a global `m`
+narrowed, and a loop whose body only calls them keeps the fact too. A call
+to a program function, `call_result`, `spawn_task`, `task_await` or a bare
+`func` does run program code and ends it.
+
+When a fact is lost, test again or bind first (`let n = no.prox` then `if n
+!= null then … end`). The diagnostic says which happened: a read after the
+fact was dropped by a call reports `'m' may be null: it was tested, but 'm'
+is a global and a call came between the test and this use`, with the fix in
+the hint (`test it again after the call, bind it first ('let v = m' before
+the 'if') and use 'v', or move the code into a function`). A top-level `let`
+is a global, so file-level code loses its facts at every call to a program
+function; inside a `func main()` the same binding is a value local and
+survives them. Facts never survive into a different function: a closure body
+starts with none.
 
 **Generics and modules.** A type parameter `T` may bind a nullable type
 (`first(ps)` with `ps: Node?[]` returns `Node?`); it still cannot bind a
@@ -887,7 +904,7 @@ let dynamic: func = exact       // exact-to-dynamic widening is valid
 let exact_again: func(int) -> int = dynamic // ERROR: no implicit narrowing
 ```
 
-Calls through bare `func` are checked by the runtime because their arity and result type are not statically known. Their compile-time result is `any`, so a function returning their result must either declare `any` or replace the bare callable with an exact signature. Explicit `ref` arguments remain references across this dynamic boundary. This keeps dynamic callbacks, decorators, handlers, and heterogeneous callable collections available without pretending their results are statically known:
+Calls through bare `func` are checked by the runtime because their arity and result type are not statically known. Their compile-time result is `any`, which crosses into a typed slot under the runtime check described at the end of this section — a function returning their result may declare the concrete type, or `any`. Explicit `ref` arguments remain references across this dynamic boundary. This keeps dynamic callbacks, decorators, handlers, and heterogeneous callable collections available without pretending their results are statically known:
 
 ```noxy
 let callbacks: func[] = [no_arguments, two_arguments]
@@ -905,6 +922,30 @@ let factory: func(int) -> int[] = make_list   // one function returning int[]
 ```
 
 Exact function types may also appear in parameters, returns, struct fields, map values, channels, and references. `any`, native functions, plugins, and untyped module exports remain dynamic boundaries and retain runtime validation; an unknown native value cannot be implicitly narrowed to an exact function type.
+
+**The dynamic boundary is checked at runtime, in every position.** A value
+whose static type is `any` — or unknown: an untyped native, a plugin, a
+module member read through a namespace, a bare `func` result — is accepted
+wherever a typed slot is expected: an annotated `let`, an argument of an
+exact signature, a `return`. The runtime checks the value against the slot's
+type at that point and names both sides on mismatch: `expected int, got
+string`, `expected map[string, any][], got int[]`, `expected Point, got
+null` (§2.4). Typed code pays nothing — the check is emitted only where the
+static type is `any` or unknown. An extension wrapper therefore returns the
+export directly:
+
+```noxy
+// dynamodb_scan is an extension export: composite results reach the
+// compiler as `any`
+func scan(client: Client, table: string, limit: int) -> map[string, any][]
+    return dynamodb_scan(client.handle, table, limit)   // checked here, at runtime
+end
+```
+
+The one exception is an exact function type: `any` is never narrowed to
+`func(int) -> int`, nor to a type containing one (`(func(int) -> int)[]`) —
+the rule above, no implicit narrowing to an exact signature, holds at every
+boundary.
 
 ### 4.3 Parameter Passing Semantics (CRITICAL)
 
@@ -2073,6 +2114,11 @@ let name: string = "Noxy"
 print(f"Hello, {name}!")
 ```
 
+Each `{e}` is compiled as `to_str(e)` and the pieces are joined with `+`.
+`to_str` is a core builtin, so an interpolation never ends a narrowing
+(§2.4): `if m != null then print(f"{m['a']} {m['b']}") end` compiles with `m`
+a global `map[string, any]?`.
+
 **Literal braces.** `{{` produces `{` and `}}` produces `}`:
 
 ```noxy
@@ -2174,6 +2220,8 @@ The core builtins have static return types where the result never varies —
 `keys(map[K, V]) -> K[]`, `slice` (same type as its first argument) — so a
 value of theirs is checked like any other expression (`let s: string =
 length(xs)` is a compile error) and can initialize an inferred `let` (§3).
+They — together with `print` and `range` — are pure natives that never run
+Noxy code, so a call to one of them never ends a narrowing (§2.4).
 `call_result` is typed by its callee (`errors.Result<R>`, §7). The others
 (`json_parse`, `task_await`, `make_chan`, ...) are dynamic-boundary builtins:
 their result is `any` or untyped and needs an annotation. A function the
@@ -2513,7 +2561,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.23.0`). It is a module binding, not a
+string `noxy --version` prints (`v0.23.1`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -636,7 +636,12 @@ during the call. That is why `f"{m['a']} {m['b']}"` (two `to_str` calls,
 §9) and `print(m["a"])` followed by `print(m["b"])` keep a global `m`
 narrowed, and a loop whose body only calls them keeps the fact too. A call
 to a program function, `call_result`, `spawn_task`, `task_await` or a bare
-`func` does run program code and ends it.
+`func` does run program code and ends it. That includes a call in the right
+operand of `&&` (or of `||`, for the false branch): it runs *after* the test
+in the left operand, so `if m != null && toca() then m["k"] end` with a
+global `m` is an error (`'m' may be null: it was tested, but 'm' is a global
+and a call in the condition ran after the test`), while `if toca() && m !=
+null then` and `if m != null && length(m) > 0 then` keep the fact.
 
 When a fact is lost, test again or bind first (`let n = no.prox` then `if n
 != null then … end`). The diagnostic says which happened: a read after the
@@ -926,13 +931,15 @@ Exact function types may also appear in parameters, returns, struct fields, map 
 **The dynamic boundary is checked at runtime, in every position.** A value
 whose static type is `any` — an `any`-typed variable, field or parameter,
 the result of a function declared `-> any`, of `json_parse`, `task_await` or
-a bare `func` call — is accepted wherever a typed slot is expected: an
-annotated `let`, an argument of an exact signature, a `return`. The runtime
+a bare `func` call — or *unknown* — an untyped native, a plugin, a module
+member called through a namespace (`m.f()`) — is accepted wherever a typed
+slot is expected: an annotated `let`, an assignment (`x = v`, `s.f = v`,
+`xs[i] = v`), an argument of an exact signature, a `return`. The runtime
 checks the value against the slot's type at that point and names both sides
 on mismatch: `expected int, got string`, `expected map[string, any][], got
 int[]`, `expected Point, got null` (§2.4). Typed code pays nothing — the
-check is emitted only where the static type is `any`. A wrapper around an
-`any`-returning function therefore returns it directly:
+check is emitted only where the static type is `any` or unknown. A wrapper
+around an `any`-returning function therefore returns it directly:
 
 ```noxy
 func itens() -> any                       // e.g. a parsed JSON payload
@@ -944,10 +951,13 @@ func scan() -> map[string, any][]
 end
 ```
 
-A value of *unknown* static type — an untyped native, a plugin, a module
-member read through a namespace — is accepted as before and is not checked
-by this guard: only a composite slot (array, map, chan) carries its runtime
-marker in every position.
+The standard library honours the same contract: a wrapper whose native
+reports failure with `null` says so in its signature — `time.parse(s) ->
+DateTime?`, `time.parse_date(s) -> DateTime?`, `sqlite.prepare(db, sql) ->
+Statement?` — so `let dt = time.parse(s)` is tested with `if dt != null
+then`, and `let stmt: Statement = sqlite.prepare(db, sql)` through the
+namespace form stops at the boundary with `expected Statement, got null`
+instead of failing later.
 
 The one exception is an exact function type: `any` is never narrowed to
 `func(int) -> int`, nor to a type containing one (`(func(int) -> int)[]`) —

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -398,7 +398,10 @@ end
 ```
 
 An argument of type `any` is accepted at compile time; the runtime checks
-the parameter mode (`function 'f' argument 1: expected ref int, got int`).
+the parameter mode (`function 'f' argument 1: expected ref int, got int`)
+and, for a `ref T` parameter, the type of the target the reference points
+to (`function 'f' argument 1: expected ref int, got ref string`); a `null`
+target is forwarded and fails on the read (§4.2).
 
 #### R6. Rebind is `=`, update is `*… =`
 
@@ -933,15 +936,14 @@ Exact function types may also appear in parameters, returns, struct fields, map 
 **The dynamic boundary is checked at runtime, in every position.** A value
 whose static type is `any` — an `any`-typed variable, field or parameter,
 the result of a function declared `-> any`, of `json_parse`, `task_await` or
-a bare `func` call — or *unknown* — an untyped native, a plugin, a module
-member called through a namespace (`m.f()`) — is accepted wherever a typed
-slot is expected: an annotated `let`, an assignment (`x = v`, `s.f = v`,
-`xs[i] = v`), an argument of an exact signature, a `return`. The runtime
-checks the value against the slot's type at that point and names both sides
-on mismatch: `expected int, got string`, `expected map[string, any][], got
-int[]`, `expected Point, got null` (§2.4). Typed code pays nothing — the
-check is emitted only where the static type is `any` or unknown. A wrapper
-around an `any`-returning function therefore returns it directly:
+a bare `func` call — is accepted wherever a typed slot is expected: an
+annotated `let`, an assignment (`x = v`, `s.f = v`, `xs[i] = v`), an
+argument of an exact signature, a `return`. The runtime checks the value
+against the slot's type at that point and names both sides on mismatch:
+`expected int, got string`, `expected map[string, any][], got int[]`,
+`expected Point, got null` (§2.4). Typed code pays nothing — the check is
+emitted only where the static type is `any`. A wrapper around an
+`any`-returning function therefore returns it directly:
 
 ```noxy
 func itens() -> any                       // e.g. a parsed JSON payload
@@ -953,22 +955,32 @@ func scan() -> map[string, any][]
 end
 ```
 
-The standard library honours the same contract: a wrapper whose native
-reports failure with `null` says so in its signature — `time.parse(s) ->
-DateTime?`, `time.parse_date(s) -> DateTime?`, `sqlite.prepare(db, sql) ->
-Statement?` — so `let dt = time.parse(s)` is tested with `if dt != null
-then`, and `let stmt: Statement = sqlite.prepare(db, sql)` through the
-namespace form stops at the boundary with `expected Statement, got null`
-instead of failing later.
+The standard library honours the `any` contract on its own side: a wrapper
+whose native reports failure with `null` says so in its signature —
+`time.parse(s) -> DateTime?`, `time.parse_date(s) -> DateTime?`,
+`sqlite.prepare(db, sql) -> Statement?` — so `let dt = parse(s)` imported
+with `select` has the static type `DateTime?` and is tested with `if dt !=
+null then`.
 
-Two limits. `any` crosses only at the *top* of a type: element, key, value,
-channel payload and `ref` target are invariant, so `any[]` is not an `int[]`,
-`map[string, any]` is not a `map[string, int]`, and `ref a` with `a: any` is
-a `ref any`, never a `ref int` — the slot it points to may change type after
-any check. And an exact function type is never a target: `any` is not
+Three limits. `any` crosses only at the *top* of a type: element, key,
+value, channel payload and `ref` target are invariant, so `any[]` is not an
+`int[]`, `map[string, any]` is not a `map[string, int]`, and `ref a` with
+`a: any` is a `ref any`, never a `ref int`. An `any` value that *carries* a
+reference (R2) may fill a `ref T` slot or parameter — R5's dynamic
+boundary — and there the target is checked, not only the mode: `inc(a)`
+with `inc(r: ref int)` and `a` holding `ref s` (`s: string`) is `function
+'inc' argument 1: expected ref int, got ref string`; `let r: ref int = a`
+is `expected ref int, got ref string`. A `null` target is forwarded as
+before and fails on the read. And an exact function type is never a target: `any` is not
 narrowed to `func(int) -> int`, nor to a type containing one
 (`(func(int) -> int)[]`) — the rule above, no implicit narrowing to an exact
 signature, holds at every boundary.
+
+A value of *unknown* static type — an untyped native, a plugin, a module
+member called through a namespace (`m.f()`) — is accepted as before and is
+not checked by this guard: the natives declare no return contract yet, and
+checking every wrapper call measured at +35–55 % per call. Only a composite
+slot (array, map, chan) carries its runtime marker in every position.
 
 ### 4.3 Parameter Passing Semantics (CRITICAL)
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -629,10 +629,12 @@ member-path fact; and entering a loop whose body assigns the root. A path
 rooted at a plain value local survives calls: value semantics (§2.2)
 guarantee nobody outside the frame can reach it.
 
-A call to a core builtin (§10: `print`, `to_str`, `length`, `fmt`, `keys`,
-`slice`, `range`, …) that the program has not shadowed ends **no**
-narrowing: those natives never run Noxy code, so nothing can reach the root
-during the call. That is why `f"{m['a']} {m['b']}"` (two `to_str` calls,
+A call to a core builtin (§10: `print`, `eprint`, `to_str`, `length`, `fmt`,
+`keys`, `slice`, `append`, `pop`, `delete`, `range`, …) that the program has
+not shadowed, or to a struct constructor, ends **no** narrowing: those never
+run Noxy code, so nothing can reach the root during the call (`json_loads` is
+the exception — it writes through its `ref` argument and may leave `null` in
+the root). That is why `f"{m['a']} {m['b']}"` (two `to_str` calls,
 §9) and `print(m["a"])` followed by `print(m["b"])` keep a global `m`
 narrowed, and a loop whose body only calls them keeps the fact too. A call
 to a program function, `call_result`, `spawn_task`, `task_await` or a bare
@@ -959,10 +961,14 @@ then`, and `let stmt: Statement = sqlite.prepare(db, sql)` through the
 namespace form stops at the boundary with `expected Statement, got null`
 instead of failing later.
 
-The one exception is an exact function type: `any` is never narrowed to
-`func(int) -> int`, nor to a type containing one (`(func(int) -> int)[]`) —
-the rule above, no implicit narrowing to an exact signature, holds at every
-boundary.
+Two limits. `any` crosses only at the *top* of a type: element, key, value,
+channel payload and `ref` target are invariant, so `any[]` is not an `int[]`,
+`map[string, any]` is not a `map[string, int]`, and `ref a` with `a: any` is
+a `ref any`, never a `ref int` — the slot it points to may change type after
+any check. And an exact function type is never a target: `any` is not
+narrowed to `func(int) -> int`, nor to a type containing one
+(`(func(int) -> int)[]`) — the rule above, no implicit narrowing to an exact
+signature, holds at every boundary.
 
 ### 4.3 Parameter Passing Semantics (CRITICAL)
 

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -924,23 +924,30 @@ let factory: func(int) -> int[] = make_list   // one function returning int[]
 Exact function types may also appear in parameters, returns, struct fields, map values, channels, and references. `any`, native functions, plugins, and untyped module exports remain dynamic boundaries and retain runtime validation; an unknown native value cannot be implicitly narrowed to an exact function type.
 
 **The dynamic boundary is checked at runtime, in every position.** A value
-whose static type is `any` — or unknown: an untyped native, a plugin, a
-module member read through a namespace, a bare `func` result — is accepted
-wherever a typed slot is expected: an annotated `let`, an argument of an
-exact signature, a `return`. The runtime checks the value against the slot's
-type at that point and names both sides on mismatch: `expected int, got
-string`, `expected map[string, any][], got int[]`, `expected Point, got
-null` (§2.4). Typed code pays nothing — the check is emitted only where the
-static type is `any` or unknown. An extension wrapper therefore returns the
-export directly:
+whose static type is `any` — an `any`-typed variable, field or parameter,
+the result of a function declared `-> any`, of `json_parse`, `task_await` or
+a bare `func` call — is accepted wherever a typed slot is expected: an
+annotated `let`, an argument of an exact signature, a `return`. The runtime
+checks the value against the slot's type at that point and names both sides
+on mismatch: `expected int, got string`, `expected map[string, any][], got
+int[]`, `expected Point, got null` (§2.4). Typed code pays nothing — the
+check is emitted only where the static type is `any`. A wrapper around an
+`any`-returning function therefore returns it directly:
 
 ```noxy
-// dynamodb_scan is an extension export: composite results reach the
-// compiler as `any`
-func scan(client: Client, table: string, limit: int) -> map[string, any][]
-    return dynamodb_scan(client.handle, table, limit)   // checked here, at runtime
+func itens() -> any                       // e.g. a parsed JSON payload
+    return json_parse(corpo)
+end
+
+func scan() -> map[string, any][]
+    return itens()                        // checked here, at runtime
 end
 ```
+
+A value of *unknown* static type — an untyped native, a plugin, a module
+member read through a namespace — is accepted as before and is not checked
+by this guard: only a composite slot (array, map, chan) carries its runtime
+marker in every position.
 
 The one exception is an exact function type: `any` is never narrowed to
 `func(int) -> int`, nor to a type containing one (`(func(int) -> int)[]`) —

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.22.0</span>
+                    <span class="version-badge-tag">v0.23.1</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.22.0
+print(sys.version)           // v0.23.1
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/compiler/any_boundary_review_test.go
+++ b/internal/compiler/any_boundary_review_test.go
@@ -1,0 +1,46 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Revisao do PR #119: `any` atravessa a fronteira so no TOPO do tipo. Um
+// `ref any` nao e um `ref int` (o slot apontado pode mudar de tipo depois), e
+// `any[]`/`map[string, any]` sao tipos concretos e invariantes — a recusa de
+// compilacao que develop tinha volta.
+
+func TestRefToAnySlotIsNotARefToInt(t *testing.T) {
+	src := "func bump(r: ref int) -> int\n    return *r + 1\nend\nlet a: any = \"texto\"\nbump(ref a)\n"
+	_, err := compileFunctionSource(t, src)
+	want := "argument 1 to 'bump': expected ref int, got ref any"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestExactCallRejectsAnyArrayForIntArrayParameter(t *testing.T) {
+	src := "func f(xs: int[]) -> int\n    return length(xs)\nend\nlet a: any[] = [1]\nf(a)\n"
+	_, err := compileFunctionSource(t, src)
+	want := "argument 1 to 'f': expected int[], got any[]"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestReturnRejectsAnyMapForTypedMap(t *testing.T) {
+	src := "func g() -> map[string, int]\n    let m: map[string, any] = {\"a\": 1}\n    return m\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "return type mismatch in 'g': expected map[string, int], got map[string, any]"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestExactCallAcceptsAnyElementArrayWhereDeclared(t *testing.T) {
+	// map[string, any][] e o tipo declarado dos dois lados: nao ha fronteira.
+	src := "func conta(xs: map[string, any][]) -> int\n    return length(xs)\nend\nlet xs: map[string, any][] = [{\"a\": 1}]\nconta(xs)\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/compiler/any_boundary_test.go
+++ b/internal/compiler/any_boundary_test.go
@@ -1,0 +1,50 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #118 item 1: `any` entra num slot tipado em qualquer posicao — let
+// anotado, argumento de assinatura exata, return — com a mesma checagem de
+// runtime. Antes so o `let` aceitava, e o wrapper de extensao precisava de
+// um `let` temporario por funcao.
+
+func TestExactCallAcceptsAnyArgument(t *testing.T) {
+	src := "func add(a: int) -> int\n    return a\nend\nlet x: any = 1\nadd(x)\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReturnAcceptsAnyValue(t *testing.T) {
+	src := "func nativo() -> any\n    return 1\nend\nfunc tipado() -> int\n    return nativo()\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtensionWrapperIdiomWithoutTemporaryLet(t *testing.T) {
+	src := "func nativo() -> any\n    return [{\"a\": 1}]\nend\nfunc scan() -> map[string, any][]\n    return nativo()\nend\nfunc conta(xs: map[string, any][]) -> int\n    return length(xs)\nend\nconta(nativo())\nconta(scan())\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExactCallRejectsAnyForExactCallableParameter(t *testing.T) {
+	src := "func apply(f: func(int) -> int) -> int\n    return f(1)\nend\nlet g: any = 1\napply(g)\n"
+	_, err := compileFunctionSource(t, src)
+	want := "argument 1 to 'apply': expected func(int) -> int, got any"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestReturnRejectsAnyForExactCallableType(t *testing.T) {
+	src := "func nativo() -> any\n    return 1\nend\nfunc pick() -> func(int) -> int\n    return nativo()\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "return type mismatch in 'pick': expected func(int) -> int, got any"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}

--- a/internal/compiler/builtin_calls.go
+++ b/internal/compiler/builtin_calls.go
@@ -116,7 +116,7 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 					c.currentLine, noxyTypeName(array.ElementType), noxyTypeName(item),
 				)
 			}
-			if err := c.emitRuntimeValueType(array.ElementType); err != nil {
+			if err := c.emitSlotGuards(array.ElementType, item); err != nil {
 				return true, nil, err
 			}
 		}
@@ -159,6 +159,9 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 				c.currentLine, noxyTypeName(mapping.KeyType), noxyTypeName(key),
 			)
 		}
+		if err := c.emitSlotGuards(mapping.KeyType, key); err != nil {
+			return true, nil, err
+		}
 		c.emitCall(2, emission, false)
 		return true, builtinType("void"), nil
 	case "json_loads":
@@ -171,6 +174,9 @@ func (c *Compiler) compileBuiltinCall(call *ast.CallExpression, emission callEmi
 				"[line %d] argument 1 to 'json_loads': expected string, got %s",
 				c.currentLine, noxyTypeName(jsonText),
 			)
+		}
+		if err := c.emitSlotGuards(builtinType("string"), jsonText); err != nil {
+			return true, nil, err
 		}
 		targetType, err := c.compileBuiltinRefArgument(call.Arguments[1], "argument 2 to 'json_loads'", "ref T")
 		if err != nil {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -138,6 +138,10 @@ type Compiler struct {
 	// narrowed: chaves estaveis provadas nao-nulas no ponto corrente
 	// (narrowing.go). Por compilador — cada corpo de funcao comeca vazio.
 	narrowed map[string]struct{}
+	// narrowLost: chaves cujo fato existiu e foi derrubado por uma chamada
+	// (dropAfterCall), com o motivo — so para o diagnostico dizer "foi
+	// testado, mas..." em vez de sugerir o `if` que ja esta ali (#118).
+	narrowLost map[string]string
 	// warnings e a lista de avisos COMPARTILHADA pela arvore de compiladores
 	// (raiz + NewChild): ponteiro, como generics/instances, para que o aviso
 	// emitido dentro de um corpo de funcao suba ate o compilador raiz, que e
@@ -320,7 +324,12 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 	case *ast.AssignStmt:
 		defer c.noteAssignment(effect.Target)
 	case *ast.CallExpression:
-		defer c.dropAfterCall()
+		// Builtin central nao sombreado (print, to_str, length...) e nativo
+		// puro: nunca roda codigo Noxy, nada alcanca a raiz — o fato fica
+		// (#118; a f-string vira to_str no parser e cai aqui).
+		if !c.isPureBuiltinCall(effect) {
+			defer c.dropAfterCall()
+		}
 	}
 	switch n := node.(type) {
 	case *ast.Program:
@@ -470,6 +479,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				return nil, nil, fmt.Errorf("[line %d] type mismatch in '%s' declaration: expected %s, got %s%s%s", c.currentLine, n.Name.Value, n.Type.String(), noxyTypeName(valType), c.derefReadHint(n.Type, valType, n.Value), c.nullMismatchHint(n.Type, valType, n.Value))
 			}
 			if err := c.emitRuntimeValueType(n.Type); err != nil {
+				return nil, nil, err
+			}
+			if err := c.emitDynamicBoundaryGuard(n.Type, valType); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -2310,6 +2322,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		if err := c.emitRuntimeValueType(expected); err != nil {
 			return nil, nil, err
 		}
+		if err := c.emitDynamicBoundaryGuard(expected, actual); err != nil {
+			return nil, nil, err
+		}
 		c.emitByte(byte(chunk.OP_RETURN))
 		return c.currentChunk, nil, nil
 
@@ -2704,6 +2719,9 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 		}
 		if isExact {
 			if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
+				return nil, nil, err
+			}
+			if err := c.emitDynamicBoundaryGuard(funcType.Params[i], argType); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -141,7 +141,7 @@ type Compiler struct {
 	// narrowLost: chaves cujo fato existiu e foi derrubado por uma chamada
 	// (dropAfterCall), com o motivo — so para o diagnostico dizer "foi
 	// testado, mas..." em vez de sugerir o `if` que ja esta ali (#118).
-	narrowLost map[string]string
+	narrowLost map[string]lostFact
 	// warnings e a lista de avisos COMPARTILHADA pela arvore de compiladores
 	// (raiz + NewChild): ponteiro, como generics/instances, para que o aviso
 	// emitido dentro de um corpo de funcao suba ate o compilador raiz, que e

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -142,6 +142,9 @@ type Compiler struct {
 	// (dropAfterCall), com o motivo — so para o diagnostico dizer "foi
 	// testado, mas..." em vez de sugerir o `if` que ja esta ali (#118).
 	narrowLost map[string]lostFact
+	// narrowLostPending: perdas registradas por conditionFacts (que roda
+	// antes do pushFacts do ramo); pushFacts as move para o ramo e zera.
+	narrowLostPending map[string]lostFact
 	// warnings e a lista de avisos COMPARTILHADA pela arvore de compiladores
 	// (raiz + NewChild): ponteiro, como generics/instances, para que o aviso
 	// emitido dentro de um corpo de funcao suba ate o compilador raiz, que e
@@ -478,10 +481,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if !c.areTypesCompatible(n.Type, valType) {
 				return nil, nil, fmt.Errorf("[line %d] type mismatch in '%s' declaration: expected %s, got %s%s%s", c.currentLine, n.Name.Value, n.Type.String(), noxyTypeName(valType), c.derefReadHint(n.Type, valType, n.Value), c.nullMismatchHint(n.Type, valType, n.Value))
 			}
-			if err := c.emitRuntimeValueType(n.Type); err != nil {
-				return nil, nil, err
-			}
-			if err := c.emitDynamicBoundaryGuard(n.Type, valType); err != nil {
+			if err := c.emitSlotGuards(n.Type, valType); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -609,7 +609,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if !c.areTypesCompatible(refT.ElementType, valType) {
 				return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment: expected %s, got %s%s", c.currentLine, refT.ElementType.String(), valType.String(), c.derefReadHint(refT.ElementType, valType, n.Value))
 			}
-			if err := c.emitRuntimeValueType(refT.ElementType); err != nil {
+			if err := c.emitSlotGuards(refT.ElementType, valType); err != nil {
 				return nil, nil, err
 			}
 
@@ -663,10 +663,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						if local.IsParam {
 							c.warn(fmt.Sprintf("rebinding ref parameter '%s' has no effect outside function", ident.Value))
 						}
-						if err := c.emitRuntimeValueType(localType); err != nil {
-							return nil, nil, err
-						}
-						if err := c.emitDynamicBoundaryGuard(localType, valType); err != nil {
+						if err := c.emitSlotGuards(localType, valType); err != nil {
 							return nil, nil, err
 						}
 						// RC: rebind de local `ref` e troca de EMPRESTIMO, nao
@@ -689,10 +686,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					if !c.areTypesCompatible(localType, valType) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s%s%s", c.currentLine, ident.Value, localType.String(), valType.String(), c.derefReadHint(localType, valType, n.Value), c.nullMismatchHint(localType, valType, n.Value))
 					}
-					if err := c.emitRuntimeValueType(localType); err != nil {
-						return nil, nil, err
-					}
-					if err := c.emitDynamicBoundaryGuard(localType, valType); err != nil {
+					if err := c.emitSlotGuards(localType, valType); err != nil {
 						return nil, nil, err
 					}
 					// RC: mesma pergunta do gemeo MUT — so slot POSSUIDOR troca
@@ -719,10 +713,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						c.currentLine, ident.Value, noxyTypeName(upvalueType), noxyTypeName(valType), c.derefReadHint(upvalueType, valType, n.Value), c.nullMismatchHint(upvalueType, valType, n.Value),
 					)
 				}
-				if err := c.emitRuntimeValueType(upvalueType); err != nil {
-					return nil, nil, err
-				}
-				if err := c.emitDynamicBoundaryGuard(upvalueType, valType); err != nil {
+				if err := c.emitSlotGuards(upvalueType, valType); err != nil {
 					return nil, nil, err
 				}
 				c.emitBytes(byte(chunk.OP_SET_UPVALUE), byte(arg))
@@ -742,10 +733,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 							}
 
 							nameConstant := c.makeConstant(value.NewString(ident.Value))
-							if err := c.emitRuntimeValueType(globalType); err != nil {
-								return nil, nil, err
-							}
-							if err := c.emitDynamicBoundaryGuard(globalType, valType); err != nil {
+							if err := c.emitSlotGuards(globalType, valType); err != nil {
 								return nil, nil, err
 							}
 							// RC: rebind de global `ref` e troca de
@@ -767,10 +755,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					if !c.areTypesCompatible(globalType, valType) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s%s%s", c.currentLine, ident.Value, globalType.String(), valType.String(), c.derefReadHint(globalType, valType, n.Value), c.nullMismatchHint(globalType, valType, n.Value))
 					}
-					if err := c.emitRuntimeValueType(globalType); err != nil {
-						return nil, nil, err
-					}
-					if err := c.emitDynamicBoundaryGuard(globalType, valType); err != nil {
+					if err := c.emitSlotGuards(globalType, valType); err != nil {
 						return nil, nil, err
 					}
 				} else if !c.globalIsKnown(ident.Value) {
@@ -873,10 +858,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					return nil, nil, fmt.Errorf("[line %d] index assignment on non-array/map type: %s", c.currentLine, leftType.String())
 				}
 			}
-			if err := c.emitRuntimeValueType(assignedType); err != nil {
-				return nil, nil, err
-			}
-			if err := c.emitDynamicBoundaryGuard(assignedType, valType); err != nil {
+			if err := c.emitSlotGuards(assignedType, valType); err != nil {
 				return nil, nil, err
 			}
 
@@ -971,10 +953,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in field assignment: expected %s, got %s%s%s", c.currentLine, fieldType.String(), valType.String(), c.derefReadHint(fieldType, valType, n.Value), c.nullMismatchHint(fieldType, valType, n.Value))
 					}
 				}
-				if err := c.emitRuntimeValueType(fieldType); err != nil {
-					return nil, nil, err
-				}
-				if err := c.emitDynamicBoundaryGuard(fieldType, valType); err != nil {
+				if err := c.emitSlotGuards(fieldType, valType); err != nil {
 					return nil, nil, err
 				}
 			}
@@ -1721,7 +1700,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// alternativo; depois do if, o fato do ramo que NAO termina sobrevive
 		// (early return: `if p == null then return end` estreita p adiante).
 		thenFacts, elseFacts := c.conditionFacts(n.Condition)
-		restoreThen := c.pushFacts(thenFacts)
+		// Perdas registradas pela condicao (`m != null && toca()`) valem nos
+		// dois ramos e depois do if — nunca fora dele por vazamento.
+		pendingLost := c.takePendingLost()
+		restoreThen := c.pushFactsWith(thenFacts, pendingLost)
 		_, _, err = c.Compile(n.Consequence)
 		restoreThen()
 		if err != nil {
@@ -1740,7 +1722,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 		// Compile Else block (Alternative)
 		if n.Alternative != nil {
-			restoreElse := c.pushFacts(elseFacts)
+			restoreElse := c.pushFactsWith(elseFacts, pendingLost)
 			_, _, err = c.Compile(n.Alternative)
 			restoreElse()
 			if err != nil {
@@ -1751,10 +1733,10 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 		// Patch End jump
 		c.patchJump(jumpToEnd)
 		if blockTerminates(n.Consequence) {
-			c.keepFacts(elseFacts)
+			c.keepFactsWith(elseFacts, pendingLost)
 		}
 		if n.Alternative != nil && blockTerminates(n.Alternative) {
-			c.keepFacts(thenFacts)
+			c.keepFactsWith(thenFacts, pendingLost)
 		}
 		return c.currentChunk, nil, nil
 
@@ -2340,10 +2322,7 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				c.derefReadHint(expected, actual, n.ReturnValue), c.nullMismatchHint(expected, actual, n.ReturnValue),
 			)
 		}
-		if err := c.emitRuntimeValueType(expected); err != nil {
-			return nil, nil, err
-		}
-		if err := c.emitDynamicBoundaryGuard(expected, actual); err != nil {
+		if err := c.emitSlotGuards(expected, actual); err != nil {
 			return nil, nil, err
 		}
 		c.emitByte(byte(chunk.OP_RETURN))
@@ -2682,13 +2661,17 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 						c.currentLine, i+1, callableName(call.Function), funcType.Params[i].String(), nullable(&ast.RefType{ElementType: refArg.element}).String(), c.nullMismatchHint(funcType.Params[i], nullable(&ast.RefType{ElementType: refArg.element}), arg),
 					)
 				}
-				if refArg.element != nil && !c.areStrictTypesCompatible(expectedRef.ElementType, refArg.element) {
+				if refArg.element != nil && !c.strictCompatibleNested(expectedRef.ElementType, refArg.element) {
 					actual := &ast.RefType{ElementType: refArg.element}
 					return nil, nil, fmt.Errorf(
 						"[line %d] argument %d to '%s': expected %s, got %s",
 						c.currentLine, i+1, callableName(call.Function), expectedRef.String(), actual.String(),
 					)
 				}
+				// Sem guarda dinamica aqui: `ref any` ja e recusado na
+				// compilacao (strictCompatibleNested) e um null encaminhado por
+				// um slot ref chega ao callee como null (convencao do
+				// ref-null-forwarding: falha na leitura, "cannot dereference").
 				if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
 					return nil, nil, err
 				}
@@ -2739,10 +2722,7 @@ func (c *Compiler) compileCallExpression(call *ast.CallExpression, emission call
 			)
 		}
 		if isExact {
-			if err := c.emitRuntimeValueType(funcType.Params[i]); err != nil {
-				return nil, nil, err
-			}
-			if err := c.emitDynamicBoundaryGuard(funcType.Params[i], argType); err != nil {
+			if err := c.emitSlotGuards(funcType.Params[i], argType); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -3113,6 +3093,10 @@ func (c *Compiler) endScope() {
 	c.scopeDepth--
 	// Pop locals from stack
 	for len(c.locals) > 0 && c.locals[len(c.locals)-1].Depth > c.scopeDepth {
+		// Spec §2.4: um fato sobre o local que sai de escopo morre com ele —
+		// uma chave morta nao pode ser reclassificada depois como upvalue ou
+		// global de mesmo nome (revisao do #119).
+		c.dropKey(c.locals[len(c.locals)-1].Name)
 		if c.locals[len(c.locals)-1].IsCaptured {
 			c.emitByte(byte(chunk.OP_CLOSE_UPVALUE))
 		} else {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -666,6 +666,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						if err := c.emitRuntimeValueType(localType); err != nil {
 							return nil, nil, err
 						}
+						if err := c.emitDynamicBoundaryGuard(localType, valType); err != nil {
+							return nil, nil, err
+						}
 						// RC: rebind de local `ref` e troca de EMPRESTIMO, nao
 						// de posse — grava no slot sem retain/release (o dono
 						// real e o campo/global/slot do chamador apontado).
@@ -687,6 +690,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to '%s': expected %s, got %s%s%s", c.currentLine, ident.Value, localType.String(), valType.String(), c.derefReadHint(localType, valType, n.Value), c.nullMismatchHint(localType, valType, n.Value))
 					}
 					if err := c.emitRuntimeValueType(localType); err != nil {
+						return nil, nil, err
+					}
+					if err := c.emitDynamicBoundaryGuard(localType, valType); err != nil {
 						return nil, nil, err
 					}
 					// RC: mesma pergunta do gemeo MUT — so slot POSSUIDOR troca
@@ -716,6 +722,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 				if err := c.emitRuntimeValueType(upvalueType); err != nil {
 					return nil, nil, err
 				}
+				if err := c.emitDynamicBoundaryGuard(upvalueType, valType); err != nil {
+					return nil, nil, err
+				}
 				c.emitBytes(byte(chunk.OP_SET_UPVALUE), byte(arg))
 				c.emitByte(byte(chunk.OP_POP))
 			} else {
@@ -734,6 +743,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 
 							nameConstant := c.makeConstant(value.NewString(ident.Value))
 							if err := c.emitRuntimeValueType(globalType); err != nil {
+								return nil, nil, err
+							}
+							if err := c.emitDynamicBoundaryGuard(globalType, valType); err != nil {
 								return nil, nil, err
 							}
 							// RC: rebind de global `ref` e troca de
@@ -756,6 +768,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 						return nil, nil, fmt.Errorf("[line %d] type mismatch in assignment to global '%s': expected %s, got %s%s%s", c.currentLine, ident.Value, globalType.String(), valType.String(), c.derefReadHint(globalType, valType, n.Value), c.nullMismatchHint(globalType, valType, n.Value))
 					}
 					if err := c.emitRuntimeValueType(globalType); err != nil {
+						return nil, nil, err
+					}
+					if err := c.emitDynamicBoundaryGuard(globalType, valType); err != nil {
 						return nil, nil, err
 					}
 				} else if !c.globalIsKnown(ident.Value) {
@@ -861,6 +876,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 			if err := c.emitRuntimeValueType(assignedType); err != nil {
 				return nil, nil, err
 			}
+			if err := c.emitDynamicBoundaryGuard(assignedType, valType); err != nil {
+				return nil, nil, err
+			}
 
 			// perf #66: elemento sem contador RC em base T[] escreve pela forma
 			// NORC, que e statement (nao empilha; sem OP_POP). O VM confere em
@@ -954,6 +972,9 @@ func (c *Compiler) Compile(node ast.Node) (*chunk.Chunk, ast.NoxyType, error) {
 					}
 				}
 				if err := c.emitRuntimeValueType(fieldType); err != nil {
+					return nil, nil, err
+				}
+				if err := c.emitDynamicBoundaryGuard(fieldType, valType); err != nil {
 					return nil, nil, err
 				}
 			}

--- a/internal/compiler/explicit_ref.go
+++ b/internal/compiler/explicit_ref.go
@@ -60,6 +60,10 @@ func (c *Compiler) compileRefArgument(arg ast.Expression) (refArgument, error) {
 		return refArgument{proven: true}, nil
 	}
 	if actual == nil || isAny(actual) {
+		// Fronteira dinamica (R5): modo validado em runtime por
+		// validateParameterModes e, desde a revisao do #119, o TIPO DO ALVO
+		// por validateRefTargets — `inc(a)` com a guardando `ref string` e
+		// `expected ref int, got ref string` na chamada, nao lixo no `*r`.
 		return refArgument{}, nil
 	}
 	return refArgument{plain: actual}, nil

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -218,7 +218,8 @@ func (c *Compiler) areStrictTypesCompatible(expected, actual ast.NoxyType) bool 
 	if isAny(actual) {
 		// #118: `any` atravessa para um slot concreto em qualquer posicao —
 		// argumento e return como o `let` — e a guarda de runtime
-		// (emitDynamicBoundaryGuard) confere o valor. A mesma regra do tipo
+		// (emitDynamicBoundaryGuard) confere o valor — para um slot `ref T`,
+		// o alvo da referencia (walk TYPE_REF). A mesma regra do tipo
 		// desconhecido (actual == nil, acima): a excecao e o callable exato,
 		// inclusive aninhado, que nunca sofre narrowing implicito (spec §4.2).
 		return !c.containsCallableType(expected, nil)

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -241,20 +241,32 @@ func (c *Compiler) areStrictTypesCompatible(expected, actual ast.NoxyType) bool 
 	case *ast.ArrayType:
 		a, ok := actual.(*ast.ArrayType)
 		return ok && (e.Size == 0 || e.Size == a.Size) &&
-			c.areStrictTypesCompatible(e.ElementType, a.ElementType)
+			c.strictCompatibleNested(e.ElementType, a.ElementType)
 	case *ast.MapType:
 		a, ok := actual.(*ast.MapType)
-		return ok && c.areStrictTypesCompatible(e.KeyType, a.KeyType) &&
-			c.areStrictTypesCompatible(e.ValueType, a.ValueType)
+		return ok && c.strictCompatibleNested(e.KeyType, a.KeyType) &&
+			c.strictCompatibleNested(e.ValueType, a.ValueType)
 	case *ast.ChanType:
 		a, ok := actual.(*ast.ChanType)
-		return ok && c.areStrictTypesCompatible(e.ElementType, a.ElementType)
+		return ok && c.strictCompatibleNested(e.ElementType, a.ElementType)
 	case *ast.RefType:
 		a, ok := actual.(*ast.RefType)
-		return ok && c.areStrictTypesCompatible(e.ElementType, a.ElementType)
+		return ok && c.strictCompatibleNested(e.ElementType, a.ElementType)
 	default:
 		return expected.String() == actual.String() || c.typesEquivalent(expected, actual)
 	}
+}
+
+// strictCompatibleNested e a regra dos tipos ANINHADOS — elemento de array,
+// chave/valor de map, payload de chan, alvo de ref: invariantes. `any` so
+// atravessa a fronteira dinamica no TOPO do tipo (areStrictTypesCompatible):
+// `any[]` nao e `int[]` e `ref any` nao e `ref int` — o slot apontado pode
+// mudar de tipo depois da checagem (revisao do #119).
+func (c *Compiler) strictCompatibleNested(expected, actual ast.NoxyType) bool {
+	if isAny(actual) {
+		return isAny(expected)
+	}
+	return c.areStrictTypesCompatible(expected, actual)
 }
 
 func commonInferredType(left, right ast.NoxyType) ast.NoxyType {

--- a/internal/compiler/function_types.go
+++ b/internal/compiler/function_types.go
@@ -216,7 +216,12 @@ func (c *Compiler) areStrictTypesCompatible(expected, actual ast.NoxyType) bool 
 		return false
 	}
 	if isAny(actual) {
-		return false
+		// #118: `any` atravessa para um slot concreto em qualquer posicao —
+		// argumento e return como o `let` — e a guarda de runtime
+		// (emitDynamicBoundaryGuard) confere o valor. A mesma regra do tipo
+		// desconhecido (actual == nil, acima): a excecao e o callable exato,
+		// inclusive aninhado, que nunca sofre narrowing implicito (spec §4.2).
+		return !c.containsCallableType(expected, nil)
 	}
 	if isBareFunctionType(expected) {
 		return isCallableType(actual)

--- a/internal/compiler/function_types_test.go
+++ b/internal/compiler/function_types_test.go
@@ -49,13 +49,23 @@ func TestFunctionTypeCompatibility(t *testing.T) {
 	}
 }
 
-func TestStrictCompatibilityRejectsActualAny(t *testing.T) {
+func TestStrictCompatibilityAcceptsActualAnyExceptExactCallable(t *testing.T) {
+	// Issue #118 item 1: `any` atravessa a fronteira para um slot concreto em
+	// qualquer posicao (let, argumento, return) — o runtime checa. A unica
+	// excecao e o callable exato (spec §4.2: nunca ha narrowing implicito).
 	c := New()
-	if c.areStrictTypesCompatible(primitive("int"), primitive("any")) {
-		t.Fatal("actual any must not satisfy concrete int in an exact contract")
+	if !c.areStrictTypesCompatible(primitive("int"), primitive("any")) {
+		t.Fatal("actual any must cross into concrete int (runtime-checked)")
 	}
 	if !c.areStrictTypesCompatible(primitive("any"), primitive("int")) {
 		t.Fatal("expected any must accept int")
+	}
+	exact := &ast.FunctionType{Params: []ast.NoxyType{primitive("int")}, Return: primitive("int")}
+	if c.areStrictTypesCompatible(exact, primitive("any")) {
+		t.Fatal("any must not narrow to an exact function type")
+	}
+	if c.areStrictTypesCompatible(&ast.ArrayType{ElementType: exact}, primitive("any")) {
+		t.Fatal("any must not narrow to an array of exact function types")
 	}
 }
 
@@ -155,11 +165,6 @@ add(1, 2)`, "expects 1 arguments, got 2"},
     return a
 end
 add("x")`, "argument 1 to 'add': expected int, got string"},
-		{"any", `func add(a: int) -> int
-    return a
-end
-let x: any = 1
-add(x)`, "expected int, got any"},
 		{"ref", `func set(v: ref int) -> void
     return
 end
@@ -324,9 +329,6 @@ end`, "void function 'bad' cannot return int"},
         return 1
     end
 end`, "may finish without returning int"},
-		{"actual any", `func bad(v: any) -> int
-    return v
-end`, "expected int, got any"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/compiler/narrowing.go
+++ b/internal/compiler/narrowing.go
@@ -56,10 +56,12 @@ func (c *Compiler) conditionFacts(cond ast.Expression) (then, els []string) {
 		case "&&":
 			lt, _ := c.conditionFacts(e.Left)
 			rt, _ := c.conditionFacts(e.Right)
+			lt = c.dropFactsCrossingCall(lt, e.Right, "&&", "!=")
 			return append(lt, rt...), nil
 		case "||":
 			_, le := c.conditionFacts(e.Left)
 			_, re := c.conditionFacts(e.Right)
+			le = c.dropFactsCrossingCall(le, e.Right, "||", "==")
 			return nil, append(le, re...)
 		}
 	case *ast.PrefixExpression:
@@ -168,11 +170,65 @@ func rootOf(key string) string {
 	return key
 }
 
-// lostFact: por que um fato foi derrubado por chamada (dropAfterCall) e se
-// foi na entrada de um laco (dropForLoop) — so para o diagnostico.
+// lostFact: por que um fato foi derrubado por chamada — a raiz (why), o que
+// aconteceu (event) e a primeira saida do hint (again) — so para o
+// diagnostico de mayBeNullError.
 type lostFact struct {
-	why    string
-	inLoop bool
+	why   string
+	event string
+	again string
+}
+
+// firstImpureCall devolve a primeira chamada de expr que encerra narrowing
+// (nao e builtin puro), ou nil.
+func (c *Compiler) firstImpureCall(expr ast.Expression) *ast.CallExpression {
+	var found *ast.CallExpression
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		if call, ok := node.(*ast.CallExpression); ok && !c.isPureBuiltinCall(call) {
+			found = call
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// dropFactsCrossingCall (#120 item 3): em `a && b` / `a || b`, uma chamada
+// nao-pura em b roda DEPOIS do teste de a — os fatos de a sobre raiz
+// compartilhada nao podem sair para o ramo (dentro da expressao o
+// dropAfterCall ja os derruba; o furo era so nos fatos exportados). Registra
+// a perda para o diagnostico apontar a chamada na condicao.
+func (c *Compiler) dropFactsCrossingCall(keys []string, right ast.Expression, op, cmp string) []string {
+	if len(keys) == 0 {
+		return keys
+	}
+	call := c.firstImpureCall(right)
+	if call == nil {
+		return keys
+	}
+	kept := keys[:0:0]
+	for _, k := range keys {
+		shared, why := c.rootSharing(rootOf(k))
+		if !strings.HasPrefix(k, "*") && !shared {
+			kept = append(kept, k)
+			continue
+		}
+		if why == "" {
+			why = fmt.Sprintf("'%s' is read through a reference", k)
+		}
+		if c.narrowLost == nil {
+			c.narrowLost = make(map[string]lostFact)
+		}
+		c.narrowLost[k] = lostFact{
+			why:   why,
+			event: "a call in the condition ran after the test",
+			again: fmt.Sprintf("put the call before the test ('%s %s %s %s null')", call.String(), op, k, cmp),
+		}
+	}
+	return kept
 }
 
 // rootSharing: a raiz pode mudar por fora deste frame — slot `ref`,
@@ -209,13 +265,14 @@ func (c *Compiler) rootIsShared(root string) bool {
 // dropAfterCall invalida o que uma chamada pode ter mudado e registra o
 // motivo, para o diagnostico de leitura sem fato (mayBeNullError).
 func (c *Compiler) dropAfterCall() {
-	c.dropSharedAfterCall(false)
+	c.dropSharedAfterCall("a call came between the test and this use", "test it again after the call")
 }
 
-// dropSharedAfterCall e o corpo de dropAfterCall; inLoop marca que a queda
-// veio da entrada de um laco (dropForLoop) — a chamada pode vir DEPOIS do
-// uso no texto e rodar antes dele na iteracao seguinte.
-func (c *Compiler) dropSharedAfterCall(inLoop bool) {
+// dropSharedAfterCall e o corpo de dropAfterCall; event/again descrevem a
+// queda no diagnostico — a entrada de um laco (dropForLoop) tem a sua: a
+// chamada pode vir DEPOIS do uso no texto e rodar antes dele na iteracao
+// seguinte.
+func (c *Compiler) dropSharedAfterCall(event, again string) {
 	for k := range c.narrowed {
 		shared, why := c.rootSharing(rootOf(k))
 		if !strings.HasPrefix(k, "*") && !shared {
@@ -228,7 +285,7 @@ func (c *Compiler) dropSharedAfterCall(inLoop bool) {
 		if c.narrowLost == nil {
 			c.narrowLost = make(map[string]lostFact)
 		}
-		c.narrowLost[k] = lostFact{why: why, inLoop: inLoop}
+		c.narrowLost[k] = lostFact{why: why, event: event, again: again}
 	}
 }
 
@@ -353,7 +410,7 @@ func (c *Compiler) dropForLoop(body *ast.BlockStatement) {
 		c.dropKey(r)
 	}
 	if hasCall {
-		c.dropSharedAfterCall(true)
+		c.dropSharedAfterCall("the loop body calls a function that can run before this use", "test it again inside the loop")
 	}
 }
 
@@ -427,15 +484,11 @@ func (c *Compiler) narrowBorrowOwner(base ast.Expression, owner ast.NoxyType) (a
 func (c *Compiler) mayBeNullError(expr ast.Expression, t ast.NoxyType) error {
 	if key, ok := stableKey(expr); ok {
 		if lost, ok := c.narrowLost[key]; ok {
-			event, again := "a call came between the test and this use", "test it again after the call"
-			if lost.inLoop {
-				event, again = "the loop body calls a function that can run before this use", "test it again inside the loop"
-			}
-			hint := fmt.Sprintf("%s, or bind it first ('let v = %s' before the 'if') and use 'v'", again, key)
+			hint := fmt.Sprintf("%s, or bind it first ('let v = %s' before the 'if') and use 'v'", lost.again, key)
 			if strings.HasSuffix(lost.why, "is a global") {
-				hint = fmt.Sprintf("%s, bind it first ('let v = %s' before the 'if') and use 'v', or move the code into a function", again, key)
+				hint = fmt.Sprintf("%s, bind it first ('let v = %s' before the 'if') and use 'v', or move the code into a function", lost.again, key)
 			}
-			return fmt.Errorf("[line %d] '%s' may be null: it was tested, but %s and %s\n  hint: %s", c.currentLine, key, lost.why, event, hint)
+			return fmt.Errorf("[line %d] '%s' may be null: it was tested, but %s and %s\n  hint: %s", c.currentLine, key, lost.why, lost.event, hint)
 		}
 		return fmt.Errorf("[line %d] '%s' may be null; test it first\n  hint: use 'if %s != null then ... end'", c.currentLine, key, key)
 	}

--- a/internal/compiler/narrowing.go
+++ b/internal/compiler/narrowing.go
@@ -95,15 +95,31 @@ func (c *Compiler) narrowType(key string, declared ast.NoxyType) ast.NoxyType {
 // O registro de fatos perdidos (narrowLost) acompanha: um fato perdido dentro
 // do ramo nao vale fora dele, e testar de novo apaga a perda.
 func (c *Compiler) pushFacts(keys []string) func() {
+	return c.pushFactsWith(keys, c.takePendingLost())
+}
+
+// takePendingLost entrega (e zera) as perdas registradas por conditionFacts
+// desde a ultima consulta. O `if` as toma uma vez e as da aos DOIS ramos.
+func (c *Compiler) takePendingLost() map[string]lostFact {
+	pending := c.narrowLostPending
+	c.narrowLostPending = nil
+	return pending
+}
+
+// pushFactsWith e pushFacts com as perdas pendentes explicitas.
+func (c *Compiler) pushFactsWith(keys []string, pending map[string]lostFact) func() {
 	saved := c.narrowed
 	next := make(map[string]struct{}, len(saved)+len(keys))
 	for k := range saved {
 		next[k] = struct{}{}
 	}
 	savedLost := c.narrowLost
-	nextLost := make(map[string]lostFact, len(savedLost))
+	nextLost := make(map[string]lostFact, len(savedLost)+len(pending))
 	for k, why := range savedLost {
 		nextLost[k] = why
+	}
+	for k, lost := range pending {
+		nextLost[k] = lost
 	}
 	for _, k := range keys {
 		next[k] = struct{}{}
@@ -119,10 +135,14 @@ func (c *Compiler) pushFacts(keys []string) func() {
 
 // keepFacts adiciona fatos sem restore (depois de um ramo que termina).
 func (c *Compiler) keepFacts(keys []string) {
-	if len(keys) == 0 {
+	c.keepFactsWith(keys, c.takePendingLost())
+}
+
+func (c *Compiler) keepFactsWith(keys []string, pending map[string]lostFact) {
+	if len(keys) == 0 && len(pending) == 0 {
 		return
 	}
-	c.pushFacts(keys)
+	c.pushFactsWith(keys, pending)
 }
 
 func keyDependsOn(key, root string) bool {
@@ -219,16 +239,32 @@ func (c *Compiler) dropFactsCrossingCall(keys []string, right ast.Expression, op
 		if why == "" {
 			why = fmt.Sprintf("'%s' is read through a reference", k)
 		}
-		if c.narrowLost == nil {
-			c.narrowLost = make(map[string]lostFact)
+		// Pendente: conditionFacts roda ANTES do pushFacts do ramo; o registro
+		// entra no ramo (e so nele) quando pushFacts o consome.
+		if c.narrowLostPending == nil {
+			c.narrowLostPending = make(map[string]lostFact)
 		}
-		c.narrowLost[k] = lostFact{
+		c.narrowLostPending[k] = lostFact{
 			why:   why,
 			event: "a call in the condition ran after the test",
-			again: fmt.Sprintf("put the call before the test ('%s %s %s %s null')", call.String(), op, k, cmp),
+			again: fmt.Sprintf("put the call before the test ('%s(...) %s %s %s null')", calleeLabel(call), op, k, cmp),
 		}
 	}
 	return kept
+}
+
+// calleeLabel e o nome do callee para um hint — nunca call.String(), que e
+// um renderer de debug (perde aspas e parenteses).
+func calleeLabel(call *ast.CallExpression) string {
+	switch fn := call.Function.(type) {
+	case *ast.Identifier:
+		return fn.Value
+	case *ast.MemberAccessExpression:
+		if base, ok := fn.Left.(*ast.Identifier); ok {
+			return base.Value + "." + fn.Member
+		}
+	}
+	return "f"
 }
 
 // rootSharing: a raiz pode mudar por fora deste frame — slot `ref`,
@@ -251,10 +287,23 @@ func (c *Compiler) rootSharing(root string) (shared bool, why string) {
 		}
 		return false, ""
 	}
-	if slot, _ := c.resolveUpvalue(root); slot != -1 {
+	if c.enclosingHasLocal(root) {
 		return true, fmt.Sprintf("'%s' is an upvalue", root)
 	}
 	return true, fmt.Sprintf("'%s' is a global", root)
+}
+
+// enclosingHasLocal: o nome resolve para um local de alguma funcao envolvente
+// — SEM capturar. resolveUpvalue marca IsCaptured e cria o upvalue; uma
+// classificacao para diagnostico nao pode mudar o programa (a revisao do #119
+// achou uma chave morta `p` capturando o `p` homonimo do pai).
+func (c *Compiler) enclosingHasLocal(name string) bool {
+	for e := c.enclosing; e != nil; e = e.enclosing {
+		if slot, _ := e.resolveLocal(name); slot != -1 {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Compiler) rootIsShared(root string) bool {
@@ -290,12 +339,18 @@ func (c *Compiler) dropSharedAfterCall(event, again string) {
 }
 
 // pureBuiltins sao os builtins centrais (builtin_return_types.go, mais os
-// sem tipo de retorno util) que nunca executam codigo Noxy: uma chamada a
-// eles nao pode reatribuir raiz nenhuma, entao nao encerra narrowing (#118).
+// sem tipo de retorno util — print/eprint/iprint/eiprint, append/pop/delete,
+// range/keys/slice) que nunca executam codigo Noxy: uma chamada a eles nao
+// pode reatribuir raiz nenhuma, entao nao encerra narrowing (#118).
 // call_result, spawn_task, task_await e chamadas via `func` bare ficam fora:
-// reentram em codigo do programa.
+// reentram em codigo do programa. json_loads tambem: escreve atraves do ref
+// e pode por null na raiz.
 var pureBuiltins = func() map[string]struct{} {
-	set := map[string]struct{}{"print": {}, "range": {}, "keys": {}, "slice": {}}
+	set := map[string]struct{}{
+		"print": {}, "eprint": {}, "iprint": {}, "eiprint": {},
+		"append": {}, "pop": {}, "delete": {},
+		"range": {}, "keys": {}, "slice": {},
+	}
 	for name := range coreBuiltinReturnTypes {
 		set[name] = struct{}{}
 	}
@@ -304,20 +359,26 @@ var pureBuiltins = func() map[string]struct{} {
 
 // isPureBuiltinCall: a chamada resolve para um builtin puro — nome na tabela
 // e nao sombreado por local, upvalue ou global declarado pelo programa (a
-// mesma regra de sombreamento de builtinReturnType, compileCallExpression).
+// mesma regra de sombreamento de builtinReturnType, compileCallExpression) —
+// ou para um construtor de struct (declarado ou template generico), que
+// tambem nao roda codigo do programa.
 func (c *Compiler) isPureBuiltinCall(call *ast.CallExpression) bool {
 	ident, ok := call.Function.(*ast.Identifier)
 	if !ok {
 		return false
 	}
-	if _, pure := pureBuiltins[ident.Value]; !pure {
-		return false
-	}
 	if c.isShadowedByLocal(ident.Value) {
 		return false
 	}
-	_, declared := c.globals[ident.Value]
-	return !declared
+	if _, pure := pureBuiltins[ident.Value]; pure {
+		_, declared := c.globals[ident.Value]
+		return !declared
+	}
+	if c.structDeclaration(ident.Value) != nil {
+		return true
+	}
+	_, isStructTemplate := c.registryOrInit().Structs[ident.Value]
+	return isStructTemplate
 }
 
 // noteAssignment invalida os fatos afetados por uma atribuicao a target.
@@ -369,6 +430,21 @@ func (c *Compiler) loopEffects(body *ast.BlockStatement) (roots []string, hasCal
 	if body == nil {
 		return nil, false
 	}
+	// A pureza e decidida ANTES de compilar o corpo: um `let print = zera`
+	// (ou `func`) declarado dentro do laco sombreia o builtin na iteracao — o
+	// nome declarado no corpo torna a chamada homonima impura (revisao #119).
+	declared := map[string]struct{}{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.LetStmt:
+			if n.Name != nil {
+				declared[n.Name.Value] = struct{}{}
+			}
+		case *ast.FunctionStatement:
+			declared[n.Name] = struct{}{}
+		}
+		return true
+	})
 	seen := map[string]struct{}{}
 	add := func(expr ast.Expression) {
 		if key, ok := stableKey(expr); ok {
@@ -390,7 +466,11 @@ func (c *Compiler) loopEffects(body *ast.BlockStatement) (roots []string, hasCal
 		case *ast.ForStatement:
 			seen[n.Identifier] = struct{}{}
 		case *ast.CallExpression:
-			if !c.isPureBuiltinCall(n) {
+			shadowedInBody := false
+			if ident, ok := n.Function.(*ast.Identifier); ok {
+				_, shadowedInBody = declared[ident.Value]
+			}
+			if shadowedInBody || !c.isPureBuiltinCall(n) {
 				hasCall = true
 			}
 		}

--- a/internal/compiler/narrowing.go
+++ b/internal/compiler/narrowing.go
@@ -99,7 +99,7 @@ func (c *Compiler) pushFacts(keys []string) func() {
 		next[k] = struct{}{}
 	}
 	savedLost := c.narrowLost
-	nextLost := make(map[string]string, len(savedLost))
+	nextLost := make(map[string]lostFact, len(savedLost))
 	for k, why := range savedLost {
 		nextLost[k] = why
 	}
@@ -168,56 +168,68 @@ func rootOf(key string) string {
 	return key
 }
 
-// rootIsShared: a raiz pode mudar por fora deste frame — slot `ref`,
-// capturada por closure, endereco tomado com `ref`, upvalue ou global.
-func (c *Compiler) rootIsShared(root string) bool {
+// lostFact: por que um fato foi derrubado por chamada (dropAfterCall) e se
+// foi na entrada de um laco (dropForLoop) — so para o diagnostico.
+type lostFact struct {
+	why    string
+	inLoop bool
+}
+
+// rootSharing: a raiz pode mudar por fora deste frame — slot `ref`,
+// capturada por closure, endereco tomado com `ref`, upvalue ou global — e o
+// motivo em palavras, para o diagnostico do fato perdido.
+func (c *Compiler) rootSharing(root string) (shared bool, why string) {
 	for i := len(c.locals) - 1; i >= 0; i-- {
 		if c.locals[i].Name != root {
 			continue
 		}
 		l := c.locals[i]
 		if _, isRef := asRefType(l.Type); isRef {
-			return true
+			return true, fmt.Sprintf("'%s' is a ref", root)
 		}
-		return l.IsCaptured || l.RefTaken
+		if l.IsCaptured {
+			return true, fmt.Sprintf("'%s' is captured by a closure", root)
+		}
+		if l.RefTaken {
+			return true, fmt.Sprintf("'%s' had its address taken with 'ref'", root)
+		}
+		return false, ""
 	}
-	return true
+	if slot, _ := c.resolveUpvalue(root); slot != -1 {
+		return true, fmt.Sprintf("'%s' is an upvalue", root)
+	}
+	return true, fmt.Sprintf("'%s' is a global", root)
+}
+
+func (c *Compiler) rootIsShared(root string) bool {
+	shared, _ := c.rootSharing(root)
+	return shared
 }
 
 // dropAfterCall invalida o que uma chamada pode ter mudado e registra o
 // motivo, para o diagnostico de leitura sem fato (mayBeNullError).
 func (c *Compiler) dropAfterCall() {
-	for k := range c.narrowed {
-		if strings.HasPrefix(k, "*") || c.rootIsShared(rootOf(k)) {
-			delete(c.narrowed, k)
-			if c.narrowLost == nil {
-				c.narrowLost = make(map[string]string)
-			}
-			c.narrowLost[k] = c.sharedRootReason(rootOf(k))
-		}
-	}
+	c.dropSharedAfterCall(false)
 }
 
-// sharedRootReason descreve por que a raiz e alcancavel durante uma chamada —
-// a mesma classificacao de rootIsShared, em palavras.
-func (c *Compiler) sharedRootReason(root string) string {
-	for i := len(c.locals) - 1; i >= 0; i-- {
-		if c.locals[i].Name != root {
+// dropSharedAfterCall e o corpo de dropAfterCall; inLoop marca que a queda
+// veio da entrada de um laco (dropForLoop) — a chamada pode vir DEPOIS do
+// uso no texto e rodar antes dele na iteracao seguinte.
+func (c *Compiler) dropSharedAfterCall(inLoop bool) {
+	for k := range c.narrowed {
+		shared, why := c.rootSharing(rootOf(k))
+		if !strings.HasPrefix(k, "*") && !shared {
 			continue
 		}
-		l := c.locals[i]
-		if _, isRef := asRefType(l.Type); isRef {
-			return fmt.Sprintf("'%s' is a ref", root)
+		delete(c.narrowed, k)
+		if why == "" {
+			why = fmt.Sprintf("'%s' is read through a reference", k)
 		}
-		if l.IsCaptured {
-			return fmt.Sprintf("'%s' is captured by a closure", root)
+		if c.narrowLost == nil {
+			c.narrowLost = make(map[string]lostFact)
 		}
-		return fmt.Sprintf("'%s' had its address taken with 'ref'", root)
+		c.narrowLost[k] = lostFact{why: why, inLoop: inLoop}
 	}
-	if slot, _ := c.resolveUpvalue(root); slot != -1 {
-		return fmt.Sprintf("'%s' is an upvalue", root)
-	}
-	return fmt.Sprintf("'%s' is a global", root)
 }
 
 // pureBuiltins sao os builtins centrais (builtin_return_types.go, mais os
@@ -341,7 +353,7 @@ func (c *Compiler) dropForLoop(body *ast.BlockStatement) {
 		c.dropKey(r)
 	}
 	if hasCall {
-		c.dropAfterCall()
+		c.dropSharedAfterCall(true)
 	}
 }
 
@@ -414,12 +426,16 @@ func (c *Compiler) narrowBorrowOwner(base ast.Expression, owner ast.NoxyType) (a
 // `if x != null` com o `if` a duas linhas de distancia e enganoso (#118).
 func (c *Compiler) mayBeNullError(expr ast.Expression, t ast.NoxyType) error {
 	if key, ok := stableKey(expr); ok {
-		if why, lost := c.narrowLost[key]; lost {
-			hint := fmt.Sprintf("test it again after the call, or bind it first ('let v = %s' before the 'if') and use 'v'", key)
-			if strings.HasSuffix(why, "is a global") {
-				hint = fmt.Sprintf("test it again after the call, bind it first ('let v = %s' before the 'if') and use 'v', or move the code into a function", key)
+		if lost, ok := c.narrowLost[key]; ok {
+			event, again := "a call came between the test and this use", "test it again after the call"
+			if lost.inLoop {
+				event, again = "the loop body calls a function that can run before this use", "test it again inside the loop"
 			}
-			return fmt.Errorf("[line %d] '%s' may be null: it was tested, but %s and a call came between the test and this use\n  hint: %s", c.currentLine, key, why, hint)
+			hint := fmt.Sprintf("%s, or bind it first ('let v = %s' before the 'if') and use 'v'", again, key)
+			if strings.HasSuffix(lost.why, "is a global") {
+				hint = fmt.Sprintf("%s, bind it first ('let v = %s' before the 'if') and use 'v', or move the code into a function", again, key)
+			}
+			return fmt.Errorf("[line %d] '%s' may be null: it was tested, but %s and %s\n  hint: %s", c.currentLine, key, lost.why, event, hint)
 		}
 		return fmt.Errorf("[line %d] '%s' may be null; test it first\n  hint: use 'if %s != null then ... end'", c.currentLine, key, key)
 	}

--- a/internal/compiler/narrowing.go
+++ b/internal/compiler/narrowing.go
@@ -90,17 +90,29 @@ func (c *Compiler) narrowType(key string, declared ast.NoxyType) ast.NoxyType {
 }
 
 // pushFacts adiciona fatos e devolve o restore que repoe o conjunto anterior.
+// O registro de fatos perdidos (narrowLost) acompanha: um fato perdido dentro
+// do ramo nao vale fora dele, e testar de novo apaga a perda.
 func (c *Compiler) pushFacts(keys []string) func() {
 	saved := c.narrowed
 	next := make(map[string]struct{}, len(saved)+len(keys))
 	for k := range saved {
 		next[k] = struct{}{}
 	}
+	savedLost := c.narrowLost
+	nextLost := make(map[string]string, len(savedLost))
+	for k, why := range savedLost {
+		nextLost[k] = why
+	}
 	for _, k := range keys {
 		next[k] = struct{}{}
+		delete(nextLost, k)
 	}
 	c.narrowed = next
-	return func() { c.narrowed = saved }
+	c.narrowLost = nextLost
+	return func() {
+		c.narrowed = saved
+		c.narrowLost = savedLost
+	}
 }
 
 // keepFacts adiciona fatos sem restore (depois de um ramo que termina).
@@ -120,10 +132,16 @@ func keyDependsOn(key, root string) bool {
 }
 
 // dropKey invalida a chave e tudo que depende dela (`x` derruba `x.a`, `*x`).
+// Uma atribuicao supera o motivo "perdido por chamada": o registro sai junto.
 func (c *Compiler) dropKey(key string) {
 	for k := range c.narrowed {
 		if keyDependsOn(k, key) {
 			delete(c.narrowed, k)
+		}
+	}
+	for k := range c.narrowLost {
+		if keyDependsOn(k, key) {
+			delete(c.narrowLost, k)
 		}
 	}
 }
@@ -133,6 +151,11 @@ func (c *Compiler) dropCompound() {
 	for k := range c.narrowed {
 		if strings.ContainsAny(k, ".*") {
 			delete(c.narrowed, k)
+		}
+	}
+	for k := range c.narrowLost {
+		if strings.ContainsAny(k, ".*") {
+			delete(c.narrowLost, k)
 		}
 	}
 }
@@ -161,13 +184,71 @@ func (c *Compiler) rootIsShared(root string) bool {
 	return true
 }
 
-// dropAfterCall invalida o que uma chamada pode ter mudado.
+// dropAfterCall invalida o que uma chamada pode ter mudado e registra o
+// motivo, para o diagnostico de leitura sem fato (mayBeNullError).
 func (c *Compiler) dropAfterCall() {
 	for k := range c.narrowed {
 		if strings.HasPrefix(k, "*") || c.rootIsShared(rootOf(k)) {
 			delete(c.narrowed, k)
+			if c.narrowLost == nil {
+				c.narrowLost = make(map[string]string)
+			}
+			c.narrowLost[k] = c.sharedRootReason(rootOf(k))
 		}
 	}
+}
+
+// sharedRootReason descreve por que a raiz e alcancavel durante uma chamada —
+// a mesma classificacao de rootIsShared, em palavras.
+func (c *Compiler) sharedRootReason(root string) string {
+	for i := len(c.locals) - 1; i >= 0; i-- {
+		if c.locals[i].Name != root {
+			continue
+		}
+		l := c.locals[i]
+		if _, isRef := asRefType(l.Type); isRef {
+			return fmt.Sprintf("'%s' is a ref", root)
+		}
+		if l.IsCaptured {
+			return fmt.Sprintf("'%s' is captured by a closure", root)
+		}
+		return fmt.Sprintf("'%s' had its address taken with 'ref'", root)
+	}
+	if slot, _ := c.resolveUpvalue(root); slot != -1 {
+		return fmt.Sprintf("'%s' is an upvalue", root)
+	}
+	return fmt.Sprintf("'%s' is a global", root)
+}
+
+// pureBuiltins sao os builtins centrais (builtin_return_types.go, mais os
+// sem tipo de retorno util) que nunca executam codigo Noxy: uma chamada a
+// eles nao pode reatribuir raiz nenhuma, entao nao encerra narrowing (#118).
+// call_result, spawn_task, task_await e chamadas via `func` bare ficam fora:
+// reentram em codigo do programa.
+var pureBuiltins = func() map[string]struct{} {
+	set := map[string]struct{}{"print": {}, "range": {}, "keys": {}, "slice": {}}
+	for name := range coreBuiltinReturnTypes {
+		set[name] = struct{}{}
+	}
+	return set
+}()
+
+// isPureBuiltinCall: a chamada resolve para um builtin puro — nome na tabela
+// e nao sombreado por local, upvalue ou global declarado pelo programa (a
+// mesma regra de sombreamento de builtinReturnType, compileCallExpression).
+func (c *Compiler) isPureBuiltinCall(call *ast.CallExpression) bool {
+	ident, ok := call.Function.(*ast.Identifier)
+	if !ok {
+		return false
+	}
+	if _, pure := pureBuiltins[ident.Value]; !pure {
+		return false
+	}
+	if c.isShadowedByLocal(ident.Value) {
+		return false
+	}
+	_, declared := c.globals[ident.Value]
+	return !declared
 }
 
 // noteAssignment invalida os fatos afetados por uma atribuicao a target.
@@ -213,8 +294,9 @@ func (c *Compiler) markRefTaken(expr ast.Expression) {
 }
 
 // loopEffects colhe as raizes atribuidas no corpo de um laco (alvo de `=`,
-// operando de `ref`, variavel do for) e se ha alguma chamada.
-func loopEffects(body *ast.BlockStatement) (roots []string, hasCall bool) {
+// operando de `ref`, variavel do for) e se ha alguma chamada que encerra
+// narrowing (builtin puro nao conta — isPureBuiltinCall).
+func (c *Compiler) loopEffects(body *ast.BlockStatement) (roots []string, hasCall bool) {
 	if body == nil {
 		return nil, false
 	}
@@ -239,7 +321,9 @@ func loopEffects(body *ast.BlockStatement) (roots []string, hasCall bool) {
 		case *ast.ForStatement:
 			seen[n.Identifier] = struct{}{}
 		case *ast.CallExpression:
-			hasCall = true
+			if !c.isPureBuiltinCall(n) {
+				hasCall = true
+			}
 		}
 		return true
 	})
@@ -252,7 +336,7 @@ func loopEffects(body *ast.BlockStatement) (roots []string, hasCall bool) {
 // dropForLoop invalida, ANTES de compilar um laco, os fatos que o corpo
 // pode derrubar em qualquer iteracao.
 func (c *Compiler) dropForLoop(body *ast.BlockStatement) {
-	roots, hasCall := loopEffects(body)
+	roots, hasCall := c.loopEffects(body)
 	for _, r := range roots {
 		c.dropKey(r)
 	}
@@ -326,8 +410,17 @@ func (c *Compiler) narrowBorrowOwner(base ast.Expression, owner ast.NoxyType) (a
 }
 
 // mayBeNullError e o diagnostico de leitura atraves de um `T?` sem teste.
+// Se o fato existiu e uma chamada o derrubou (narrowLost), diz isso: sugerir
+// `if x != null` com o `if` a duas linhas de distancia e enganoso (#118).
 func (c *Compiler) mayBeNullError(expr ast.Expression, t ast.NoxyType) error {
 	if key, ok := stableKey(expr); ok {
+		if why, lost := c.narrowLost[key]; lost {
+			hint := fmt.Sprintf("test it again after the call, or bind it first ('let v = %s' before the 'if') and use 'v'", key)
+			if strings.HasSuffix(why, "is a global") {
+				hint = fmt.Sprintf("test it again after the call, bind it first ('let v = %s' before the 'if') and use 'v', or move the code into a function", key)
+			}
+			return fmt.Errorf("[line %d] '%s' may be null: it was tested, but %s and a call came between the test and this use\n  hint: %s", c.currentLine, key, why, hint)
+		}
 		return fmt.Errorf("[line %d] '%s' may be null; test it first\n  hint: use 'if %s != null then ... end'", c.currentLine, key, key)
 	}
 	return fmt.Errorf("[line %d] value of type %s may be null; test it first\n  hint: bind it with 'let' and test for null", c.currentLine, t.String())

--- a/internal/compiler/narrowing_condition_calls_test.go
+++ b/internal/compiler/narrowing_condition_calls_test.go
@@ -1,0 +1,59 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #120 item 3: em `a && b` / `a || b`, uma chamada nao-pura no operando
+// direito pode derrubar a raiz compartilhada DEPOIS do teste do esquerdo —
+// os fatos exportados para o ramo nao podem incluir essa raiz.
+
+const narrowingCondPrelude = "func busca() -> map[string, any]?\n    return {\"nome\": \"Ana\"}\nend\nfunc toca() -> bool\n    m = null\n    return true\nend\nlet m: map[string, any]? = busca()\n"
+
+func TestNarrowingAndOperandCallDropsSharedRootFacts(t *testing.T) {
+	src := narrowingCondPrelude + "if m != null && toca() then\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "[line 10] 'm' may be null: it was tested, but 'm' is a global and a call in the condition ran after the test\n  hint: put the call before the test ('toca() && m != null'), bind it first ('let v = m' before the 'if') and use 'v', or move the code into a function"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestNarrowingOrOperandCallDropsElseFacts(t *testing.T) {
+	src := narrowingCondPrelude + "if m == null || toca() then\n    print(\"vazio\")\nelse\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	if err == nil || !strings.Contains(err.Error(), "'m' may be null: it was tested, but 'm' is a global and a call in the condition ran after the test") {
+		t.Fatalf("want lost-in-condition diagnostic, got %v", err)
+	}
+}
+
+func TestNarrowingWhileConditionCallDropsSharedRootFacts(t *testing.T) {
+	src := narrowingCondPrelude + "while m != null && toca() do\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	if err == nil || !strings.Contains(err.Error(), "'m' may be null: it was tested, but 'm' is a global and a call in the condition ran after the test") {
+		t.Fatalf("want lost-in-condition diagnostic, got %v", err)
+	}
+}
+
+func TestNarrowingAndOperandPureBuiltinKeepsFacts(t *testing.T) {
+	src := narrowingCondPrelude + "if m != null && length(m) > 0 then\n    print(m[\"nome\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingAndOperandCallKeepsValueLocalFacts(t *testing.T) {
+	// Local de valor: ninguem fora do frame alcanca `p` durante toca().
+	src := "struct P\n    x: int\nend\nfunc toca() -> bool\n    return true\nend\nfunc f(p: P?) -> int\n    if p != null && toca() then\n        return p.x\n    end\n    return 0\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingCallBeforeTestInConditionKeepsFacts(t *testing.T) {
+	src := narrowingCondPrelude + "if toca() && m != null then\n    print(m[\"nome\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/compiler/narrowing_condition_calls_test.go
+++ b/internal/compiler/narrowing_condition_calls_test.go
@@ -14,7 +14,7 @@ const narrowingCondPrelude = "func busca() -> map[string, any]?\n    return {\"n
 func TestNarrowingAndOperandCallDropsSharedRootFacts(t *testing.T) {
 	src := narrowingCondPrelude + "if m != null && toca() then\n    print(m[\"nome\"])\nend\n"
 	_, err := compileFunctionSource(t, src)
-	want := "[line 10] 'm' may be null: it was tested, but 'm' is a global and a call in the condition ran after the test\n  hint: put the call before the test ('toca() && m != null'), bind it first ('let v = m' before the 'if') and use 'v', or move the code into a function"
+	want := "[line 10] 'm' may be null: it was tested, but 'm' is a global and a call in the condition ran after the test\n  hint: put the call before the test ('toca(...) && m != null'), bind it first ('let v = m' before the 'if') and use 'v', or move the code into a function"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("want %q, got %v", want, err)
 	}

--- a/internal/compiler/narrowing_pure_builtins_test.go
+++ b/internal/compiler/narrowing_pure_builtins_test.go
@@ -88,6 +88,18 @@ func TestNarrowingLostDiagnosticDoesNotLeakOutsideTheBranch(t *testing.T) {
 	}
 }
 
+func TestNarrowingLostInLoopDiagnosticNamesTheLoop(t *testing.T) {
+	// O fato cai na ENTRADA do laco (dropForLoop): a chamada vem depois do
+	// uso no texto, mas roda antes dele na iteracao seguinte — a mensagem
+	// nao pode dizer "a call came between the test and this use".
+	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    let i: int = 0\n    while i < 2 do\n        print(m[\"nome\"])\n        toca()\n        i = i + 1\n    end\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "[line 11] 'm' may be null: it was tested, but 'm' is a global and the loop body calls a function that can run before this use\n  hint: test it again inside the loop, bind it first ('let v = m' before the 'if') and use 'v', or move the code into a function"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
 func TestNarrowingLostDiagnosticClearedWhenTestedAgain(t *testing.T) {
 	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    toca()\n    if m != null then\n        print(m[\"nome\"])\n    end\nend\n"
 	if _, err := compileFunctionSource(t, src); err != nil {

--- a/internal/compiler/narrowing_pure_builtins_test.go
+++ b/internal/compiler/narrowing_pure_builtins_test.go
@@ -1,0 +1,96 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #118 item 2: uma chamada a builtin central (print, to_str, length...)
+// nao encerra o narrowing — sao nativos que nunca executam codigo Noxy, entao
+// nada alcanca a raiz durante a chamada. A f-string vira `to_str(...)` no
+// parser, logo `f"{m['a']} {m['b']}"` sobre um global estreitado compila.
+
+const narrowingGlobalMapPrelude = "func busca() -> map[string, any]?\n    return {\"nome\": \"Ana\", \"idade\": 30}\nend\nlet m: map[string, any]? = busca()\n"
+
+func TestNarrowingGlobalSurvivesFStringInterpolations(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "if m != null then\n    print(f\"{m['nome']} {m['idade']}\")\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingGlobalSurvivesCoreBuiltinCalls(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "if m != null then\n    print(to_str(m[\"nome\"]) + \" \" + to_str(m[\"idade\"]))\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingGlobalSurvivesPrintBetweenUses(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "if m != null then\n    print(m[\"nome\"])\n    print(m[\"idade\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingGlobalSurvivesLoopWithOnlyCoreBuiltinCalls(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "if m != null then\n    let i: int = 0\n    while i < 2 do\n        print(m[\"nome\"])\n        i = i + 1\n    end\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingGlobalLostAfterUserFunctionCall(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    toca()\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	if err == nil || !strings.Contains(err.Error(), "'m' may be null") {
+		t.Fatalf("want 'm' may be null, got %v", err)
+	}
+}
+
+func TestNarrowingShadowedBuiltinEndsNarrowing(t *testing.T) {
+	// `to_str` declarado pelo programa nao e o nativo puro: pode reatribuir m.
+	src := narrowingGlobalMapPrelude + "func to_str(v: any) -> string\n    m = null\n    return \"x\"\nend\nif m != null then\n    print(to_str(m[\"nome\"]) + to_str(m[\"idade\"]))\nend\n"
+	_, err := compileFunctionSource(t, src)
+	if err == nil || !strings.Contains(err.Error(), "'m' may be null") {
+		t.Fatalf("want 'm' may be null, got %v", err)
+	}
+}
+
+// Issue #118 item 3: quando o fato existiu e foi derrubado por uma chamada, o
+// diagnostico diz isso — e nao sugere o `if` que ja esta ali.
+
+func TestNarrowingLostAfterCallDiagnosticNamesGlobalRoot(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    toca()\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "[line 10] 'm' may be null: it was tested, but 'm' is a global and a call came between the test and this use\n  hint: test it again after the call, bind it first ('let v = m' before the 'if') and use 'v', or move the code into a function"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestNarrowingLostAfterCallDiagnosticNamesRefRoot(t *testing.T) {
+	src := "struct Node\n    valor: int\n    prox: Node?\nend\nfunc toca(n: ref Node) -> void\n    n.prox = null\nend\nfunc f(no: ref Node) -> int\n    if no.prox != null then\n        toca(no)\n        return no.prox.valor\n    end\n    return 0\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "'no.prox' may be null: it was tested, but 'no' is a ref and a call came between the test and this use\n  hint: test it again after the call, or bind it first ('let v = no.prox' before the 'if') and use 'v'"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestNarrowingLostDiagnosticDoesNotLeakOutsideTheBranch(t *testing.T) {
+	// Fora do `if` nunca houve fato: a mensagem e a comum, nao a de fato perdido.
+	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    toca()\nend\nprint(m[\"nome\"])\n"
+	_, err := compileFunctionSource(t, src)
+	want := "'m' may be null; test it first\n  hint: use 'if m != null then ... end'"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+func TestNarrowingLostDiagnosticClearedWhenTestedAgain(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "func toca() -> void\n    m = null\nend\nif m != null then\n    toca()\n    if m != null then\n        print(m[\"nome\"])\n    end\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/compiler/narrowing_review_test.go
+++ b/internal/compiler/narrowing_review_test.go
@@ -1,0 +1,73 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+)
+
+// Revisao do PR #119 — regressoes e lacunas do narrowing.
+
+// rootSharing chamava resolveUpvalue, que MUTA (marca IsCaptured e cria o
+// upvalue): uma chave morta `p` deixada por um `let p` num laco dentro da
+// closure capturava o `p` homonimo da funcao externa e derrubava o narrowing
+// dela. Tambem: fatos de um local que sai de escopo nao podem sobreviver.
+func TestNarrowingDeadFactDoesNotCaptureOuterLocal(t *testing.T) {
+	src := "struct P\n    x: int\nend\nfunc toca() -> void\n    return\nend\nfunc f(p: P?) -> int\n    let g = func() -> void\n        for i in range(1) do\n            let p: P? = P(1)\n            if p == null then\n                continue\n            end\n        end\n        toca()\n    end\n    g()\n    if p != null then\n        g()\n        return p.x\n    end\n    return 2\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// loopEffects decidia a pureza pelo nome ANTES de compilar o corpo: `let
+// print = zera` dentro do laco passava como builtin puro e o fato sobrevivia.
+func TestNarrowingLoopShadowedBuiltinIsImpure(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "func zera(v: any) -> void\n    m = null\nend\nif m != null then\n    let i: int = 0\n    while i < 2 do\n        let print = zera\n        print(m[\"nome\"])\n        i = i + 1\n    end\nend\n"
+	_, err := compileFunctionSource(t, src)
+	if err == nil || !strings.Contains(err.Error(), "'m' may be null") {
+		t.Fatalf("want 'm' may be null, got %v", err)
+	}
+}
+
+// Construtor de struct nao roda codigo do programa: e puro como um builtin.
+func TestNarrowingStructConstructorIsPureInCondition(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "struct P\n    x: int\nend\nif m != null && P(1).x == 1 then\n    print(m[\"nome\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNarrowingStructConstructorIsPureBetweenUses(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "struct P\n    x: int\nend\nif m != null then\n    let p: P = P(1)\n    print(m[\"nome\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// eprint/iprint sao builtins centrais (spec §10) e nao rodam codigo Noxy.
+func TestNarrowingGlobalSurvivesEprint(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "if m != null then\n    eprint(m[\"nome\"])\n    eprint(m[\"idade\"])\nend\n"
+	if _, err := compileFunctionSource(t, src); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// O registro do fato perdido na condicao vale so dentro do ramo.
+func TestNarrowingLostInConditionDoesNotLeakOutsideTheBranch(t *testing.T) {
+	src := narrowingCondPrelude + "if m != null && toca() then\n    print(\"x\")\nend\nprint(m[\"nome\"])\n"
+	_, err := compileFunctionSource(t, src)
+	want := "'m' may be null; test it first\n  hint: use 'if m != null then ... end'"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}
+
+// O hint nao renderiza a chamada inteira (call.String() e um renderer de
+// debug que perde aspas): so o nome do callee.
+func TestNarrowingLostInConditionHintNamesTheCallee(t *testing.T) {
+	src := narrowingGlobalMapPrelude + "func toca2(k: string) -> bool\n    m = null\n    return true\nend\nif m != null && toca2(\"k\") then\n    print(m[\"nome\"])\nend\n"
+	_, err := compileFunctionSource(t, src)
+	want := "hint: put the call before the test ('toca2(...) && m != null')"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("want %q, got %v", want, err)
+	}
+}

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -51,6 +51,19 @@ func (c *Compiler) emitDynamicBoundaryGuard(expected, actual ast.NoxyType) error
 	return c.emitMarkRuntimeValueType(expected)
 }
 
+// emitSlotGuards e o UNICO ponto de emissao das checagens de um slot tipado
+// que recebe um valor (let, atribuicao, argumento, return, elemento de
+// append, chave de delete...): metadado de composto (emitRuntimeValueType) e
+// guarda da fronteira dinamica (emitDynamicBoundaryGuard). Todo site de slot
+// passa por aqui — a revisao do #119 achou tres sites que emitiam so o
+// primeiro.
+func (c *Compiler) emitSlotGuards(expected, actual ast.NoxyType) error {
+	if err := c.emitRuntimeValueType(expected); err != nil {
+		return err
+	}
+	return c.emitDynamicBoundaryGuard(expected, actual)
+}
+
 // emitMarkRuntimeValueType emite OP_MARK_RUNTIME_VALUE_TYPE para o tipo t
 // sobre o valor no topo da pilha; no-op para tipos sem descricao de runtime.
 func (c *Compiler) emitMarkRuntimeValueType(t ast.NoxyType) error {

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -22,6 +22,32 @@ func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
 	if !c.requiresRuntimeValueType(t, make(map[*ast.StructStatement]bool), "") {
 		return nil
 	}
+	return c.emitMarkRuntimeValueType(t)
+}
+
+// emitDynamicBoundaryGuard e a checagem de runtime da fronteira dinamica
+// (spec §4.2, #118): quando o tipo estatico do valor e `any` ou desconhecido
+// e o slot tem tipo concreto, o valor no topo da pilha e conferido contra o
+// tipo do slot — `expected int, got string`. Vale para let anotado, argumento
+// de assinatura exata e return. Tipos que ja carregam metadado (array, map,
+// chan) foram marcados — e validados — por emitRuntimeValueType; o resto
+// (primitivos, structs, refs) so passa por aqui. Codigo tipado nao paga nada.
+func (c *Compiler) emitDynamicBoundaryGuard(expected, actual ast.NoxyType) error {
+	if expected == nil || isAny(expected) {
+		return nil
+	}
+	if actual != nil && !isAny(actual) {
+		return nil
+	}
+	if c.requiresRuntimeValueType(expected, make(map[*ast.StructStatement]bool), "") {
+		return nil
+	}
+	return c.emitMarkRuntimeValueType(expected)
+}
+
+// emitMarkRuntimeValueType emite OP_MARK_RUNTIME_VALUE_TYPE para o tipo t
+// sobre o valor no topo da pilha; no-op para tipos sem descricao de runtime.
+func (c *Compiler) emitMarkRuntimeValueType(t ast.NoxyType) error {
 	runtimeType := c.runtimeTypeInfo(t)
 	if runtimeType == nil {
 		return nil

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -26,22 +26,23 @@ func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
 }
 
 // emitDynamicBoundaryGuard e a checagem de runtime da fronteira dinamica
-// (spec §4.2, #118): quando o tipo estatico do valor e `any` e o slot tem
-// tipo concreto, o valor no topo da pilha e conferido contra o tipo do slot
-// — `expected int, got string`. Vale para let anotado, argumento de
-// assinatura exata e return. Tipos que ja carregam metadado (array, map,
-// chan) foram marcados — e validados — por emitRuntimeValueType; o resto
-// (primitivos, structs, refs) so passa por aqui. Codigo tipado nao paga nada.
+// (spec §4.2, #118/#120): quando o tipo estatico do valor e `any` ou
+// DESCONHECIDO (nil: nativo sem assinatura, membro de namespace, plugin) e o
+// slot tem tipo concreto, o valor no topo da pilha e conferido contra o tipo
+// do slot — `expected int, got string`, `expected Statement, got null`. Vale
+// para let anotado, atribuicao, argumento de assinatura exata e return.
+// Tipos que ja carregam metadado (array, map, chan) foram marcados — e
+// validados — por emitRuntimeValueType; o resto (primitivos, structs, refs)
+// so passa por aqui. Codigo tipado nao paga nada.
 //
-// Tipo estatico DESCONHECIDO (nil: nativo sem assinatura, membro de
-// namespace) fica de fora de proposito: wrappers da stdlib devolvem null num
-// `-> T` (time.parse, sqlite.prepare) e a guarda os abortaria — contrato da
-// stdlib a corrigir antes (follow-up do #118), nao aqui.
+// Os wrappers da stdlib cujo nativo devolve null como resultado de dado
+// (time.parse/parse_date, sqlite.prepare) dizem `T?` na assinatura (#120
+// item 1) — foi o que permitiu ligar a guarda para tipo desconhecido.
 func (c *Compiler) emitDynamicBoundaryGuard(expected, actual ast.NoxyType) error {
 	if expected == nil || isAny(expected) {
 		return nil
 	}
-	if !isAny(actual) {
+	if actual != nil && !isAny(actual) {
 		return nil
 	}
 	if c.requiresRuntimeValueType(expected, make(map[*ast.StructStatement]bool), "") {

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -26,23 +26,25 @@ func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
 }
 
 // emitDynamicBoundaryGuard e a checagem de runtime da fronteira dinamica
-// (spec §4.2, #118/#120): quando o tipo estatico do valor e `any` ou
-// DESCONHECIDO (nil: nativo sem assinatura, membro de namespace, plugin) e o
-// slot tem tipo concreto, o valor no topo da pilha e conferido contra o tipo
-// do slot — `expected int, got string`, `expected Statement, got null`. Vale
-// para let anotado, atribuicao, argumento de assinatura exata e return.
-// Tipos que ja carregam metadado (array, map, chan) foram marcados — e
-// validados — por emitRuntimeValueType; o resto (primitivos, structs, refs)
-// so passa por aqui. Codigo tipado nao paga nada.
+// (spec §4.2, #118/#120): quando o tipo estatico do valor e `any` e o slot
+// tem tipo concreto, o valor no topo da pilha e conferido contra o tipo do
+// slot — `expected int, got string`. Vale para let anotado, atribuicao,
+// argumento de assinatura exata e return. Tipos que ja carregam metadado
+// (array, map, chan) foram marcados — e validados — por emitRuntimeValueType;
+// o resto (primitivos, structs) so passa por aqui. Codigo tipado nao paga
+// nada.
 //
-// Os wrappers da stdlib cujo nativo devolve null como resultado de dado
-// (time.parse/parse_date, sqlite.prepare) dizem `T?` na assinatura (#120
-// item 1) — foi o que permitiu ligar a guarda para tipo desconhecido.
+// Tipo estatico DESCONHECIDO (nil: nativo sem assinatura, membro de
+// namespace `m.f()`, plugin) fica de fora de proposito (revisao do #119,
+// decisao B): 134 natives da stdlib nao declaram contrato de retorno, e a
+// guarda em cada `return native(...)` custava +35-55 % por chamada de
+// wrapper, alem de transformar nulls silenciosos de crypto/net em aborts
+// dentro da stdlib. Contrato de retorno dos natives e issue propria.
 func (c *Compiler) emitDynamicBoundaryGuard(expected, actual ast.NoxyType) error {
 	if expected == nil || isAny(expected) {
 		return nil
 	}
-	if actual != nil && !isAny(actual) {
+	if !isAny(actual) {
 		return nil
 	}
 	if c.requiresRuntimeValueType(expected, make(map[*ast.StructStatement]bool), "") {

--- a/internal/compiler/runtime_types.go
+++ b/internal/compiler/runtime_types.go
@@ -26,17 +26,22 @@ func (c *Compiler) emitRuntimeValueType(t ast.NoxyType) error {
 }
 
 // emitDynamicBoundaryGuard e a checagem de runtime da fronteira dinamica
-// (spec §4.2, #118): quando o tipo estatico do valor e `any` ou desconhecido
-// e o slot tem tipo concreto, o valor no topo da pilha e conferido contra o
-// tipo do slot — `expected int, got string`. Vale para let anotado, argumento
-// de assinatura exata e return. Tipos que ja carregam metadado (array, map,
+// (spec §4.2, #118): quando o tipo estatico do valor e `any` e o slot tem
+// tipo concreto, o valor no topo da pilha e conferido contra o tipo do slot
+// — `expected int, got string`. Vale para let anotado, argumento de
+// assinatura exata e return. Tipos que ja carregam metadado (array, map,
 // chan) foram marcados — e validados — por emitRuntimeValueType; o resto
 // (primitivos, structs, refs) so passa por aqui. Codigo tipado nao paga nada.
+//
+// Tipo estatico DESCONHECIDO (nil: nativo sem assinatura, membro de
+// namespace) fica de fora de proposito: wrappers da stdlib devolvem null num
+// `-> T` (time.parse, sqlite.prepare) e a guarda os abortaria — contrato da
+// stdlib a corrigir antes (follow-up do #118), nao aqui.
 func (c *Compiler) emitDynamicBoundaryGuard(expected, actual ast.NoxyType) error {
 	if expected == nil || isAny(expected) {
 		return nil
 	}
-	if actual != nil && !isAny(actual) {
+	if !isAny(actual) {
 		return nil
 	}
 	if c.requiresRuntimeValueType(expected, make(map[*ast.StructStatement]bool), "") {

--- a/internal/compiler/typed_index.go
+++ b/internal/compiler/typed_index.go
@@ -152,7 +152,7 @@ func (c *Compiler) tryFuseLocalIndexAssign(target *ast.IndexExpression, valueExp
 	if !c.areTypesCompatible(arrType.ElementType, valType) {
 		return true, fmt.Errorf("[line %d] type mismatch in array assignment: expected %s, got %s%s", c.currentLine, arrType.ElementType.String(), valType.String(), c.derefReadHint(arrType.ElementType, valType, valueExpr))
 	}
-	if err := c.emitRuntimeValueType(arrType.ElementType); err != nil {
+	if err := c.emitSlotGuards(arrType.ElementType, valType); err != nil {
 		return true, err
 	}
 	c.emitBytes(byte(op), byte(arg))

--- a/internal/stdlib/sqlite.nx
+++ b/internal/stdlib/sqlite.nx
@@ -48,7 +48,9 @@ func execute_params(db: Database, sql: string, params: any[]) -> ExecResult
     return sqlite_exec_params(db, sql, params, ExecResult(false, "", 0, 0))
 end
 
-func prepare(db: Database, sql: string) -> Statement
+// Prepara um statement; null se o banco esta fechado ou o SQL nao compila
+// (teste com `if stmt != null then`).
+func prepare(db: Database, sql: string) -> Statement?
     return sqlite_prepare(db, sql, Statement(0))
 end
 

--- a/internal/stdlib/time.nx
+++ b/internal/stdlib/time.nx
@@ -95,13 +95,14 @@ end
 // Parsing
 // ============================================
 
-// Parse string "YYYY-MM-DD HH:MM:SS" -> DateTime
-func parse(s: string) -> DateTime
+// Parse string "YYYY-MM-DD HH:MM:SS" -> DateTime; null se a string nao casa
+// o formato (teste com `if dt != null then`).
+func parse(s: string) -> DateTime?
     return time_parse(s, DateTime)
 end
 
-// Parse apenas data "YYYY-MM-DD"
-func parse_date(s: string) -> DateTime
+// Parse apenas data "YYYY-MM-DD"; null se a string nao casa o formato.
+func parse_date(s: string) -> DateTime?
     return time_parse_date(s, DateTime)
 end
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.23.0"
+const Version = "v0.23.1"

--- a/internal/vm/any_boundary_guard_holes_test.go
+++ b/internal/vm/any_boundary_guard_holes_test.go
@@ -1,0 +1,44 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// Revisao do PR #119: tres sites de slot tipado ficaram sem a guarda da
+// fronteira — `*r = v`, o caminho fundido de `xs[i] = v` com xs local e
+// `append(ref xs, v)`. Todos com v de tipo estatico `any`.
+
+func TestAnyBoundaryGuardDerefAssignmentFromAny(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"let x: int = 1\nlet r: ref int = ref x\n*r = nativo()\nprint(x)\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardFusedLocalIndexAssignmentFromAny(t *testing.T) {
+	// xs local + indice e valor sem efeito colateral = tryFuseLocalIndexAssign.
+	err := interpretOrCompileErr(t, New(), "func f() -> int\n    let xs: int[] = [1, 2]\n    let v: any = \"texto\"\n    xs[0] = v\n    return xs[0]\nend\nf()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardFusedRefLocalIndexAssignmentFromAny(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "func f(xs: ref int[]) -> int\n    let v: any = \"texto\"\n    xs[0] = v\n    return xs[0]\nend\nlet a: int[] = [1, 2]\nf(ref a)\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAppendFromAny(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"let xs: int[] = [1]\nappend(ref xs, nativo())\nprint(xs)\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAppendLetsMatchingValueThrough(t *testing.T) {
+	got := captureVMSource(t, "func nativo() -> any\n    return 7\nend\nlet xs: int[] = [1]\nappend(ref xs, nativo())\ntest_report(xs[1])\n")
+	testExpectedObject(t, 7, got)
+}

--- a/internal/vm/any_boundary_guard_test.go
+++ b/internal/vm/any_boundary_guard_test.go
@@ -3,6 +3,8 @@ package vm
 import (
 	"strings"
 	"testing"
+
+	"noxy-vm/internal/value"
 )
 
 // Issue #118 item 1: a fronteira `any` -> slot tipado e checada em runtime em
@@ -115,4 +117,37 @@ end
 let x: any = 41
 test_report(add(x) * 1000 + tipado() * 10 + conta(itens()) + conta(scan()))`)
 	testExpectedObject(t, 42*1000+41*10+2+2, got)
+}
+
+func TestAnyBoundaryGuardSkipsUnknownStaticType(t *testing.T) {
+	// Tipo estatico DESCONHECIDO (nativo sem assinatura, membro de namespace)
+	// nao e `any`: a guarda nao dispara e o comportamento anterior fica —
+	// wrappers da stdlib como time.parse devolvem null num `-> DateTime`
+	// (revisao do #118; contrato da stdlib e follow-up, nao este PR).
+	machine := New()
+	machine.DefineNative("__untyped_null", func(args []value.Value) value.Value {
+		return value.NewNull()
+	})
+	captured := value.NewInt(-1)
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	err := interpretVMSource(t, machine, `
+struct P
+    x: int
+end
+func wrapper() -> P
+    return __untyped_null()
+end
+let p: P = wrapper()
+test_report(p)`)
+	if err != nil {
+		t.Fatalf("unknown static type must keep the pre-#118 behavior, got %v", err)
+	}
+	if captured.Type != value.VAL_NULL {
+		t.Fatalf("want null through the untyped wrapper, got %v", captured)
+	}
 }

--- a/internal/vm/any_boundary_guard_test.go
+++ b/internal/vm/any_boundary_guard_test.go
@@ -1,0 +1,118 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #118 item 1: a fronteira `any` -> slot tipado e checada em runtime em
+// TODAS as posicoes (let anotado, argumento, return), com `expected T, got U`.
+// Antes o let deixava passar um primitivo errado em silencio (x: int com
+// "texto" dentro) e return/argumento nem compilavam.
+
+func TestAnyBoundaryGuardLetPrimitiveMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+func nativo() -> any
+    return "texto"
+end
+let x: int = nativo()`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardArgumentMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+func add(a: int) -> int
+    return a + 1
+end
+func nativo() -> any
+    return "texto"
+end
+add(nativo())`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardReturnMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+func nativo() -> any
+    return "texto"
+end
+func tipado() -> int
+    return nativo()
+end
+tipado()`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardStructMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+struct P
+    x: int
+end
+func nativo() -> any
+    return 42
+end
+let p: P = nativo()`)
+	if err == nil || !strings.Contains(err.Error(), "expected P, got int") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardCompositeMismatchNamesBothTypes(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+func nativo() -> any
+    let xs: int[] = [1, 2]
+    return xs
+end
+func conta(xs: map[string, any][]) -> int
+    return length(xs)
+end
+conta(nativo())`)
+	if err == nil || !strings.Contains(err.Error(), "expected map[string, any][], got int[]") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardNullIntoNonNullableSlot(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
+func nativo() -> any
+    return null
+end
+func tipado() -> int
+    return nativo()
+end
+tipado()`)
+	if err == nil || !strings.Contains(err.Error(), "expected int, got null\n  hint: declare the slot as 'int?' to allow null") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardLetsMatchingValuesThrough(t *testing.T) {
+	got := captureVMSource(t, `
+func add(a: int) -> int
+    return a + 1
+end
+func nativo() -> any
+    return 41
+end
+func tipado() -> int
+    return nativo()
+end
+func itens() -> any
+    return [{"a": 1}, {"b": 2}]
+end
+func conta(xs: map[string, any][]) -> int
+    return length(xs)
+end
+func scan() -> map[string, any][]
+    return itens()
+end
+let x: any = 41
+test_report(add(x) * 1000 + tipado() * 10 + conta(itens()) + conta(scan()))`)
+	testExpectedObject(t, 42*1000+41*10+2+2, got)
+}

--- a/internal/vm/any_boundary_guard_test.go
+++ b/internal/vm/any_boundary_guard_test.go
@@ -119,11 +119,83 @@ test_report(add(x) * 1000 + tipado() * 10 + conta(itens()) + conta(scan()))`)
 	testExpectedObject(t, 42*1000+41*10+2+2, got)
 }
 
-func TestAnyBoundaryGuardSkipsUnknownStaticType(t *testing.T) {
+// Issue #120 item 2: atribuicao (`x = v`, `s.f = v`, `xs[i] = v`) tem a mesma
+// guarda do let anotado para um valor de tipo estatico `any`.
+
+const anyBoundaryTexto = "func nativo() -> any\n    return \"texto\"\nend\n"
+
+func TestAnyBoundaryGuardAssignmentLocalMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"func f() -> int\n    let x: int = 1\n    x = nativo()\n    return x\nend\nf()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentGlobalMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"let x: int = 1\nx = nativo()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentUpvalueMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"func f() -> int\n    let x: int = 1\n    let set = func() -> void\n        x = nativo()\n    end\n    set()\n    return x\nend\nf()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentFieldMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"struct P\n    x: int\nend\nlet p: P = P(1)\np.x = nativo()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentIndexMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"let xs: int[] = [1]\nxs[0] = nativo()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentMapValueMismatch(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyBoundaryTexto+"let m: map[string, int] = {\"a\": 1}\nm[\"a\"] = nativo()\n")
+	if err == nil || !strings.Contains(err.Error(), "expected int, got string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyBoundaryGuardAssignmentLetsMatchingValuesThrough(t *testing.T) {
+	got := captureVMSource(t, `
+func nativo() -> any
+    return 7
+end
+struct P
+    x: int
+end
+let g: int = 0
+g = nativo()
+func f() -> int
+    let x: int = 1
+    x = nativo()
+    let p: P = P(1)
+    p.x = nativo()
+    let xs: int[] = [1]
+    xs[0] = nativo()
+    let m: map[string, int] = {"a": 1}
+    m["a"] = nativo()
+    return x + p.x + xs[0] + m["a"] + g
+end
+test_report(f())`)
+	testExpectedObject(t, 35, got)
+}
+
+func TestAnyBoundaryGuardChecksUnknownStaticType(t *testing.T) {
 	// Tipo estatico DESCONHECIDO (nativo sem assinatura, membro de namespace)
-	// nao e `any`: a guarda nao dispara e o comportamento anterior fica —
-	// wrappers da stdlib como time.parse devolvem null num `-> DateTime`
-	// (revisao do #118; contrato da stdlib e follow-up, nao este PR).
+	// e fronteira dinamica como `any` (spec §4.2): a guarda confere o valor.
+	// Ficou de fora ate os contratos da stdlib serem corrigidos (#120 item 1:
+	// time.parse/parse_date -> DateTime?, sqlite.prepare -> Statement?).
 	machine := New()
 	machine.DefineNative("__untyped_null", func(args []value.Value) value.Value {
 		return value.NewNull()
@@ -144,10 +216,10 @@ func wrapper() -> P
 end
 let p: P = wrapper()
 test_report(p)`)
-	if err != nil {
-		t.Fatalf("unknown static type must keep the pre-#118 behavior, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "expected P, got null\n  hint: declare the slot as 'P?' to allow null") {
+		t.Fatalf("unknown static type must be checked at the boundary, got %v", err)
 	}
-	if captured.Type != value.VAL_NULL {
-		t.Fatalf("want null through the untyped wrapper, got %v", captured)
+	if captured.Type != value.VAL_INT || captured.Int() != -1 {
+		t.Fatalf("the null must not reach test_report, got %v", captured)
 	}
 }

--- a/internal/vm/any_boundary_guard_test.go
+++ b/internal/vm/any_boundary_guard_test.go
@@ -191,11 +191,12 @@ test_report(f())`)
 	testExpectedObject(t, 35, got)
 }
 
-func TestAnyBoundaryGuardChecksUnknownStaticType(t *testing.T) {
+func TestAnyBoundaryGuardSkipsUnknownStaticType(t *testing.T) {
 	// Tipo estatico DESCONHECIDO (nativo sem assinatura, membro de namespace)
-	// e fronteira dinamica como `any` (spec §4.2): a guarda confere o valor.
-	// Ficou de fora ate os contratos da stdlib serem corrigidos (#120 item 1:
-	// time.parse/parse_date -> DateTime?, sqlite.prepare -> Statement?).
+	// NAO e checado por esta guarda: 134 natives da stdlib nao tem contrato
+	// de retorno declarado e a guarda custava +35-55 % por chamada de wrapper
+	// (revisao do #119, decisao B). O contrato de retorno dos natives e uma
+	// issue propria; ate la o comportamento anterior fica.
 	machine := New()
 	machine.DefineNative("__untyped_null", func(args []value.Value) value.Value {
 		return value.NewNull()
@@ -216,10 +217,10 @@ func wrapper() -> P
 end
 let p: P = wrapper()
 test_report(p)`)
-	if err == nil || !strings.Contains(err.Error(), "expected P, got null\n  hint: declare the slot as 'P?' to allow null") {
-		t.Fatalf("unknown static type must be checked at the boundary, got %v", err)
+	if err != nil {
+		t.Fatalf("unknown static type must keep the pre-#118 behavior, got %v", err)
 	}
-	if captured.Type != value.VAL_INT || captured.Int() != -1 {
-		t.Fatalf("the null must not reach test_report, got %v", captured)
+	if captured.Type != value.VAL_NULL {
+		t.Fatalf("want null through the untyped wrapper, got %v", captured)
 	}
 }

--- a/internal/vm/any_ref_runtime_test.go
+++ b/internal/vm/any_ref_runtime_test.go
@@ -1,0 +1,56 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// Revisao do PR #119, condicao 2 (furo residual): `any` pode carregar uma
+// referencia (R2) e entrar num parametro/slot `ref T` — R5 diz que o modo e
+// validado em runtime — mas ninguem conferia o TIPO DO ALVO: `inc(a)` com a
+// guardando `ref string` lia a string como int. Agora a chamada (OP_CALL,
+// modo nao provado) e o slot (`let`/`return`, via OP_MARK) conferem o alvo;
+// um alvo null segue encaminhado (ref-null-forwarding) e falha na leitura.
+
+const anyRefTexto = "let s: string = \"texto\"\nlet a: any = ref s\n"
+
+func TestAnyRefArgumentTargetTypeIsCheckedAtCall(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "func inc(r: ref int) -> int\n    return *r + 1\nend\n"+anyRefTexto+"inc(a)\n")
+	if err == nil || !strings.Contains(err.Error(), "function 'inc' argument 1: expected ref int, got ref string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyRefArgumentWithMatchingTargetPasses(t *testing.T) {
+	got := captureVMSource(t, "func inc(r: ref int) -> int\n    *r = *r + 1\n    return *r\nend\nlet n: int = 41\nlet a: any = ref n\ntest_report(inc(a) * 100 + n)\n")
+	testExpectedObject(t, 42*100+42, got)
+}
+
+func TestAnyRefArgumentNullTargetIsStillForwarded(t *testing.T) {
+	// Convencao ref-null-forwarding: o null chega ao callee e falha na leitura.
+	err := interpretOrCompileErr(t, New(), "struct Node\n    next: ref Node?\nend\nfunc le(r: ref Node) -> int\n    return 1\nend\nlet n: Node = Node(null)\nlet a: any = n.next\nlet z: int = le(a)\nprint(z)\n")
+	if err != nil {
+		t.Fatalf("a null target must be forwarded, not reported as a target-type mismatch, got %v", err)
+	}
+}
+
+func TestAnyRefLetTargetTypeIsChecked(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyRefTexto+"let r: ref int = a\nprint(*r)\n")
+	if err == nil || !strings.Contains(err.Error(), "expected ref int, got ref string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyRefReturnTargetTypeIsChecked(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), anyRefTexto+"func pega() -> ref int\n    return a\nend\nlet r: ref int = pega()\nprint(*r)\n")
+	if err == nil || !strings.Contains(err.Error(), "expected ref int, got ref string") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestAnyRefNullableParameterTargetTypeIsChecked(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "func inc(r: ref int?) -> int\n    return 1\nend\n"+anyRefTexto+"inc(a)\n")
+	if err == nil || !strings.Contains(err.Error(), "function 'inc' argument 1: expected ref int?, got ref string") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/vm/call_validation.go
+++ b/internal/vm/call_validation.go
@@ -36,6 +36,34 @@ func runtimeValueMode(v value.Value) string {
 	}
 }
 
+// validateRefTargets confere o TIPO DO ALVO de cada argumento `ref` contra o
+// parametro `ref T` (revisao do #119, condicao 2): validateParameterModes so
+// olha o modo, e um `any` guardando `ref string` entrava num `ref int` e era
+// lido como int. Roda so no caminho de modo nao provado (OP_CALL com
+// argumento any/desconhecido) — codigo tipado usa OP_CALL_STATIC e nao passa
+// aqui. Alvo null segue encaminhado (ref-null-forwarding: falha na leitura).
+func (vm *VM) validateRefTargets(name string, schema *value.RuntimeTypeInfo, args []value.Value) error {
+	if schema == nil || len(schema.ParamIsRef) != len(schema.Params) {
+		return nil
+	}
+	for i, param := range schema.Params {
+		if i >= len(args) || !schema.ParamIsRef[i] || args[i].Type != value.VAL_REF {
+			continue
+		}
+		if param == nil || param.Kind != value.TYPE_REF || param.Element == nil {
+			continue
+		}
+		target, err := vm.resolveReferenceValue(args[i])
+		if err != nil || target.Type == value.VAL_NULL {
+			continue
+		}
+		if !vm.runtimeValueMatchesType(target, param.Element) {
+			return fmt.Errorf("function '%s' argument %d: expected %s, got %s", name, i+1, param.String(), vm.runtimeValueDescription(args[i]))
+		}
+	}
+	return nil
+}
+
 func validateParameterModes(name string, params []value.ParamInfo, args []value.Value) error {
 	for i, param := range params {
 		if i >= len(args) {

--- a/internal/vm/calls.go
+++ b/internal/vm/calls.go
@@ -125,6 +125,9 @@ func (vm *VM) call(closure *value.ObjClosure, argCount int, c *chunk.Chunk, ip i
 	if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
 		return false, vm.runtimeError(c, ip, "%s", err)
 	}
+	if err := vm.validateRefTargets(fn.Name, fn.RuntimeType, args); err != nil {
+		return false, vm.runtimeError(c, ip, "%s", err)
+	}
 	// RC: fronteira de valor para parametros nao-ref nao precisa de marcacao
 	// aqui — a copia so acontece se alguem mutar (unicize), e a posse do
 	// slot novo e decidida por ownSlot/Retain dentro de callPreparedClosure.

--- a/internal/vm/defer.go
+++ b/internal/vm/defer.go
@@ -32,6 +32,9 @@ func (vm *VM) prepareDeferredCall(callee value.Value, args []value.Value, regist
 		if err := validateParameterModes(fn.Name, fn.Params, args); err != nil {
 			return PreparedCall{}, err
 		}
+		if err := vm.validateRefTargets(fn.Name, fn.RuntimeType, args); err != nil {
+			return PreparedCall{}, err
+		}
 		vm.retainPreparedArguments(prepared.Arguments, fn.Params)
 		return prepared, nil
 

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -630,7 +630,9 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				if vm.peek(0).Type == value.VAL_NULL {
 					return vm.runtimeError(c, ip, "expected %s, got null\n  hint: declare the slot as '%s?' to allow null", runtimeType.String(), runtimeType.String())
 				}
-				return vm.runtimeError(c, ip, "runtime value metadata conflicts with static context")
+				// Fronteira dinamica (#118): nomeia os dois tipos, como o
+				// checador estatico faz.
+				return vm.runtimeError(c, ip, "expected %s, got %s", runtimeType.String(), runtimeValueDescription(vm.peek(0)))
 			}
 
 		case chunk.OP_DEREF:

--- a/internal/vm/executor.go
+++ b/internal/vm/executor.go
@@ -632,7 +632,7 @@ func (vm *VM) run(minFrameCount int, terminalResult *value.Value) (err error) {
 				}
 				// Fronteira dinamica (#118): nomeia os dois tipos, como o
 				// checador estatico faz.
-				return vm.runtimeError(c, ip, "expected %s, got %s", runtimeType.String(), runtimeValueDescription(vm.peek(0)))
+				return vm.runtimeError(c, ip, "expected %s, got %s", runtimeType.String(), vm.runtimeValueDescription(vm.peek(0)))
 			}
 
 		case chunk.OP_DEREF:

--- a/internal/vm/native_signatures_test.go
+++ b/internal/vm/native_signatures_test.go
@@ -1089,7 +1089,7 @@ let text: chan string = make_chan(1)
 let dynamic: any = text
 let integer: chan int = make_chan(1)
 integer = dynamic`)
-		if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
+		if err == nil || !strings.Contains(err.Error(), "expected chan int, got chan string") {
 			t.Fatalf("error=%v", err)
 		}
 	})
@@ -1885,24 +1885,24 @@ test_report(length(target) * 10 + length(keys(item)))`)
 }
 
 func TestConflictingCollectionAndChannelMetadataFailsWithoutOverwrite(t *testing.T) {
-	tests := []string{
-		`let dynamic: int[] = [1, 2, 3, 4]
+	tests := []struct{ source, want string }{
+		{`let dynamic: int[] = [1, 2, 3, 4]
 let fixed: int[4] = [1, 2, 3, 4]
 let erased: any = dynamic
-fixed = erased`,
-		`let text: map[string, int] = {"value": 1}
+fixed = erased`, "expected int[4], got int[]"},
+		{`let text: map[string, int] = {"value": 1}
 let integer: map[int, string] = {1: "value"}
 let erased: any = integer
-text = erased`,
-		`let text: chan string = make_chan(1)
+text = erased`, "expected map[string, int], got map[int, string]"},
+		{`let text: chan string = make_chan(1)
 let integer: chan int = make_chan(1)
 let erased: any = text
-integer = erased`,
+integer = erased`, "expected chan int, got chan string"},
 	}
-	for _, source := range tests {
-		err := runTypedFunctionProgramError(t, source)
-		if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
-			t.Fatalf("error=%v", err)
+	for _, tt := range tests {
+		err := runTypedFunctionProgramError(t, tt.source)
+		if err == nil || !strings.Contains(err.Error(), tt.want) {
+			t.Fatalf("want %q, got error=%v", tt.want, err)
 		}
 	}
 }

--- a/internal/vm/runtime_type_name.go
+++ b/internal/vm/runtime_type_name.go
@@ -19,10 +19,15 @@ func displayStructName(name string) string {
 
 // runtimeValueDescription e o nome de tipo de um valor nos diagnosticos de
 // fronteira dinamica (`expected T, got U`, #118): um composto ja etiquetado
-// mostra a etiqueta (`int[4]`, `map[string, int]`, `chan string`); o resto,
-// o nome de runtime de sempre (runtimeTypeName).
-func runtimeValueDescription(val value.Value) string {
+// mostra a etiqueta (`int[4]`, `map[string, int]`, `chan string`), uma
+// referencia mostra o alvo (`ref string`, `ref null`); o resto, o nome de
+// runtime de sempre (runtimeTypeName).
+func (vm *VM) runtimeValueDescription(val value.Value) string {
 	switch val.Type {
+	case value.VAL_REF:
+		if target, err := vm.resolveReferenceValue(val); err == nil {
+			return "ref " + vm.runtimeValueDescription(target)
+		}
 	case value.VAL_OBJ:
 		switch obj := val.Obj.(type) {
 		case *value.ObjArray:

--- a/internal/vm/runtime_type_name.go
+++ b/internal/vm/runtime_type_name.go
@@ -17,6 +17,36 @@ func displayStructName(name string) string {
 	return moduleQualifierPattern.ReplaceAllString(name, "")
 }
 
+// runtimeValueDescription e o nome de tipo de um valor nos diagnosticos de
+// fronteira dinamica (`expected T, got U`, #118): um composto ja etiquetado
+// mostra a etiqueta (`int[4]`, `map[string, int]`, `chan string`); o resto,
+// o nome de runtime de sempre (runtimeTypeName).
+func runtimeValueDescription(val value.Value) string {
+	switch val.Type {
+	case value.VAL_OBJ:
+		switch obj := val.Obj.(type) {
+		case *value.ObjArray:
+			if tag := obj.RuntimeType.Load(); tag != nil {
+				return tag.String()
+			}
+		case *value.ObjMap:
+			if tag := obj.RuntimeType.Load(); tag != nil {
+				return tag.String()
+			}
+		}
+	case value.VAL_CHANNEL:
+		if channel, ok := val.Obj.(*value.ObjChannel); ok && channel != nil {
+			channel.Lock.Lock()
+			elementType := channel.ElementType
+			channel.Lock.Unlock()
+			if elementType != nil {
+				return (&value.RuntimeTypeInfo{Kind: value.TYPE_CHANNEL, Element: elementType}).String()
+			}
+		}
+	}
+	return runtimeTypeName(val)
+}
+
 // runtimeTypeName e a fonte unica dos nomes de tipo em runtime, compartilhada
 // pelo builtin `type` e pelo verbo %T do fmt.
 func runtimeTypeName(val value.Value) string {

--- a/internal/vm/runtime_type_validation_test.go
+++ b/internal/vm/runtime_type_validation_test.go
@@ -275,8 +275,8 @@ end
 let r: Envelope = __test_dynamic_envelope_bad()
 `
 	err := interpretVMSource(t, machine, source)
-	if err == nil || !strings.Contains(err.Error(), "runtime value metadata conflicts with static context") {
-		t.Fatalf("want the existing marker-rejection error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "expected Envelope, got map") {
+		t.Fatalf("want the marker-rejection error naming both types, got: %v", err)
 	}
 }
 

--- a/internal/vm/stdlib_nullable_contracts_test.go
+++ b/internal/vm/stdlib_nullable_contracts_test.go
@@ -3,8 +3,6 @@ package vm
 import (
 	"strings"
 	"testing"
-
-	"noxy-vm/internal/value"
 )
 
 // Issue #120 item 1: wrappers da stdlib cujo nativo devolve null como
@@ -43,5 +41,4 @@ func TestNamespaceCallIntoNonNullableSlotIsCheckedAtRuntime(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "expected Statement, got null\n  hint: declare the slot as 'Statement?' to allow null") {
 		t.Fatalf("want the runtime null guard, got %v", err)
 	}
-	_ = value.NewNull
 }

--- a/internal/vm/stdlib_nullable_contracts_test.go
+++ b/internal/vm/stdlib_nullable_contracts_test.go
@@ -33,12 +33,3 @@ func TestSqlitePrepareNullOnBadSqlIsTestable(t *testing.T) {
 	got := captureVMSource(t, "use sqlite select *\nlet db: Database = open(\":memory:\")\nlet bad = prepare(db, \"SELECT * FROM tabela_inexistente\")\nlet ok = prepare(db, \"SELECT 1\")\nlet score: int = 0\nif bad == null then\n    score = score + 1\nend\nif ok != null then\n    if ok.handle > 0 then\n        score = score + 10\n    end\n    finalize(ok)\nend\nclose(db)\ntest_report(score)\n")
 	testExpectedObject(t, 11, got)
 }
-
-func TestNamespaceCallIntoNonNullableSlotIsCheckedAtRuntime(t *testing.T) {
-	// Pela forma de namespace (`sqlite.prepare`) o membro nao tem tipo
-	// estatico: a guarda de tipo desconhecido e quem segura o null.
-	err := interpretOrCompileErr(t, New(), "use sqlite\nlet db: sqlite.Database = sqlite.open(\":memory:\")\nlet stmt: sqlite.Statement = sqlite.prepare(db, \"SELECT * FROM tabela_inexistente\")\n")
-	if err == nil || !strings.Contains(err.Error(), "expected Statement, got null\n  hint: declare the slot as 'Statement?' to allow null") {
-		t.Fatalf("want the runtime null guard, got %v", err)
-	}
-}

--- a/internal/vm/stdlib_nullable_contracts_test.go
+++ b/internal/vm/stdlib_nullable_contracts_test.go
@@ -1,0 +1,47 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Issue #120 item 1: wrappers da stdlib cujo nativo devolve null como
+// resultado de dado dizem isso na assinatura — `time.parse`/`parse_date`
+// -> DateTime?, `sqlite.prepare` -> Statement?. Com `use m select *` o nome
+// importado carrega o tipo declarado, entao o contrato e estatico.
+
+func TestTimeParseReturnsNullableDateTime(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "use time select *\nlet d: DateTime = parse(\"2024-02-29 14:05:06\")\n")
+	if err == nil || !strings.Contains(err.Error(), "expected DateTime, got DateTime?") {
+		t.Fatalf("want the nullable contract in the static type, got %v", err)
+	}
+}
+
+func TestTimeParseNullOnBadInputIsTestable(t *testing.T) {
+	got := captureVMSource(t, "use time select *\nlet d = parse(\"not-a-date\")\nlet ok = parse_date(\"2024-02-29\")\nlet bad = parse_date(\"2024-02-30\")\nlet score: int = 0\nif d == null then\n    score = score + 1\nend\nif ok != null then\n    score = score + 10 * ok.day\nend\nif bad == null then\n    score = score + 100\nend\ntest_report(score)\n")
+	testExpectedObject(t, 1+290+100, got)
+}
+
+func TestSqlitePrepareReturnsNullableStatement(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "use sqlite select *\nlet db: Database = open(\":memory:\")\nlet stmt: Statement = prepare(db, \"SELECT 1\")\n")
+	if err == nil || !strings.Contains(err.Error(), "expected Statement, got Statement?") {
+		t.Fatalf("want the nullable contract in the static type, got %v", err)
+	}
+}
+
+func TestSqlitePrepareNullOnBadSqlIsTestable(t *testing.T) {
+	got := captureVMSource(t, "use sqlite select *\nlet db: Database = open(\":memory:\")\nlet bad = prepare(db, \"SELECT * FROM tabela_inexistente\")\nlet ok = prepare(db, \"SELECT 1\")\nlet score: int = 0\nif bad == null then\n    score = score + 1\nend\nif ok != null then\n    if ok.handle > 0 then\n        score = score + 10\n    end\n    finalize(ok)\nend\nclose(db)\ntest_report(score)\n")
+	testExpectedObject(t, 11, got)
+}
+
+func TestNamespaceCallIntoNonNullableSlotIsCheckedAtRuntime(t *testing.T) {
+	// Pela forma de namespace (`sqlite.prepare`) o membro nao tem tipo
+	// estatico: a guarda de tipo desconhecido e quem segura o null.
+	err := interpretOrCompileErr(t, New(), "use sqlite\nlet db: sqlite.Database = sqlite.open(\":memory:\")\nlet stmt: sqlite.Statement = sqlite.prepare(db, \"SELECT * FROM tabela_inexistente\")\n")
+	if err == nil || !strings.Contains(err.Error(), "expected Statement, got null\n  hint: declare the slot as 'Statement?' to allow null") {
+		t.Fatalf("want the runtime null guard, got %v", err)
+	}
+	_ = value.NewNull
+}

--- a/internal/vm/typed_index_e2e_test.go
+++ b/internal/vm/typed_index_e2e_test.go
@@ -40,20 +40,20 @@ test_report(f())
 	}
 }
 
-// Elemento composto vindo por `any` numa base int[]: o NORC ve que o valor e
-// rastreado e cai no generico, que retem — o composto ganha o dono do
-// elemento, como no caminho generico.
-func TestTypedIndexNorcRetainsCompositeFromAny(t *testing.T) {
-	got := captureVMSource(t, `
+// Elemento composto vindo por `any` numa base int[]: desde a guarda da
+// fronteira dinamica em atribuicao (#120 item 2) o valor e recusado ANTES da
+// escrita — `expected int, got int[]` — em vez de cair no caminho generico
+// do NORC com um int[] dentro de um int[]. O fallback do NORC continua na VM
+// como defesa; da linguagem nao se chega mais a ele com tipo errado.
+func TestTypedIndexRejectsCompositeFromAnyBeforeTheStore(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), `
 let inner: int[] = [7]
 let xs: int[] = [1, 2]
 let v: any = inner
 xs[0] = v
-test_report(xs)
 `)
-	outer := got.Obj.(*value.ObjArray)
-	if value.OwnersCount(outer.Elements[0]) < 2 {
-		t.Fatalf("composto escrito via any deve ter o dono do elemento alem do global: owners=%d", value.OwnersCount(outer.Elements[0]))
+	if err == nil || !strings.Contains(err.Error(), "expected int, got int[]") {
+		t.Fatalf("want the boundary guard to reject int[] into an int element, got %v", err)
 	}
 }
 

--- a/noxy.mod
+++ b/noxy.mod
@@ -1,6 +1,6 @@
 module noxy
 
-noxy v0.23.0
+noxy v0.23.1
 
 require github.com/estevaofon/quicksort v0.1.0
 require github.com/estevaofon/noxy_dynamodb v0.3.0

--- a/noxy_examples/defer_lifo.nx
+++ b/noxy_examples/defer_lifo.nx
@@ -30,12 +30,14 @@ func cleanup_sqlite() -> void
     let create: sqlite.ExecResult = sqlite.exec(db, "CREATE TABLE cleanup_values (value INTEGER NOT NULL)")
     assert(create.ok, "SQLite table must be created")
 
-    let statement: sqlite.Statement = sqlite.prepare(db, "INSERT INTO cleanup_values VALUES (?)")
-    assert(statement.handle > 0, "SQLite statement must prepare")
-    defer sqlite.finalize(statement)
-    sqlite.bind_int(statement, 1, 21)
-    let inserted: sqlite.ExecResult = sqlite.step_exec(statement)
-    assert(inserted.ok, "SQLite statement must execute")
+    let statement: sqlite.Statement? = sqlite.prepare(db, "INSERT INTO cleanup_values VALUES (?)")
+    assert(statement != null, "SQLite statement must prepare")
+    if statement != null then
+        defer sqlite.finalize(statement)
+        sqlite.bind_int(statement, 1, 21)
+        let inserted: sqlite.ExecResult = sqlite.step_exec(statement)
+        assert(inserted.ok, "SQLite statement must execute")
+    end
 end
 
 func cleanup_resources() -> void

--- a/noxy_examples/sqlite_showcase.nx
+++ b/noxy_examples/sqlite_showcase.nx
@@ -28,6 +28,7 @@ if begin(db) then
         print("Transação commitada com sucesso.")
     else
         print("Erro ao preparar o INSERT (a tabela 'produtos' existe?).")
+        rollback(db)
     end
 else
     print("Erro ao iniciar transação.")

--- a/noxy_examples/sqlite_showcase.nx
+++ b/noxy_examples/sqlite_showcase.nx
@@ -12,20 +12,23 @@ print("=== Início do Showcase SQLite ===")
 // 1. Transação com Commit (Insert em massa)
 print("\n[1] Inserindo produtos em transação...")
 if begin(db) then
-    let stmt: Statement = prepare(db, "INSERT INTO produtos (nome, preco) VALUES (?, ?)")
-    
-    bind_text(stmt, 1, "Tablet")
-    bind_float(stmt, 2, 1200.50)
-    step_exec(stmt)
-    reset(stmt)
-    
-    bind_text(stmt, 1, "Smartphone")
-    bind_float(stmt, 2, 3500.00)
-    step_exec(stmt)
-    
-    finalize(stmt)
-    commit(db)
-    print("Transação commitada com sucesso.")
+    let stmt = prepare(db, "INSERT INTO produtos (nome, preco) VALUES (?, ?)")   // Statement? — null se o SQL falhar
+    if stmt != null then
+        bind_text(stmt, 1, "Tablet")
+        bind_float(stmt, 2, 1200.50)
+        step_exec(stmt)
+        reset(stmt)
+
+        bind_text(stmt, 1, "Smartphone")
+        bind_float(stmt, 2, 3500.00)
+        step_exec(stmt)
+
+        finalize(stmt)
+        commit(db)
+        print("Transação commitada com sucesso.")
+    else
+        print("Erro ao preparar o INSERT (a tabela 'produtos' existe?).")
+    end
 else
     print("Erro ao iniciar transação.")
 end

--- a/noxy_examples/time_demo.nx
+++ b/noxy_examples/time_demo.nx
@@ -71,10 +71,14 @@ print("Nome do mês (atual):", month_name(dt.month))
 
 // 6. Parsing
 print("\n--- 6. Parsing ---")
-let parsed: DateTime = parse("2023-01-01 12:00:00")
-print("Parse '2023-01-01 12:00:00':", format(parsed))
+let parsed = parse("2023-01-01 12:00:00")       // DateTime? — null se nao casar o formato
+if parsed != null then
+    print("Parse '2023-01-01 12:00:00':", format(parsed))
+end
 
-let parsed_date: DateTime = parse_date("2023-01-01")
-print("Parse Date '2023-01-01':", format(parsed_date))
+let parsed_date = parse_date("2023-01-01")
+if parsed_date != null then
+    print("Parse Date '2023-01-01':", format(parsed_date))
+end
 
 print("\n=== Verificação Concluída ===")


### PR DESCRIPTION
## Summary
- Issue #118: `any` passa a entrar num slot tipado em **qualquer** posição — `let` anotado, argumento de assinatura exata e `return` — com guarda de runtime (`expected int, got string`); antes só o `let` aceitava e o wrapper de extensão precisava de um `let` temporário por função. Exceção mantida: callable exato (spec §4.2).
- A guarda do `let` anotado passou a valer também para primitivos e structs: `let x: int = nativo()` com `nativo() -> any` devolvendo string rodava em silêncio; agora é erro de runtime. Emitida só onde o tipo estático é `any` (tipo desconhecido fica como antes — ver #120) — código tipado não paga nada. Corpus de exemplos: 151 iguais, 0 divergentes.
- Chamadas a builtins centrais não sombreados (`print`, `to_str`, `length`, `fmt`, `keys`, `slice`, `range` e a tabela de `builtin_return_types.go`) não encerram narrowing — são nativos que nunca rodam código Noxy. A f-string vira `to_str(...)` no parser, então `f"{m['a']} {m['b']}"` sobre global estreitado compila; vale também na entrada de laço.
- Diagnóstico do fato perdido: `'m' may be null: it was tested, but 'm' is a global and a call came between the test and this use` + hint (testar de novo / `let v = m` antes do `if` / mover para função), em vez de sugerir o `if` que já está ali.
- Mensagem de `OP_MARK_RUNTIME_VALUE_TYPE` que falha nomeia os dois tipos (`expected chan int, got chan string`) no lugar de `runtime value metadata conflicts with static context`.
- **#120 (resolvida aqui, 4º commit):** (1) auditoria wrappers × nativos — só `time.parse`, `time.parse_date` e `sqlite.prepare` devolvem `null` como resultado de dado; assinaturas viram `DateTime?`/`Statement?` (BREAKING pontual, migração no CHANGELOG; `time_demo.nx` e `sqlite_showcase.nx` migrados) e a guarda passa a cobrir **tipo estático desconhecido** (`m.f()` por namespace, nativo sem assinatura); (2) guarda em **atribuição** (local, upvalue, global, índice, campo); (3) `&&`/`||` com chamada não-pura no operando direito não exportam o fato de raiz compartilhada para o ramo — diagnóstico `a call in the condition ran after the test` + hint `put the call before the test ('toca() && m != null')`.
- **Revisão consolidada (5º commit):** `any` atravessa só no topo do tipo (`ref any` ≠ `ref int`, `any[]` ≠ `int[]`, como develop); `emitSlotGuards` é o ponto único de emissão e cobre `*r = v`, `xs[i] = v` fundido, `append`/`delete`/`json_loads`; narrowing sem mutação (`enclosingHasLocal`), fato morre com o escopo, `let print = …` no laço é impuro, construtor de struct é puro, `eprint`/`append`/`pop`/`delete` no conjunto puro; registro do fato perdido na condição fica nos ramos; hint com nome do callee; `rollback` no `else` do showcase; `noxy.mod`/`docs/index.html` em v0.23.1.
- **Decisão B (6º commit):** guarda só para tipo estático `any` — tipo desconhecido (`m.f()`, nativo sem assinatura, plugin) fica como antes; os quatro rastros (spec §4.2, CHANGELOG, 2 testes, comentário) revertidos juntos; `T?` de `time.parse*`/`sqlite.prepare` mantidos. Perf sob B: **156 ms = 156 ms** do develop (min de 7×1M `strings.index_of`). Furo residual `any`-com-ref → `ref T` fechado **em runtime** (`validateRefTargets`: `function 'inc' argument 1: expected ref int, got ref string`, só no caminho `OP_CALL` de modo não provado; alvo `null` segue encaminhado) — recusar na compilação contradizia R5 e 6 testes existentes. Issues #121 (natives que devolvem `null` como dado: crypto/net) e #122 (contrato de retorno dos natives + fast path no `OP_MARK`).
- Versão v0.23.1 (patch com migração no CHANGELOG: guarda nova do `let`/atribuição e os três contratos `T?` da stdlib).

## Components
- `internal/compiler/function_types.go` — `areStrictTypesCompatible`: `any` actual segue a regra do tipo desconhecido (`!containsCallableType`).
- `internal/compiler/runtime_types.go` — `emitDynamicBoundaryGuard` + `emitMarkRuntimeValueType` (extraído de `emitRuntimeValueType`).
- `internal/compiler/compiler.go` — guarda nos sites de `let`, `return` e argumento; `CallExpression` só faz `dropAfterCall` se não for builtin puro; campo `narrowLost`.
- `internal/compiler/narrowing.go` — `pureBuiltins`/`isPureBuiltinCall`, `loopEffects` como método, `narrowLost` (snapshot em `pushFacts`, limpo em `dropKey`/`dropCompound`), `rootSharing` (classificação + motivo), `mayBeNullError` com a mensagem nova (variante para laço).
- `internal/vm/executor.go`, `internal/vm/runtime_type_name.go` — mensagem `expected T, got U` e `runtimeValueDescription`.
- Testes: `internal/compiler/narrowing_pure_builtins_test.go`, `internal/compiler/any_boundary_test.go`, `internal/vm/any_boundary_guard_test.go`; `function_types_test.go`, `native_signatures_test.go` e `runtime_type_validation_test.go` atualizados (os três fixavam a recusa de `any` / a mensagem antiga).
- Docs: `docs/NOXY_LANGUAGE_SPEC.md` §2.4, §4.2, §9, §10; `CHANGELOG.md` `[0.23.1]`; bump em `internal/version/version.go`, `AGENTS.md`, `README.md`.

## Related Issues
- Closes #118
- Closes #120

## Test Plan
- [x] TDD: testes RED confirmados antes de cada implementação (compiler e vm)
- [x] `go test ./...` verde (suíte completa, 2 rodadas: após código e após bump/docs)
- [x] `benchmarks/compare_examples.ps1` develop × candidato: 151 iguais, 0 divergentes, 70 excluídos
- [x] Os oito trechos da issue rodados com o binário novo (1a/1b/1c compilam e rodam; 2a/2b/2c compilam com `m` global; fato perdido dá o diagnóstico novo)
- [x] `go vet` e `gofmt` limpos nos arquivos alterados
- [x] Revisão independente (subagente fresh) sobre `87987bb..94ce33d`: Critical confirmado por execução (guarda em tipo **desconhecido** abortava `time.parse("x")`/`sqlite.prepare` que devolvem `null` num `-> T`) → guarda restrita a `any` no 3º commit; minors 3 (mensagem no laço) e 5 (`rootSharing`) aplicados; corpus e suíte re-rodados após o fix
- [x] #120 item 1: auditoria dos wrappers `-> T` × `return null` dos nativos (6 arquivos); `T?` nos três reais; testes `stdlib_nullable_contracts_test.go` (tipo estático via `select *`, null testável, guarda pela forma `m.f()`); guarda estendida a tipo desconhecido com corpus + runner + suíte re-rodados
- [x] #120 item 2: guarda em atribuição — testes RED→GREEN por site (local, upvalue, global, campo, índice, map) + caminho feliz
- [x] #120 item 3: `&&`/`||`/`while` com chamada no operando direito — testes RED→GREEN (`narrowing_condition_calls_test.go`), incluindo builtin puro, local de valor e chamada antes do teste
- [x] Revisão consolidada (humana + agente): bloqueantes 1 e 2 e médios/baixos corrigidos com teste RED→GREEN por achado (`any_boundary_review_test.go`, `narrowing_review_test.go`, `any_boundary_guard_holes_test.go`); 7 testes existentes do ref-null-forwarding mantidos (ramo `ref` sem guarda dinâmica)
- [x] Revisão item 3/4 — decisão B aplicada (guarda só para `any`); perf medida com probe interno (min de 7×1M `index_of`: candidato 156 ms, develop 156 ms); contratos crypto/net → #121; contrato de retorno dos natives + fast path → #122
- [x] Condição 2 — `any` com ref → `ref T`: alvo conferido em runtime (`any_ref_runtime_test.go`: mismatch em argumento/`let`/`return`/`ref int?`, caminho feliz, alvo `null` encaminhado); R5 e os 6 testes de ref-null-forwarding intactos
- [x] Pós-B: `go test ./...` verde, `run_all_tests_concurrent.nx` 179/179, `compare_examples.ps1` develop × candidato
- [ ] Validar o wrapper `noxy_dynamodb.nx` sem os `let` temporários (repo `noxy_dynamodb`, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NiBKGKfb49w5UVGVi52ZV
