### PR TITLE
fix(vm,stdlib): natives nao devolvem null sob wrapper -> T — crypto erra tipado, aes256_gcm_decrypt -> bytes?, net aceita Socket por fd (issue #121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — Guia para agentes de IA no Noxy VM
 
 Máquina virtual de bytecode para a linguagem Noxy, em Go (módulo `noxy-vm`,
-Go 1.25). Versão corrente: `v0.23.1` (`internal/version/version.go`).
+Go 1.25). Versão corrente: `v0.23.2` (`internal/version/version.go`).
 
 **Fonte da verdade da linguagem: `docs/NOXY_LANGUAGE_SPEC.md`.** Regra de
 linguagem vem da spec ou de teste no binário — nunca de um exemplo. Este
@@ -176,4 +176,4 @@ hashes de todos em `noxy.sum`. Ver `docs/EXTENSIONS.md` e
 
 ---
 
-**Versão**: 1.2 (Noxy VM 0.23.1) — atualizado em 2026-08-29
+**Versão**: 1.2 (Noxy VM 0.23.2) — atualizado em 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ da stdlib (crypto e net; bug desde 0.23.0, achado na revisão do #119). O
 null passava em silêncio pela forma `m.f()` e pelo `select` (o tipo do
 wrapper mentia) e só quebrava depois, longe da causa. Decisão por função:
 `T?` na assinatura quando o null é resultado de dado; erro tipado do native
-quando é argumento inválido. Nunca null silencioso.
+quando é argumento inválido. Argumento inválido nunca mais vira null; o null
+de dado passa a ser **tipado** — o que o `select` confere estaticamente, mas
+a forma `m.f()` (tipo desconhecido, sem guarda até a #122) não: ver a
+migração abaixo.
 
 ### Changed
 - **`crypto.aes256_gcm_decrypt` → `bytes?` (BREAKING)**: null é resultado
@@ -15,11 +18,13 @@ quando é argumento inválido. Nunca null silencioso.
   demais para conter o nonce). Migração: com `use crypto select …`,
   `let texto: bytes = aes256_gcm_decrypt(k, d)` vira `expected bytes, got
   bytes?` — escreva `let texto = aes256_gcm_decrypt(k, d)` e teste
-  `if texto != null then`; pela forma `m.f()` (sem tipo estático) compila
-  como antes, e a forma honesta é `let texto: bytes? =
-  crypto.aes256_gcm_decrypt(k, d)`. `password_manager/server.nx` e
-  `test_crypto_debug.nx` migrados; `docs/CRYPTO_MODULE.md` já prometia o
-  null, agora o tipo diz o mesmo.
+  `if texto != null then`. Pela forma `m.f()` (sem tipo estático) nada é
+  conferido: até a #122, `let texto: bytes = crypto.aes256_gcm_decrypt(k,
+  d)` compila **e em runtime ainda recebe o null em silêncio** (`texto ==
+  null` é `true`, `length(texto)` é 0) — a forma honesta é `let texto:
+  bytes? = crypto.aes256_gcm_decrypt(k, d)` e testar. `password_manager/
+  server.nx`, `test_crypto_debug.nx` e `test_crypto_aes.nx` migrados;
+  `docs/CRYPTO_MODULE.md` já prometia o null, agora o tipo diz o mesmo.
 - **Argumento inválido em crypto é erro de runtime, não null**:
   `random_bytes(0)` → `native 'crypto_random_bytes' failed:
   crypto_random_bytes: n must be > 0, got 0`; `pbkdf2_sha256` com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [0.23.2] - 2026-08-29
+
+Issue #121 — natives que devolviam `null` como dado sob um wrapper `-> T`
+da stdlib (crypto e net; bug desde 0.23.0, achado na revisão do #119). O
+null passava em silêncio pela forma `m.f()` e pelo `select` (o tipo do
+wrapper mentia) e só quebrava depois, longe da causa. Decisão por função:
+`T?` na assinatura quando o null é resultado de dado; erro tipado do native
+quando é argumento inválido. Nunca null silencioso.
+
+### Changed
+- **`crypto.aes256_gcm_decrypt` → `bytes?` (BREAKING)**: null é resultado
+  de dado — os dados não autenticam (chave errada, adulteração, curtos
+  demais para conter o nonce). Migração: com `use crypto select …`,
+  `let texto: bytes = aes256_gcm_decrypt(k, d)` vira `expected bytes, got
+  bytes?` — escreva `let texto = aes256_gcm_decrypt(k, d)` e teste
+  `if texto != null then`; pela forma `m.f()` (sem tipo estático) compila
+  como antes, e a forma honesta é `let texto: bytes? =
+  crypto.aes256_gcm_decrypt(k, d)`. `password_manager/server.nx` e
+  `test_crypto_debug.nx` migrados; `docs/CRYPTO_MODULE.md` já prometia o
+  null, agora o tipo diz o mesmo.
+- **Argumento inválido em crypto é erro de runtime, não null**:
+  `random_bytes(0)` → `native 'crypto_random_bytes' failed:
+  crypto_random_bytes: n must be > 0, got 0`; `pbkdf2_sha256` com
+  `iteracoes <= 0` ou `tamanho <= 0` (`iterations must be > 0`, `key length
+  must be > 0`); `aes256_gcm_encrypt`/`aes256_gcm_decrypt` com chave que não
+  tem 32 bytes (`key must be 32 bytes, got 5`). Aridade e tipo errados numa
+  chamada dinâmica também erram (`expects exactly 4 arguments, got 3`, `n
+  must be an int, got string`). Em 0.23.0/0.23.1 os quatro devolviam null
+  num `-> bytes`, e `length(null)` = 0 escondia o problema.
+- **`net.socket_recv`/`socket_send`/`accept` aceitam qualquer `Socket` com
+  `fd` int** — inclusive o `Socket(...)` que `net.poll` reconstrói (achado
+  da revisão: `socket_recv(poll(...).read[0], n)` devolvia null desde
+  0.22.0, porque o native só aceitava o map que o runtime constrói). A
+  identidade do socket é o fd registrado, não a forma do valor — o mesmo
+  `networkSocketDescriptor` de `settimeout`: fd fora do registro (socket
+  construído pelo programa, ou já fechado) segue `NetResult{ok: false,
+  error: "invalid socket"}` / `Socket(fd: -1, open: false)`, como sempre foi
+  para o map; valor que não tem a forma de socket é erro tipado `invalid
+  socket`; aridade errada erra (`net_recv expects exactly 2 arguments`).
+  `net.socket_close` também aceita a instância.
+- Varredura dos demais `builtins_*.go` (o #120 cobriu io/sqlite/time/
+  strings/sys só para null de dado): fora crypto/net, todo `return null`
+  alcançável está atrás de `-> any`, de wrapper `-> void`, já vem com erro
+  tipado, ou é aridade/asserção interna que o wrapper tipado nunca produz.
+  `time.parse*`/`sqlite.prepare` (#120) e `crypto.aes256_gcm_decrypt` são
+  os únicos `T?` da stdlib. Fora do escopo: `hex()`/`slice()` sem argumentos
+  (null de aridade num builtin tipado pelo compilador, sem wrapper).
+
+### Docs
+- `docs/CRYPTO_MODULE.md` (assinatura `bytes?`, erros por argumento,
+  exemplos com `bytes?`), spec §4.2 (lista dos `T?` da stdlib; argumento
+  inválido é erro, nunca null sob `-> T`).
+
 ## [0.23.1] - 2026-08-29
 
 Issue #118 — dois atritos do wrapper de extensão (`noxy_dynamodb`): uma

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![noxy 0.23.1](https://img.shields.io/badge/noxy-0.23.1-blue)](CHANGELOG.md)
+[![noxy 0.23.2](https://img.shields.io/badge/noxy-0.23.2-blue)](CHANGELOG.md)
 
 # Noxy
 
@@ -222,7 +222,7 @@ exits with code `1`.
 Noxy includes a powerful REPL (Read-Eval-Print Loop) for interactive coding. Just run `noxy` without arguments.
 
 ```noxy
-Noxy REPL v0.23.1
+Noxy REPL v0.23.2
 Type 'exit' to quit.
 >>> let x: int = 10
 >>> x + 5

--- a/docs/CRYPTO_MODULE.md
+++ b/docs/CRYPTO_MODULE.md
@@ -23,6 +23,7 @@ let hash: string = crypto.sha256(b"hello")
 crypto.random_bytes(n: int) -> bytes
 ```
 Gera `n` bytes criptograficamente seguros usando o CSPRNG do sistema operacional.
+`n <= 0` é erro de runtime (`crypto_random_bytes: n must be > 0, got 0`), nunca `null`.
 
 ```noxy
 let salt: bytes = crypto.random_bytes(16)  // 16 bytes aleatórios
@@ -44,6 +45,9 @@ Deriva uma chave criptográfica a partir de uma senha usando PBKDF2 com HMAC-SHA
 | `iteracoes` | Número de iterações | 100.000+ para senhas |
 | `tamanho` | Tamanho da chave em bytes | 32 para AES-256 |
 
+`iteracoes <= 0` ou `tamanho <= 0` é erro de runtime (`crypto_pbkdf2_sha256:
+iterations must be > 0, got 0`), nunca `null`.
+
 ```noxy
 let salt: bytes = crypto.random_bytes(16)
 let chave: bytes = crypto.pbkdf2_sha256("senha_forte", salt, 200000, 32)
@@ -57,7 +61,8 @@ crypto.aes256_gcm_encrypt(chave: bytes, texto: bytes) -> bytes
 ```
 Criptografa dados usando AES-256-GCM (Authenticated Encryption).
 
-- **Chave**: Deve ter exatamente 32 bytes
+- **Chave**: Deve ter exatamente 32 bytes — outro tamanho é erro de runtime
+  (`crypto_aes256_gcm_encrypt: key must be 32 bytes, got 5`), nunca `null`
 - **Retorno**: `nonce (12 bytes) + ciphertext + tag (16 bytes)`
 - **Nonce**: Gerado automaticamente (único por operação)
 
@@ -69,19 +74,29 @@ let dados: bytes = crypto.aes256_gcm_encrypt(chave, b"segredo")
 
 ### AES-256-GCM Decrypt
 ```noxy
-crypto.aes256_gcm_decrypt(chave: bytes, dados: bytes) -> bytes
+crypto.aes256_gcm_decrypt(chave: bytes, dados: bytes) -> bytes?
 ```
 Descriptografa e valida dados criptografados com AES-256-GCM.
 
-- Retorna `null` se a autenticação falhar (dados corrompidos ou chave errada)
+- Retorna `null` se a autenticação falhar (dados corrompidos, chave errada ou
+  dados curtos demais para conter o nonce) — por isso o tipo é `bytes?`
 - Valida automaticamente o MAC/tag para detectar adulteração
+- Chave que não tem 32 bytes é erro de runtime (`crypto_aes256_gcm_decrypt:
+  key must be 32 bytes, got 5`), não `null`: o `null` é sempre sobre os dados
 
 ```noxy
-let texto: bytes = crypto.aes256_gcm_decrypt(chave, dados)
+let texto: bytes? = crypto.aes256_gcm_decrypt(chave, dados)
 if texto == null then
     print("Erro: descriptografia falhou")
+else
+    print(to_str(texto))
 end
 ```
+
+Com `use crypto select aes256_gcm_decrypt` o tipo estático é `bytes?`:
+`let texto: bytes = aes256_gcm_decrypt(chave, dados)` é erro de compilação
+(`expected bytes, got bytes?`) — escreva `let texto = aes256_gcm_decrypt(chave, dados)`
+e teste `if texto != null then`.
 
 ---
 
@@ -105,8 +120,10 @@ let hex_cifrado: string = hex_encode(cifrado)
 
 // 5. Recuperar
 let cifrado_bytes: bytes = hex_decode(hex_cifrado)
-let senha_original: bytes = crypto.aes256_gcm_decrypt(chave, cifrado_bytes)
-print(to_str(senha_original))  // "fb_password_123"
+let senha_original: bytes? = crypto.aes256_gcm_decrypt(chave, cifrado_bytes)
+if senha_original != null then
+    print(to_str(senha_original))  // "fb_password_123"
+end
 ```
 
 ---

--- a/docs/NOXY_LANGUAGE_SPEC.md
+++ b/docs/NOXY_LANGUAGE_SPEC.md
@@ -958,9 +958,12 @@ end
 The standard library honours the `any` contract on its own side: a wrapper
 whose native reports failure with `null` says so in its signature —
 `time.parse(s) -> DateTime?`, `time.parse_date(s) -> DateTime?`,
-`sqlite.prepare(db, sql) -> Statement?` — so `let dt = parse(s)` imported
-with `select` has the static type `DateTime?` and is tested with `if dt !=
-null then`.
+`sqlite.prepare(db, sql) -> Statement?`, `crypto.aes256_gcm_decrypt(key,
+data) -> bytes?` — so `let dt = parse(s)` imported with `select` has the
+static type `DateTime?` and is tested with `if dt != null then`. A native
+that rejects an *argument* (`crypto.random_bytes(0)`, a 5-byte AES-256 key,
+a value that is not a socket) raises a runtime error instead: `null` under a
+`-> T` wrapper is never a way of saying "bad argument".
 
 Three limits. `any` crosses only at the *top* of a type: element, key,
 value, channel payload and `ref` target are invariant, so `any[]` is not an
@@ -2596,7 +2599,7 @@ io.close(f)
 ### System (`sys`)
 
 `sys.version` is the version of the Noxy running the program — the same
-string `noxy --version` prints (`v0.23.1`). It is a module binding, not a
+string `noxy --version` prints (`v0.23.2`). It is a module binding, not a
 call: `use sys` then `print(sys.version)`, or `use sys select version`, which
 brings it in typed as `string`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
             <div class="hero-content">
                 <a href="https://github.com/estevaofon/noxy/blob/main/CHANGELOG.md" class="version-badge"
                     target="_blank">
-                    <span class="version-badge-tag">v0.23.1</span>
+                    <span class="version-badge-tag">v0.23.2</span>
                     Latest release &middot; changelog
                     <i class="fas fa-arrow-right"></i>
                 </a>
@@ -382,7 +382,7 @@ use sys
 
 print(time.now())            // unix timestamp
 print(length(sys.argv()))    // command-line args
-print(sys.version)           // v0.23.1
+print(sys.version)           // v0.23.2
 
 let user: map[string, any] = {"name": "Ana", "age": 30}
 print(json_dumps(user))      // {"age":30,"name":"Ana"}</code></pre>

--- a/internal/stdlib/crypto.nx
+++ b/internal/stdlib/crypto.nx
@@ -182,22 +182,28 @@ end
 // Funções de Criptografia Simétrica (Nativas)
 // ============================================
 
-// Gera n bytes criptograficamente seguros
+// Argumento inválido é erro de runtime do native (issue #121): nenhum destes
+// wrappers devolve null por argumento — `-> bytes` é verdade.
+
+// Gera n bytes criptograficamente seguros. n <= 0 é erro.
 func random_bytes(n: int) -> bytes
     return crypto_random_bytes(n)
 end
 
-// Deriva chave usando PBKDF2 com HMAC-SHA256
+// Deriva chave usando PBKDF2 com HMAC-SHA256. iteracoes <= 0 ou tamanho <= 0 é erro.
 func pbkdf2_sha256(senha: string, salt: bytes, iteracoes: int, tamanho: int) -> bytes
     return crypto_pbkdf2_sha256(senha, salt, iteracoes, tamanho)
 end
 
-// Criptografa com AES-256-GCM (retorna nonce + ciphertext + tag)
+// Criptografa com AES-256-GCM (retorna nonce + ciphertext + tag). Chave que
+// não tem 32 bytes é erro.
 func aes256_gcm_encrypt(chave: bytes, texto: bytes) -> bytes
     return crypto_aes256_gcm_encrypt(chave, texto)
 end
 
-// Descriptografa AES-256-GCM (valida autenticação)
-func aes256_gcm_decrypt(chave: bytes, dados: bytes) -> bytes
+// Descriptografa AES-256-GCM (valida autenticação). null é resultado de
+// dado: os dados não autenticam (chave errada, adulteração, curtos demais
+// para conter o nonce) — por isso `bytes?`. Chave que não tem 32 bytes é erro.
+func aes256_gcm_decrypt(chave: bytes, dados: bytes) -> bytes?
     return crypto_aes256_gcm_decrypt(chave, dados)
 end

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.23.1"
+const Version = "v0.23.2"

--- a/internal/vm/builtins_crypto.go
+++ b/internal/vm/builtins_crypto.go
@@ -6,152 +6,149 @@ import (
 	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 
 	"noxy-vm/internal/value"
 )
 
+// Issue #121: nenhuma destas natives devolve null por argumento invalido.
+// Sob o wrapper `-> bytes` de crypto.nx o null passava em silencio — a
+// forma `m.f()` nao tem tipo estatico e o `select` confiava na assinatura —
+// e so quebrava longe da causa. Argumento invalido (n <= 0, iteracoes ou
+// tamanho <= 0, chave que nao tem 32 bytes) e erro tipado; o unico null que
+// sobra e resultado de DADO: decrypt que nao autentica, e o wrapper diz
+// `-> bytes?`.
+
+func cryptoArity(native string, args []value.Value, want int) error {
+	if len(args) == want {
+		return nil
+	}
+	plural := "s"
+	if want == 1 {
+		plural = ""
+	}
+	return fmt.Errorf("%s: expects exactly %d argument%s, got %d", native, want, plural, len(args))
+}
+
+func cryptoIntArgument(native, label string, arg value.Value) (int64, error) {
+	if arg.Type != value.VAL_INT {
+		return 0, fmt.Errorf("%s: %s must be an int, got %s", native, label, runtimeTypeName(arg))
+	}
+	return arg.Int(), nil
+}
+
+func cryptoBytesArgument(arg value.Value) []byte {
+	if arg.Type == value.VAL_BYTES {
+		return []byte(arg.Obj.(string))
+	}
+	return []byte(arg.String())
+}
+
+func cryptoAES256GCM(native string, key []byte) (cipher.AEAD, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("%s: key must be 32 bytes, got %d", native, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", native, err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", native, err)
+	}
+	return gcm, nil
+}
+
 func (vm *VM) defineCryptoBuiltins() {
-	// Crypto Module - Native implementations for cryptographic operations
-	vm.DefineNative("crypto_random_bytes", func(args []value.Value) value.Value {
-		if len(args) < 1 {
-			return value.NewNull()
+	vm.DefineContextualNative("crypto_random_bytes", func(_ value.NativeContext, args []value.Value) (value.Value, error) {
+		const native = "crypto_random_bytes"
+		if err := cryptoArity(native, args, 1); err != nil {
+			return value.NewNull(), err
 		}
-		n := int(args[0].Int())
+		n, err := cryptoIntArgument(native, "n", args[0])
+		if err != nil {
+			return value.NewNull(), err
+		}
 		if n <= 0 {
-			return value.NewNull()
+			return value.NewNull(), fmt.Errorf("%s: n must be > 0, got %d", native, n)
 		}
-
-		bytes := make([]byte, n)
-		if _, err := rand.Read(bytes); err != nil {
-			return value.NewNull()
+		buffer := make([]byte, n)
+		if _, err := rand.Read(buffer); err != nil {
+			return value.NewNull(), fmt.Errorf("%s: %w", native, err)
 		}
-
-		return value.NewBytes(string(bytes))
+		return value.NewBytes(string(buffer)), nil
 	})
 
-	vm.defineValueNative("crypto_pbkdf2_sha256", func(args []value.Value) value.Value {
+	vm.defineValueNativeErr("crypto_pbkdf2_sha256", func(args []value.Value) (value.Value, error) {
 		// args: (senha: string, salt: bytes, iteracoes: int, tamanho: int)
-		if len(args) < 4 {
-			return value.NewNull()
+		const native = "crypto_pbkdf2_sha256"
+		if err := cryptoArity(native, args, 4); err != nil {
+			return value.NewNull(), err
 		}
-
-		senha := args[0].String()
-		var salt []byte
-		if args[1].Type == value.VAL_BYTES {
-			salt = []byte(args[1].Obj.(string))
-		} else {
-			salt = []byte(args[1].String())
-		}
-		iteracoes := int(args[2].Int())
-		tamanho := int(args[3].Int())
-
-		if iteracoes <= 0 || tamanho <= 0 {
-			return value.NewNull()
-		}
-
-		chave, err := pbkdf2.Key(sha256.New, senha, salt, iteracoes, tamanho)
+		password := args[0].String()
+		salt := cryptoBytesArgument(args[1])
+		iterations, err := cryptoIntArgument(native, "iterations", args[2])
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), err
 		}
-		return value.NewBytes(string(chave))
+		length, err := cryptoIntArgument(native, "key length", args[3])
+		if err != nil {
+			return value.NewNull(), err
+		}
+		if iterations <= 0 {
+			return value.NewNull(), fmt.Errorf("%s: iterations must be > 0, got %d", native, iterations)
+		}
+		if length <= 0 {
+			return value.NewNull(), fmt.Errorf("%s: key length must be > 0, got %d", native, length)
+		}
+		key, deriveErr := pbkdf2.Key(sha256.New, password, salt, int(iterations), int(length))
+		if deriveErr != nil {
+			return value.NewNull(), fmt.Errorf("%s: %w", native, deriveErr)
+		}
+		return value.NewBytes(string(key)), nil
 	})
 
-	vm.defineValueNative("crypto_aes256_gcm_encrypt", func(args []value.Value) value.Value {
+	vm.defineValueNativeErr("crypto_aes256_gcm_encrypt", func(args []value.Value) (value.Value, error) {
 		// args: (chave: bytes, texto: bytes) -> bytes (nonce + ciphertext + tag)
-		if len(args) < 2 {
-			return value.NewNull()
+		const native = "crypto_aes256_gcm_encrypt"
+		if err := cryptoArity(native, args, 2); err != nil {
+			return value.NewNull(), err
 		}
-
-		var chave []byte
-		if args[0].Type == value.VAL_BYTES {
-			chave = []byte(args[0].Obj.(string))
-		} else {
-			chave = []byte(args[0].String())
-		}
-
-		var texto []byte
-		if args[1].Type == value.VAL_BYTES {
-			texto = []byte(args[1].Obj.(string))
-		} else {
-			texto = []byte(args[1].String())
-		}
-
-		// Validate key size (32 bytes for AES-256)
-		if len(chave) != 32 {
-			return value.NewNull()
-		}
-
-		block, err := aes.NewCipher(chave)
+		gcm, err := cryptoAES256GCM(native, cryptoBytesArgument(args[0]))
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), err
 		}
-
-		gcm, err := cipher.NewGCM(block)
-		if err != nil {
-			return value.NewNull()
-		}
-
-		// Generate random nonce (12 bytes for GCM)
+		// Nonce aleatorio (12 bytes no GCM), unico por operacao
 		nonce := make([]byte, gcm.NonceSize())
 		if _, err := rand.Read(nonce); err != nil {
-			return value.NewNull()
+			return value.NewNull(), fmt.Errorf("%s: %w", native, err)
 		}
-
-		// Seal: result = nonce + ciphertext + tag
-		resultado := gcm.Seal(nonce, nonce, texto, nil)
-		return value.NewBytes(string(resultado))
+		// Seal: resultado = nonce + ciphertext + tag
+		sealed := gcm.Seal(nonce, nonce, cryptoBytesArgument(args[1]), nil)
+		return value.NewBytes(string(sealed)), nil
 	})
 
-	vm.defineValueNative("crypto_aes256_gcm_decrypt", func(args []value.Value) value.Value {
-		// args: (chave: bytes, dados: bytes) -> bytes (plaintext)
-		if len(args) < 2 {
-			return value.NewNull()
+	vm.defineValueNativeErr("crypto_aes256_gcm_decrypt", func(args []value.Value) (value.Value, error) {
+		// args: (chave: bytes, dados: bytes) -> bytes? (plaintext; null se nao autentica)
+		const native = "crypto_aes256_gcm_decrypt"
+		if err := cryptoArity(native, args, 2); err != nil {
+			return value.NewNull(), err
 		}
-
-		var chave []byte
-		if args[0].Type == value.VAL_BYTES {
-			chave = []byte(args[0].Obj.(string))
-		} else {
-			chave = []byte(args[0].String())
-		}
-
-		var dados []byte
-		if args[1].Type == value.VAL_BYTES {
-			dados = []byte(args[1].Obj.(string))
-		} else {
-			dados = []byte(args[1].String())
-		}
-
-		// Validate key size (32 bytes for AES-256)
-		if len(chave) != 32 {
-			return value.NewNull()
-		}
-
-		block, err := aes.NewCipher(chave)
+		gcm, err := cryptoAES256GCM(native, cryptoBytesArgument(args[0]))
 		if err != nil {
-			return value.NewNull()
+			return value.NewNull(), err
 		}
-
-		gcm, err := cipher.NewGCM(block)
-		if err != nil {
-			return value.NewNull()
-		}
-
+		data := cryptoBytesArgument(args[1])
 		nonceSize := gcm.NonceSize()
-		if len(dados) < nonceSize {
-			return value.NewNull()
+		if len(data) < nonceSize {
+			// Curto demais para conter o nonce: nao e um ciphertext — resultado
+			// de dado, como a tag que nao confere.
+			return value.NewNull(), nil
 		}
-
-		// Separate nonce from ciphertext
-		nonce := dados[:nonceSize]
-		ciphertext := dados[nonceSize:]
-
-		// Open: decrypt and validate authentication
-		texto, err := gcm.Open(nil, nonce, ciphertext, nil)
-		if err != nil {
-			return value.NewNull()
+		plaintext, openErr := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
+		if openErr != nil {
+			return value.NewNull(), nil
 		}
-
-		return value.NewBytes(string(texto))
+		return value.NewBytes(string(plaintext)), nil
 	})
 }

--- a/internal/vm/builtins_crypto_test.go
+++ b/internal/vm/builtins_crypto_test.go
@@ -1,56 +1,111 @@
 package vm
 
 import (
+	"strings"
 	"testing"
 
 	"noxy-vm/internal/value"
 )
 
-func TestCryptoRandomBytesAndPBKDF2Shapes(t *testing.T) {
+// requireBuiltinError chama o native esperando erro tipado cuja mensagem
+// contem want. Issue #121: os sentinelas null de validacao de argumento
+// viraram erro — sob o wrapper `-> bytes` da stdlib um null passava em
+// silencio e so quebrava longe da causa.
+func requireBuiltinError(t *testing.T, machine *VM, want string, name string, args ...value.Value) {
+	t.Helper()
+	got, err := invokeBuiltin(t, machine, name, args...)
+	if err == nil {
+		t.Fatalf("%s with %d args = %s, want error containing %q", name, len(args), got.String(), want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("%s error = %q, want it to contain %q", name, err.Error(), want)
+	}
+}
+
+func requireBytesOfLength(t *testing.T, name string, got value.Value, want int) {
+	t.Helper()
+	if got.Type != value.VAL_BYTES {
+		t.Fatalf("%s type = %v, want bytes", name, got.Type)
+	}
+	if length := len(got.Obj.(string)); length != want {
+		t.Fatalf("%s length = %d, want %d", name, length, want)
+	}
+}
+
+func TestCryptoRandomBytesShape(t *testing.T) {
 	machine := New()
+	requireBytesOfLength(t, "crypto_random_bytes", callBuiltin(t, machine, "crypto_random_bytes", value.NewInt(32)), 32)
+}
 
-	random := callBuiltin(t, machine, "crypto_random_bytes", value.NewInt(32))
-	if random.Type != value.VAL_BYTES {
-		t.Fatalf("crypto_random_bytes type = %v, want bytes", random.Type)
-	}
-	if got := len(random.Obj.(string)); got != 32 {
-		t.Fatalf("crypto_random_bytes length = %d, want 32", got)
-	}
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_random_bytes"), value.NewNull())
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_random_bytes", value.NewInt(0)), value.NewNull())
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_random_bytes", value.NewInt(-1)), value.NewNull())
+func TestCryptoRandomBytesRejectsInvalidLength(t *testing.T) {
+	machine := New()
+	requireBuiltinError(t, machine, "crypto_random_bytes: expects exactly 1 argument, got 0", "crypto_random_bytes")
+	requireBuiltinError(t, machine, "crypto_random_bytes: n must be > 0, got 0", "crypto_random_bytes", value.NewInt(0))
+	requireBuiltinError(t, machine, "crypto_random_bytes: n must be > 0, got -1", "crypto_random_bytes", value.NewInt(-1))
+	requireBuiltinError(t, machine, "crypto_random_bytes: n must be an int, got string", "crypto_random_bytes", value.NewString("16"))
+}
 
+func TestCryptoPBKDF2Shape(t *testing.T) {
+	machine := New()
 	derived := callBuiltin(t, machine, "crypto_pbkdf2_sha256",
 		value.NewString("fixed-password"), value.NewBytes("fixed-salt"), value.NewInt(100), value.NewInt(24),
 	)
-	if derived.Type != value.VAL_BYTES {
-		t.Fatalf("crypto_pbkdf2_sha256 type = %v, want bytes", derived.Type)
-	}
-	if got := len(derived.Obj.(string)); got != 24 {
-		t.Fatalf("crypto_pbkdf2_sha256 length = %d, want 24", got)
-	}
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_pbkdf2_sha256",
-		value.NewString("password"), value.NewBytes("salt"), value.NewInt(0), value.NewInt(24),
-	), value.NewNull())
+	requireBytesOfLength(t, "crypto_pbkdf2_sha256", derived, 24)
 }
 
-func TestAES256GCMRoundTripAndFailureSentinels(t *testing.T) {
+func TestCryptoPBKDF2RejectsInvalidArguments(t *testing.T) {
 	machine := New()
-	key := value.NewBytes("0123456789abcdef0123456789abcdef")
-	plaintext := value.NewBytes("stateful builtin round trip\x00")
+	password, salt := value.NewString("password"), value.NewBytes("salt")
+	requireBuiltinError(t, machine, "crypto_pbkdf2_sha256: iterations must be > 0, got 0",
+		"crypto_pbkdf2_sha256", password, salt, value.NewInt(0), value.NewInt(24))
+	requireBuiltinError(t, machine, "crypto_pbkdf2_sha256: key length must be > 0, got -3",
+		"crypto_pbkdf2_sha256", password, salt, value.NewInt(1), value.NewInt(-3))
+	requireBuiltinError(t, machine, "crypto_pbkdf2_sha256: iterations must be an int, got string",
+		"crypto_pbkdf2_sha256", password, salt, value.NewString("1000"), value.NewInt(24))
+	requireBuiltinError(t, machine, "crypto_pbkdf2_sha256: expects exactly 4 arguments, got 3",
+		"crypto_pbkdf2_sha256", password, salt, value.NewInt(1))
+}
 
-	ciphertext := callBuiltin(t, machine, "crypto_aes256_gcm_encrypt", key, plaintext)
+func aes256GCMFixture(t *testing.T, machine *VM) (key, plaintext, ciphertext value.Value) {
+	t.Helper()
+	key = value.NewBytes("0123456789abcdef0123456789abcdef")
+	plaintext = value.NewBytes("stateful builtin round trip\x00")
+	ciphertext = callBuiltin(t, machine, "crypto_aes256_gcm_encrypt", key, plaintext)
 	if ciphertext.Type != value.VAL_BYTES {
 		t.Fatalf("encrypt type = %v, want bytes", ciphertext.Type)
 	}
 	if got, minimum := len(ciphertext.Obj.(string)), 12+16; got < minimum {
 		t.Fatalf("encrypted payload length = %d, want at least nonce+tag length %d", got, minimum)
 	}
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_decrypt", key, ciphertext), plaintext)
+	return key, plaintext, ciphertext
+}
 
+func TestAES256GCMRoundTrip(t *testing.T) {
+	machine := New()
+	key, plaintext, ciphertext := aes256GCMFixture(t, machine)
+	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_decrypt", key, ciphertext), plaintext)
+}
+
+func TestAES256GCMRejectsWrongKeyLength(t *testing.T) {
+	machine := New()
+	_, plaintext, ciphertext := aes256GCMFixture(t, machine)
 	shortKey := value.NewBytes("short")
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_encrypt", shortKey, plaintext), value.NewNull())
-	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_decrypt", shortKey, ciphertext), value.NewNull())
+	requireBuiltinError(t, machine, "crypto_aes256_gcm_encrypt: key must be 32 bytes, got 5",
+		"crypto_aes256_gcm_encrypt", shortKey, plaintext)
+	requireBuiltinError(t, machine, "crypto_aes256_gcm_decrypt: key must be 32 bytes, got 5",
+		"crypto_aes256_gcm_decrypt", shortKey, ciphertext)
+	requireBuiltinError(t, machine, "crypto_aes256_gcm_encrypt: expects exactly 2 arguments, got 1",
+		"crypto_aes256_gcm_encrypt", shortKey)
+	requireBuiltinError(t, machine, "crypto_aes256_gcm_decrypt: expects exactly 2 arguments, got 1",
+		"crypto_aes256_gcm_decrypt", shortKey)
+}
+
+// null e resultado de DADO do decrypt (o wrapper diz `-> bytes?`): dados
+// curtos demais para conter o nonce, nonce sem tag, tag adulterada — nada
+// disso e erro de argumento, e a chave certa nao muda o veredito.
+func TestAES256GCMDecryptReturnsNullForUndecryptableData(t *testing.T) {
+	machine := New()
+	key, _, ciphertext := aes256GCMFixture(t, machine)
 	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_decrypt", key, value.NewBytes("short nonce")), value.NewNull())
 	assertBuiltinValue(t, callBuiltin(t, machine, "crypto_aes256_gcm_decrypt", key, value.NewBytes("123456789012")), value.NewNull())
 

--- a/internal/vm/builtins_net.go
+++ b/internal/vm/builtins_net.go
@@ -478,18 +478,14 @@ func (vm *VM) defineNetworkBuiltins() {
 		if err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) < 1 {
-			return value.NewNull(), nil
+		if len(args) != 1 {
+			return value.NewNull(), fmt.Errorf("net_accept expects exactly 1 argument")
 		}
-		socket, ok := args[0].Obj.(*value.ObjMap)
-		if !ok {
-			return value.NewNull(), nil
+		listenerFD, descriptorErr := networkSocketDescriptor(args[0])
+		if descriptorErr != nil {
+			return value.NewNull(), descriptorErr
 		}
-		fdValue, exists := socket.Get("fd")
-		if !exists {
-			return value.NewNull(), nil
-		}
-		resource, exists := machine.shared.Listeners.get(int(fdValue.Int()))
+		resource, exists := machine.shared.Listeners.get(listenerFD)
 		if !exists {
 			return socketValue(-1, "", 0, false), nil
 		}
@@ -528,15 +524,14 @@ func (vm *VM) defineNetworkBuiltins() {
 		if err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) < 2 {
-			return value.NewNull(), nil
+		if len(args) != 2 {
+			return value.NewNull(), fmt.Errorf("net_recv expects exactly 2 arguments")
 		}
-		socket, ok := args[0].Obj.(*value.ObjMap)
-		if !ok {
-			return value.NewNull(), nil
+		handle, descriptorErr := networkSocketDescriptor(args[0])
+		if descriptorErr != nil {
+			return value.NewNull(), descriptorErr
 		}
-		fdValue, _ := socket.Get("fd")
-		resource, exists := machine.shared.Sockets.get(int(fdValue.Int()))
+		resource, exists := machine.shared.Sockets.get(handle)
 		if !exists {
 			return netResult(false, "", 0, "invalid socket"), nil
 		}
@@ -548,19 +543,18 @@ func (vm *VM) defineNetworkBuiltins() {
 		if err != nil {
 			return value.NewNull(), err
 		}
-		if len(args) < 2 {
-			return value.NewNull(), nil
+		if len(args) != 2 {
+			return value.NewNull(), fmt.Errorf("net_send expects exactly 2 arguments")
 		}
-		socket, ok := args[0].Obj.(*value.ObjMap)
-		if !ok {
-			return value.NewNull(), nil
+		handle, descriptorErr := networkSocketDescriptor(args[0])
+		if descriptorErr != nil {
+			return value.NewNull(), descriptorErr
 		}
-		fdValue, _ := socket.Get("fd")
 		data := args[1].String()
 		if args[1].Type == value.VAL_BYTES {
 			data = args[1].Obj.(string)
 		}
-		resource, exists := machine.shared.Sockets.get(int(fdValue.Int()))
+		resource, exists := machine.shared.Sockets.get(handle)
 		if !exists {
 			return netResult(false, "", 0, "invalid socket"), nil
 		}
@@ -579,10 +573,8 @@ func (vm *VM) defineNetworkBuiltins() {
 		if args[0].Type == value.VAL_INT {
 			fd = int(args[0].Int())
 		} else if args[0].Type == value.VAL_OBJ {
-			if socket, ok := args[0].Obj.(*value.ObjMap); ok {
-				if fdValue, found := socket.Get("fd"); found {
-					fd = int(fdValue.Int())
-				}
+			if handle, descriptorErr := networkSocketDescriptor(args[0]); descriptorErr == nil {
+				fd = handle
 			}
 		} else {
 			return value.NewNull(), nil

--- a/internal/vm/builtins_net_typed_socket_test.go
+++ b/internal/vm/builtins_net_typed_socket_test.go
@@ -1,0 +1,171 @@
+package vm
+
+import (
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"noxy-vm/internal/value"
+)
+
+// Issue #121: net_accept/net_recv/net_send aceitavam so o map que o runtime
+// constroi (socketValue) e devolviam null para qualquer outra forma — sob os
+// wrappers `-> NetResult`/`-> Socket` da stdlib. Uma dessas formas e o
+// `Socket(...)` que net.poll reconstroi, entao socket_recv sobre
+// poll(...).read[0] devolvia null. A identidade do socket e o fd registrado,
+// nao a forma do valor (networkSocketDescriptor, o mesmo de settimeout).
+
+func typedSocketInstance(fd int) value.Value {
+	definition := &value.ObjStruct{Name: "Socket", Fields: []string{"fd", "addr", "port", "open"}}
+	instance := value.NewInstance(definition)
+	instance.Obj.(*value.ObjInstance).MustSet("fd", value.NewInt(int64(fd)))
+	instance.Obj.(*value.ObjInstance).MustSet("addr", value.NewString("127.0.0.1"))
+	instance.Obj.(*value.ObjInstance).MustSet("port", value.NewInt(0))
+	instance.Obj.(*value.ObjInstance).MustSet("open", value.NewBool(true))
+	return instance
+}
+
+func TestNetRecvAndSendAcceptTypedSocketInstance(t *testing.T) {
+	machine := New()
+	connection, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connection.Close()
+		_ = peer.Close()
+	})
+	handle := machine.shared.Sockets.add(&SocketResource{connection: connection})
+	t.Cleanup(func() { machine.shared.Sockets.remove(handle) })
+	socket := typedSocketInstance(handle)
+
+	go func() { _, _ = peer.Write([]byte("hi")) }()
+	received := callBuiltinWithinBound(t, machine, "net_recv", socket, value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, received, "data"), value.NewBytes("hi"))
+
+	go func() {
+		buffer := make([]byte, 2)
+		_, _ = io.ReadFull(peer, buffer)
+	}()
+	sent := callBuiltinWithinBound(t, machine, "net_send", socket, value.NewBytes("ok"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(true))
+	assertBuiltinValue(t, builtinMapField(t, sent, "count"), value.NewInt(2))
+}
+
+// Socket com a forma certa mas fd fora do registro (construido pelo
+// programa, ou ja fechado): resultado tipado — ok=false / open=false — como
+// sempre foi para o map do runtime. Nunca null.
+func TestNetWrappersOnUnregisteredSocketReturnTypedFailure(t *testing.T) {
+	machine := New()
+	ghost := typedSocketInstance(9999)
+
+	received := callBuiltinWithinBound(t, machine, "net_recv", ghost, value.NewInt(2))
+	assertBuiltinValue(t, builtinMapField(t, received, "ok"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, received, "error"), value.NewString("invalid socket"))
+
+	sent := callBuiltinWithinBound(t, machine, "net_send", ghost, value.NewBytes("x"))
+	assertBuiltinValue(t, builtinMapField(t, sent, "ok"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, sent, "error"), value.NewString("invalid socket"))
+
+	accepted := callBuiltinWithinBound(t, machine, "net_accept", ghost)
+	assertBuiltinValue(t, builtinMapField(t, accepted, "open"), value.NewBool(false))
+	assertBuiltinValue(t, builtinMapField(t, accepted, "fd"), value.NewInt(-1))
+}
+
+// Valor que nao tem a forma de socket (sem campo fd int): erro tipado, a
+// mesma mensagem de net_settimeout — nunca null.
+func TestNetRecvSendAcceptRejectNonSocketWithError(t *testing.T) {
+	machine := New()
+	invalid := []value.Value{
+		value.NewString("not a socket"),
+		value.NewMap(),
+		value.NewMapWithData(map[string]value.Value{"fd": value.NewString("1")}),
+		{Type: value.VAL_OBJ, Obj: (*value.ObjInstance)(nil)},
+	}
+	for _, socket := range invalid {
+		for _, name := range []string{"net_recv", "net_send", "net_accept"} {
+			args := []value.Value{socket}
+			if name != "net_accept" {
+				args = append(args, value.NewInt(1))
+			}
+			if _, err := invokeBuiltin(t, machine, name, args...); err == nil || !strings.Contains(err.Error(), "invalid socket") {
+				t.Fatalf("%s(%#v) error = %v, want invalid socket", name, socket, err)
+			}
+		}
+	}
+	for name, args := range map[string][]value.Value{
+		"net_recv":   {typedSocketInstance(1)},
+		"net_send":   {typedSocketInstance(1)},
+		"net_accept": {},
+	} {
+		if _, err := invokeBuiltin(t, machine, name, args...); err == nil || !strings.Contains(err.Error(), name+" expects exactly") {
+			t.Fatalf("%s with %d args error = %v, want an arity error", name, len(args), err)
+		}
+	}
+}
+
+func captureNetProgram(t *testing.T, source string) value.Value {
+	t.Helper()
+	machine := New()
+	captured := value.NewNull()
+	machine.DefineNative("test_report", func(args []value.Value) value.Value {
+		if len(args) == 1 {
+			captured = args[0]
+		}
+		return value.NewNull()
+	})
+	if err := interpretVMSourceWithinBound(t, machine, source); err != nil {
+		t.Fatal(err)
+	}
+	return captured
+}
+
+// Fluxo completo em loopback pela stdlib: o Socket que sai de
+// net.poll(...).read[0] (instancia reconstruida em net.nx) recebe os bytes.
+func TestNetRecvOnPolledSocketDeliversData(t *testing.T) {
+	got := captureNetProgram(t, `use net
+let listener: net.Socket = net.listen("127.0.0.1", 0)
+let client: net.Socket = net.connect("127.0.0.1", listener.port)
+let server: net.Socket = net.accept(listener)
+net.settimeout(server, 2000)
+let sent: net.NetResult = net.socket_send(client, b"poll-data")
+let server_read: net.Socket?[64] = net.socket_set()
+let empty: net.Socket?[64] = net.socket_set()
+server_read[0] = server
+let ready: net.SelectResult = net.poll(server_read, empty, empty, 2000)
+let score: int = 0
+if sent.ok && sent.count == 9 then
+    score = score + 1
+end
+if ready.read_count == 1 then
+    let polled: net.Socket = ready.read[0]
+    let received: net.NetResult = net.socket_recv(polled, 64)
+    if received.ok && received.data == b"poll-data" then
+        score = score + 10
+    end
+end
+net.socket_close(server)
+net.socket_close(client)
+net.socket_close(listener)
+test_report(score)`)
+	testExpectedObject(t, 11, got)
+}
+
+func TestNetWrappersOnProgramBuiltSocketNeverReturnNull(t *testing.T) {
+	got := captureNetProgram(t, `use net
+let ghost: net.Socket = net.Socket(9999, "x", 0, true)
+let received: net.NetResult = net.socket_recv(ghost, 10)
+let sent: net.NetResult = net.socket_send(ghost, b"hi")
+let accepted: net.Socket = net.accept(ghost)
+let score: int = 0
+if !received.ok && received.error == "invalid socket" then
+    score = score + 1
+end
+if !sent.ok && sent.error == "invalid socket" then
+    score = score + 10
+end
+if !accepted.open && accepted.fd == -1 then
+    score = score + 100
+end
+test_report(score)`)
+	testExpectedObject(t, 111, got)
+}

--- a/internal/vm/native_ref_args.go
+++ b/internal/vm/native_ref_args.go
@@ -42,21 +42,30 @@ func rejectRefArgs(name string, args []value.Value) error {
 // mao porque value.NewContextualNative nao o guarda, e sem ele
 // stampReadonlyArgs perderia o flag CoW da native convertida.
 func (vm *VM) defineValueNative(name string, fn value.NativeFunc) {
-	vm.defineValueNativeErr(name, func(args []value.Value) (value.Value, error) {
+	vm.registerValueNative(name, func(_ value.NativeContext, args []value.Value) (value.Value, error) {
+		if err := rejectRefArgs(name, args); err != nil {
+			return value.NewNull(), err
+		}
 		return fn(args), nil
 	})
 }
 
 // defineValueNativeErr e defineValueNative para a native de valor que
 // devolve erro tipado (issue #121: argumento invalido nas natives de cripto
-// e erro, nao null) — mesmo registro, mesma rejectRefArgs antes de fn.
+// e erro, nao null) — mesmo registro, mesma rejectRefArgs antes de fn. Cada
+// variante monta o proprio closure: o caminho por chamada de fmt/to_bytes/
+// hex*/json_* (defineValueNative) nao ganha um salto a mais por causa desta.
 func (vm *VM) defineValueNativeErr(name string, fn func(args []value.Value) (value.Value, error)) {
-	native := value.NewContextualNative(name, func(_ value.NativeContext, args []value.Value) (value.Value, error) {
+	vm.registerValueNative(name, func(_ value.NativeContext, args []value.Value) (value.Value, error) {
 		if err := rejectRefArgs(name, args); err != nil {
 			return value.NewNull(), err
 		}
 		return fn(args)
 	})
+}
+
+func (vm *VM) registerValueNative(name string, fn value.ContextualNativeFunc) {
+	native := value.NewContextualNative(name, fn)
 	if obj, ok := native.Obj.(*value.ObjNative); ok {
 		obj.Name = name
 	}

--- a/internal/vm/native_ref_args.go
+++ b/internal/vm/native_ref_args.go
@@ -42,11 +42,20 @@ func rejectRefArgs(name string, args []value.Value) error {
 // mao porque value.NewContextualNative nao o guarda, e sem ele
 // stampReadonlyArgs perderia o flag CoW da native convertida.
 func (vm *VM) defineValueNative(name string, fn value.NativeFunc) {
+	vm.defineValueNativeErr(name, func(args []value.Value) (value.Value, error) {
+		return fn(args), nil
+	})
+}
+
+// defineValueNativeErr e defineValueNative para a native de valor que
+// devolve erro tipado (issue #121: argumento invalido nas natives de cripto
+// e erro, nao null) — mesmo registro, mesma rejectRefArgs antes de fn.
+func (vm *VM) defineValueNativeErr(name string, fn func(args []value.Value) (value.Value, error)) {
 	native := value.NewContextualNative(name, func(_ value.NativeContext, args []value.Value) (value.Value, error) {
 		if err := rejectRefArgs(name, args); err != nil {
 			return value.NewNull(), err
 		}
-		return fn(args), nil
+		return fn(args)
 	})
 	if obj, ok := native.Obj.(*value.ObjNative); ok {
 		obj.Name = name

--- a/internal/vm/stdlib_hygiene_test.go
+++ b/internal/vm/stdlib_hygiene_test.go
@@ -28,6 +28,7 @@ var nativeRegistrationHelpers = map[string]bool{
 	// defineValueNative (native_ref_args.go) e um DefineNative que interpoe
 	// rejectRefArgs: registra native igual, e o coletor tem de ve-lo.
 	"defineValueNative":                   true,
+	"defineValueNativeErr":                true,
 	"DefineNative":                        true,
 	"DefineNativeWithSignature":           true,
 	"DefineContextualNative":              true,

--- a/internal/vm/stdlib_nullable_contracts_test.go
+++ b/internal/vm/stdlib_nullable_contracts_test.go
@@ -33,3 +33,59 @@ func TestSqlitePrepareNullOnBadSqlIsTestable(t *testing.T) {
 	got := captureVMSource(t, "use sqlite select *\nlet db: Database = open(\":memory:\")\nlet bad = prepare(db, \"SELECT * FROM tabela_inexistente\")\nlet ok = prepare(db, \"SELECT 1\")\nlet score: int = 0\nif bad == null then\n    score = score + 1\nend\nif ok != null then\n    if ok.handle > 0 then\n        score = score + 10\n    end\n    finalize(ok)\nend\nclose(db)\ntest_report(score)\n")
 	testExpectedObject(t, 11, got)
 }
+
+// Issue #121: em crypto so `aes256_gcm_decrypt` tem null como resultado de
+// dado (autenticacao falhou, dados curtos demais) — a assinatura diz
+// `-> bytes?`. Os outros nulls (n <= 0, iteracoes/tamanho <= 0, chave que
+// nao tem 32 bytes) eram validacao de argumento e viraram erro tipado do
+// native: nenhum wrapper `-> bytes` deixa null passar.
+
+func TestCryptoDecryptReturnsNullableBytes(t *testing.T) {
+	err := interpretOrCompileErr(t, New(), "use crypto select *\nlet key: bytes = random_bytes(32)\nlet plain: bytes = aes256_gcm_decrypt(key, b\"x\")\n")
+	if err == nil || !strings.Contains(err.Error(), "expected bytes, got bytes?") {
+		t.Fatalf("want the nullable contract in the static type, got %v", err)
+	}
+}
+
+func TestCryptoDecryptNullOnUndecryptableDataIsTestable(t *testing.T) {
+	got := captureVMSource(t, `use crypto select *
+let key: bytes = random_bytes(32)
+let sealed: bytes = aes256_gcm_encrypt(key, b"segredo")
+let opened = aes256_gcm_decrypt(key, sealed)
+let garbage = aes256_gcm_decrypt(key, b"123456789012xx")
+let short = aes256_gcm_decrypt(key, b"x")
+let score: int = 0
+if opened != null then
+    if opened == b"segredo" then
+        score = score + 1
+    end
+end
+if garbage == null then
+    score = score + 10
+end
+if short == null then
+    score = score + 100
+end
+test_report(score)
+`)
+	testExpectedObject(t, 111, got)
+}
+
+func TestCryptoInvalidArgumentsRaiseInsteadOfNull(t *testing.T) {
+	tests := []struct{ name, source, want string }{
+		{"random_bytes zero", "use crypto select *\nlet z: bytes = random_bytes(0)\n", "crypto_random_bytes: n must be > 0, got 0"},
+		{"random_bytes member form", "use crypto\nlet z: bytes = crypto.random_bytes(-1)\n", "crypto_random_bytes: n must be > 0, got -1"},
+		{"pbkdf2 zero iterations", "use crypto select *\nlet k: bytes = pbkdf2_sha256(\"pw\", b\"salt\", 0, 32)\n", "crypto_pbkdf2_sha256: iterations must be > 0, got 0"},
+		{"pbkdf2 zero length", "use crypto select *\nlet k: bytes = pbkdf2_sha256(\"pw\", b\"salt\", 1000, 0)\n", "crypto_pbkdf2_sha256: key length must be > 0, got 0"},
+		{"encrypt short key", "use crypto select *\nlet e: bytes = aes256_gcm_encrypt(b\"short\", b\"texto\")\n", "crypto_aes256_gcm_encrypt: key must be 32 bytes, got 5"},
+		{"decrypt short key", "use crypto select *\nlet d = aes256_gcm_decrypt(b\"short\", b\"texto\")\n", "crypto_aes256_gcm_decrypt: key must be 32 bytes, got 5"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := interpretOrCompileErr(t, New(), test.source)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("want runtime error containing %q, got %v", test.want, err)
+			}
+		})
+	}
+}

--- a/noxy.mod
+++ b/noxy.mod
@@ -1,6 +1,6 @@
 module noxy
 
-noxy v0.23.1
+noxy v0.23.2
 
 require github.com/estevaofon/quicksort v0.1.0
 require github.com/estevaofon/noxy_dynamodb v0.3.0

--- a/noxy_examples/password_manager/server.nx
+++ b/noxy_examples/password_manager/server.nx
@@ -110,7 +110,8 @@ func decrypt(hex_str: string) -> string
         return ""
     end
     let encrypted_bytes: bytes = hex_decode(hex_str)
-    let decrypted: bytes = crypto.aes256_gcm_decrypt(master_key, encrypted_bytes)
+    // aes256_gcm_decrypt -> bytes?: null quando os dados nao autenticam
+    let decrypted: bytes? = crypto.aes256_gcm_decrypt(master_key, encrypted_bytes)
     if decrypted == null then
         return "[ERRO: falha na descriptografia]"
     end

--- a/noxy_examples/test_crypto_aes.nx
+++ b/noxy_examples/test_crypto_aes.nx
@@ -41,12 +41,17 @@ end
 
 print("")
 print("=== Teste crypto.aes256_gcm_decrypt ===")
-let senha_recuperada: bytes = crypto.aes256_gcm_decrypt(chave, dados_criptografados)
-print(f"Senha recuperada: {to_str(senha_recuperada)}")
-if to_str(senha_recuperada) == "fb_pass_456" then
-    print("PASS: Descriptografia bem sucedida!")
+// aes256_gcm_decrypt -> bytes?: null quando os dados nao autenticam
+let senha_recuperada: bytes? = crypto.aes256_gcm_decrypt(chave, dados_criptografados)
+if senha_recuperada == null then
+    print("FAIL: aes256_gcm_decrypt devolveu null")
 else
-    print("FAIL: Senha recuperada diferente da original")
+    print(f"Senha recuperada: {to_str(senha_recuperada)}")
+    if to_str(senha_recuperada) == "fb_pass_456" then
+        print("PASS: Descriptografia bem sucedida!")
+    else
+        print("FAIL: Senha recuperada diferente da original")
+    end
 end
 
 print("")
@@ -58,14 +63,18 @@ let chave2: bytes = crypto.pbkdf2_sha256("outra_senha", salt2, 10000, 32)
 // Criptografar e descriptografar
 let segredo: bytes = b"Meu segredo super importante!"
 let cifrado: bytes = crypto.aes256_gcm_encrypt(chave2, segredo)
-let decifrado: bytes = crypto.aes256_gcm_decrypt(chave2, cifrado)
+let decifrado: bytes? = crypto.aes256_gcm_decrypt(chave2, cifrado)
 
-if to_str(decifrado) == "Meu segredo super importante!" then
-    print("PASS: Ciclo completo encrypt/decrypt funcionando!")
+if decifrado == null then
+    print("FAIL: Ciclo falhou - aes256_gcm_decrypt devolveu null")
 else
-    print("FAIL: Ciclo falhou")
-    print(f"Esperado: Meu segredo super importante!")
-    print(f"Obtido: {to_str(decifrado)}")
+    if to_str(decifrado) == "Meu segredo super importante!" then
+        print("PASS: Ciclo completo encrypt/decrypt funcionando!")
+    else
+        print("FAIL: Ciclo falhou")
+        print(f"Esperado: Meu segredo super importante!")
+        print(f"Obtido: {to_str(decifrado)}")
+    end
 end
 
 print("")

--- a/noxy_examples/test_crypto_debug.nx
+++ b/noxy_examples/test_crypto_debug.nx
@@ -97,7 +97,8 @@ else
     sys.exit(1)
 end
 
-let decrypted2: bytes = crypto.aes256_gcm_decrypt(chave, back_to_bytes)
+// aes256_gcm_decrypt -> bytes?: null quando os dados nao autenticam
+let decrypted2: bytes? = crypto.aes256_gcm_decrypt(chave, back_to_bytes)
 if decrypted2 == null then
     print("FAIL: Descriptografia após hex falhou")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- Issue #121: natives que devolviam `null` como dado sob um wrapper `-> T` da stdlib (crypto e net). O null passava em silêncio pela forma `m.f()` e pelo `select` (o tipo do wrapper mentia) e só quebrava longe da causa. Decisão por função: `T?` quando o null é resultado de dado, erro tipado do native quando é argumento inválido. Argumento inválido nunca mais vira null; o null de dado passa a ser **tipado** — o que o `select` confere estaticamente, mas a forma `m.f()` (tipo desconhecido, sem guarda até a #122) não: `let x: bytes = crypto.aes256_gcm_decrypt(k, lixo)` compila e em runtime ainda recebe null em silêncio (`x == null` → `true`, `length(x)` → 0). A forma honesta ali é `let x: bytes? = …`; está no CHANGELOG.
- **crypto**: `random_bytes(n <= 0)`, `pbkdf2_sha256` com `iteracoes`/`tamanho <= 0` e `aes256_gcm_encrypt`/`decrypt` com chave ≠ 32 bytes → erro de runtime (`native 'crypto_random_bytes' failed: crypto_random_bytes: n must be > 0, got 0`). Aridade/tipo errados em chamada dinâmica também erram. O único null que sobra é resultado de dado: **`aes256_gcm_decrypt -> bytes?` (BREAKING)**, com migração no CHANGELOG (`let x: bytes? = crypto.aes256_gcm_decrypt(...)` / `let x = aes256_gcm_decrypt(...)` com `select`). `docs/CRYPTO_MODULE.md` já prometia esse null; agora o tipo diz o mesmo.
- **net** (achado por execução durante a auditoria, além do que a issue lista): `net_accept`/`net_recv`/`net_send` só aceitavam o map do runtime — e **`socket_recv(poll(...).read[0], n)` devolvia null**, porque `net.poll` reconstrói `Socket(...)` (instância). Passam a usar `networkSocketDescriptor` (o mesmo de `settimeout`): a identidade do socket é o **fd registrado**, não a forma do valor. fd fora do registro segue `NetResult{ok: false, error: "invalid socket"}` / `Socket(fd: -1, open: false)` como sempre foi para o map; valor sem a forma de socket é erro tipado `invalid socket`; aridade errada erra. `net_close` também aceita a instância.
- Varredura dos demais `builtins_*.go` (o #120 cobriu io/sqlite/time/strings/sys só para null de dado): fora crypto/net, todo `return null` alcançável está atrás de `-> any`, de wrapper `-> void`, já erra tipado, ou é aridade/asserção interna que o wrapper tipado nunca produz. `time.parse*`/`sqlite.prepare` e `crypto.aes256_gcm_decrypt` são os únicos `T?` da stdlib. Fora do escopo (anotado no CHANGELOG): `hex()`/`slice()` sem argumentos — null de aridade num builtin tipado pelo compilador, sem wrapper.
- Versão **v0.23.2** (patch: correção com BREAKING pontual + migração, conforme convenção).

### Decisão que desvia da letra da issue (para revisão)
A issue pedia "erro tipado para `Socket` que não é o do runtime". Como o próprio `net.poll` produz `Socket(...)` (instância) e `settimeout` já aceita as duas formas via `networkSocketDescriptor`, a forma do valor não pode ser o critério — o fd é. Então: valor sem `fd` int → erro tipado; `Socket` com fd desconhecido → o resultado tipado de falha que o map já recebia (`ok=false`/`open=false`). Trocar isso por erro mudaria também o contrato de socket **fechado** (`recv` num socket fechado hoje devolve `ok=false, "invalid socket"`, usado pelo http_server).

## Components
- `internal/vm/builtins_crypto.go` — 4 natives reescritas com erro tipado (`cryptoArity`, `cryptoIntArgument`, `cryptoAES256GCM`); só `decrypt` devolve null (dados não autenticam / curtos demais para o nonce).
- `internal/vm/native_ref_args.go` — `defineValueNativeErr` (native de valor com erro); `defineValueNative` delega.
- `internal/vm/builtins_net.go` — `net_accept`/`net_recv`/`net_send`/`net_close` via `networkSocketDescriptor`; aridade estrita nos três primeiros.
- `internal/stdlib/crypto.nx` — `aes256_gcm_decrypt -> bytes?`; comentários de contrato nos quatro wrappers.
- Testes: `builtins_crypto_test.go` (reescrito: erros por caso + null só como dado), `builtins_net_typed_socket_test.go` (novo: instância com fd registrado recebe/envia via `net.Pipe`, fd desconhecido → resultado tipado, não-socket → `invalid socket`, aridade; fluxo `.nx` em loopback `poll → read[0] → socket_recv`; `Socket(...)` do programa nunca null), `stdlib_nullable_contracts_test.go` (+3: `expected bytes, got bytes?` no `select`, null de dado testável, erros por argumento nas formas `select` e `m.f()`), `stdlib_hygiene_test.go` (coletor reconhece `defineValueNativeErr`).
- Exemplos migrados: `noxy_examples/password_manager/server.nx`, `noxy_examples/test_crypto_debug.nx`, `noxy_examples/test_crypto_aes.nx` (`let x: bytes? = ...` + teste de null).
- Docs: `CHANGELOG.md` (0.23.2 com migração), `docs/CRYPTO_MODULE.md` (assinatura `bytes?`, erros por argumento, exemplos), `docs/NOXY_LANGUAGE_SPEC.md` §4.2 (lista dos `T?` da stdlib; argumento inválido é erro). Bump em `README.md`, `AGENTS.md`, `docs/index.html`, `noxy.mod`, `internal/version/version.go`.

## Related Issues
- Closes #121 (base `develop` não fecha automaticamente — fechar à mão após o merge)
- Segue #120 (contratos `T?` de `time.parse*`/`sqlite.prepare`); #122 (contrato de retorno dos natives + fast path) fica como está

## Test Plan
- [x] RED→GREEN: 10 testes novos vistos falhando antes da implementação (null no lugar de erro; `bytes` no lugar de `bytes?`; `null.ok` no fluxo do `poll`) e passando depois
- [x] `go test ./... -count=1` verde (14 pacotes `ok`, 0 `FAIL`), `go vet ./internal/vm ./internal/compiler` limpo, gofmt limpo (cópias LF dos arquivos CRLF)
- [x] Oráculos por execução (`go run ./cmd/noxy`): `crypto.random_bytes(0)` via `m.f()` → runtime error; `let d: bytes = aes256_gcm_decrypt(...)` via `select` → `expected bytes, got bytes?`; `socket_recv`/`socket_send`/`accept` num `net.Socket(9999, ...)` → resultado tipado; `socket_recv` no socket de `poll(...).read[0]` recebe os dados (antes: null)
- [x] `test_crypto_debug.nx` e `test_crypto_aes.nx` executados (PASS); `password_manager/server.nx` compila (teste descartável no pacote `compiler`, removido)
- [x] Revisão 1: decisão de net (fd como identidade) aceita; patch 0.23.2 confirmado; `test_crypto_aes.nx` migrado; texto do `m.f()` ajustado (CHANGELOG + este corpo)
- [x] Performance: sem regressão mensurável (comentário abaixo); custo teórico do closure extra removido em d99949e
- [x] Rodar `benchmarks/compare_examples.ps1` (exemplos de crypto estão na lista de exclusão por saída aleatória; net por rede) — não rodado aqui

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EjcNDFLvDsaXSP8LEbTT2
